### PR TITLE
Add comment to DateTime constructor

### DIFF
--- a/bson/constructor.go
+++ b/bson/constructor.go
@@ -11,11 +11,11 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson/decimal"
 	"github.com/mongodb/mongo-go-driver/bson/elements"
 	"github.com/mongodb/mongo-go-driver/bson/objectid"
-	"time"
 )
 
 // EC is a convenience variable provided for access to the ElementConstructor methods.

--- a/bson/constructor.go
+++ b/bson/constructor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/bson/decimal"
 	"github.com/mongodb/mongo-go-driver/bson/elements"
 	"github.com/mongodb/mongo-go-driver/bson/objectid"
+	"time"
 )
 
 // EC is a convenience variable provided for access to the ElementConstructor methods.
@@ -325,6 +326,7 @@ func (ElementConstructor) Boolean(key string, b bool) *Element {
 }
 
 // DateTime creates a datetime element with the given key and value.
+// dt represents milliseconds since the Unix epoch
 func (ElementConstructor) DateTime(key string, dt int64) *Element {
 	size := uint32(1 + len(key) + 1 + 8)
 	elem := newElement(0, 1+uint32(len(key))+1)
@@ -336,6 +338,11 @@ func (ElementConstructor) DateTime(key string, dt int64) *Element {
 	}
 
 	return elem
+}
+
+// Time creates a datetime element with the given key and value.
+func (c ElementConstructor) Time(key string, time time.Time) *Element {
+	return c.DateTime(key, time.Unix()*1000)
 }
 
 // Null creates a null element with the given key.

--- a/bson/constructor_test.go
+++ b/bson/constructor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/bson/decimal"
 	"github.com/stretchr/testify/require"
+	"time"
 )
 
 func requireElementsEqual(t *testing.T, expected *Element, actual *Element) {
@@ -269,6 +270,25 @@ func TestConstructor(t *testing.T) {
 			actual := EC.DateTime("foo", 17)
 
 			requireElementsEqual(t, expected, actual)
+		})
+
+		t.Run("time", func(t *testing.T) {
+			buf := []byte{
+				// type
+				0x9,
+				// key
+				0x66, 0x6f, 0x6f, 0x0,
+				// value
+				0xC8, 0x6C, 0x3C, 0xAF, 0x60, 0x1, 0x0, 0x0,
+			}
+
+			expected := &Element{&Value{start: 0, offset: 5, data: buf, d: nil}}
+
+			actualTime := EC.Time("foo", time.Date(2018, 1, 1, 1, 1, 1, 1, time.UTC))
+			actualDateTime := EC.DateTime("foo", 1514768461000)
+
+			requireElementsEqual(t, expected, actualTime)
+			requireElementsEqual(t, expected, actualDateTime)
 		})
 
 		t.Run("Null", func(t *testing.T) {

--- a/bson/constructor_test.go
+++ b/bson/constructor_test.go
@@ -9,10 +9,10 @@ package bson
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson/decimal"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 func requireElementsEqual(t *testing.T, expected *Element, actual *Element) {

--- a/bson/constructor_test.go
+++ b/bson/constructor_test.go
@@ -284,8 +284,9 @@ func TestConstructor(t *testing.T) {
 
 			expected := &Element{&Value{start: 0, offset: 5, data: buf, d: nil}}
 
-			actualTime := EC.Time("foo", time.Date(2018, 1, 1, 1, 1, 1, 1, time.UTC))
-			actualDateTime := EC.DateTime("foo", 1514768461000)
+			date := time.Date(2018, 1, 1, 1, 1, 1, 1, time.UTC)
+			actualTime := EC.Time("foo", date)
+			actualDateTime := EC.DateTime("foo", date.Unix()*1000)
 
 			requireElementsEqual(t, expected, actualTime)
 			requireElementsEqual(t, expected, actualDateTime)


### PR DESCRIPTION
Also I would like to create constructor from time.Time, if you allow me. Like that:
```go
// Time creates a datetime element with the given key and value.
func (c ElementConstructor) Time(key string, time time.Time) *Element {
	return c.DateTime(key, time.Unix() * 1000)
}
```