### PR TITLE
[GODRIVER-538] Fix readpref.WithTags function

### DIFF
--- a/core/readpref/options.go
+++ b/core/readpref/options.go
@@ -34,14 +34,15 @@ func WithMaxStaleness(ms time.Duration) Option {
 // overrides all previous calls to either method.
 func WithTags(tags ...string) Option {
 	return func(rp *ReadPref) error {
-		if len(tags)%2 != 0 {
+		l := len(tags)
+		if l < 2 || l % 2 != 0 {
 			return ErrInvalidTagSet
 		}
 
-		tagset := make(tag.Set, 0)
+		tagset := make(tag.Set, 0, l/2)
 
-		for i := 0; i < len(tags)/2; i++ {
-			tagset = append(tagset, tag.Tag{Name: tags[i], Value: tags[i+1]})
+		for i := 1; i < l; i+=2 {
+			tagset = append(tagset, tag.Tag{Name: tags[i-1], Value: tags[i]})
 		}
 
 		return WithTagSets(tagset)(rp)

--- a/core/readpref/options.go
+++ b/core/readpref/options.go
@@ -34,14 +34,14 @@ func WithMaxStaleness(ms time.Duration) Option {
 // overrides all previous calls to either method.
 func WithTags(tags ...string) Option {
 	return func(rp *ReadPref) error {
-		l := len(tags)
-		if l < 2 || l % 2 != 0 {
+		length := len(tags)
+		if length < 2 || length % 2 != 0 {
 			return ErrInvalidTagSet
 		}
 
-		tagset := make(tag.Set, 0, l/2)
+		tagset := make(tag.Set, 0, length/2)
 
-		for i := 1; i < l; i+=2 {
+		for i := 1; i < length; i+=2 {
 			tagset = append(tagset, tag.Tag{Name: tags[i-1], Value: tags[i]})
 		}
 

--- a/core/readpref/readpref_test.go
+++ b/core/readpref/readpref_test.go
@@ -39,14 +39,14 @@ func TestPrimaryPreferred_with_options(t *testing.T) {
 	require := require.New(t)
 	subject := PrimaryPreferred(
 		WithMaxStaleness(time.Duration(10)),
-		WithTags("a", "1"),
+		WithTags("a", "1", "b", "2"),
 	)
 
 	require.Equal(PrimaryPreferredMode, subject.Mode())
 	ms, set := subject.MaxStaleness()
 	require.True(set)
 	require.Equal(time.Duration(10), ms)
-	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"}}}, subject.TagSets())
+	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"},tag.Tag{Name: "b", Value: "2"}}}, subject.TagSets())
 }
 
 func TestSecondaryPreferred(t *testing.T) {
@@ -63,14 +63,14 @@ func TestSecondaryPreferred_with_options(t *testing.T) {
 	require := require.New(t)
 	subject := SecondaryPreferred(
 		WithMaxStaleness(time.Duration(10)),
-		WithTags("a", "1"),
+		WithTags("a", "1", "b", "2"),
 	)
 
 	require.Equal(SecondaryPreferredMode, subject.Mode())
 	ms, set := subject.MaxStaleness()
 	require.True(set)
 	require.Equal(time.Duration(10), ms)
-	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"}}}, subject.TagSets())
+	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"},tag.Tag{Name: "b", Value: "2"}}}, subject.TagSets())
 }
 
 func TestSecondary(t *testing.T) {
@@ -87,14 +87,14 @@ func TestSecondary_with_options(t *testing.T) {
 	require := require.New(t)
 	subject := Secondary(
 		WithMaxStaleness(time.Duration(10)),
-		WithTags("a", "1"),
+		WithTags("a", "1", "b", "2"),
 	)
 
 	require.Equal(SecondaryMode, subject.Mode())
 	ms, set := subject.MaxStaleness()
 	require.True(set)
 	require.Equal(time.Duration(10), ms)
-	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"}}}, subject.TagSets())
+	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"},tag.Tag{Name: "b", Value: "2"}}}, subject.TagSets())
 }
 
 func TestNearest(t *testing.T) {
@@ -111,12 +111,12 @@ func TestNearest_with_options(t *testing.T) {
 	require := require.New(t)
 	subject := Nearest(
 		WithMaxStaleness(time.Duration(10)),
-		WithTags("a", "1"),
+		WithTags("a", "1", "b", "2"),
 	)
 
 	require.Equal(NearestMode, subject.Mode())
 	ms, set := subject.MaxStaleness()
 	require.True(set)
 	require.Equal(time.Duration(10), ms)
-	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"}}}, subject.TagSets())
+	require.Equal([]tag.Set{{tag.Tag{Name: "a", Value: "1"},tag.Tag{Name: "b", Value: "2"}}}, subject.TagSets())
 }


### PR DESCRIPTION
GODRIVER-538

The readpref.WithTags function was entirely broken for any length of arguments n*2 where n > 1 or exactly 0 arguments.

0 arguments:
It only checked for length % 2 == 0 which a length of 0 obviously passes but that obviously isn't a legal tag.

Multiple of 2 arguments:
That for-loop was just completely wrong only accidentally being correct for exactly 2 tags.
It essentially made every key into a name and what should have been the next name into a key,
because it didn't skip any index but instead terminated at just half length, which also meant it would not include any actual later tags pairs.

Checking out just the altered tests in https://github.com/mongodb/mongo-go-driver/commit/c596cc5e83400d59c65b356a0f9d2090d97c8833 and running them clearly demonstrates that behavior.

I have not created an issue in your ticket system nor do I know if anyone else did because I frankly can't be bothered. It was broken, now it isn't. :smile: 