### PR TITLE
GODRIVER-564 Use same time.Time conversion in Encoder and ElementConstructor

### DIFF
--- a/bson/constructor.go
+++ b/bson/constructor.go
@@ -343,7 +343,7 @@ func (ElementConstructor) DateTime(key string, dt int64) *Element {
 // Time creates a datetime element with the given key and value.
 func (c ElementConstructor) Time(key string, t time.Time) *Element {
 	// Apply nanoseconds to milliseconds conversion
-	return c.DateTime(key, t.UnixNano()/int64(time.Millisecond))
+	return c.DateTime(key, convertTimeToInt64(t))
 }
 
 // Null creates a null element with the given key.


### PR DESCRIPTION
I'm happy to add a test but it didn't seem like we have tests for internal consistency.