### PR TITLE
Change "too precise" float32 behavior

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -366,9 +366,7 @@ func (d *decoder) getReflectValue(v *Value, containerType reflect.Type, outer re
 			}
 
 		case tFloat32:
-			if float64(float32(f)) == f {
-				val = reflect.ValueOf(float32(f))
-			}
+			val = reflect.ValueOf(float32(f))
 
 		case tFloat64, tEmpty:
 			val = reflect.ValueOf(f)

--- a/bson/decode_test.go
+++ b/bson/decode_test.go
@@ -1855,7 +1855,7 @@ func TestDecoder(t *testing.T) {
 					&struct {
 						Baz float32
 					}{
-						0,
+						3,
 					},
 					&struct {
 						Baz float32


### PR DESCRIPTION
I understand this is not a bug as much as a feature, but I think it's the wrong behavior:

Right now if trying to deserialize a float to a float32, the decoder will return 0 if the float is too precise for 32 bits, without giving an error. I think the ideal solution would be to return an error, but that would require major changes. If we have to fail silently, the imprecise number seems better than 0.