### PR TITLE
GODRIVER-72: fix hostname resolution during server discovery

### DIFF
--- a/model/addr.go
+++ b/model/addr.go
@@ -22,6 +22,9 @@ func (a Addr) Network() string {
 func (a Addr) String() string {
 	// TODO: unicode case folding?
 	s := strings.ToLower(string(a))
+	if len(s) == 0 {
+		return ""
+	}
 	if a.Network() != "unix" {
 		_, _, err := net.SplitHostPort(s)
 		if err != nil && strings.Contains(err.Error(), "missing port in address") {

--- a/model/server.go
+++ b/model/server.go
@@ -53,7 +53,7 @@ func BuildServer(addr Addr, isMasterResult *internal.IsMasterResult, buildInfoRe
 	i := &Server{
 		Addr: addr,
 
-		CanonicalAddr:   Addr(isMasterResult.Me),
+		CanonicalAddr:   Addr(isMasterResult.Me).Canonicalize(),
 		ElectionID:      isMasterResult.ElectionID,
 		GitVersion:      buildInfoResult.GitVersion,
 		LastUpdateTime:  time.Now().UTC(),


### PR DESCRIPTION
This fixes an issue with server discovery finding (and removing) servers that have a capital letter in them.