### PR TITLE
Handle nil ObjectID in MarshalJSON and UnmarshalJSON

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -79,6 +79,9 @@ func ObjectIDFromHex(s string) (ObjectID, error) {
 
 // MarshalJSON returns the ObjectID as a string
 func (id ObjectID) MarshalJSON() ([]byte, error) {
+	if id.IsZero() {
+		return json.Marshal(nil)
+	}
 	return json.Marshal(id.Hex())
 }
 
@@ -98,6 +101,12 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+
+		if res == nil {
+			*id = NilObjectID
+			return err
+		}
+
 		str, ok := res.(string)
 		if !ok {
 			m, ok := res.(map[string]interface{})
@@ -114,7 +123,11 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 			}
 		}
 
-		if len(str) != 24 {
+		n := len(str)
+		if n == 0 {
+			*id = NilObjectID
+			return err
+		} else if n != 24 {
 			return fmt.Errorf("cannot unmarshal into an ObjectID, the length must be 12 but it is %d", len(str))
 		}
 


### PR DESCRIPTION
Currently `UnmarshalJSON` on `ObjectID` will return an error for `""` and `null` values. This is inconsistent with the design of other basic types in Go which treat `null` as the zero value. With `int` a json `null` will translate to `0`. For `bool` a `null` will translate to `false`. To be consistent and prevent unexpected errors an empty string or null value in json should be treated as a `NilObjectID`. This was also how the mgo library handled empty strings and null values.

Additionally a `NilObjectID` will marshal to json as `"000000000000000000000000"` in `MarshalJSON`, no other languages are going to view this value as null. To prevent unexpected parsing issues with other languages this value should either be `null` or `""`. The ObjectID is generally stored internally in byte form so I think it would be more consistent to marshal `NilObjectID` to `null` instead of `""` as it is in the mgo library. This commit will marshal `NilObjectID` to `null`.