### PR TITLE
GODRIVER-887 Properly set default registry when using UploadOptions

### DIFF
--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -526,6 +526,9 @@ func (b *Bucket) parseUploadOptions(opts ...*options.UploadOptions) (*Upload, er
 	if uo.ChunkSizeBytes != nil {
 		upload.chunkSize = *uo.ChunkSizeBytes
 	}
+	if uo.Registry == nil {
+		uo.Registry = bson.DefaultRegistry
+	}
 	if uo.Metadata != nil {
 		raw, err := bson.MarshalWithRegistry(uo.Registry, uo.Metadata)
 		if err != nil {

--- a/mongo/options/gridfsoptions.go
+++ b/mongo/options/gridfsoptions.go
@@ -9,6 +9,7 @@ package options
 import (
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -111,7 +112,7 @@ type UploadOptions struct {
 
 // GridFSUpload creates a new *UploadOptions
 func GridFSUpload() *UploadOptions {
-	return &UploadOptions{}
+	return &UploadOptions{Registry: bson.DefaultRegistry}
 }
 
 // SetChunkSizeBytes sets the chunk size in bytes for the upload. Defaults to 255KB if not set.


### PR DESCRIPTION
[GODRIVER-887](https://jira.mongodb.org/browse/GODRIVER-887)
