### PR TITLE
GODRIVER-693: Fix error on decoding using a change stream cursor on a database

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -451,7 +451,7 @@ func (cs *changeStream) Decode(out interface{}) error {
 		return err
 	}
 
-	return bson.UnmarshalWithRegistry(cs.coll.registry, br, out)
+	return bson.UnmarshalWithRegistry(cs.db.registry, br, out)
 }
 
 func (cs *changeStream) DecodeBytes() (bson.Raw, error) {

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -451,7 +451,7 @@ func (cs *changeStream) Decode(out interface{}) error {
 		return err
 	}
 
-	return bson.UnmarshalWithRegistry(cs.db.registry, br, out)
+	return bson.UnmarshalWithRegistry(cs.registry, br, out)
 }
 
 func (cs *changeStream) DecodeBytes() (bson.Raw, error) {


### PR DESCRIPTION
On opening a change stream cursor for any database, whenever the cursor is used to decode, it panics on runtime.

Generate the case using: https://gist.github.com/Shivam010/bf057e4fcf65954c62751b0e544bbd1e

[GODRIVER-693](https://jira.mongodb.org/browse/GODRIVER-693)