### PR TITLE
GODRIVER-410: Check for omitempty and IsZero before encoding the field.

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -488,6 +488,10 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 
 		field := val.Field(i)
 
+		if omitempty && e.isZero(field) {
+			continue
+		}
+
 		switch t := field.Interface().(type) {
 		case *Element:
 			elems = append(elems, t)
@@ -522,10 +526,6 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 		}
 		field = e.underlyingVal(field)
 
-		if omitempty && e.isZero(field) {
-			continue
-		}
-		
 		if inline {
 			switch sf.Type.Kind() {
 			case reflect.Map:

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -751,6 +751,16 @@ func reflectionEncoderTest(t *testing.T) {
 			nil,
 		},
 		{
+			"omitempty",
+			struct {
+				A time.Time `bson:",omitempty"`
+			}{
+				A: time.Time{},
+			},
+			docToBytes(NewDocument()),
+			nil,
+		},
+		{
 			"no private fields",
 			struct {
 				a string

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -751,7 +751,7 @@ func reflectionEncoderTest(t *testing.T) {
 			nil,
 		},
 		{
-			"omitempty",
+			"omitempty, empty time",
 			struct {
 				A time.Time `bson:",omitempty"`
 			}{


### PR DESCRIPTION
As suggested in [GODRIVER-410](https://jira.mongodb.org/browse/GODRIVER-410)