### PR TITLE
Error of nil conversion from bson.D decoded using UnmarshalExtJSON

### DIFF
--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -309,12 +309,17 @@ func (dve DefaultValueEncoders) ArrayEncodeValue(ec EncodeContext, vw bsonrw.Val
 				return err
 			}
 
-			encoder, err := ec.LookupEncoder(reflect.TypeOf(e.Value))
+			ve := e.Value
+			if reflect.TypeOf(ve) == nil {
+				ve = primitive.Null{}
+			}
+
+			encoder, err := ec.LookupEncoder(reflect.TypeOf(ve))
 			if err != nil {
 				return err
 			}
 
-			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(e.Value))
+			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(ve))
 			if err != nil {
 				return err
 			}
@@ -372,12 +377,16 @@ func (dve DefaultValueEncoders) SliceEncodeValue(ec EncodeContext, vw bsonrw.Val
 				return err
 			}
 
-			encoder, err := ec.LookupEncoder(reflect.TypeOf(e.Value))
+			ve := e.Value
+			if reflect.TypeOf(ve) == nil {
+				ve = primitive.Null{}
+			}
+			encoder, err := ec.LookupEncoder(reflect.TypeOf(ve))
 			if err != nil {
 				return err
 			}
 
-			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(e.Value))
+			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(ve))
 			if err != nil {
 				return err
 			}

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -309,19 +309,21 @@ func (dve DefaultValueEncoders) ArrayEncodeValue(ec EncodeContext, vw bsonrw.Val
 				return err
 			}
 
-			ve := e.Value
-			if reflect.TypeOf(ve) == nil {
-				ve = primitive.Null{}
-			}
+			if e.Value == nil {
+				err = vw.WriteNull()
+				if err != nil {
+					return err
+				}
+			} else {
+				encoder, err := ec.LookupEncoder(reflect.TypeOf(e.Value))
+				if err != nil {
+					return err
+				}
 
-			encoder, err := ec.LookupEncoder(reflect.TypeOf(ve))
-			if err != nil {
-				return err
-			}
-
-			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(ve))
-			if err != nil {
-				return err
+				err = encoder.EncodeValue(ec, vw, reflect.ValueOf(e.Value))
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -377,18 +379,21 @@ func (dve DefaultValueEncoders) SliceEncodeValue(ec EncodeContext, vw bsonrw.Val
 				return err
 			}
 
-			ve := e.Value
-			if reflect.TypeOf(ve) == nil {
-				ve = primitive.Null{}
-			}
-			encoder, err := ec.LookupEncoder(reflect.TypeOf(ve))
-			if err != nil {
-				return err
-			}
+			if e.Value == nil {
+				err = vw.WriteNull()
+				if err != nil {
+					return err
+				}
+			} else {
+				encoder, err := ec.LookupEncoder(reflect.TypeOf(e.Value))
+				if err != nil {
+					return err
+				}
 
-			err = encoder.EncodeValue(ec, vw, reflect.ValueOf(ve))
-			if err != nil {
-				return err
+				err = encoder.EncodeValue(ec, vw, reflect.ValueOf(e.Value))
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -304,6 +304,14 @@ func TestDefaultValueEncoders(t *testing.T) {
 					bsonrwtest.WriteDocumentEnd,
 					nil,
 				},
+				{
+					"[1]primitive.E/success",
+					[1]primitive.E{{"hello", nil}},
+					&EncodeContext{Registry: buildDefaultRegistry()},
+					nil,
+					bsonrwtest.WriteDocumentEnd,
+					nil,
+				},
 			},
 		},
 		{
@@ -353,6 +361,14 @@ func TestDefaultValueEncoders(t *testing.T) {
 				{
 					"D/success",
 					primitive.D{{"hello", "world"}},
+					&EncodeContext{Registry: buildDefaultRegistry()},
+					nil,
+					bsonrwtest.WriteDocumentEnd,
+					nil,
+				},
+				{
+					"D/success",
+					primitive.D{{"hello", nil}},
 					&EncodeContext{Registry: buildDefaultRegistry()},
 					nil,
 					bsonrwtest.WriteDocumentEnd,


### PR DESCRIPTION
Came across a problem of encoding `bson.D` / `primitive.D`, decoded with `UnmarshalExtJSON`...

To be short: I've got a json file with a command to MongoDB, written in extended JSON format, I want to read that command from file and execute it with `db.RunCommand`. First of all, I came across a problem, that MongoDB is sensitive to order of elements in command, that is executed (`"insert": <coll-name>`, for example, has to be the first element in command), so it means that ordinary `map` is not usable. So, I started to use `bson.D` instead. Everything was pretty good, till recent, when some changes with `reflect` were merged.

The problem is, that I have `nil` value for some key in my json file. When I execute `db.RunCommand` it returns `error`, saying `cannot transform type primitive.D to a *bsonx.Document`.

As it turned out, `bson.D` aka `primitive.D` after decoding, contains `nil` (not a `primitive.Null`) value. I think, that it is expected behaviour, as instead of `primitive.D` there could be some custom type or `map[string]interface{}` as a target for decoding, so it looks good.

On the other hand, it's really confusing, that calls are done from the same package and they lead to an error.

Sample code (I simulated read-from-file via map's declaration and marshaling it as an ordinary json):

```
package main

import (
	"context"
	"encoding/json"
	"log"

	"github.com/mongodb/mongo-go-driver/bson"
	"github.com/mongodb/mongo-go-driver/bson/primitive"
	"github.com/mongodb/mongo-go-driver/mongo"
)

func simulateReadData() []byte {
	op := map[string]interface{}{
		"insert": "test_collection",
		"documents": []map[string]interface{}{
			{
				"_id":   "1234",
				"value": nil,
				"name":  "some value",
			},
		},
	}

	data, err := json.Marshal(op)
	if err != nil {
		log.Fatalf("Failed to marshal. Error: %+v", err)
	}
	return data
}

func main() {
	data := simulateReadData()

	doc := primitive.D{}
	err := bson.UnmarshalExtJSON(data, false, &doc)
	if err != nil {
		log.Fatalf("Failed to parse D. Error: %+v", err)
	}

	ctx := context.Background()
	client, err := mongo.Connect(ctx, "mongodb://localhost:27017/some_db")
	if err != nil {
		log.Fatalf("Failed to connect. Error: %+v", err)
	}
	db := client.Database("some_db")

	res := db.RunCommand(ctx, doc) //Here we will get an error
	err = res.Err()
	if err != nil {
		log.Fatalf("Failed to apply command. Error: %+v", err)
	}
}
```
