### PR TITLE
fix result unmarshalling

### DIFF
--- a/ops/cursor.go
+++ b/ops/cursor.go
@@ -45,14 +45,18 @@ func NewCursor(cursorResult CursorResult, batchSize int32, server Server) (Curso
 	}, nil
 }
 
-// Cursor instances iterate a stream of documents. Each document is decoded into the result according to the rules of
-// the bson package.  A typical usage of the Cursor interface would be:
+// Cursor instances iterate a stream of documents. Each document is
+// decoded into the result according to the rules of the bson package.
 //
-//      cursor := ...    // get a cursor from some operation
-//      var doc bson.D
-//      for cursor.Next(&doc) {
-//              fmt.Println(doc)
-//      err := cursor.Close()
+// A typical usage of the Cursor interface would be:
+//
+//		cursor := ...    // get a cursor from some operation
+//		ctx := ...       // create a context for the operation
+//		var doc bson.D
+//		for cursor.Next(ctx, &doc) {
+//			...
+//		}
+//		err := cursor.Close()
 type Cursor interface {
 	// Get the next result from the cursor.
 	// Returns true if there were no errors and there is a next result.
@@ -142,9 +146,9 @@ func (c *cursorImpl) Close(ctx context.Context) error {
 	return c.err
 }
 
-func (c *cursorImpl) getNextFromCurrentBatch(result interface{}) bool {
+func (c *cursorImpl) getNextFromCurrentBatch(out interface{}) bool {
 	if c.current < len(c.currentBatch) {
-		err := bson.Unmarshal(c.currentBatch[c.current].Data, result)
+		err := c.currentBatch[c.current].Unmarshal(out)
 		if err != nil {
 			c.err = err
 			return false

--- a/ops/cursor_test.go
+++ b/ops/cursor_test.go
@@ -161,10 +161,11 @@ func TestCursorError(t *testing.T) {
 	cursorResult := find(s, collectionName, 2, t)
 
 	subject, _ := NewCursor(cursorResult, 2, s)
-	var next string
+	var next bson.D
 	var hasNext bool
 
-	hasNext = subject.Next(context.Background(), &next)
+	// unmarshalling into a non-pointer struct should fail
+	hasNext = subject.Next(context.Background(), next)
 	require.NotNil(t, subject.Err(), "Unexpected error")
 	require.False(t, hasNext, "Should not have result")
 }


### PR DESCRIPTION
Making a call like: `iter.Next(&bson.D{})` when iterating on a `$sample` aggregation command fails with this error: `Unsupported document type for unmarshalling: bson.D`.

This updates the way we unmarshal results from `err := bson.Unmarshal(c.currentBatch[c.current].Data, result)` to `err := c.currentBatch[c.current].Unmarshal(out)`.

This change ensures that we utilize the `bson.Raw` kind - (in `c.currentBatch[c.current]`) - in decoding the result and allows clients pass arbitrary pointer types to the cursor's `Next(..)` method.

P.S.
Still tracking down what code path in the bson package and driver use is causing this problem with the `$sample` aggregation command - since the result should always be a document.