### PR TITLE
fix pointers' decoding

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -484,9 +484,7 @@ func (d *decoder) getReflectValue(v *Value, containerType reflect.Type, outer re
 		if reflect.PtrTo(typeToCreate) == empty.Type() {
 			empty = empty.Elem()
 			if isPtr {
-				valPtr := reflect.New(empty.Type())
-				valPtr.Elem().Set(empty)
-				empty = valPtr
+				empty = convertToPtr(empty)
 				isPtr = false
 			}
 		}

--- a/bson/decode_test.go
+++ b/bson/decode_test.go
@@ -664,6 +664,9 @@ func TestDecoder(t *testing.T) {
 	})
 
 	t.Run("struct", func(t *testing.T) {
+		stringValue := "bar"
+		int32Value := int32(32)
+		int32Value12 := int32(12)
 		testCases := []struct {
 			name     string
 			reader   *bytes.Buffer
@@ -727,6 +730,56 @@ func TestDecoder(t *testing.T) {
 					Foo string
 					Baz int32
 					R   Regex
+				}{},
+				nil,
+			},
+			{
+				"non-empty doc pointers",
+				bytes.NewBuffer([]byte{
+					// length
+					0x25, 0x0, 0x0, 0x0,
+
+					// type - string
+					0x2,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string "bar"
+					0x62, 0x61, 0x72, 0x0,
+
+					// type - int32
+					0x10,
+					// key - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+					// value - int32(32)
+					0x20, 0x0, 0x0, 0x0,
+
+					// type - regex
+					0xb,
+					// key - "r"
+					0x72, 0x0,
+					// value - pattern("WoRd")
+					0x57, 0x6f, 0x52, 0x64, 0x0,
+					// value - options("i")
+					0x69, 0x0,
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo *string
+					Baz *int32
+					R   *Regex
+				}{
+					&stringValue,
+					&int32Value,
+					&Regex{Pattern: "WoRd", Options: "i"},
+				},
+				&struct {
+					Foo *string
+					Baz *int32
+					R   *Regex
 				}{},
 				nil,
 			},
@@ -853,6 +906,63 @@ func TestDecoder(t *testing.T) {
 				nil,
 			},
 			{
+				"nested doc pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x26, 0x0, 0x0, 0x0,
+
+					// type - string
+					0x2,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string "bar"
+					0x62, 0x61, 0x72, 0x0,
+
+					// type - document
+					0x3,
+					// key - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// -- begin subdocument --
+
+					// length
+					0xf, 0x0, 0x0, 0x0,
+
+					// type - int32
+					0x10,
+					// key - "bang"
+					0x62, 0x61, 0x6e, 0x67, 0x0,
+					// value - int32(12)
+					0xc, 0x0, 0x0, 0x0,
+
+					// null terminator
+					0x0,
+
+					// -- end subdocument
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo *string
+					Baz *struct {
+						Bang *int32
+					}
+				}{
+					&stringValue,
+					&struct{ Bang *int32 }{&int32Value12},
+				},
+				&struct {
+					Foo *string
+					Baz *struct {
+						Bang *int32
+					}
+				}{},
+				nil,
+			},
+			{
 				"struct tags",
 				bytes.NewBuffer([]byte{
 					// length
@@ -890,6 +1000,44 @@ func TestDecoder(t *testing.T) {
 				}{},
 				nil,
 			},
+			{
+				"struct with pointers tags",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1b, 0x0, 0x0, 0x0,
+
+					// type - string
+					0x2,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string "bar"
+					0x62, 0x61, 0x72, 0x0,
+
+					// type - int32
+					0x10,
+					// key - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+					// value - int32(32)
+					0x20, 0x0, 0x0, 0x0,
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					A *string `bson:"foo"`
+					B *int32  `bson:"baz,omitempty"`
+				}{
+					&stringValue,
+					&int32Value,
+				},
+				&struct {
+					A *string `bson:"foo"`
+					B *int32  `bson:"baz,omitempty"`
+				}{},
+				nil,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -909,6 +1057,18 @@ func TestDecoder(t *testing.T) {
 
 	t.Run("numbers", func(t *testing.T) {
 		t.Run("decode int32", func(t *testing.T) {
+			uint8Val := uint8(1)
+			uint16Val := uint16(2)
+			uint32Val := uint32(3)
+			uint64Val := uint64(4)
+			uintVal := uint(5)
+			int8Val := int8(6)
+			int16Val := int16(7)
+			int32Val := int32(8)
+			int64Val := int64(9)
+			intVal := int(10)
+			float32Val := float32(11.0)
+			float64Val := float64(12.0)
 			testCases := []struct {
 				name     string
 				reader   *bytes.Buffer
@@ -943,6 +1103,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint8 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(-27)
+						0xe5, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint8
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint8
+					}{},
+					nil,
+				},
+				{
 					"negative into uint16",
 					bytes.NewBuffer([]byte{
 						// length
@@ -965,6 +1151,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint16
+					}{},
+					nil,
+				},
+				{
+					"negative into uint16 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(-27)
+						0xe5, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint16
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint16
 					}{},
 					nil,
 				},
@@ -995,6 +1207,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint32 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(-27)
+						0xe5, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint32
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint32
+					}{},
+					nil,
+				},
+				{
 					"negative into uint64",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1017,6 +1255,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint64
+					}{},
+					nil,
+				},
+				{
+					"negative into uint64 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(-27)
+						0xe5, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint64
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint64
 					}{},
 					nil,
 				},
@@ -1047,6 +1311,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(-27)
+						0xe5, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint
+					}{},
+					nil,
+				},
+				{
 					"too high for int8",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1073,6 +1363,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"too high for int8 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(2^24)
+						0x0, 0x0, 0x0, 0x1,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *int8
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int8
+					}{},
+					nil,
+				},
+				{
 					"too high for int16",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1095,6 +1411,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz int16
+					}{},
+					nil,
+				},
+				{
+					"too high for int16 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0xe, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int32(2^24)
+						0x0, 0x0, 0x0, 0x1,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *int16
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int16
 					}{},
 					nil,
 				},
