### PR TITLE
Comment fixups

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -92,7 +92,7 @@ func (iv IndexView) CreateOne(ctx context.Context, model IndexModel, opts ...*op
 }
 
 // CreateMany creates multiple indexes in the collection specified by the models. The names of the
-// creates indexes are returned.
+// created indexes are returned.
 func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ...*options.CreateIndexesOptions) ([]string, error) {
 	names := make([]string, 0, len(models))
 	indexes := bsonx.Arr{}

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -8,7 +8,7 @@ package options
 
 import "time"
 
-// AggregateOptions represents all possible options to the aggregate() function
+// AggregateOptions represents all possible options to the Aggregate() function.
 type AggregateOptions struct {
 	AllowDiskUse             *bool          // Enables writing to temporary files. When set to true, aggregation stages can write data to the _tmp subdirectory in the dbPath directory
 	BatchSize                *int32         // The number of documents to return per batch

--- a/mongo/options/countoptions.go
+++ b/mongo/options/countoptions.go
@@ -8,7 +8,7 @@ package options
 
 import "time"
 
-// CountOptions represents all possible options to the count() function
+// CountOptions represents all possible options to the Count() function.
 type CountOptions struct {
 	Collation *Collation     // Specifies a collation
 	Hint      interface{}    // The index to use

--- a/mongo/options/deleteoptions.go
+++ b/mongo/options/deleteoptions.go
@@ -6,7 +6,7 @@
 
 package options
 
-// DeleteOptions represents all possible options to the deleteOne() and deleteMany() functions
+// DeleteOptions represents all possible options to the DeleteOne() and DeleteMany() functions.
 type DeleteOptions struct {
 	Collation *Collation // Specifies a collation
 }

--- a/mongo/options/distinctoptions.go
+++ b/mongo/options/distinctoptions.go
@@ -8,7 +8,7 @@ package options
 
 import "time"
 
-// DistinctOptions represents all possible options to the distinct() function
+// DistinctOptions represents all possible options to the Distinct() function.
 type DistinctOptions struct {
 	Collation *Collation     // Specifies a collation
 	MaxTime   *time.Duration // The maximum amount of time to allow the operation to run

--- a/mongo/options/estimatedcountoptions.go
+++ b/mongo/options/estimatedcountoptions.go
@@ -8,7 +8,7 @@ package options
 
 import "time"
 
-// EstimatedDocumentCountOptions represents all possible options to the estimatedDocumentCount() function
+// EstimatedDocumentCountOptions represents all possible options to the EstimatedDocumentCount() function.
 type EstimatedDocumentCountOptions struct {
 	MaxTime *time.Duration // The maximum amount of time to allow the operation to run
 }

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// FindOptions represent all possible options to the find() function.
+// FindOptions represent all possible options to the Find() function.
 type FindOptions struct {
 	AllowPartialResults *bool          // If true, allows partial results to be returned if some shards are down.
 	BatchSize           *int32         // Specifies the number of documents to return in every batch.
@@ -230,7 +230,7 @@ func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 	return fo
 }
 
-// FindOneOptions represent all possible options to the findOne() function.
+// FindOneOptions represent all possible options to the FindOne() function.
 type FindOneOptions struct {
 	AllowPartialResults *bool          // If true, allows partial results to be returned if some shards are down.
 	BatchSize           *int32         // Specifies the number of documents to return in every batch.
@@ -433,7 +433,7 @@ func MergeFindOneOptions(opts ...*FindOneOptions) *FindOneOptions {
 	return fo
 }
 
-// FindOneAndReplaceOptions represent all possible options to the findOne() function.
+// FindOneAndReplaceOptions represent all possible options to the FindOneAndReplace() function.
 type FindOneAndReplaceOptions struct {
 	BypassDocumentValidation *bool           // If true, allows the write to opt out of document-level validation.
 	Collation                *Collation      // Specifies a collation to be used
@@ -527,7 +527,7 @@ func MergeFindOneAndReplaceOptions(opts ...*FindOneAndReplaceOptions) *FindOneAn
 	return fo
 }
 
-// FindOneAndUpdateOptions represent all possible options to the findOne() function.
+// FindOneAndUpdateOptions represent all possible options to the FindOneAndUpdate() function.
 type FindOneAndUpdateOptions struct {
 	ArrayFilters             *ArrayFilters   // A set of filters specifying to which array elements an update should apply.
 	BypassDocumentValidation *bool           // If true, allows the write to opt out of document-level validation.
@@ -630,7 +630,7 @@ func MergeFindOneAndUpdateOptions(opts ...*FindOneAndUpdateOptions) *FindOneAndU
 	return fo
 }
 
-// FindOneAndDeleteOptions represent all possible options to the findOne() function.
+// FindOneAndDeleteOptions represent all possible options to the FindOneAndDelete() function.
 type FindOneAndDeleteOptions struct {
 	Collation  *Collation     // Specifies a collation to be used
 	MaxTime    *time.Duration // Specifies the maximum amount of time to allow the query to run.

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// CreateIndexesOptions represents all possible options for the create() function.
+// CreateIndexesOptions represents all possible options for the CreateOne() and CreateMany() functions.
 type CreateIndexesOptions struct {
 	MaxTime *time.Duration // The maximum amount of time to allow the query to run.
 }
@@ -42,7 +42,7 @@ func MergeCreateIndexesOptions(opts ...*CreateIndexesOptions) *CreateIndexesOpti
 	return c
 }
 
-// DropIndexesOptions represents all possible options for the create() function.
+// DropIndexesOptions represents all possible options for the DropIndexes() function.
 type DropIndexesOptions struct {
 	MaxTime *time.Duration
 }
@@ -74,7 +74,7 @@ func MergeDropIndexesOptions(opts ...*DropIndexesOptions) *DropIndexesOptions {
 	return c
 }
 
-// ListIndexesOptions represents all possible options for the create() function.
+// ListIndexesOptions represents all possible options for the ListIndexes() function.
 type ListIndexesOptions struct {
 	BatchSize *int32
 	MaxTime   *time.Duration

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -6,7 +6,7 @@
 
 package options
 
-// InsertOneOptions represents all possible options to the insertOne()
+// InsertOneOptions represents all possible options to the InsertOne() function.
 type InsertOneOptions struct {
 	BypassDocumentValidation *bool // If true, allows the write to opt-out of document level validation
 }
@@ -38,7 +38,7 @@ func MergeInsertOneOptions(opts ...*InsertOneOptions) *InsertOneOptions {
 	return ioOpts
 }
 
-// InsertManyOptions represents all possible options to the insertMany()
+// InsertManyOptions represents all possible options to the InsertMany() function.
 type InsertManyOptions struct {
 	BypassDocumentValidation *bool // If true, allows the write to opt-out of document level validation
 	Ordered                  *bool // If true, when an insert fails, return without performing the remaining inserts. Defaults to true.

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -6,7 +6,7 @@
 
 package options
 
-// ReplaceOptions represents all possible options to the replaceOne() function
+// ReplaceOptions represents all possible options to the ReplaceOne() function.
 type ReplaceOptions struct {
 	BypassDocumentValidation *bool      // If true, allows the write to opt-out of document level validation
 	Collation                *Collation // Specifies a collation

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -6,7 +6,7 @@
 
 package options
 
-// UpdateOptions represents all possible options to the updateOne() and updateMany() functions
+// UpdateOptions represents all possible options to the UpdateOne() and UpdateMany() functions.
 type UpdateOptions struct {
 	ArrayFilters             *ArrayFilters // A set of filters specifying to which array elements an update should apply
 	BypassDocumentValidation *bool         // If true, allows the write to opt-out of document level validation


### PR DESCRIPTION
* "creates" -> "created" - grammar typo
* Update options type main comments to consistent sentence format - i.e. "// DoStuffOptions represents all possible options to the DoStuff() function." 
* Fixed a few references to the wrong things - e.g. "DropIndexesOptions represents all possible options for the create() function."