### PR TITLE
GODRIVER-515: add context.Context to events

### DIFF
--- a/core/connection/connection.go
+++ b/core/connection/connection.go
@@ -364,7 +364,6 @@ func (c *connection) commandStartedEvent(ctx context.Context, wm wiremessage.Wir
 	}
 
 	startedEvent := &event.CommandStartedEvent{
-		Context:      ctx,
 		ConnectionID: c.id,
 	}
 
@@ -418,7 +417,7 @@ func (c *connection) commandStartedEvent(ctx context.Context, wm wiremessage.Wir
 		startedEvent.Command = emptyDoc
 	}
 
-	c.cmdMonitor.Started(startedEvent)
+	c.cmdMonitor.Started(ctx, startedEvent)
 
 	if !acknowledged {
 		if c.cmdMonitor.Succeeded == nil {
@@ -427,14 +426,13 @@ func (c *connection) commandStartedEvent(ctx context.Context, wm wiremessage.Wir
 
 		// unack writes must provide a CommandSucceededEvent with an { ok: 1 } reply
 		finishedEvent := event.CommandFinishedEvent{
-			Context:       ctx,
 			DurationNanos: 0,
 			CommandName:   startedEvent.CommandName,
 			RequestID:     startedEvent.RequestID,
 			ConnectionID:  c.id,
 		}
 
-		c.cmdMonitor.Succeeded(&event.CommandSucceededEvent{
+		c.cmdMonitor.Succeeded(ctx, &event.CommandSucceededEvent{
 			CommandFinishedEvent: finishedEvent,
 			Reply: bson.NewDocument(
 				bson.EC.Int32("ok", 1),
@@ -522,7 +520,6 @@ func (c *connection) commandFinishedEvent(ctx context.Context, wm wiremessage.Wi
 	}
 
 	finishedEvent := event.CommandFinishedEvent{
-		Context:       ctx,
 		DurationNanos: cmdMetadata.TimeDifference(),
 		CommandName:   cmdMetadata.Name,
 		RequestID:     requestID,
@@ -535,7 +532,7 @@ func (c *connection) commandFinishedEvent(ctx context.Context, wm wiremessage.Wi
 				Reply:                emptyDoc,
 				CommandFinishedEvent: finishedEvent,
 			}
-			c.cmdMonitor.Succeeded(successEvent)
+			c.cmdMonitor.Succeeded(ctx, successEvent)
 			return nil
 		}
 
@@ -556,7 +553,7 @@ func (c *connection) commandFinishedEvent(ctx context.Context, wm wiremessage.Wi
 			CommandFinishedEvent: finishedEvent,
 		}
 
-		c.cmdMonitor.Succeeded(successEvent)
+		c.cmdMonitor.Succeeded(ctx, successEvent)
 		return nil
 	}
 
@@ -565,7 +562,7 @@ func (c *connection) commandFinishedEvent(ctx context.Context, wm wiremessage.Wi
 		CommandFinishedEvent: finishedEvent,
 	}
 
-	c.cmdMonitor.Failed(failureEvent)
+	c.cmdMonitor.Failed(ctx, failureEvent)
 	return nil
 }
 

--- a/core/event/monitoring.go
+++ b/core/event/monitoring.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"time"
 
 	"github.com/mongodb/mongo-go-driver/bson"
@@ -29,6 +30,7 @@ func (cm *CommandMetadata) TimeDifference() int64 {
 
 // CommandStartedEvent represents an event generated when a command is sent to a server.
 type CommandStartedEvent struct {
+	Context      context.Context
 	Command      *bson.Document
 	DatabaseName string
 	CommandName  string
@@ -38,6 +40,7 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
+	Context       context.Context
 	DurationNanos int64
 	CommandName   string
 	RequestID     int64

--- a/core/event/monitoring.go
+++ b/core/event/monitoring.go
@@ -30,7 +30,6 @@ func (cm *CommandMetadata) TimeDifference() int64 {
 
 // CommandStartedEvent represents an event generated when a command is sent to a server.
 type CommandStartedEvent struct {
-	Context      context.Context
 	Command      *bson.Document
 	DatabaseName string
 	CommandName  string
@@ -40,7 +39,6 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
-	Context       context.Context
 	DurationNanos int64
 	CommandName   string
 	RequestID     int64
@@ -61,7 +59,7 @@ type CommandFailedEvent struct {
 
 // CommandMonitor represents a monitor that is triggered for different events.
 type CommandMonitor struct {
-	Started   func(*CommandStartedEvent)
-	Succeeded func(*CommandSucceededEvent)
-	Failed    func(*CommandFailedEvent)
+	Started   func(context.Context, *CommandStartedEvent)
+	Succeeded func(context.Context, *CommandSucceededEvent)
+	Failed    func(context.Context, *CommandFailedEvent)
 }

--- a/mongo/causal_consistency_test.go
+++ b/mongo/causal_consistency_test.go
@@ -1,6 +1,7 @@
 package mongo
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
@@ -17,10 +18,10 @@ var ccStarted *event.CommandStartedEvent
 var ccSucceeded *event.CommandSucceededEvent
 
 var ccMonitor = &event.CommandMonitor{
-	Started: func(cse *event.CommandStartedEvent) {
+	Started: func(ctx context.Context, cse *event.CommandStartedEvent) {
 		ccStarted = cse
 	},
-	Succeeded: func(cse *event.CommandSucceededEvent) {
+	Succeeded: func(ctx context.Context, cse *event.CommandSucceededEvent) {
 		ccSucceeded = cse
 	},
 }

--- a/mongo/command_monitoring_test.go
+++ b/mongo/command_monitoring_test.go
@@ -32,13 +32,13 @@ var failedChan = make(chan *event.CommandFailedEvent, 100)
 var cursorID int64
 
 var monitor = &event.CommandMonitor{
-	Started: func(cse *event.CommandStartedEvent) {
+	Started: func(ctx context.Context, cse *event.CommandStartedEvent) {
 		startedChan <- cse
 	},
-	Succeeded: func(cse *event.CommandSucceededEvent) {
+	Succeeded: func(ctx context.Context, cse *event.CommandSucceededEvent) {
 		succeededChan <- cse
 	},
-	Failed: func(cfe *event.CommandFailedEvent) {
+	Failed: func(ctx context.Context, cfe *event.CommandFailedEvent) {
 		failedChan <- cfe
 	},
 }

--- a/mongo/sessions_test.go
+++ b/mongo/sessions_test.go
@@ -47,10 +47,10 @@ var sessionSucceeded *event.CommandSucceededEvent
 var sessionsMonitoredTop *topology.Topology
 
 var sessionsMonitor = &event.CommandMonitor{
-	Started: func(cse *event.CommandStartedEvent) {
+	Started: func(ctx context.Context, cse *event.CommandStartedEvent) {
 		sessionStarted = cse
 	},
-	Succeeded: func(cse *event.CommandSucceededEvent) {
+	Succeeded: func(ctx context.Context, cse *event.CommandSucceededEvent) {
 		sessionSucceeded = cse
 	},
 }


### PR DESCRIPTION
For: https://jira.mongodb.org/browse/GODRIVER-515

This change passes the `context.Context` through to the events. In our case `Context` is used to pass IDs for tracing, but this could be useful for other things as well.