@@ -1234,6 +1576,142 @@ func TestDecoder(t *testing.T) {
 					}{},
 					nil,
 				},
+				{
+					"success pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x59, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "a"
+						0x61, 0x0,
+						// value - int32(1)
+						0x1, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "b"
+						0x62, 0x0,
+						// value - int32(2)
+						0x2, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "c"
+						0x63, 0x0,
+						// value - int32(3)
+						0x3, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "d"
+						0x64, 0x0,
+						// value - int32(4)
+						0x4, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "e"
+						0x65, 0x0,
+						// value - int32(5)
+						0x5, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "f"
+						0x66, 0x0,
+						// value - int32(6)
+						0x6, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "g"
+						0x67, 0x0,
+						// value - int32(7)
+						0x7, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "h"
+						0x68, 0x0,
+						// value - int32(8)
+						0x8, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "i"
+						0x69, 0x0,
+						// value - int32(9)
+						0x9, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "j"
+						0x6a, 0x0,
+						// value - int32(10)
+						0xa, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "k"
+						0x6b, 0x0,
+						// value - int32(11)
+						0xb, 0x0, 0x0, 0x0,
+
+						// type - int32
+						0x10,
+						// key - "l"
+						0x6c, 0x0,
+						// value - int32(12)
+						0xc, 0x0, 0x0, 0x0,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{
+						&uint8Val,
+						&uint16Val,
+						&uint32Val,
+						&uint64Val,
+						&uintVal,
+						&int8Val,
+						&int16Val,
+						&int32Val,
+						&int64Val,
+						&intVal,
+						&float32Val,
+						&float64Val,
+					},
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{},
+					nil,
+				},
 			}
 
 			for _, tc := range testCases {
@@ -1252,6 +1730,18 @@ func TestDecoder(t *testing.T) {
 		})
 
 		t.Run("decode int64", func(t *testing.T) {
+			uint8Val := uint8(1)
+			uint16Val := uint16(2)
+			uint32Val := uint32(3)
+			uint64Val := uint64(4)
+			uintVal := uint(5)
+			int8Val := int8(6)
+			int16Val := int16(7)
+			int32Val := int32(8)
+			int64Val := int64(9)
+			intVal := int(10)
+			float32Val := float32(11.0)
+			float64Val := float64(12.0)
 			testCases := []struct {
 				name     string
 				reader   *bytes.Buffer
@@ -1286,6 +1776,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint8 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(-27)
+						0xe5, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint8
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint8
+					}{},
+					nil,
+				},
+				{
 					"negative into uint16",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1308,6 +1824,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint16
+					}{},
+					nil,
+				},
+				{
+					"negative into uint16 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(-27)
+						0xe5, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint16
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint16
 					}{},
 					nil,
 				},
