### PR TITLE
GODRIVER-533: ObjectId is now read to a string when the tag says so

### DIFF
--- a/bson/decode.go
+++ b/bson/decode.go
@@ -506,6 +506,9 @@ func (d *decoder) getReflectValue(v *Value, containerType reflect.Type, outer re
 		val = reflect.ValueOf(Undefined)
 	case 0x7:
 		if containerType != tOID && containerType != tEmpty {
+			if containerType == tString {
+				return reflect.ValueOf(v.ObjectID().Hex()), nil
+			}
 			return val, nil
 		}
 


### PR DESCRIPTION
Fix GODRIVER-533

Just a very simple patch to read an ObjectId to a string when needed.