### PR TITLE
fix race condition

### DIFF
--- a/ops/list_collections_test.go
+++ b/ops/list_collections_test.go
@@ -31,9 +31,9 @@ func TestListCollections(t *testing.T) {
 
 	s := getServer()
 
-	collectionNameOne := "TestListCollectionsMultipleBatches1"
-	collectionNameTwo := "TestListCollectionsMultipleBatches2"
-	collectionNameThree := "TestListCollectionsMultipleBatches3"
+	collectionNameOne := "TestListCollections1"
+	collectionNameTwo := "TestListCollections2"
+	collectionNameThree := "TestListCollections3"
 
 	dropCollection(s, collectionNameOne, t)
 	dropCollection(s, collectionNameTwo, t)


### PR DESCRIPTION
The `TestListCollections` and `TestListCollectionsMultipleBatches` tests (which are allowed to run in parallel) referenced the same set of collections - thus causing a race condition. This change uniquely namespaces the collections to avoid that.