### PR TITLE
fix swapped T, I values for Timestamp

### DIFF
--- a/bson/value.go
+++ b/bson/value.go
@@ -817,7 +817,7 @@ func (v *Value) Timestamp() (uint32, uint32) {
 	if v.data[v.start] != '\x11' {
 		panic(ElementTypeError{"compact.Element.timestamp", Type(v.data[v.start])})
 	}
-	return binary.LittleEndian.Uint32(v.data[v.offset : v.offset+4]), binary.LittleEndian.Uint32(v.data[v.offset+4 : v.offset+8])
+	return binary.LittleEndian.Uint32(v.data[v.offset+4 : v.offset+8]), binary.LittleEndian.Uint32(v.data[v.offset : v.offset+4])
 }
 
 // TimestampOK is the same as Timestamp, except that it returns a boolean


### PR DESCRIPTION
It seems to me the T, I values are getting swapped when a Timestamp is read.  This change returns the high 32 bits, T, first and the low 32 bits, I, second to match the caller expected order (in same file).  