@@ -1338,6 +1880,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint32 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(-27)
+						0xe5, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint32
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint32
+					}{},
+					nil,
+				},
+				{
 					"negative into uint64",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1360,6 +1928,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint64
+					}{},
+					nil,
+				},
+				{
+					"negative into uint64 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(-27)
+						0xe5, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint64
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint64
 					}{},
 					nil,
 				},
@@ -1390,6 +1984,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"negative into uint pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(-27)
+						0xe5, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *uint
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint
+					}{},
+					nil,
+				},
+				{
 					"too high for int8",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1412,6 +2032,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz int8
+					}{},
+					nil,
+				},
+				{
+					"too high for int8 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(2^56)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *int8
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int8
 					}{},
 					nil,
 				},
@@ -1442,6 +2088,32 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"too high for int16 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(2^56)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *int16
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int16
+					}{},
+					nil,
+				},
+				{
 					"too high for int32",
 					bytes.NewBuffer([]byte{
 						// length
@@ -1464,6 +2136,32 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz int32
+					}{},
+					nil,
+				},
+				{
+					"too high for int32 pointer",
+					bytes.NewBuffer([]byte{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+						// value - int64(2^56)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						Baz *int32
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int32
 					}{},
 					nil,
 				},
@@ -1603,6 +2301,142 @@ func TestDecoder(t *testing.T) {
 					}{},
 					nil,
 				},
+				{
+					"success pointers",
+					bytes.NewBuffer([]byte{
+						// length
+						0x89, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "a"
+						0x61, 0x0,
+						// value - int64(1)
+						0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "b"
+						0x62, 0x0,
+						// value - int64(2)
+						0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "c"
+						0x63, 0x0,
+						// value - int64(3)
+						0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "d"
+						0x64, 0x0,
+						// value - int64(4)
+						0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "e"
+						0x65, 0x0,
+						// value - int64(5)
+						0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "f"
+						0x66, 0x0,
+						// value - int64(6)
+						0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "g"
+						0x67, 0x0,
+						// value - int64(7)
+						0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "h"
+						0x68, 0x0,
+						// value - int64(8)
+						0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "i"
+						0x69, 0x0,
+						// value - int64(9)
+						0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "j"
+						0x6a, 0x0,
+						// value - int64(10)
+						0xa, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "k"
+						0x6b, 0x0,
+						// value - int64(11)
+						0xb, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// type - int64
+						0x12,
+						// key - "l"
+						0x6c, 0x0,
+						// value - int64(12)
+						0xc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{
+						&uint8Val,
+						&uint16Val,
+						&uint32Val,
+						&uint64Val,
+						&uintVal,
+						&int8Val,
+						&int16Val,
+						&int32Val,
+						&int64Val,
+						&intVal,
+						&float32Val,
+						&float64Val,
+					},
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{},
+					nil,
+				},
 			}
 
 			for _, tc := range testCases {
@@ -1621,6 +2455,36 @@ func TestDecoder(t *testing.T) {
 		})
 
 		t.Run("decode double", func(t *testing.T) {
+			/*var uint8Value uint8
+			var uint16Value uint16*/
+			dataToDecode := []byte{
+				// length
+				0x12, 0x0, 0x0, 0x0,
+
+				// type - double
+				0x1,
+				// key - "baz"
+				0x62, 0x61, 0x7a, 0x0,
+				// value - double(0.5)
+				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
+
+				// null terminator
+				0x0,
+			}
+
+			uint8Val := uint8(1)
+			uint16Val := uint16(2)
+			uint32Val := uint32(3)
+			uint64Val := uint64(4)
+			uintVal := uint(5)
+			int8Val := int8(6)
+			int16Val := int16(7)
+			int32Val := int32(8)
+			int64Val := int64(9)
+			intVal := int(10)
+			float32Val := float32(11.0)
+			float64Val := float64(12.0)
+
 			testCases := []struct {
 				name     string
 				reader   *bytes.Buffer
@@ -1630,20 +2494,7 @@ func TestDecoder(t *testing.T) {
 			}{
 				{
 					"fraction into uint8",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz uint8
 					}{
@@ -1651,25 +2502,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint8
+					}{},
+					nil,
+				},
+				{
+					"fraction into uint8 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *uint8
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint8
 					}{},
 					nil,
 				},
 				{
 					"fraction into uint16",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz uint16
 					}{
@@ -1677,25 +2528,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint16
+					}{},
+					nil,
+				},
+				{
+					"fraction into uint16 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *uint16
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint16
 					}{},
 					nil,
 				},
 				{
 					"fraction into uint32",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz uint32
 					}{
@@ -1703,25 +2554,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint32
+					}{},
+					nil,
+				},
+				{
+					"fraction into uint32 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *uint32
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint32
 					}{},
 					nil,
 				},
 				{
 					"fraction into uint64",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz uint64
 					}{
@@ -1729,25 +2580,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint64
+					}{},
+					nil,
+				},
+				{
+					"fraction into uint64 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *uint64
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint64
 					}{},
 					nil,
 				},
 				{
 					"fraction into uint",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz uint
 					}{
@@ -1755,25 +2606,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz uint
+					}{},
+					nil,
+				},
+				{
+					"fraction into uint pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *uint
+					}{
+						nil,
+					},
+					&struct {
+						Baz *uint
 					}{},
 					nil,
 				},
 				{
 					"fraction into int32",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz int32
 					}{
@@ -1781,25 +2632,25 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz int32
+					}{},
+					nil,
+				},
+				{
+					"fraction into int32 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *int32
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int32
 					}{},
 					nil,
 				},
 				{
 					"fraction into int64",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz int64
 					}{
@@ -1811,21 +2662,21 @@ func TestDecoder(t *testing.T) {
 					nil,
 				},
 				{
+					"fraction into int64 pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *int64
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int64
+					}{},
+					nil,
+				},
+				{
 					"fraction into int",
-					bytes.NewBuffer([]byte{
-						// length
-						0x12, 0x0, 0x0, 0x0,
-
-						// type - double
-						0x1,
-						// key - "baz"
-						0x62, 0x61, 0x7a, 0x0,
-						// value - double(0.5)
-						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe0, 0x3f,
-
-						// null terminator
-						0x0,
-					}),
+					bytes.NewBuffer(dataToDecode),
 					&struct {
 						Baz int
 					}{
@@ -1833,6 +2684,19 @@ func TestDecoder(t *testing.T) {
 					},
 					&struct {
 						Baz int
+					}{},
+					nil,
+				},
+				{
+					"fraction into int pointer",
+					bytes.NewBuffer(dataToDecode),
+					&struct {
+						Baz *int
+					}{
+						nil,
+					},
+					&struct {
+						Baz *int
 					}{},
 					nil,
 				},
@@ -1998,6 +2862,142 @@ func TestDecoder(t *testing.T) {
 					}{},
 					nil,
 				},
