### PR TITLE
GODRIVER-71: add support for read preference tags

### DIFF
--- a/internal/results.go
+++ b/internal/results.go
@@ -9,28 +9,28 @@ import (
 // IsMasterResult is the result of executing this
 // ismaster command.
 type IsMasterResult struct {
-	Arbiters            []string      `bson:"arbiters,omitempty"`
-	ArbiterOnly         bool          `bson:"arbiterOnly,omitempty"`
-	ElectionID          bson.ObjectId `bson:"electionId,omitempty"`
-	Hidden              bool          `bson:"hidden,omitempty"`
-	Hosts               []string      `bson:"hosts,omitempty"`
-	IsMaster            bool          `bson:"ismaster,omitempty"`
-	IsReplicaSet        bool          `bson:"isreplicaset,omitempty"`
-	LastWriteTimestamp  time.Time     `bson:"lastWriteDate,omitempty"`
-	MaxBSONObjectSize   uint32        `bson:"maxBsonObjectSize,omitempty"`
-	MaxMessageSizeBytes uint32        `bson:"maxMessageSizeBytes,omitempty"`
-	MaxWriteBatchSize   uint16        `bson:"maxWriteBatchSize,omitempty"`
-	Me                  string        `bson:"me,omitempty"`
-	MaxWireVersion      uint8         `bson:"maxWireVersion,omitempty"`
-	MinWireVersion      uint8         `bson:"minWireVersion,omitempty"`
-	Msg                 string        `bson:"msg,omitempty"`
-	OK                  bool          `bson:"ok"`
-	Passives            []string      `bson:"passives,omitempty"`
-	ReadOnly            bool          `bson:"readOnly,omitempty"`
-	Secondary           bool          `bson:"secondary,omitempty"`
-	SetName             string        `bson:"setName,omitempty"`
-	SetVersion          uint32        `bson:"setVersion,omitempty"`
-	Tags                []bson.D      `bson:"tags,omitempty"`
+	Arbiters            []string          `bson:"arbiters,omitempty"`
+	ArbiterOnly         bool              `bson:"arbiterOnly,omitempty"`
+	ElectionID          bson.ObjectId     `bson:"electionId,omitempty"`
+	Hidden              bool              `bson:"hidden,omitempty"`
+	Hosts               []string          `bson:"hosts,omitempty"`
+	IsMaster            bool              `bson:"ismaster,omitempty"`
+	IsReplicaSet        bool              `bson:"isreplicaset,omitempty"`
+	LastWriteTimestamp  time.Time         `bson:"lastWriteDate,omitempty"`
+	MaxBSONObjectSize   uint32            `bson:"maxBsonObjectSize,omitempty"`
+	MaxMessageSizeBytes uint32            `bson:"maxMessageSizeBytes,omitempty"`
+	MaxWriteBatchSize   uint16            `bson:"maxWriteBatchSize,omitempty"`
+	Me                  string            `bson:"me,omitempty"`
+	MaxWireVersion      uint8             `bson:"maxWireVersion,omitempty"`
+	MinWireVersion      uint8             `bson:"minWireVersion,omitempty"`
+	Msg                 string            `bson:"msg,omitempty"`
+	OK                  bool              `bson:"ok"`
+	Passives            []string          `bson:"passives,omitempty"`
+	ReadOnly            bool              `bson:"readOnly,omitempty"`
+	Secondary           bool              `bson:"secondary,omitempty"`
+	SetName             string            `bson:"setName,omitempty"`
+	SetVersion          uint32            `bson:"setVersion,omitempty"`
+	Tags                map[string]string `bson:"tags,omitempty"`
 }
 
 // BuildInfoResult is the result of executing the

--- a/model/server.go
+++ b/model/server.go
@@ -63,7 +63,7 @@ func BuildServer(addr Addr, isMasterResult *internal.IsMasterResult, buildInfoRe
 		MaxMessageSize:  isMasterResult.MaxMessageSizeBytes,
 		SetName:         isMasterResult.SetName,
 		SetVersion:      isMasterResult.SetVersion,
-		Tags:            nil, // TODO: get tags
+		Tags:            NewTagSetFromMap(isMasterResult.Tags),
 		Version: Version{
 			Desc:  buildInfoResult.Version,
 			Parts: buildInfoResult.VersionArray,


### PR DESCRIPTION
This adds full support for tag sets to the driver. It also fixes an issue with passing tags to mongos for sharded clusters.