### PR TITLE
GODRIVER-508 - call Stop() on heartbeatTicker and rateLimitr

### DIFF
--- a/core/topology/server.go
+++ b/core/topology/server.go
@@ -251,6 +251,8 @@ func (s *Server) update() {
 	defer s.closewg.Done()
 	heartbeatTicker := time.NewTicker(s.cfg.heartbeatInterval)
 	rateLimiter := time.NewTicker(minHeartbeatInterval)
+	defer heartbeatTicker.Stop()
+	defer rateLimiter.Stop()
 	checkNow := s.checkNow
 	done := s.done
 


### PR DESCRIPTION
This should fix a memory leak in topology.Server's update()