### PR TITLE
GODRIVER-5: trimmed whitespace from quoted keys in json decoder

### DIFF
--- a/internal/json/decode.go
+++ b/internal/json/decode.go
@@ -773,7 +773,7 @@ func (d *decodeState) isNull(off int) bool {
 // name consumes a const or function from d.data[d.off-1:], decoding into the value v.
 // the first byte of the function name has been read already.
 func (d *decodeState) name(v reflect.Value) {
-	if d.isNull(d.off-1) {
+	if d.isNull(d.off - 1) {
 		d.literal(v)
 		return
 	}
@@ -1036,7 +1036,7 @@ func (d *decodeState) keyed() (interface{}, bool) {
 		break
 	}
 
-	name := d.data[d.off-1+start : d.off-1+end]
+	name := bytes.Trim(d.data[d.off-1+start:d.off-1+end], " \n\t")
 
 	var key []byte
 	var ok bool
@@ -1076,9 +1076,9 @@ func (d *decodeState) storeKeyed(v reflect.Value) bool {
 }
 
 var (
-	trueBytes = []byte("true")
+	trueBytes  = []byte("true")
 	falseBytes = []byte("false")
-	nullBytes = []byte("null")
+	nullBytes  = []byte("null")
 )
 
 func (d *decodeState) storeValue(v reflect.Value, from interface{}) {

--- a/internal/json/extension_test.go
+++ b/internal/json/extension_test.go
@@ -131,6 +131,9 @@ var extDecodeTests = []extDecodeTest{
 	{in: `Const1`, ptr: new(interface{}), out: const1},
 	{in: `{"c": Const1}`, ptr: new(struct{ C *const1Type }), out: struct{ C *const1Type }{const1}},
 
+	// Space after quoted key
+	{in: `{"c" : Const1}`, ptr: new(struct{ C *const1Type }), out: struct{ C *const1Type }{const1}},
+
 	// Keyed documents
 	{in: `{"v": {"$key1": 1}}`, ptr: new(interface{}), out: map[string]interface{}{"v": keyed(`{"$key1": 1}`)}},
 	{in: `{"k": {"$key1": 1}}`, ptr: new(keyedType), out: keyedType{K: keyed(`{"$key1": 1}`)}},


### PR DESCRIPTION
Same change as in MGO https://github.com/10gen/mgo/commit/1826d82b4485bcededc6841c7bdae2de3a240b9b