### PR TITLE
Fix parsing of string array with more than one value (extJSONParser)

### DIFF
--- a/bson/bsonrw/extjson_parser.go
+++ b/bson/bsonrw/extjson_parser.go
@@ -467,11 +467,13 @@ func (ejp *extJSONParser) advanceState() {
 			ejp.s = jpsInvalidState
 		}
 	case jttString:
-		switch ejp.s {
-		case jpsSawBeginObject, jpsSawComma:
-			ejp.s = jpsSawKey
-			ejp.k = jt.v.(string)
-			return
+		if ejp.peekMode() != jpmArrayMode {
+			switch ejp.s {
+			case jpsSawBeginObject, jpsSawComma:
+				ejp.s = jpsSawKey
+				ejp.k = jt.v.(string)
+				return
+			}
 		}
 		fallthrough
 	default:

--- a/bson/bsonrw/extjson_parser_test.go
+++ b/bson/bsonrw/extjson_parser_test.go
@@ -466,6 +466,7 @@ func TestExtJSONParserAllTypes(t *testing.T) {
 			, "MaxKey"				: { "$maxKey": 1 }
 			, "Null"				: null
 			, "Undefined"			: { "$undefined": true }
+			, "MultipleStrsArray"   : ["value_01", "value_02", "value_03"]
 			}`
 
 	ejp := newExtJSONParser(strings.NewReader(in), true)
@@ -682,6 +683,15 @@ func TestExtJSONParserAllTypes(t *testing.T) {
 		{
 			f: expectSingleValue, p: ejp,
 			k: "Undefined", t: bsontype.Undefined, v: &extJSONValue{t: bsontype.Boolean, v: true},
+		},
+		{
+			f: expectArray, p: ejp,
+			k: "MultipleStrsArray", t: bsontype.Array,
+			v: []ejpKeyTypValTriple{
+				{typ: bsontype.String, val: &extJSONValue{t: bsontype.String, v: "value_01"}},
+				{typ: bsontype.String, val: &extJSONValue{t: bsontype.String, v: "value_02"}},
+				{typ: bsontype.String, val: &extJSONValue{t: bsontype.String, v: "value_03"}},
+			},
 		},
 	}
 


### PR DESCRIPTION
Came across a problem, using `bson.UnmarshalExtJSON`, turned out to be a problem in `extJSONParser`. It was returning error, when ext-json was having array of strings with length > 1.
Simple example below.

```
package main

import (
	"github.com/mongodb/mongo-go-driver/bson"

	"log"
)


func main() {
	res := bson.D{}
	err := bson.UnmarshalExtJSON([]byte("{\"sample\":[\"v1\", \"v2\"]}"), false, &res)
	if err != nil {
		log.Fatalf("Failed. Error: %v", err)
	}
}
```

Will give you: `Failed. Error: Cannot read unknown BSON type invalid`

As I found out that it was due to parser treating second element in array to be a key, rather than value. And key is prohibited (obviously) in "array-mode", so it caused parser to return an error.
