### PR TITLE
fix nil pointer dereference

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -199,6 +199,9 @@ func readPreferenceFromConnString(cs *connstring.ConnString) (*readpref.ReadPref
 			}
 		}
 	}
+	if rp == nil {
+		rp = readpref.Primary()
+	}
 	return rp, nil
 }
 


### PR DESCRIPTION
I was playing around with atlas and fresh version of mongo-go-driver.
Got this:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x53f896]

goroutine 1 [running]:
github.com/mongodb/mongo-go-driver/core/readpref.(*ReadPref).MaxStaleness(...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/readpref/readpref.go:87
github.com/mongodb/mongo-go-driver/core/description.ReadPrefSelector.func1(0x0, 0x0, 0x0, 0xc400000000, 0x0, 0x0, 0x0, 0x3, 0x3, 0xc420052c80, ...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/description/server_selector.go:120 +0x36
github.com/mongodb/mongo-go-driver/core/description.ServerSelectorFunc.SelectServer(0xc420010a60, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc4200b2229, 0xc420052ce8, ...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/description/server_selector.go:29 +0x80
github.com/mongodb/mongo-go-driver/core/description.(*compositeSelector).SelectServer(0xc42000c780, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42000e078, 0xc420052de8, ...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/description/server_selector.go:44 +0xeb
github.com/mongodb/mongo-go-driver/core/topology.(*Topology).selectServer(0xc420098090, 0x786d60, 0xc420014148, 0xc4200623c0, 0x783c60, 0xc42000c780, 0xc420062360, 0x0, 0x0, 0x0, ...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/topology/topology.go:292 +0x230
github.com/mongodb/mongo-go-driver/core/topology.(*Topology).SelectServer(0xc420098090, 0x786d60, 0xc420014148, 0x783c60, 0xc42000c780, 0x0, 0x0, 0x0)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/topology/topology.go:233 +0x144
github.com/mongodb/mongo-go-driver/core/dispatch.Find(0x786d60, 0xc420014148, 0x66e1a4, 0xc, 0x66dcea, 0xb, 0xc42005e580, 0xc420010a70, 0x1, 0x1, ...)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/core/dispatch/find.go:28 +0xa7
github.com/mongodb/mongo-go-driver/mongo.(*Collection).FindOne(0xc420053f18, 0x786d60, 0xc420014148, 0x662160, 0xc42005e580, 0x0, 0x0, 0x0, 0x0)
	/home/cold/develop/gitlab/go/src/github.com/mongodb/mongo-go-driver/mongo/collection.go:579 +0x3ab
main.main()
	/home/cold/develop/gitlab/go/src/bitbucket.org/test/mongo/main.go:23 +0x291
```

Code to reproduce:
```
package main

import (
	"context"
	"github.com/mongodb/mongo-go-driver/bson"
	"github.com/mongodb/mongo-go-driver/mongo"
	"log"
)

func main() {
	mgConnect, err := mongo.Connect(context.Background(), "mongodb+srv://username:password@atlas-somewhere/", nil)
	if err != nil {
		log.Fatalf("Failed to connect to mongo-db. Error: %v", err)
	}
	db := mgConnect.Database("dbname")
	if db == nil {
		log.Fatalf("DB object is nil")
	}
	coll := db.Collection("collection")
	if coll == nil {
		log.Fatalf("Collection is nil")
	}
	res := advertisers.FindOne(context.Background(), bson.NewDocument(bson.EC.String("somefield", "somevalue")))
	if res == nil {
		log.Fatalf("Res document is nil")
	}
	obj := map[string]interface{}{}
	err = res.Decode(obj)
	if err != nil {
		log.Fatalf("Failed to decode object. Error: %v", err)
	}
	log.Printf("Decoded object: %+v", obj)
}
```

As it comes out, client's `readPreference` were initialised with `readpref.Primary()` prior to recent changes in funciton `readPreferenceFromConnString`. Now it is possible to have `readPreference == nil` and they are used without comparison to nil, see `core/description/server_selector.go` function `func ReadPrefSelector(rp *readpref.ReadPref) ServerSelector {`

This fix is in attempt to get rid of nil-pointer dereference, may be not proper one, but it seems to be close to old behaviour.