### PR TITLE
GODRIVER-265 Implemented Stringer for ObjectID

### DIFF
--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -49,7 +49,7 @@ func (id *ObjectID) Hex() string {
 	return hex.EncodeToString(id[:])
 }
 
-func (id ObjectID) String() string {
+func (id *ObjectID) String() string {
 	return fmt.Sprintf("ObjectId(%q)", id.Hex())
 }
 

--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -49,6 +49,10 @@ func (id *ObjectID) Hex() string {
 	return hex.EncodeToString(id[:])
 }
 
+func (id ObjectID) String() string {
+	return fmt.Sprintf("ObjectId(%q)", id.Hex())
+}
+
 // FromHex creates a new ObjectID from a hex string. It returns an error if the hex string is not a
 // valid ObjectID.
 func FromHex(s string) (ObjectID, error) {

--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -45,11 +45,11 @@ func New() ObjectID {
 }
 
 // Hex returns the hex encoding of the ObjectID as a string.
-func (id *ObjectID) Hex() string {
+func (id ObjectID) Hex() string {
 	return hex.EncodeToString(id[:])
 }
 
-func (id *ObjectID) String() string {
+func (id ObjectID) String() string {
 	return fmt.Sprintf("ObjectID(%q)", id.Hex())
 }
 

--- a/bson/objectid/objectid.go
+++ b/bson/objectid/objectid.go
@@ -50,7 +50,7 @@ func (id *ObjectID) Hex() string {
 }
 
 func (id *ObjectID) String() string {
-	return fmt.Sprintf("ObjectId(%q)", id.Hex())
+	return fmt.Sprintf("ObjectID(%q)", id.Hex())
 }
 
 // FromHex creates a new ObjectID from a hex string. It returns an error if the hex string is not a

--- a/bson/objectid/objectid_test.go
+++ b/bson/objectid/objectid_test.go
@@ -17,6 +17,11 @@ func TestNew(t *testing.T) {
 	New()
 }
 
+func TestString(t *testing.T) {
+	id := New()
+	require.Contains(t, id.String(), id.Hex())
+}
+
 func TestFromHex_RoundTrip(t *testing.T) {
 	before := New()
 	after, err := FromHex(before.Hex())


### PR DESCRIPTION
The following is a copy of what I wrote in JIRA... still trying to figure out your process :)

I was playing around with the driver and noticed when I print an ObjectID, an array of bytes is printed (ex: [90 150 78 63 112 202 150 82 152 208 62 199]). 
As my first "contribution" I thought I would like to implement the Stringer interface for this type.
The string method will return a string with something like: ObjectId("5a964bd0939f8aaf8d729fc6").

I just noticed that we call go type "ObjectID" and the value printed in
the mongo shell is "ObjectId," note the lower case character 'd'
I decided to go with the value printed in the shell as it will be more
familiar to the shell users, although in general, I feel ObjectID reads
better.