### PR TITLE
Update  clientoptions.go

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -58,6 +58,7 @@ type Credential struct {
 	AuthMechanism           string
 	AuthMechanismProperties map[string]string
 	AuthSource              string
+	Database                string
 	Username                string
 	Password                string
 	PasswordSet             bool
@@ -130,6 +131,7 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 			AuthMechanism:           cs.AuthMechanism,
 			AuthMechanismProperties: cs.AuthMechanismProperties,
 			AuthSource:              cs.AuthSource,
+			Database:                cs.Database,
 			Username:                cs.Username,
 			Password:                cs.Password,
 			PasswordSet:             cs.PasswordSet,


### PR DESCRIPTION
Add the "Database" field on "Credential" struct
This is very usable when usage the dbname in URI like : 
```bash
mongodb+srv://root:<password>@cluster-xxxxx.mongodb.net/dbname?retryWrites=true
```

Curently the dbname is loss not parsed in to ClientOptions

Please help to merge this propose pull request

Thx
Dwi BudUt