### PR TITLE
Add non-single letter aliases for BSON types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ GerritHub.
 Patches should generally be made against the master (default) branch and include relevant tests, if applicable.
 
 Code should compile and tests should pass under all go versions which the driver currently supports.  Currently the driver
-supports a minimum version of go 1.7. Please ensure the following tools have been run on the code: gofmt, golint, errcheck,
+supports a minimum version of go 1.10. Please ensure the following tools have been run on the code: gofmt, golint, errcheck,
 go test (with coverage and with the race detector), and go vet. For convenience, you can run 'make' to run all these tools.
 **By default, running the tests requires that you have a mongod server running on localhost, listening on the default port.**
 At minimum, please test against the latest release version of the MongoDB server.

--- a/bson/bson.go
+++ b/bson/bson.go
@@ -22,39 +22,50 @@ type Zeroer interface {
 	IsZero() bool
 }
 
-// D represents a BSON Document. This type can be used to represent BSON in a concise and readable
+// Document represents a BSON Document. This type can be used to represent BSON in a concise and readable
 // manner. It should generally be used when serializing to BSON. For deserializing, the Raw or
 // Document types should be used.
 //
 // Example usage:
 //
-// 		bson.D{{"foo", "bar"}, {"hello", "world"}, {"pi", 3.14159}}
+// 		bson.Document{{"foo", "bar"}, {"hello", "world"}, {"pi", 3.14159}}
 //
 // This type should be used in situations where order matters, such as MongoDB commands. If the
 // order is not important, a map is more comfortable and concise.
+type Document = primitive.D
+
+// D is an alias of bson.Document, shortened for convinience
 type D = primitive.D
 
-// E represents a BSON element for a D. It is usually used inside a D.
+// Element represents a BSON element for a Document. It is usually used inside a Document.
+type Element = primitive.E
+
+// E is an alias of bson.Element, shortened for convinience
 type E = primitive.E
 
-// M is an unordered, concise representation of a BSON Document. It should generally be used to
+// Map is an unordered, concise representation of a BSON Document. It should generally be used to
 // serialize BSON when the order of the elements of a BSON document do not matter. If the element
 // order matters, use a D instead.
 //
 // Example usage:
 //
-// 		bson.M{"foo": "bar", "hello": "world", "pi": 3.14159}
+// 		bson.Map{"foo": "bar", "hello": "world", "pi": 3.14159}
 //
 // This type is handled in the encoders as a regular map[string]interface{}. The elements will be
 // serialized in an undefined, random order, and the order will be different each time.
+type Map = primitive.M
+
+// M is an alias of bson.Map, shortened for convinience
 type M = primitive.M
 
-// An A represents a BSON array. This type can be used to represent a BSON array in a concise and
+// Array represents a BSON array. This type can be used to represent a BSON array in a concise and
 // readable manner. It should generally be used when serializing to BSON. For deserializing, the
 // RawArray or Array types should be used.
 //
 // Example usage:
 //
-// 		bson.A{"bar", "world", 3.14159, bson.D{{"qux", 12345}}}
-//
+// 		bson.Array{"bar", "world", 3.14159, bson.D{{"qux", 12345}}}
+type Array = primitive.A
+
+// An A is an alias of bson.Array, shortened for convinience
 type A = primitive.A


### PR DESCRIPTION
**This PR:** Adds full-name aliases for the BSON types, eg adding an alias `bson.Document` that addresses the same primitive type as `bson.D`. I found that upon installing the driver, it was pretty difficult to figure out which type was which without digging through documentation. On top of making onboarding into the driver easier, it makes code written with the driver significantly more glancible.

Also, I can't access Evergreen to see what's failiing - if I could get access that would be fabulous!

