### PR TITLE
GODRIVER-407: allow readPreference to be implicit in connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ debug
 *.ipr
 *.iws
 .idea
+*.sublime-project
+*.sublime-workspace

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -190,6 +190,7 @@ func readPreferenceFromConnString(cs *connstring.ConnString) (*readpref.ReadPref
 	if cs.MaxStaleness != 0 {
 		options = append(options, readpref.WithMaxStaleness(cs.MaxStaleness))
 	}
+
 	if len(cs.ReadPreference) > 0 {
 		if rp == nil {
 			mode, _ := readpref.ModeFromString(cs.ReadPreference)
@@ -199,7 +200,8 @@ func readPreferenceFromConnString(cs *connstring.ConnString) (*readpref.ReadPref
 			}
 		}
 	}
-	return rp, nil
+
+	return readPref.Primary();
 }
 
 // Database returns a handle for a given database.

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -118,13 +118,19 @@ func newClient(cs connstring.ConnString, opts *ClientOptions) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	client.topology = topo
+
 	client.readConcern = readConcernFromConnString(&client.connString)
 	client.writeConcern = writeConcernFromConnString(&client.connString)
-	client.readPreference, err = readPreferenceFromConnString(&client.connString)
+
+	rp, err := readPreferenceFromConnString(&client.connString)
 	if err != nil {
 		return nil, err
+	}
+	if rp != nil {
+		client.readPreference = rp
+	} else {
+		client.readPreference = readpref.Primary()
 	}
 
 	return client, nil
@@ -201,7 +207,7 @@ func readPreferenceFromConnString(cs *connstring.ConnString) (*readpref.ReadPref
 		}
 	}
 
-	return readPref.Primary();
+	return rp, nil
 }
 
 // Database returns a handle for a given database.

--- a/mongo/client_internal_test.go
+++ b/mongo/client_internal_test.go
@@ -331,5 +331,17 @@ func TestClient_ReadPreference(t *testing.T) {
 	d, flag := c.readPreference.MaxStaleness()
 	require.True(t, flag)
 	require.Equal(t, time.Duration(5)*time.Second, d)
+}
 
+func TestClient_ReadPreferenceAbsent(t *testing.T) {
+	t.Parallel()
+
+	cs := testutil.ConnString(t)
+	c, err := NewClient(cs.String())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.Equal(t, readpref.PrimaryMode, c.readPreference.Mode())
+	require.Empty(t, c.readPreference.TagSets())
+	_, flag := c.readPreference.MaxStaleness()
+	require.False(t, flag)
 }


### PR DESCRIPTION
Because client_internal_test assumes a ```readpref.Primary()``` I determined to use the same when creating a ```mongo.Client```

I considered and rejected two other options
-modifying connection string parsing to provide implicit default, but this was too much "special case"
-modifying database object creation, which initializes server selection functions, but it seemed that read-preference is more appropriately a property of the Client than a state-based mystery of server selection.

A new test-case has not been created, since this fixes an existing test that happens to be outside scope of Makefile & depends on a single local running MongoDB instance.