### PR TITLE
GODRIVER-567 Returned time.Time instead of int64 when decoding an IsoDate

### DIFF
--- a/bson/bsoncodec/bsoncodec_test.go
+++ b/bson/bsoncodec/bsoncodec_test.go
@@ -75,3 +75,28 @@ func TestTimeRoundTrip(t *testing.T) {
 		t.Errorf("Did not get zero time as expected.")
 	}
 }
+
+func TestNonNullTimeRoundTrip(t *testing.T) {
+	now := time.Now()
+	now = time.Unix(now.Unix(), 0)
+	val := struct {
+		Value time.Time
+		ID    string
+	}{
+		ID:    "time-rt-test",
+		Value: now,
+	}
+
+	bsonOut, err := Marshal(val)
+	noerr(t, err)
+	rtval := struct {
+		Value time.Time
+		ID    string
+	}{}
+
+	err = Unmarshal(bsonOut, &rtval)
+	noerr(t, err)
+	if !cmp.Equal(val, rtval) {
+		t.Errorf("Did not round trip properly. got %v; want %v", val, rtval)
+	}
+}


### PR DESCRIPTION
Hi, the value returned in case of null time is an empty time.Time struct, when teh time is not null, however, an int64 is returned, which makes no sense and prevents from decoding an ISODate into time.Time

There was no test for a non empty Time value, so I added it.

This is for teh JIRA ticket GODRIVER-567