### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Several query methods return a cursor, which can be used like this:
 
 ```go
 ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-cur, err := collection.Find(ctx, nil)
+cur, err := collection.Find(ctx, bson.M{})
 if err != nil { log.Fatal(err) }
 defer cur.Close(ctx)
 for cur.Next(ctx) {


### PR DESCRIPTION
When reviewing the Readme, I believe most users would not expect a code example to pass `nil` as a param to a function which will cause it to error. 

The example gives the impression that if `nil` is passed as second parameter Into `Find` as `collection.Find(context.Background(), nil)` the mongo package would implicitly use `bson.M{}` as filter. Almost feels like that _should_ be default behavior, but that is a discussion for a separate thread.

This simple update just updates the readme example to pass `bson.M{}` as filter to `collection.Find`