### PR TITLE
Validate clientOptions on client creation

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -76,6 +76,11 @@ func Connect(ctx context.Context, opts ...*options.ClientOptions) (*Client, erro
 func NewClient(opts ...*options.ClientOptions) (*Client, error) {
 	clientOpt := options.MergeClientOptions(opts...)
 
+	err := clientOpt.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	id, err := uuid.New()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add a verification of ClientOptions to prevent error and strange behavior.