+				{
+					"success pointers",
+					bytes.NewBuffer([]byte{
+						// length
+						0x89, 0x0, 0x0, 0x0,
+
+						// type - double
+						0x1,
+						// key - "a"
+						0x61, 0x0,
+						// value - double(1.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f,
+
+						// type - double
+						0x1,
+						// key - "b"
+						0x62, 0x0,
+						// value - double(2.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40,
+
+						// type - double
+						0x1,
+						// key - "c"
+						0x63, 0x0,
+						// value - double(3.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x40,
+
+						// type - double
+						0x1,
+						// key - "d"
+						0x64, 0x0,
+						// value - double(4.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, 0x40,
+
+						// type - double
+						0x1,
+						// key - "e"
+						0x65, 0x0,
+						// value - double(5.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x14, 0x40,
+
+						// type - double
+						0x1,
+						// key - "f"
+						0x66, 0x0,
+						// value - double(6.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x18, 0x40,
+
+						// type - double
+						0x1,
+						// key - "g"
+						0x67, 0x0,
+						// value - double(7.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1c, 0x40,
+
+						// type - double
+						0x1,
+						// key - "h"
+						0x68, 0x0,
+						// value - double(8.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x20, 0x40,
+
+						// type - double
+						0x1,
+						// key - "i"
+						0x69, 0x0,
+						// value - double(9.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x22, 0x40,
+
+						// type - double
+						0x1,
+						// key - "j"
+						0x6a, 0x0,
+						// value - double(10.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x24, 0x40,
+
+						// type - double
+						0x1,
+						// key - "k"
+						0x6b, 0x0,
+						// value - double(11.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x26, 0x40,
+
+						// type - double
+						0x1,
+						// key - "j"
+						0x6c, 0x0,
+						// value - double(12.0)
+						0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x28, 0x40,
+
+						// null terminator
+						0x0,
+					}),
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{
+						&uint8Val,
+						&uint16Val,
+						&uint32Val,
+						&uint64Val,
+						&uintVal,
+						&int8Val,
+						&int16Val,
+						&int32Val,
+						&int64Val,
+						&intVal,
+						&float32Val,
+						&float64Val,
+					},
+					&struct {
+						A *uint8
+						B *uint16
+						C *uint32
+						D *uint64
+						E *uint
+						F *int8
+						G *int16
+						H *int32
+						I *int64
+						J *int
+						K *float32
+						L *float64
+					}{},
+					nil,
+				},
 			}
 
 			for _, tc := range testCases {
@@ -2040,6 +3040,19 @@ func TestDecoder(t *testing.T) {
 					}{},
 					nil,
 				},
