### PR TITLE
panic: too small

### DIFF
--- a/bson/element.go
+++ b/bson/element.go
@@ -399,19 +399,7 @@ func convertValueToElem(key string, v *Value) *Element {
 
 	elem := newElement(0, uint32(keyLen+2))
 	elem.value.data = d
-
-	if v.d == nil {
-		return elem
-	}
-	mdata, err := v.d.MarshalBSON()
-	if err != nil {
-		return nil
-	}
-	elem.value.d, err = ReadDocument(mdata)
-	if err != nil {
-		return nil
-	}
-
+	elem.value.d = v.d
 
 	return elem
 }

--- a/bson/element.go
+++ b/bson/element.go
@@ -400,5 +400,18 @@ func convertValueToElem(key string, v *Value) *Element {
 	elem := newElement(0, uint32(keyLen+2))
 	elem.value.data = d
 
+	if v.d == nil {
+		return elem
+	}
+	mdata, err := v.d.MarshalBSON()
+	if err != nil {
+		return nil
+	}
+	elem.value.d, err = ReadDocument(mdata)
+	if err != nil {
+		return nil
+	}
+
+
 	return elem
 }


### PR DESCRIPTION
Created a dirty fix just to show the reason.
Steps to reproduce:
```
package main

import (
	"github.com/mongodb/mongo-go-driver/bson"
	"log"
)

func main() {
	log.Printf("%+v", bson.EC.Interface("test", bson.VC.ArrayFromValues(bson.VC.String("test01"), bson.VC.String("test02"))).String())
}
```

Result is:
```
panic: too small

goroutine 1 [running]:
github.com/mongodb/mongo-go-driver/bson.(*Value).MutableArray(0xc42007a720, 0x4)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/bson/value.go:528 +0x2ae
github.com/mongodb/mongo-go-driver/bson.(*Value).Interface(0xc42007a720, 0xc4200182a0, 0xc4200800f0)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/bson/value.go:64 +0x191
github.com/mongodb/mongo-go-driver/bson.(*Element).String(0xc42000e070, 0x4, 0x674de0)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/bson/element.go:350 +0x43
```
as far as I see from code, `bson.NewArray` constructs array object with field `doc`, that is ignored when calling `bson.EC.Interface`. Somewhere inside the function from pull request `bson.convertValueToElem` is called. It copies `value.d`, but ignores `value.doc`. I did a dirty fix through `MarshalBSON` and `ReadDocument` to make a deep copy easily.