### PR TITLE
GODRIVER-833 Fix GridFS default chunk size is 255 kB, not 255 KiB

### DIFF
--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -30,7 +30,7 @@ import (
 // TODO: add sessions options
 
 // DefaultChunkSize is the default size of each file chunk.
-const DefaultChunkSize int32 = 255 * 1000 // 255 KB
+const DefaultChunkSize int32 = 255 * 1024 // 255 KiB
 
 // ErrFileNotFound occurs if a user asks to download a file with a file ID that isn't found in the files collection.
 var ErrFileNotFound = errors.New("file with given parameters not found")

--- a/mongo/gridfs/upload_stream.go
+++ b/mongo/gridfs/upload_stream.go
@@ -21,7 +21,7 @@ import (
 
 // UploadBufferSize is the size in bytes of one stream batch. Chunks will be written to the db after the sum of chunk
 // lengths is equal to the batch size.
-const UploadBufferSize = 16 * 1000000 // 16 MB
+const UploadBufferSize = 16 * 1024 * 1024 // 16 MiB
 
 // ErrStreamClosed is an error returned if an operation is attempted on a closed/aborted stream.
 var ErrStreamClosed = errors.New("stream is closed or aborted")

--- a/mongo/options/gridfsoptions.go
+++ b/mongo/options/gridfsoptions.go
@@ -9,7 +9,6 @@ package options
 import (
 	"time"
 
-	"github.com/mongodb/mongo-go-driver/mongo/gridfs"
 	"github.com/mongodb/mongo-go-driver/mongo/readconcern"
 	"github.com/mongodb/mongo-go-driver/mongo/readpref"
 	"github.com/mongodb/mongo-go-driver/mongo/writeconcern"
@@ -20,7 +19,7 @@ import (
 var DefaultName = "fs"
 
 // DefaultChunkSize is the default size of each file chunk in bytes.
-var DefaultChunkSize = gridfs.DefaultChunkSize
+var DefaultChunkSize int32 = 255 * 1024 // 255 KiB
 
 // DefaultRevision is the default revision number for a download by name operation.
 var DefaultRevision int32 = -1

--- a/mongo/options/gridfsoptions.go
+++ b/mongo/options/gridfsoptions.go
@@ -9,6 +9,7 @@ package options
 import (
 	"time"
 
+	"github.com/mongodb/mongo-go-driver/mongo/gridfs"
 	"github.com/mongodb/mongo-go-driver/mongo/readconcern"
 	"github.com/mongodb/mongo-go-driver/mongo/readpref"
 	"github.com/mongodb/mongo-go-driver/mongo/writeconcern"
@@ -19,7 +20,7 @@ import (
 var DefaultName = "fs"
 
 // DefaultChunkSize is the default size of each file chunk in bytes.
-var DefaultChunkSize int32 = 255 * 1000
+var DefaultChunkSize = gridfs.DefaultChunkSize
 
 // DefaultRevision is the default revision number for a download by name operation.
 var DefaultRevision int32 = -1


### PR DESCRIPTION
[GODRIVER-833](https://jira.mongodb.com/browse/GODRIVER-833)

This PR updates the Go driver's GridFS constants to assume the KiB/MiB definition of MB/KB as other drivers do.

Note: I just set off the evergreen [patch](https://evergreen.mongodb.com/version/5c6608e60305b95db5c3b3ab) before leaving. If it is red, I'll look into it in the morning. 