### PR TITLE
Fix bugs in bson/decode

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -702,6 +702,9 @@ func (d *Decoder) decodeBSONArrayToSlice(sliceType reflect.Type) (reflect.Value,
 			break
 		}
 
+		if sliceType.Elem().Kind() == reflect.Ptr {
+			elem = elem.Addr()
+		}
 		out.Index(i).Set(elem)
 	}
 
@@ -787,11 +790,12 @@ func matchesField(key string, field string, sType reflect.Type) bool {
 
 	tag, ok := sField.Tag.Lookup("bson")
 	if !ok {
+		// Get the full tag string
+		tag = string(sField.Tag)
+
 		if len(sField.Tag) == 0 || strings.ContainsRune(tag, ':') {
 			return strings.ToLower(key) == strings.ToLower(field)
 		}
-
-		tag = string(sField.Tag)
 	}
 
 	var fieldKey string


### PR DESCRIPTION
Sorry about the lack of test, I tried, but I feel like the framework is too far away from where it needs to be to write efficient tests.

First fix is about deserializing to a slice of pointers. If the type of the elements of the slice is a pointer, then it adds the address of the new element to the slice instead of the element itself.

Second fix is about non-bson tags. The Lookup was returning an empty string when the bson tag wasn't found, so it never contained the `:`. A tag like `json:"xyz"` was not returning true for either condition, so it compared the full tag with the desired key.