### PR TITLE
Example Several query method doesn't work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Several query methods return a cursor, which can be used like this:
 
 ```go
 ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-cur, err := collection.Find(ctx, nil)
+cur, err := collection.Find(ctx, bson.D{})
 if err != nil { log.Fatal(err) }
 defer cur.Close(ctx)
 for cur.Next(ctx) {


### PR DESCRIPTION
If passing nil, It'll return "document is nil".

Note: v1 It works, but v2 doesn't work