### PR TITLE
Adds support for go time struct.

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -669,11 +669,18 @@ func (e *encoder) valueFromValue(val reflect.Value, minsize bool) (*Value, error
 			elem = VC.ArrayFromValues(arrayElems...)
 		}
 	case reflect.Struct:
-		structElems, err := e.encodeStruct(val)
-		if err != nil {
-			return nil, err
+		switch val.Interface().(type) {
+		case time.Time:
+			t := val.Interface().(time.Time)
+
+			elem = VC.DateTime(t.UnixNano() / int64(time.Millisecond))
+		default:
+			structElems, err := e.encodeStruct(val)
+			if err != nil {
+				return nil, err
+			}
+			elem = VC.DocumentFromElements(structElems...)
 		}
-		elem = VC.DocumentFromElements(structElems...)
 	default:
 		return nil, fmt.Errorf("Unsupported value type %s", val.Kind())
 	}

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson/objectid"
 )
@@ -564,11 +565,18 @@ func (e *encoder) elemFromValue(key string, val reflect.Value, minsize bool) (*E
 			elem = EC.ArrayFromElements(key, arrayElems...)
 		}
 	case reflect.Struct:
-		structElems, err := e.encodeStruct(val)
-		if err != nil {
-			return nil, err
+		switch val.Interface().(type) {
+		case time.Time:
+			t := val.Interface().(time.Time)
+
+			elem = EC.DateTime(key, t.UnixNano()/int64(time.Millisecond))
+		default:
+			structElems, err := e.encodeStruct(val)
+			if err != nil {
+				return nil, err
+			}
+			elem = EC.SubDocumentFromElements(key, structElems...)
 		}
-		elem = EC.SubDocumentFromElements(key, structElems...)
 	default:
 		return nil, fmt.Errorf("Unsupported value type %s", val.Kind())
 	}

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -361,6 +361,7 @@ func reflectionEncoderTest(t *testing.T) {
 	oids := []objectid.ObjectID{objectid.New(), objectid.New(), objectid.New()}
 	var str = new(string)
 	*str = "bar"
+	now := time.Now()
 
 	testCases := []struct {
 		name  string
@@ -856,7 +857,7 @@ func reflectionEncoderTest(t *testing.T) {
 				W: nil,
 				X: []map[struct{}]struct{}{},   // Should be empty BSON Array
 				Y: []map[struct{}]struct{}{{}}, // Should be BSON array with one element, an empty BSON SubDocument
-				Z: time.Now(),
+				Z: now,
 			},
 			docToBytes(NewDocument(
 				EC.ArrayFromElements("a", VC.Boolean(true)),
@@ -883,7 +884,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.Null("w"),
 				EC.Array("x", NewArray()),
 				EC.ArrayFromElements("y", VC.Document(NewDocument())),
-				EC.DateTime("z", time.Now().UnixNano()/int64(time.Millisecond)),
+				EC.DateTime("z", now.UnixNano()/int64(time.Millisecond)),
 			)),
 			nil,
 		},

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mongodb/mongo-go-driver/bson/objectid"
@@ -823,6 +824,7 @@ func reflectionEncoderTest(t *testing.T) {
 				W []map[struct{}]struct{}
 				X []map[struct{}]struct{}
 				Y []map[struct{}]struct{}
+				Z time.Time
 			}{
 				A: []bool{true},
 				B: []int32{123},
@@ -854,6 +856,7 @@ func reflectionEncoderTest(t *testing.T) {
 				W: nil,
 				X: []map[struct{}]struct{}{},   // Should be empty BSON Array
 				Y: []map[struct{}]struct{}{{}}, // Should be BSON array with one element, an empty BSON SubDocument
+				Z: time.Now(),
 			},
 			docToBytes(NewDocument(
 				EC.ArrayFromElements("a", VC.Boolean(true)),
@@ -880,6 +883,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.Null("w"),
 				EC.Array("x", NewArray()),
 				EC.ArrayFromElements("y", VC.Document(NewDocument())),
+				EC.DateTime("z", time.Now().UnixNano()/int64(time.Millisecond)),
 			)),
 			nil,
 		},

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -740,6 +740,7 @@ func reflectionEncoderTest(t *testing.T) {
 				V _Interface
 				W map[struct{}]struct{}
 				X map[struct{}]struct{}
+				Z time.Time
 			}{
 				A: true,
 				B: 123,
@@ -768,6 +769,7 @@ func reflectionEncoderTest(t *testing.T) {
 				V: _Interface((*_impl)(nil)), // typed nil
 				W: map[struct{}]struct{}{},
 				X: nil,
+				Z: now,
 			},
 			docToBytes(NewDocument(
 				EC.Boolean("a", true),
@@ -793,6 +795,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.Null("v"),
 				EC.SubDocument("w", NewDocument()),
 				EC.Null("x"),
+				EC.DateTime("z", now.UnixNano()/int64(time.Millisecond)),
 			)),
 			nil,
 		},
@@ -825,7 +828,7 @@ func reflectionEncoderTest(t *testing.T) {
 				W []map[struct{}]struct{}
 				X []map[struct{}]struct{}
 				Y []map[struct{}]struct{}
-				Z time.Time
+				Z []time.Time
 			}{
 				A: []bool{true},
 				B: []int32{123},
@@ -857,7 +860,7 @@ func reflectionEncoderTest(t *testing.T) {
 				W: nil,
 				X: []map[struct{}]struct{}{},   // Should be empty BSON Array
 				Y: []map[struct{}]struct{}{{}}, // Should be BSON array with one element, an empty BSON SubDocument
-				Z: now,
+				Z: []time.Time{now, now},
 			},
 			docToBytes(NewDocument(
 				EC.ArrayFromElements("a", VC.Boolean(true)),
@@ -884,7 +887,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.Null("w"),
 				EC.Array("x", NewArray()),
 				EC.ArrayFromElements("y", VC.Document(NewDocument())),
-				EC.DateTime("z", now.UnixNano()/int64(time.Millisecond)),
+				EC.ArrayFromElements("z", VC.DateTime(now.UnixNano()/int64(time.Millisecond)), VC.DateTime(now.UnixNano()/int64(time.Millisecond))),
 			)),
 			nil,
 		},


### PR DESCRIPTION
When there is time.Time type in a struct, encoder encodes it into MongoDB DateTime format.