### PR TITLE
GODRIVER-886 Fix panic when using non-ObjectID fileID in bucket.OpenDownloadStream

### DIFF
--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -351,7 +351,7 @@ func (b *Bucket) openDownloadStream(filter interface{}, opts ...*options.FindOpt
 		return newDownloadStream(nil, b.chunkSize, 0), nil
 	}
 
-	chunksCursor, err := b.findChunks(ctx, fileIDElem.ObjectID())
+	chunksCursor, err := b.findChunks(ctx, fileIDElem)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[GODRIVER-886](https://jira.mongodb.org/browse/GODRIVER-886)

[evergreen](https://evergreen.mongodb.com/version/5c900963c9ec4457930c4f24)