### PR TITLE
Check for 'omitempty' before inline handling

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -516,6 +516,10 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 		}
 		field = e.underlyingVal(field)
 
+		if omitempty && e.isZero(field) {
+			continue
+		}
+		
 		if inline {
 			switch sf.Type.Kind() {
 			case reflect.Map:
@@ -537,9 +541,6 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 			}
 		}
 
-		if omitempty && e.isZero(field) {
-			continue
-		}
 		elem, err := e.elemFromValue(key, field, minsize)
 		if err != nil {
 			return nil, err

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -819,11 +819,13 @@ func reflectionEncoderTest(t *testing.T) {
 		{
 			"inline, omitempty",
 			struct {
-				A string `bson:",omitempty,inline"`
+				A   string
+				Foo zeroTest `bson:"omitempty,inline"`
 			}{
-				A: "",
+				A:   "bar",
+				Foo: zeroTest{true},
 			},
-			docToBytes(NewDocument()),
+			docToBytes(NewDocument(EC.String("a", "bar"))),
 			nil,
 		},
 		{

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -817,6 +817,16 @@ func reflectionEncoderTest(t *testing.T) {
 			nil,
 		},
 		{
+			"inline, omitempty",
+			struct {
+				A string `bson:",omitempty,inline"`
+			}{
+				A: "",
+			},
+			docToBytes(NewDocument()),
+			nil,
+		},
+		{
 			"struct{}",
 			struct {
 				A bool


### PR DESCRIPTION
The tag combination `bson:"inline,omitempty"` does not work properly.
If the struct field is zero value, all fields get included to the outer struct.

`if omitempty && e.isZero(field) {
   continue
}`

has to be before the inline handling.