### PR TITLE
Fix encoding of *time.Time

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -123,7 +123,7 @@ func NewDocumentEncoder() DocumentEncoder {
 }
 
 func convertTimeToInt64(t time.Time) int64 {
-	return t.Unix()*1000+int64(t.Nanosecond()/1e6)
+	return t.Unix()*1000 + int64(t.Nanosecond()/1e6)
 }
 
 func (e *encoder) Encode(v interface{}) error {

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -122,6 +122,10 @@ func NewDocumentEncoder() DocumentEncoder {
 	return &encoder{}
 }
 
+func convertTimeToInt64(t time.Time) int64 {
+	return t.Unix()*1000+int64(t.Nanosecond()/1e6)
+}
+
 func (e *encoder) Encode(v interface{}) error {
 	var err error
 
@@ -438,7 +442,10 @@ func (e *encoder) encodeSliceAsArray(rval reflect.Value, minsize bool) ([]*Value
 			vals = append(vals, VC.Decimal128(t))
 			continue
 		case time.Time:
-			vals = append(vals, VC.DateTime(t.Unix()*1000+int64(t.Nanosecond()/1e6)))
+			vals = append(vals, VC.DateTime(convertTimeToInt64(t)))
+			continue
+		case *time.Time:
+			vals = append(vals, VC.DateTime(convertTimeToInt64(*t)))
 			continue
 		}
 
@@ -521,7 +528,10 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 			elems = append(elems, EC.Decimal128(key, t))
 			continue
 		case time.Time:
-			elems = append(elems, EC.DateTime(key, t.Unix()*1000+int64(t.Nanosecond()/1e6)))
+			elems = append(elems, EC.DateTime(key, convertTimeToInt64(t)))
+			continue
+		case *time.Time:
+			elems = append(elems, EC.DateTime(key, convertTimeToInt64(*t)))
 			continue
 		}
 		field = e.underlyingVal(field)

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -871,6 +871,7 @@ func reflectionEncoderTest(t *testing.T) {
 				AA json.Number
 				AB *url.URL
 				AC decimal.Decimal128
+				AD *time.Time
 			}{
 				A: true,
 				B: 123,
@@ -904,6 +905,7 @@ func reflectionEncoderTest(t *testing.T) {
 				AA: json.Number("10.10"),
 				AB: murl,
 				AC: decimal128,
+				AD: &now,
 			},
 			docToBytes(NewDocument(
 				EC.Boolean("a", true),
@@ -934,6 +936,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.Double("aa", 10.10),
 				EC.String("ab", murl.String()),
 				EC.Decimal128("ac", decimal128),
+				EC.DateTime("ad", now.UnixNano()/int64(time.Millisecond)),
 			)),
 			nil,
 		},
@@ -970,6 +973,7 @@ func reflectionEncoderTest(t *testing.T) {
 				AA []json.Number
 				AB []*url.URL
 				AC []decimal.Decimal128
+				AD []*time.Time
 			}{
 				A: []bool{true},
 				B: []int32{123},
@@ -1005,6 +1009,7 @@ func reflectionEncoderTest(t *testing.T) {
 				AA: []json.Number{json.Number("5"), json.Number("10.10")},
 				AB: []*url.URL{murl},
 				AC: []decimal.Decimal128{decimal128},
+				AD: []*time.Time{&now, &now},
 			},
 			docToBytes(NewDocument(
 				EC.ArrayFromElements("a", VC.Boolean(true)),
@@ -1035,6 +1040,7 @@ func reflectionEncoderTest(t *testing.T) {
 				EC.ArrayFromElements("aa", VC.Int64(5), VC.Double(10.10)),
 				EC.ArrayFromElements("ab", VC.String(murl.String())),
 				EC.ArrayFromElements("ac", VC.Decimal128(decimal128)),
+				EC.ArrayFromElements("ad", VC.DateTime(now.UnixNano()/int64(time.Millisecond)), VC.DateTime(now.UnixNano()/int64(time.Millisecond))),
 			)),
 			nil,
 		},


### PR DESCRIPTION
Came across a problem with encoding *time.Time. It turned out that it is ignored during encoding process.
Code to reproduce:
```
package main

import (
	"log"
	"time"

	"github.com/mongodb/mongo-go-driver/bson"
)

type testStruct struct {
	FieldA time.Time  `bson:"field_a"`
	FieldB *time.Time `bson:"field_b"`
}

func main() {
	now := time.Now()
	test := testStruct{
		FieldA: now,
		FieldB: &now,
	}
	data, err := bson.Marshal(test)
	if err != nil {
		log.Fatalf("Failed to marshal. Error: %v", err)
	}
	unTest := testStruct{}
	err = bson.Unmarshal(data, &unTest)
	if err != nil {
		log.Fatalf("Failed to marshal. Error: %v", err)
	}
	log.Printf("Marshaled: %+v", test)
	log.Printf("Unmarshaled:%+v", unTest)
}
```
Will give something like this:
```
2018/05/25 11:24:09 Marshaled: {FieldA:2018-05-25 11:24:09.703404724 +1000 AEST m=+0.001358642 FieldB:2018-05-25 11:24:09.703404724 +1000 AEST m=+0.001358642}
2018/05/25 11:24:09 Unmarshaled:{FieldA:2018-05-25 11:24:09.703 +1000 AEST FieldB:0001-01-01 00:00:00 +0000 UTC}
```
So, value for `FiledB` was not encoded.