### PR TITLE
handle unmarshalling of empty objectId fields by returning a zero value

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -125,6 +125,11 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 			}
 		}
 
+		if len(str) == 0 {
+			id = &NilObjectID
+			return nil
+		}
+
 		if len(str) != 24 {
 			return fmt.Errorf("cannot unmarshal into an ObjectID, the length must be 12 but it is %d", len(str))
 		}


### PR DESCRIPTION
This PR handles unmarshalling of empty objectId fields by returning a zero value instead of an instead of anonymous decoding error

https://jira.mongodb.org/browse/GODRIVER-1020

copied from the Jira Issue

> Currently, when ObjectIds are unmarshalled from a JSON payload https://github.com/mongodb/mongo-go-driver/blob/master/bson/primitive/objectid.go#L100 , 64 and 12 byte strings are properly converted to an objectId. All others return decoding errors. This is expected functionality.
> 
>  
> 
> However an empty string or empty field also returns an error instead of a zero/null valued objectId. This makes using the primitive.ObjectID type within a struct definition very opinionated, and negates the need for IsZero methods. For example, if a service layer is responsible for decoding a struct and then setting ObjectID values based on claims information, the request will hit a decoding error since the payload will not contain the objectIds.
> 
> It forces the use of struct composition to decode input values, by necessitating the extension to a more complete struct definition to apply the ObjectIds. It could very easily be argued that this is a best practice, but it should not be the responsibility of the mongo-driver to force such a high level design decision
> 
>  
> 
> Request: ObjectIds should be decoded for 64/12 bytes and for empty fields it should initialize a zero valued objectId that can then be validated, initialized or handled in the application logic