### PR TITLE
GO-43: fixed issue with not clearing the connection pool when a read/…

### DIFF
--- a/internal/conntest/mock.go
+++ b/internal/conntest/mock.go
@@ -12,6 +12,7 @@ type MockConnection struct {
 	Dead      bool
 	Sent      []msg.Request
 	ResponseQ []*msg.Reply
+	ReadErr   error
 	WriteErr  error
 
 	SkipResponseToFixup bool
@@ -39,6 +40,12 @@ func (c *MockConnection) Expired() bool {
 }
 
 func (c *MockConnection) Read(ctx context.Context, responseTo int32) (msg.Response, error) {
+	if c.ReadErr != nil {
+		err := c.ReadErr
+		c.ReadErr = nil
+		return nil, err
+	}
+
 	if len(c.ResponseQ) == 0 {
 		return nil, fmt.Errorf("no response queued")
 	}

--- a/internal/error.go
+++ b/internal/error.go
@@ -26,6 +26,19 @@ func RolledUpErrorMessage(err error) string {
 	return err.Error()
 }
 
+//UnwrapError attempts to unwrap the error down to its root cause.
+func UnwrapError(err error) error {
+
+	switch tErr := err.(type) {
+	case WrappedError:
+		return UnwrapError(tErr.Inner())
+	case *multiError:
+		return UnwrapError(tErr.errors[0])
+	}
+
+	return err
+}
+
 // WrapError wraps an error with a message.
 func WrapError(inner error, message string) error {
 	return &wrappedError{message, inner}

--- a/server/server.go
+++ b/server/server.go
@@ -3,9 +3,13 @@ package server
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 
+	"net/url"
+
 	"github.com/10gen/mongo-go-driver/conn"
+	"github.com/10gen/mongo-go-driver/internal"
 	"github.com/10gen/mongo-go-driver/model"
 	"github.com/10gen/mongo-go-driver/msg"
 )
@@ -165,18 +169,40 @@ type serverConn struct {
 // Read reads a message from the connection.
 func (c *serverConn) Read(ctx context.Context, responseTo int32) (msg.Response, error) {
 	resp, err := c.Connection.Read(ctx, responseTo)
-	if err != nil {
-		c.server.monitor.RequestImmediateCheck()
-	}
+	c.handleErr(err)
 	return resp, err
 }
 
 // Write writes a number of messages to the connection.
 func (c *serverConn) Write(ctx context.Context, reqs ...msg.Request) error {
 	err := c.Connection.Write(ctx, reqs...)
-	if err != nil {
-		c.server.monitor.RequestImmediateCheck()
+	c.handleErr(err)
+	return err
+}
+
+func (c *serverConn) handleErr(err error) {
+	if err == nil {
+		return
 	}
 
-	return err
+	err = internal.UnwrapError(err)
+
+	switch tErr := err.(type) {
+	case net.Error:
+		if tErr.Temporary() || tErr.Timeout() {
+			return
+		}
+	case *url.Error:
+		if netErr, ok := tErr.Err.(net.Error); ok && (netErr.Temporary() || netErr.Timeout()) {
+			return
+		}
+	default:
+		if tErr == context.Canceled || tErr == context.DeadlineExceeded {
+			return
+		}
+	}
+
+	// this is not a timeout or otherwise error localized to this connection
+	// so we'll be pragmatic and clear the pool.
+	c.server.conns.Clear()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,8 @@ package server_test
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -147,7 +149,7 @@ func TestServer_Connection_should_clear_pool_when_monitor_fails(t *testing.T) {
 	require.Len(t, created, 4)
 }
 
-func TestServer_Connection_Read_failure_should_cause_immediate_monitor_check(t *testing.T) {
+func TestServer_Connection_Read_non_specific_error_should_clear_the_pool(t *testing.T) {
 	t.Parallel()
 
 	var created []*conntest.MockConnection
@@ -171,9 +173,9 @@ func TestServer_Connection_Read_failure_should_cause_immediate_monitor_check(t *
 	require.NoError(t, err)
 	require.Len(t, created, 2)
 
-	fake.SetKind(model.Unknown)
 	c1.Write(context.Background(), &msg.Query{})
 	c1.Read(context.Background(), 0)
+	c1.MarkDead()
 
 	c1.Close()
 	c2.Close()
@@ -189,7 +191,71 @@ func TestServer_Connection_Read_failure_should_cause_immediate_monitor_check(t *
 	require.Len(t, created, 4)
 }
 
-func TestServer_Connection_Write_failure_should_cause_immediate_monitor_check(t *testing.T) {
+var ignoredErrs []error = []error{
+	&net.DNSError{
+		IsTimeout: true,
+	},
+	&net.DNSError{
+		IsTemporary: true,
+	},
+	&url.Error{
+		Err: &net.DNSError{
+			IsTimeout: true,
+		},
+	},
+	context.DeadlineExceeded,
+	context.Canceled,
+}
+
+func TestServer_Connection_Read_specific_error_should_not_clear_the_pool(t *testing.T) {
+
+	for _, ignoredErr := range ignoredErrs {
+		t.Run(ignoredErr.Error(), func(t *testing.T) {
+			t.Parallel()
+
+			var created []*conntest.MockConnection
+			dialer := func(ctx context.Context, addr model.Addr, opts ...conn.Option) (conn.Connection, error) {
+				created = append(created, &conntest.MockConnection{})
+				return created[len(created)-1], nil
+			}
+
+			fake := servertest.NewFakeMonitor(model.Standalone, model.Addr("localhost:27017"), WithHeartbeatInterval(100*time.Second))
+			s, _ := NewWithMonitor(
+				fake.Monitor,
+				WithConnectionOpener(dialer),
+				WithMaxConnections(2),
+			)
+
+			c1, err := s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 1)
+
+			c2, err := s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 2)
+
+			created[0].ReadErr = ignoredErr
+			c1.Write(context.Background(), &msg.Query{})
+			c1.Read(context.Background(), 0)
+			c1.MarkDead()
+
+			c1.Close()
+			c2.Close()
+
+			time.Sleep(1 * time.Second)
+
+			_, err = s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 2)
+
+			_, err = s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 3)
+		})
+	}
+}
+
+func TestServer_Connection_Write_non_specific_error_should_clear_the_pool(t *testing.T) {
 	t.Parallel()
 
 	var created []*conntest.MockConnection
@@ -213,9 +279,9 @@ func TestServer_Connection_Write_failure_should_cause_immediate_monitor_check(t 
 	require.NoError(t, err)
 	require.Len(t, created, 2)
 
-	fake.SetKind(model.Unknown)
 	created[0].WriteErr = fmt.Errorf("forced write error")
 	c1.Write(context.Background(), &msg.Query{})
+	c1.MarkDead()
 
 	c1.Close()
 	c2.Close()
@@ -229,4 +295,50 @@ func TestServer_Connection_Write_failure_should_cause_immediate_monitor_check(t 
 	_, err = s.Connection(context.Background())
 	require.NoError(t, err)
 	require.Len(t, created, 4)
+}
+
+func TestServer_Connection_Write_specific_error_should_not_clear_the_pool(t *testing.T) {
+	for _, ignoredErr := range ignoredErrs {
+		t.Run(ignoredErr.Error(), func(t *testing.T) {
+			t.Parallel()
+
+			var created []*conntest.MockConnection
+			dialer := func(ctx context.Context, addr model.Addr, opts ...conn.Option) (conn.Connection, error) {
+				created = append(created, &conntest.MockConnection{})
+				return created[len(created)-1], nil
+			}
+
+			fake := servertest.NewFakeMonitor(model.Standalone, model.Addr("localhost:27017"), WithHeartbeatInterval(100*time.Second))
+			s, _ := NewWithMonitor(
+				fake.Monitor,
+				WithConnectionOpener(dialer),
+				WithMaxConnections(2),
+			)
+
+			c1, err := s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 1)
+
+			c2, err := s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 2)
+
+			created[0].WriteErr = ignoredErr
+			c1.Write(context.Background(), &msg.Query{})
+			c1.MarkDead()
+
+			c1.Close()
+			c2.Close()
+
+			time.Sleep(1 * time.Second)
+
+			_, err = s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 2)
+
+			_, err = s.Connection(context.Background())
+			require.NoError(t, err)
+			require.Len(t, created, 3)
+		})
+	}
 }


### PR DESCRIPTION
…write error occurs, generally indicative of the whole pool being poisoned due to a network error.

This is spec'ed in SDAM, but I did the exact opposite of what was specified. Instead of clearing the pool, I requested an immediate heartbeat check. This works most of the time, but ends up in a nefarious situation where the server comes back prior to the heartbeat, essentially leaving all pooled connections in a dead state. Added some tests and fixed the issue.