### PR TITLE
fix nil dereference panic when receiving nil *time.Time 

### DIFF
--- a/bson/encode.go
+++ b/bson/encode.go
@@ -122,7 +122,8 @@ func NewDocumentEncoder() DocumentEncoder {
 	return &encoder{}
 }
 
-func convertTimeToInt64(t time.Time) int64 {
+func convertTimeToInt64(t *time.Time) int64 {
+	if t == nil { return 0 }
 	return t.Unix()*1000 + int64(t.Nanosecond()/1e6)
 }
 
@@ -442,10 +443,10 @@ func (e *encoder) encodeSliceAsArray(rval reflect.Value, minsize bool) ([]*Value
 			vals = append(vals, VC.Decimal128(t))
 			continue
 		case time.Time:
-			vals = append(vals, VC.DateTime(convertTimeToInt64(t)))
+			vals = append(vals, VC.DateTime(convertTimeToInt64(&t)))
 			continue
 		case *time.Time:
-			vals = append(vals, VC.DateTime(convertTimeToInt64(*t)))
+			vals = append(vals, VC.DateTime(convertTimeToInt64(t)))
 			continue
 		}
 
@@ -528,10 +529,10 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 			elems = append(elems, EC.Decimal128(key, t))
 			continue
 		case time.Time:
-			elems = append(elems, EC.DateTime(key, convertTimeToInt64(t)))
+			elems = append(elems, EC.DateTime(key, convertTimeToInt64(&t)))
 			continue
 		case *time.Time:
-			elems = append(elems, EC.DateTime(key, convertTimeToInt64(*t)))
+			elems = append(elems, EC.DateTime(key, convertTimeToInt64(t)))
 			continue
 		}
 		field = e.underlyingVal(field)

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -122,8 +122,7 @@ func NewDocumentEncoder() DocumentEncoder {
 	return &encoder{}
 }
 
-func convertTimeToInt64(t *time.Time) int64 {
-	if t == nil { return 0 }
+func convertTimeToInt64(t time.Time) int64 {
 	return t.Unix()*1000 + int64(t.Nanosecond()/1e6)
 }
 
@@ -443,10 +442,14 @@ func (e *encoder) encodeSliceAsArray(rval reflect.Value, minsize bool) ([]*Value
 			vals = append(vals, VC.Decimal128(t))
 			continue
 		case time.Time:
-			vals = append(vals, VC.DateTime(convertTimeToInt64(&t)))
+			vals = append(vals, VC.DateTime(convertTimeToInt64(t)))
 			continue
 		case *time.Time:
-			vals = append(vals, VC.DateTime(convertTimeToInt64(t)))
+			if t == nil {
+				vals = append(vals, VC.Null())
+			} else {
+				vals = append(vals, VC.DateTime(convertTimeToInt64(*t)))
+			}
 			continue
 		}
 
@@ -529,10 +532,14 @@ func (e *encoder) encodeStruct(val reflect.Value) ([]*Element, error) {
 			elems = append(elems, EC.Decimal128(key, t))
 			continue
 		case time.Time:
-			elems = append(elems, EC.DateTime(key, convertTimeToInt64(&t)))
+			elems = append(elems, EC.DateTime(key, convertTimeToInt64(t)))
 			continue
 		case *time.Time:
-			elems = append(elems, EC.DateTime(key, convertTimeToInt64(t)))
+			if t == nil {
+				elems = append(elems, EC.Null(key))
+			} else {
+				elems = append(elems, EC.DateTime(key, convertTimeToInt64(*t)))
+			}
 			continue
 		}
 		field = e.underlyingVal(field)

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -1100,6 +1100,19 @@ func TestZeoerInterfaceUsedByDecoder(t *testing.T) {
 
 }
 
+type timePrtStruct struct { timePtrField *time.Time }
+func TestRegressionNoDereferenceNilTimePtr (t *testing.T) {
+	enc := &encoder{}
+
+	assert.NotPanics(t, func () {
+		enc.encodeStruct(reflect.ValueOf(timePrtStruct{}))
+	})
+
+	assert.NotPanics(t, func () {
+		enc.encodeSliceAsArray(reflect.ValueOf([]*time.Time{nil, nil, nil}), false)
+	})
+}
+
 func docToBytes(d *Document) []byte {
 	b, err := d.MarshalBSON()
 	if err != nil {

--- a/bson/encode_test.go
+++ b/bson/encode_test.go
@@ -1100,16 +1100,20 @@ func TestZeoerInterfaceUsedByDecoder(t *testing.T) {
 
 }
 
-type timePrtStruct struct { timePtrField *time.Time }
+type timePrtStruct struct { TimePtrField *time.Time }
 func TestRegressionNoDereferenceNilTimePtr (t *testing.T) {
 	enc := &encoder{}
 
 	assert.NotPanics(t, func () {
-		enc.encodeStruct(reflect.ValueOf(timePrtStruct{}))
+		res, err := enc.encodeStruct(reflect.ValueOf(timePrtStruct{}))
+		assert.Len(t, res, 1)
+		assert.Nil(t, err)
 	})
 
 	assert.NotPanics(t, func () {
-		enc.encodeSliceAsArray(reflect.ValueOf([]*time.Time{nil, nil, nil}), false)
+		res, err := enc.encodeSliceAsArray(reflect.ValueOf([]*time.Time{nil, nil, nil}), false)
+		assert.Len(t, res, 3)
+		assert.Nil(t, err)
 	})
 }
 


### PR DESCRIPTION
As the title says.

On lines 448 and 534 you get a panic when trying to dereference a nil pointer.