### PR TITLE
Check value validity before use value methods.

### DIFF
--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -220,6 +220,12 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr ValueReader, i interface{
 
 func (sc *StructCodec) isZero(i interface{}) bool {
 	v := reflect.ValueOf(i)
+
+	// check the value validity
+	if !v.IsValid() {
+		return true
+	}
+
 	if z, ok := v.Interface().(bson.Zeroer); ok {
 		return z.IsZero()
 	}


### PR DESCRIPTION
If the value is nil then using `Interface` method on it causes panic. For example, write following struct
```go
type State struct {
    Value struct {
        Object interface{} `bson:",omitempty"`
    }
}
```
with the following value:
```go
s := State{}
s.Value.Object = nil
```
case panic if there is not check for validity.