+				{
+					"decimal128 pointer",
+					docToBytes(NewDocument(EC.Decimal128("a", decimal128))),
+					&struct {
+						A *decimal.Decimal128
+					}{
+						A: &decimal128,
+					},
+					&struct {
+						A *decimal.Decimal128
+					}{},
+					nil,
+				},
 			}
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
@@ -2058,6 +3071,7 @@ func TestDecoder(t *testing.T) {
 	})
 
 	t.Run("mixed types", func(t *testing.T) {
+		stringValue := "baz"
 		testCases := []struct {
 			name     string
 			reader   *bytes.Buffer
@@ -2108,6 +3122,48 @@ func TestDecoder(t *testing.T) {
 				nil,
 			},
 			{
+				"struct containing slice pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1a, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - array
+					0x4,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x10, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "0"
+					0x30, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo *[]string
+				}{
+					&[]string{"baz"},
+				},
+				&struct {
+					Foo *[]string
+				}{},
+				nil,
+			},
+			{
 				"struct containing array",
 				bytes.NewBuffer([]byte{
 					// length
@@ -2146,6 +3202,48 @@ func TestDecoder(t *testing.T) {
 				},
 				&struct {
 					Foo [1]string
+				}{},
+				nil,
+			},
+			{
+				"struct containing array pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1a, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - array
+					0x4,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x10, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "0"
+					0x30, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo *[1]string
+				}{
+					&[...]string{"baz"},
+				},
+				&struct {
+					Foo *[1]string
 				}{},
 				nil,
 			},
@@ -2190,6 +3288,51 @@ func TestDecoder(t *testing.T) {
 				},
 				&struct {
 					Foo map[string]string
+				}{},
+				nil,
+			},
+
+			{
+				"struct containing map of pointers",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1c, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - document
+					0x3,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x12, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "bar"
+					0x62, 0x61, 0x72, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo map[string]*string
+				}{
+					map[string]*string{
+						"bar": &stringValue,
+					},
+				},
+				&struct {
+					Foo map[string]*string
 				}{},
 				nil,
 			},
@@ -2295,6 +3438,62 @@ func TestDecoder(t *testing.T) {
 				}{},
 				nil,
 			},
