### PR TITLE
GODRIVER-776: doc and example clarification for nil filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Several query methods return a cursor, which can be used like this:
 
 ```go
 ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-cur, err := collection.Find(ctx, nil)
+cur, err := collection.Find(ctx, bson.D{})
 if err != nil { log.Fatal(err) }
 defer cur.Close(ctx)
 for cur.Next(ctx) {

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -31,7 +31,7 @@
 //
 // Several methods return a cursor, which can be used like this:
 //
-//    cur, err := collection.Find(context.Background(), nil)
+//    cur, err := collection.Find(context.Background(), bson.D{})
 //    if err != nil { log.Fatal(err) }
 //    defer cur.Close(context.Background())
 //    for cur.Next(context.Background()) {


### PR DESCRIPTION
Jira ticket: [GODRIVER-776](https://jira.mongodb.org/projects/GODRIVER/issues/GODRIVER-776?filter=allopenissues)

As explained in the ticket some of the examples and docs portrayed that passing a filter with a value of nil was valid. Passing a nil value results in `ErrNilDocument`



