### PR TITLE
Fix: ObjectId.IsZero to be a pointer receive and support nil IDs

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -55,8 +55,8 @@ func (id ObjectID) String() string {
 }
 
 // IsZero returns true if id is the empty ObjectID.
-func (id ObjectID) IsZero() bool {
-	return bytes.Equal(id[:], NilObjectID[:])
+func (id *ObjectID) IsZero() bool {
+	return id == nil || bytes.Equal(id[:], NilObjectID[:])
 }
 
 // ObjectIDFromHex creates a new ObjectID from a hex string. It returns an error if the hex string is not a


### PR DESCRIPTION
When using pointers for `ObjectId`s, some methods panic (like updates with a `$set`) - when trying to check for a zero value. This PR updates the `IsZero` method to be a pointer receiver so both pointers + non-pointer values are supported.