+			{
+				"struct containing reader pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1c, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - document
+					0x3,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x12, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "bar"
+					0x62, 0x61, 0x72, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				&struct {
+					Foo *Reader
+				}{
+					&Reader{
+						// length
+						0x12, 0x0, 0x0, 0x0,
+						// type - string
+						0x2,
+						// key - "bar"
+						0x62, 0x61, 0x72, 0x0,
+						// value - string length
+						0x4, 0x0, 0x0, 0x0,
+						// value - "baz"
+						0x62, 0x61, 0x7a, 0x0,
+
+						// null terminator
+						0x0,
+					},
+				},
+				&struct {
+					Foo *Reader
+				}{},
+				nil,
+			},
 
 			{
 				"map containing slice",
@@ -2332,6 +3531,44 @@ func TestDecoder(t *testing.T) {
 					"foo": {"baz"},
 				},
 				make(map[string][]string),
+				nil,
+			},
+			{
+				"map containing slice pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1a, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - array
+					0x4,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x10, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "0"
+					0x30, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				map[string]*[]string{
+					"foo": {"baz"},
+				},
+				make(map[string]*[]string),
 				nil,
 			},
 			{
@@ -2373,6 +3610,44 @@ func TestDecoder(t *testing.T) {
 				nil,
 			},
 			{
+				"map containing array pointer",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1a, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - array
+					0x4,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x10, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "0"
+					0x30, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				map[string]*[1]string{
+					"foo": {"baz"},
+				},
+				make(map[string]*[1]string),
+				nil,
+			},
+			{
 				"map containing struct",
 				bytes.NewBuffer([]byte{
 					// length
@@ -2410,6 +3685,120 @@ func TestDecoder(t *testing.T) {
 				make(map[string]struct{ Bar string }),
 				nil,
 			},
+			{
+				"map containing pointer to struct",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1c, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - document
+					0x3,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x12, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "bar"
+					0x62, 0x61, 0x72, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				map[string]*struct{ Bar string }{
+					"foo": {Bar: "baz"},
+				},
+				make(map[string]*struct{ Bar string }),
+				nil,
+			},
+			{
+				"map containing struct with pointers",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1c, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - document
+					0x3,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x12, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "bar"
+					0x62, 0x61, 0x72, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				map[string]struct{ Bar *string }{
+					"foo": {Bar: &stringValue},
+				},
+				make(map[string]struct{ Bar *string }),
+				nil,
+			},
+			{
+				"map containing pointer to struct with pointers",
+				bytes.NewBuffer([]byte{
+					// length
+					0x1c, 0x0, 0x0, 0x0,
+
+					// --- begin array ---
+
+					// type - document
+					0x3,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+
+					// length
+					0x12, 0x0, 0x0, 0x0,
+					// type - string
+					0x2,
+					// key - "bar"
+					0x62, 0x61, 0x72, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+
+					// --- end array ---
+
+					// null terminator
+					0x0,
+				}),
+				map[string]*struct{ Bar *string }{
+					"foo": {Bar: &stringValue},
+				},
+				make(map[string]*struct{ Bar *string }),
+				nil,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -2427,6 +3816,8 @@ func TestDecoder(t *testing.T) {
 		}
 	})
 	t.Run("pluggable types", func(t *testing.T) {
+		intJsonNumber := json.Number("5")
+		floatJsonNumber := json.Number("10.1")
 		murl, err := url.Parse("https://mongodb.com/random-url?hello=world")
 		if err != nil {
 			t.Errorf("Error parsing URL: %v", err)
@@ -2465,6 +3856,22 @@ func TestDecoder(t *testing.T) {
 				&struct {
 					A json.Number
 					B json.Number
+				}{},
+				nil,
+			},
+			{
+				"json.Number pointer",
+				docToBytes(NewDocument(EC.Int64("a", 5), EC.Double("b", 10.10))),
+				&struct {
+					A *json.Number
+					B *json.Number
+				}{
+					A: &intJsonNumber,
+					B: &floatJsonNumber,
+				},
+				&struct {
+					A *json.Number
+					B *json.Number
 				}{},
 				nil,
 			},

--- a/bson/decode_test.go
+++ b/bson/decode_test.go
@@ -3816,8 +3816,8 @@ func TestDecoder(t *testing.T) {
 		}
 	})
 	t.Run("pluggable types", func(t *testing.T) {
-		intJsonNumber := json.Number("5")
-		floatJsonNumber := json.Number("10.1")
+		intJSONNumber := json.Number("5")
+		floatJSONNumber := json.Number("10.1")
 		murl, err := url.Parse("https://mongodb.com/random-url?hello=world")
 		if err != nil {
 			t.Errorf("Error parsing URL: %v", err)
@@ -3866,8 +3866,8 @@ func TestDecoder(t *testing.T) {
 					A *json.Number
 					B *json.Number
 				}{
-					A: &intJsonNumber,
-					B: &floatJsonNumber,
+					A: &intJSONNumber,
+					B: &floatJSONNumber,
 				},
 				&struct {
 					A *json.Number


### PR DESCRIPTION
Came across a problem with decoding pointers.
Example of code to reproduce common issue:
```
package main

import (
	"github.com/mongodb/mongo-go-driver/bson"
	"log"
)

type TestStruct struct {
	TestValue *string `bson:"test_value,omitempty"`
}

func main() {
	testString := "test value goes here"
	t := TestStruct{
		TestValue: &testString,
	}
	data, err := bson.Marshal(t)
	if err != nil {
		log.Fatalf("Failed to marshal. Error: %v", err)
	}
	unt := TestStruct{}
	err = bson.Unmarshal(data, &unt)
	if err != nil {
		log.Fatalf("Failed to unmarshal. Error: %v", err)
	}
	log.Printf("Result: %+v")
	if unt.TestValue == nil {
		return
	}
	log.Printf("Contained string: %+v", *unt.TestValue)
}
```
Code like the one above gives error like:
```
reflect.Value.Addr of unaddressable value
```