### PR TITLE
Release/1.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -715,7 +715,7 @@ buildvariants:
   run_on:
     - ubuntu1604-build
   expansions:
-    GO_DIST: "/opt/golang/go1.9"
+    GO_DIST: "/opt/golang/go1.11"
   tasks:
     - name: ".static-analysis"
 

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ update-notices:
 
 .PHONY: vet
 vet:
-	go vet -cgocall=false -composites=false -structtags=false -unusedstringmethods="Error" $(PKGS)
+	go vet -cgocall=false -composites=false -unusedstringmethods="Error" $(PKGS)
 
 
 # Evergreen specific targets

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The MongoDB supported driver for Go.
 The recommended way to get started using the MongoDB Go driver is by using `dep` to install the dependency in your project.
 
 ```bash
-dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.0"
+dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.1"
 ```
 
 -------------------------

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The MongoDB supported driver for Go.
 The recommended way to get started using the MongoDB Go driver is by using `dep` to install the dependency in your project.
 
 ```bash
-dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.1"
+dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.2"
 ```
 
 -------------------------

--- a/bson/bsoncodec/bsoncodec_test.go
+++ b/bson/bsoncodec/bsoncodec_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
@@ -51,6 +52,13 @@ func noerr(t *testing.T, err error) {
 		t.Errorf("Unexpected error: (%T)%v", err, err)
 		t.FailNow()
 	}
+}
+
+func compareTime(t1, t2 time.Time) bool {
+	if t1.Location() != t2.Location() {
+		return false
+	}
+	return t1.Equal(t2)
 }
 
 func compareErrors(err1, err2 error) bool {

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -614,7 +614,7 @@ func (dvd DefaultValueDecoders) TimeDecodeValue(dc DecodeContext, vr bsonrw.Valu
 		return ValueDecoderError{Name: "TimeDecodeValue", Types: []reflect.Type{tTime}, Received: val}
 	}
 
-	val.Set(reflect.ValueOf(time.Unix(dt/1000, dt%1000*1000000)))
+	val.Set(reflect.ValueOf(time.Unix(dt/1000, dt%1000*1000000).UTC()))
 	return nil
 }
 

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -2035,7 +2035,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		oids := []primitive.ObjectID{primitive.NewObjectID(), primitive.NewObjectID(), primitive.NewObjectID()}
 		var str = new(string)
 		*str = "bar"
-		now := time.Now().Truncate(time.Millisecond)
+		now := time.Now().Truncate(time.Millisecond).UTC()
 		murl, err := url.Parse("https://mongodb.com/random-url?hello=world")
 		if err != nil {
 			t.Errorf("Error parsing URL: %v", err)
@@ -2573,6 +2573,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 						cmp.Comparer(compareDecimal128),
 						cmp.Comparer(compareNoPrivateFields),
 						cmp.Comparer(compareZeroTest),
+						cmp.Comparer(compareTime),
 					); diff != "" {
 						t.Errorf("difference:\n%s", diff)
 						t.Errorf("Values are not equal.\ngot: %#v\nwant:%#v", got, want)

--- a/bson/bsonrw/extjson_parser_test.go
+++ b/bson/bsonrw/extjson_parser_test.go
@@ -716,3 +716,21 @@ func TestExtJSONParserAllTypes(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestExtJSONValue(t *testing.T) {
+	t.Run("Large Date", func(t *testing.T) {
+		val := &extJSONValue{
+			t: bsontype.String,
+			v: "3001-01-01T00:00:00Z",
+		}
+
+		intVal, err := val.parseDateTime()
+		if err != nil {
+			t.Fatalf("error parsing date time: %v", err)
+		}
+
+		if intVal <= 0 {
+			t.Fatalf("expected value above 0, got %v", intVal)
+		}
+	})
+}

--- a/bson/bsonrw/extjson_wrappers.go
+++ b/bson/bsonrw/extjson_wrappers.go
@@ -203,7 +203,7 @@ func parseDatetimeString(data string) (int64, error) {
 		return 0, fmt.Errorf("invalid $date value string: %s", data)
 	}
 
-	return t.UnixNano() / 1e6, nil
+	return t.Unix()*1e3 + int64(t.Nanosecond())/1e6, nil
 }
 
 func parseDatetimeObject(data *extJSONObject) (d int64, err error) {

--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -288,12 +288,12 @@ func (vr *valueReader) nextElementLength() (int32, error) {
 			err = io.EOF
 			break
 		}
-		pattern := bytes.IndexByte(vr.d[regex+1:], 0x00)
+		pattern := bytes.IndexByte(vr.d[vr.offset+int64(regex)+1:], 0x00)
 		if pattern < 0 {
 			err = io.EOF
 			break
 		}
-		length = int32(int64(regex) + 1 + int64(pattern) + 1 - vr.offset)
+		length = int32(int64(regex) + 1 + int64(pattern) + 1)
 	default:
 		return 0, fmt.Errorf("attempted to read bytes of unknown BSON type %v", vr.stack[vr.frame].vType)
 	}

--- a/bson/bsonrw/value_reader_test.go
+++ b/bson/bsonrw/value_reader_test.go
@@ -1204,184 +1204,185 @@ func TestValueReader(t *testing.T) {
 		cwsbytes := bsoncore.AppendCodeWithScope(nil, "var hellow = world;", docb)
 		strbytes := []byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00}
 		testCases := []struct {
-			name   string
-			t      bsontype.Type
-			data   []byte
-			err    error
-			offset int64
+			name           string
+			t              bsontype.Type
+			data           []byte
+			err            error
+			offset         int64
+			startingOffset int64
 		}{
 			{
 				"Array/invalid length",
 				bsontype.Array,
 				[]byte{0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Array/not enough bytes",
 				bsontype.Array,
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Array/success",
 				bsontype.Array,
 				[]byte{0x08, 0x00, 0x00, 0x00, 0x0A, '1', 0x00, 0x00},
-				nil, 8,
+				nil, 8, 0,
 			},
 			{
 				"EmbeddedDocument/invalid length",
 				bsontype.EmbeddedDocument,
 				[]byte{0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"EmbeddedDocument/not enough bytes",
 				bsontype.EmbeddedDocument,
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"EmbeddedDocument/success",
 				bsontype.EmbeddedDocument,
 				[]byte{0x08, 0x00, 0x00, 0x00, 0x0A, 'A', 0x00, 0x00},
-				nil, 8,
+				nil, 8, 0,
 			},
 			{
 				"CodeWithScope/invalid length",
 				bsontype.CodeWithScope,
 				[]byte{0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"CodeWithScope/not enough bytes",
 				bsontype.CodeWithScope,
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"CodeWithScope/success",
 				bsontype.CodeWithScope,
 				cwsbytes,
-				nil, 41,
+				nil, 41, 0,
 			},
 			{
 				"Binary/invalid length",
 				bsontype.Binary,
 				[]byte{0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Binary/not enough bytes",
 				bsontype.Binary,
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Binary/success",
 				bsontype.Binary,
 				[]byte{0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				nil, 8,
+				nil, 8, 0,
 			},
 			{
 				"Boolean/invalid length",
 				bsontype.Boolean,
 				[]byte{},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Boolean/success",
 				bsontype.Boolean,
 				[]byte{0x01},
-				nil, 1,
+				nil, 1, 0,
 			},
 			{
 				"DBPointer/invalid length",
 				bsontype.DBPointer,
 				[]byte{0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"DBPointer/not enough bytes",
 				bsontype.DBPointer,
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"DBPointer/success",
 				bsontype.DBPointer,
 				[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
-				nil, 17,
+				nil, 17, 0,
 			},
-			{"DBPointer/not enough bytes", bsontype.DateTime, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0},
-			{"DBPointer/success", bsontype.DateTime, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8},
-			{"Double/not enough bytes", bsontype.Double, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0},
-			{"Double/success", bsontype.Double, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8},
-			{"Int64/not enough bytes", bsontype.Int64, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0},
-			{"Int64/success", bsontype.Int64, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8},
-			{"Timestamp/not enough bytes", bsontype.Timestamp, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0},
-			{"Timestamp/success", bsontype.Timestamp, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8},
+			{"DBPointer/not enough bytes", bsontype.DateTime, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0, 0},
+			{"DBPointer/success", bsontype.DateTime, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8, 0},
+			{"Double/not enough bytes", bsontype.Double, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0, 0},
+			{"Double/success", bsontype.Double, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8, 0},
+			{"Int64/not enough bytes", bsontype.Int64, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0, 0},
+			{"Int64/success", bsontype.Int64, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8, 0},
+			{"Timestamp/not enough bytes", bsontype.Timestamp, []byte{0x01, 0x02, 0x03, 0x04}, io.EOF, 0, 0},
+			{"Timestamp/success", bsontype.Timestamp, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, nil, 8, 0},
 			{
 				"Decimal128/not enough bytes",
 				bsontype.Decimal128,
 				[]byte{0x01, 0x02, 0x03, 0x04},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Decimal128/success",
 				bsontype.Decimal128,
 				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10},
-				nil, 16,
+				nil, 16, 0,
 			},
-			{"Int32/not enough bytes", bsontype.Int32, []byte{0x01, 0x02}, io.EOF, 0},
-			{"Int32/success", bsontype.Int32, []byte{0x01, 0x02, 0x03, 0x04}, nil, 4},
-			{"Javascript/invalid length", bsontype.JavaScript, strbytes[:2], io.EOF, 0},
-			{"Javascript/not enough bytes", bsontype.JavaScript, strbytes[:5], io.EOF, 0},
-			{"Javascript/success", bsontype.JavaScript, strbytes, nil, 8},
-			{"String/invalid length", bsontype.String, strbytes[:2], io.EOF, 0},
-			{"String/not enough bytes", bsontype.String, strbytes[:5], io.EOF, 0},
-			{"String/success", bsontype.String, strbytes, nil, 8},
-			{"Symbol/invalid length", bsontype.Symbol, strbytes[:2], io.EOF, 0},
-			{"Symbol/not enough bytes", bsontype.Symbol, strbytes[:5], io.EOF, 0},
-			{"Symbol/success", bsontype.Symbol, strbytes, nil, 8},
-			{"MaxKey/success", bsontype.MaxKey, []byte{}, nil, 0},
-			{"MinKey/success", bsontype.MinKey, []byte{}, nil, 0},
-			{"Null/success", bsontype.Null, []byte{}, nil, 0},
-			{"Undefined/success", bsontype.Undefined, []byte{}, nil, 0},
+			{"Int32/not enough bytes", bsontype.Int32, []byte{0x01, 0x02}, io.EOF, 0, 0},
+			{"Int32/success", bsontype.Int32, []byte{0x01, 0x02, 0x03, 0x04}, nil, 4, 0},
+			{"Javascript/invalid length", bsontype.JavaScript, strbytes[:2], io.EOF, 0, 0},
+			{"Javascript/not enough bytes", bsontype.JavaScript, strbytes[:5], io.EOF, 0, 0},
+			{"Javascript/success", bsontype.JavaScript, strbytes, nil, 8, 0},
+			{"String/invalid length", bsontype.String, strbytes[:2], io.EOF, 0, 0},
+			{"String/not enough bytes", bsontype.String, strbytes[:5], io.EOF, 0, 0},
+			{"String/success", bsontype.String, strbytes, nil, 8, 0},
+			{"Symbol/invalid length", bsontype.Symbol, strbytes[:2], io.EOF, 0, 0},
+			{"Symbol/not enough bytes", bsontype.Symbol, strbytes[:5], io.EOF, 0, 0},
+			{"Symbol/success", bsontype.Symbol, strbytes, nil, 8, 0},
+			{"MaxKey/success", bsontype.MaxKey, []byte{}, nil, 0, 0},
+			{"MinKey/success", bsontype.MinKey, []byte{}, nil, 0, 0},
+			{"Null/success", bsontype.Null, []byte{}, nil, 0, 0},
+			{"Undefined/success", bsontype.Undefined, []byte{}, nil, 0, 0},
 			{
 				"ObjectID/not enough bytes",
 				bsontype.ObjectID,
 				[]byte{0x01, 0x02, 0x03, 0x04},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"ObjectID/success",
 				bsontype.ObjectID,
 				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
-				nil, 12,
+				nil, 12, 0,
 			},
 			{
 				"Regex/not enough bytes (first string)",
 				bsontype.Regex,
 				[]byte{'f', 'o', 'o'},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Regex/not enough bytes (second string)",
 				bsontype.Regex,
 				[]byte{'f', 'o', 'o', 0x00, 'b', 'a', 'r'},
-				io.EOF, 0,
+				io.EOF, 0, 0,
 			},
 			{
 				"Regex/success",
 				bsontype.Regex,
-				[]byte{'f', 'o', 'o', 0x00, 'b', 'a', 'r', 0x00},
-				nil, 8,
+				[]byte{0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00, 'i', 0x00},
+				nil, 9, 3,
 			},
 			{
 				"Unknown Type",
 				bsontype.Type(0),
 				nil,
-				fmt.Errorf("attempted to read bytes of unknown BSON type %v", bsontype.Type(0)), 0,
+				fmt.Errorf("attempted to read bytes of unknown BSON type %v", bsontype.Type(0)), 0, 0,
 			},
 		}
 
@@ -1394,7 +1395,8 @@ func TestValueReader(t *testing.T) {
 							{mode: mTopLevel},
 							{mode: mElement, vType: tc.t},
 						},
-						frame: 1,
+						frame:  1,
+						offset: tc.startingOffset,
 					}
 
 					err := vr.Skip()
@@ -1412,7 +1414,8 @@ func TestValueReader(t *testing.T) {
 							{mode: mTopLevel},
 							{mode: mElement, vType: tc.t},
 						},
-						frame: 1,
+						frame:  1,
+						offset: tc.startingOffset,
 					}
 
 					_, got, err := vr.ReadValueBytes(nil)
@@ -1422,8 +1425,8 @@ func TestValueReader(t *testing.T) {
 					if tc.err == nil && vr.offset != tc.offset {
 						t.Errorf("Offset not set at correct position; got %d; want %d", vr.offset, tc.offset)
 					}
-					if tc.err == nil && !bytes.Equal(got, tc.data) {
-						t.Errorf("Did not receive expected bytes. got %v; want %v", got, tc.data)
+					if tc.err == nil && !bytes.Equal(got, tc.data[tc.startingOffset:]) {
+						t.Errorf("Did not receive expected bytes. got %v; want %v", got, tc.data[tc.startingOffset:])
 					}
 				})
 			})

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -16,6 +16,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 )
 
+// ErrDecodeToNil is the error returned when trying to decode to a nil value
+var ErrDecodeToNil = errors.New("cannot Decode to nil value")
+
 // This pool is used to keep the allocations of Decoders down. This is only used for the Marshal*
 // methods and is not consumable from outside of this package. The Decoders retrieved from this pool
 // must have both Reset and SetRegistry called on them.
@@ -77,6 +80,9 @@ func (d *Decoder) Decode(val interface{}) error {
 	rval := reflect.ValueOf(val)
 	if rval.Kind() != reflect.Ptr {
 		return fmt.Errorf("argument to Decode must be a pointer to a type, but got %v", rval)
+	}
+	if rval.IsNil() {
+		return ErrDecodeToNil
 	}
 	rval = rval.Elem()
 	decoder, err := d.dc.LookupDecoder(rval.Type())

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -235,6 +235,18 @@ func TestDecoderv2(t *testing.T) {
 			t.Errorf("Decoder should use the Registry provided. got %v; want %v", dec.dc, dc2)
 		}
 	})
+	t.Run("DecodeToNil", func(t *testing.T) {
+		data := docToBytes(D{{"item", "canvas"}, {"qty", 4}})
+		vr := bsonrw.NewBSONDocumentReader(data)
+		dec, err := NewDecoder(vr)
+		noerr(t, err)
+
+		var got *D
+		err = dec.Decode(got)
+		if err != ErrDecodeToNil {
+			t.Fatalf("Decode error mismatch; expected %v, got %v", ErrDecodeToNil, err)
+		}
+	})
 }
 
 type testDecoderCodec struct {

--- a/data/transactions/error-labels.yml
+++ b/data/transactions/error-labels.yml
@@ -491,7 +491,7 @@ tests:
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          errorCode: 11602  # InterruptedDueToReplStateChange
+          errorCode: 11602  # InterruptedDueToStepDown
 
     operations:
       - name: startTransaction

--- a/data/transactions/retryable-abort.yml
+++ b/data/transactions/retryable-abort.yml
@@ -459,7 +459,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after InterruptedDueToReplStateChange
+  - description: abortTransaction succeeds after InterruptedDueToStepDown
 
     failPoint:
       configureFailPoint: failCommand
@@ -1069,7 +1069,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
+  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToStepDown
 
     failPoint:
       configureFailPoint: failCommand

--- a/data/transactions/retryable-commit.yml
+++ b/data/transactions/retryable-commit.yml
@@ -584,7 +584,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after InterruptedDueToReplStateChange
+  - description: commitTransaction succeeds after InterruptedDueToStepDown
 
     failPoint:
       configureFailPoint: failCommand
@@ -1211,7 +1211,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
+  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToStepDown
 
     failPoint:
       configureFailPoint: failCommand

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -76,11 +76,6 @@ func Connect(ctx context.Context, opts ...*options.ClientOptions) (*Client, erro
 func NewClient(opts ...*options.ClientOptions) (*Client, error) {
 	clientOpt := options.MergeClientOptions(opts...)
 
-	err := clientOpt.Validate()
-	if err != nil {
-		return nil, err
-	}
-
 	id, err := uuid.New()
 	if err != nil {
 		return nil, err

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -76,6 +76,11 @@ func Connect(ctx context.Context, opts ...*options.ClientOptions) (*Client, erro
 func NewClient(opts ...*options.ClientOptions) (*Client, error) {
 	clientOpt := options.MergeClientOptions(opts...)
 
+	err := clientOpt.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	id, err := uuid.New()
 	if err != nil {
 		return nil, err

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -531,6 +531,9 @@ func (c *Client) UseSessionWithOptions(ctx context.Context, opts *options.Sessio
 // The client must have read concern majority or no read concern for a change stream to be created successfully.
 func (c *Client) Watch(ctx context.Context, pipeline interface{},
 	opts ...*options.ChangeStreamOptions) (*ChangeStream, error) {
+	if c.topology.SessionPool == nil {
+		return nil, ErrClientDisconnected
+	}
 
 	return newClientChangeStream(ctx, c, pipeline, opts...)
 }

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -230,7 +230,9 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		))
 	}
 	// Handshaker
-	var handshaker connection.Handshaker = &command.Handshake{Client: command.ClientDoc(appName), Compressors: comps}
+	var handshaker = func(connection.Handshaker) connection.Handshaker {
+		return &command.Handshake{Client: command.ClientDoc(appName), Compressors: comps}
+	}
 	// Auth & Database & Password & Username
 	if opts.Auth != nil {
 		cred := &auth.Cred{
@@ -272,11 +274,11 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			}
 		}
 
-		handshaker = auth.Handshaker(nil, handshakeOpts)
+		handshaker = func(connection.Handshaker) connection.Handshaker {
+			return auth.Handshaker(nil, handshakeOpts)
+		}
 	}
-	connOpts = append(connOpts, connection.WithHandshaker(
-		func(connection.Handshaker) connection.Handshaker { return handshaker },
-	))
+	connOpts = append(connOpts, connection.WithHandshaker(handshaker))
 	// ConnectTimeout
 	if opts.ConnectTimeout != nil {
 		serverOpts = append(serverOpts, topology.WithHeartbeatTimeout(

--- a/mongo/client_internal_test.go
+++ b/mongo/client_internal_test.go
@@ -536,3 +536,12 @@ func TestClient_Disconnect_NilContext(t *testing.T) {
 	err = c.Disconnect(nil)
 	require.NoError(t, err)
 }
+
+func TestClient_Watch_Disconnected(t *testing.T) {
+	cs := testutil.ConnString(t)
+	c, err := NewClient(options.Client().ApplyURI(cs.String()))
+	require.NoError(t, err)
+	change, err := c.Watch(context.Background(), []bson.D{})
+	require.Nil(t, change)
+	require.Equal(t, err, ErrClientDisconnected)
+}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -187,26 +187,16 @@ func (coll *Collection) BulkWrite(ctx context.Context, models []WriteModel,
 		coll.registry,
 		opts...,
 	)
-
-	if err != nil {
-		if conv, ok := err.(driver.BulkWriteException); ok {
-			return &BulkWriteResult{}, BulkWriteException{
-				WriteConcernError: convertWriteConcernError(conv.WriteConcernError),
-				WriteErrors:       convertBulkWriteErrors(conv.WriteErrors),
-			}
-		}
-
-		return &BulkWriteResult{}, replaceErrors(err)
-	}
-
-	return &BulkWriteResult{
+	result := BulkWriteResult{
 		InsertedCount: res.InsertedCount,
 		MatchedCount:  res.MatchedCount,
 		ModifiedCount: res.ModifiedCount,
 		DeletedCount:  res.DeletedCount,
 		UpsertedCount: res.UpsertedCount,
 		UpsertedIDs:   res.UpsertedIDs,
-	}, nil
+	}
+
+	return &result, replaceErrors(err)
 }
 
 // InsertOne inserts a single document into the collection.

--- a/mongo/collection_internal_test.go
+++ b/mongo/collection_internal_test.go
@@ -1747,6 +1747,21 @@ func TestCollection_Find_Error(t *testing.T) {
 	})
 }
 
+func TestCollection_Find_NegativeLimit(t *testing.T) {
+	coll := createTestCollection(t, nil, nil)
+	initCollection(t, coll)
+
+	c, err := coll.Find(ctx, bson.D{}, options.Find().SetLimit(-2))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), c.ID()) // single batch returned so cursor should not have valid ID
+
+	var numDocs int
+	for c.Next(ctx) {
+		numDocs++
+	}
+	require.Equal(t, 2, numDocs)
+}
+
 func TestCollection_FindOne_found(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/mongo/collection_internal_test.go
+++ b/mongo/collection_internal_test.go
@@ -1672,6 +1672,38 @@ func TestCollection_Find_found(t *testing.T) {
 	require.Equal(t, results, []int{1, 2, 3, 4, 5})
 }
 
+func TestCollection_Find_With_Limit_And_BatchSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	coll := createTestCollection(t, nil, nil)
+	initCollection(t, coll)
+
+	batchSizes := []int32{2, 3, 4}
+	for _, b := range batchSizes {
+		name := fmt.Sprintf("Limit: 3, BatchSize: %v", b)
+		t.Run(name, func(t *testing.T) {
+			cursor, err := coll.Find(context.Background(), bson.D{}, options.Find().SetLimit(3).SetBatchSize(b))
+
+			numRecieved := 0
+			var doc bson.Raw
+			for cursor.Next(context.Background()) {
+				err = cursor.Decode(&doc)
+				require.NoError(t, err)
+
+				_, err = doc.LookupErr("_id")
+				require.NoError(t, err)
+
+				numRecieved++
+			}
+
+			require.NoError(t, cursor.Err())
+			require.Equal(t, 3, numRecieved)
+		})
+	}
+}
+
 func TestCollection_Find_notFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -118,7 +118,7 @@ func (c *Cursor) Next(ctx context.Context) bool {
 	}
 }
 
-// Decode will decode the current document into val.
+// Decode will decode the current document into val. If val is nil or is a typed nil, an error will be returned.
 func (c *Cursor) Decode(val interface{}) error {
 	return bson.UnmarshalWithRegistry(c.registry, c.Current, val)
 }

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"reflect"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
@@ -129,68 +128,3 @@ func (c *Cursor) Err() error { return c.err }
 
 // Close closes this cursor.
 func (c *Cursor) Close(ctx context.Context) error { return c.bc.Close(ctx) }
-
-// All iterates the cursor and decodes each document into results.
-// The results parameter must be a pointer to a slice. The slice pointed to by results will be completely overwritten.
-// If the cursor has been iterated, any previously iterated documents will not be included in results.
-func (c *Cursor) All(ctx context.Context, results interface{}) error {
-	resultsVal := reflect.ValueOf(results)
-	if resultsVal.Kind() != reflect.Ptr {
-		return errors.New("results argument must be a pointer to a slice")
-	}
-
-	sliceVal := resultsVal.Elem()
-	elementType := sliceVal.Type().Elem()
-	var index int
-	var err error
-
-	batch := c.batch // exhaust the current batch before iterating the batch cursor
-	for {
-		sliceVal, index, err = c.addFromBatch(sliceVal, elementType, batch, index)
-		if err != nil {
-			return err
-		}
-
-		if !c.bc.Next(ctx) {
-			break
-		}
-
-		batch = c.bc.Batch()
-	}
-
-	if err = c.bc.Err(); err != nil {
-		return err
-	}
-
-	resultsVal.Elem().Set(sliceVal.Slice(0, index))
-	return nil
-}
-
-// addFromBatch adds all documents from batch to sliceVal starting at the given index. It returns the new slice value,
-// the next empty index in the slice, and an error if one occurs.
-func (c *Cursor) addFromBatch(sliceVal reflect.Value, elemType reflect.Type, batch *bsoncore.DocumentSequence,
-	index int) (reflect.Value, int, error) {
-
-	docs, err := batch.Documents()
-	if err != nil {
-		return sliceVal, index, err
-	}
-
-	for _, doc := range docs {
-		if sliceVal.Len() == index {
-			// slice is full
-			newElem := reflect.New(elemType)
-			sliceVal = reflect.Append(sliceVal, newElem.Elem())
-			sliceVal = sliceVal.Slice(0, sliceVal.Cap())
-		}
-
-		currElem := sliceVal.Index(index).Addr().Interface()
-		if err = bson.UnmarshalWithRegistry(c.registry, doc, currElem); err != nil {
-			return sliceVal, index, err
-		}
-
-		index++
-	}
-
-	return sliceVal, index, nil
-}

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"reflect"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
@@ -128,3 +129,68 @@ func (c *Cursor) Err() error { return c.err }
 
 // Close closes this cursor.
 func (c *Cursor) Close(ctx context.Context) error { return c.bc.Close(ctx) }
+
+// All iterates the cursor and decodes each document into results.
+// The results parameter must be a pointer to a slice. The slice pointed to by results will be completely overwritten.
+// If the cursor has been iterated, any previously iterated documents will not be included in results.
+func (c *Cursor) All(ctx context.Context, results interface{}) error {
+	resultsVal := reflect.ValueOf(results)
+	if resultsVal.Kind() != reflect.Ptr {
+		return errors.New("results argument must be a pointer to a slice")
+	}
+
+	sliceVal := resultsVal.Elem()
+	elementType := sliceVal.Type().Elem()
+	var index int
+	var err error
+
+	batch := c.batch // exhaust the current batch before iterating the batch cursor
+	for {
+		sliceVal, index, err = c.addFromBatch(sliceVal, elementType, batch, index)
+		if err != nil {
+			return err
+		}
+
+		if !c.bc.Next(ctx) {
+			break
+		}
+
+		batch = c.bc.Batch()
+	}
+
+	if err = c.bc.Err(); err != nil {
+		return err
+	}
+
+	resultsVal.Elem().Set(sliceVal.Slice(0, index))
+	return nil
+}
+
+// addFromBatch adds all documents from batch to sliceVal starting at the given index. It returns the new slice value,
+// the next empty index in the slice, and an error if one occurs.
+func (c *Cursor) addFromBatch(sliceVal reflect.Value, elemType reflect.Type, batch *bsoncore.DocumentSequence,
+	index int) (reflect.Value, int, error) {
+
+	docs, err := batch.Documents()
+	if err != nil {
+		return sliceVal, index, err
+	}
+
+	for _, doc := range docs {
+		if sliceVal.Len() == index {
+			// slice is full
+			newElem := reflect.New(elemType)
+			sliceVal = reflect.Append(sliceVal, newElem.Elem())
+			sliceVal = sliceVal.Slice(0, sliceVal.Cap())
+		}
+
+		currElem := sliceVal.Index(index).Addr().Interface()
+		if err = bson.UnmarshalWithRegistry(c.registry, doc, currElem); err != nil {
+			return sliceVal, index, err
+		}
+
+		index++
+	}
+
+	return sliceVal, index, nil
+}

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -1,10 +1,137 @@
 package mongo
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+)
+
+type testBatchCursor struct {
+	batches []*bsoncore.DocumentSequence
+	batch   *bsoncore.DocumentSequence
+}
+
+func newTestBatchCursor(numBatches, batchSize int) *testBatchCursor {
+	batches := make([]*bsoncore.DocumentSequence, 0, numBatches)
+
+	counter := 0
+	for batch := 0; batch < numBatches; batch++ {
+		var docSequence []byte
+
+		for doc := 0; doc < batchSize; doc++ {
+			var elem []byte
+			elem = bsoncore.AppendInt32Element(elem, "foo", int32(counter))
+			counter++
+
+			var doc []byte
+			doc = bsoncore.BuildDocumentFromElements(doc, elem)
+			docSequence = append(docSequence, doc...)
+		}
+
+		batches = append(batches, &bsoncore.DocumentSequence{
+			Style: bsoncore.SequenceStyle,
+			Data:  docSequence,
+		})
+	}
+
+	return &testBatchCursor{
+		batches: batches,
+	}
+}
+
+func (tbc *testBatchCursor) ID() int64 {
+	if len(tbc.batches) == 0 {
+		return 0 // cursor exhausted
+	}
+
+	return 10
+}
+
+func (tbc *testBatchCursor) Next(context.Context) bool {
+	if len(tbc.batches) == 0 {
+		return false
+	}
+
+	tbc.batch = tbc.batches[0]
+	tbc.batches = tbc.batches[1:]
+	return true
+}
+
+func (tbc *testBatchCursor) Batch() *bsoncore.DocumentSequence {
+	return tbc.batch
+}
+
+func (tbc *testBatchCursor) Server() *topology.Server {
+	return nil
+}
+
+func (tbc *testBatchCursor) Err() error {
+	return nil
+}
+
+func (tbc *testBatchCursor) Close(context.Context) error {
+	return nil
+}
 
 func TestCursor(t *testing.T) {
 	t.Run("loops until docs available", func(t *testing.T) {})
 	t.Run("returns false on context cancellation", func(t *testing.T) {})
 	t.Run("returns false if error occurred", func(t *testing.T) {})
 	t.Run("returns false if ID is zero and no more docs", func(t *testing.T) {})
+
+	t.Run("TestAll", func(t *testing.T) {
+		t.Run("errors if argument is not pointer to slice", func(t *testing.T) {
+			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
+			require.Nil(t, err)
+			err = cursor.All(context.Background(), []bson.D{})
+			require.NotNil(t, err)
+		})
+
+		t.Run("fills slice with all documents", func(t *testing.T) {
+			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
+			require.Nil(t, err)
+
+			var docs []bson.D
+			err = cursor.All(context.Background(), &docs)
+			require.Nil(t, err)
+			require.Equal(t, 5, len(docs))
+
+			for index, doc := range docs {
+				require.Equal(t, doc, bson.D{{"foo", int32(index)}})
+			}
+		})
+
+		t.Run("decodes each document into slice type", func(t *testing.T) {
+			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
+			require.Nil(t, err)
+
+			type Document struct {
+				Foo int32 `bson:"foo"`
+			}
+			var docs []Document
+			err = cursor.All(context.Background(), &docs)
+			require.Nil(t, err)
+			require.Equal(t, 5, len(docs))
+
+			for index, doc := range docs {
+				require.Equal(t, doc, Document{Foo: int32(index)})
+			}
+		})
+
+		t.Run("multiple batches are included", func(t *testing.T) {
+			cursor, err := newCursor(newTestBatchCursor(2, 5), nil)
+			var docs []bson.D
+			err = cursor.All(context.Background(), &docs)
+			require.Nil(t, err)
+			require.Equal(t, 10, len(docs))
+
+			for index, doc := range docs {
+				require.Equal(t, doc, bson.D{{"foo", int32(index)}})
+			}
+		})
+	})
 }

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
@@ -82,56 +80,4 @@ func TestCursor(t *testing.T) {
 	t.Run("returns false on context cancellation", func(t *testing.T) {})
 	t.Run("returns false if error occurred", func(t *testing.T) {})
 	t.Run("returns false if ID is zero and no more docs", func(t *testing.T) {})
-
-	t.Run("TestAll", func(t *testing.T) {
-		t.Run("errors if argument is not pointer to slice", func(t *testing.T) {
-			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
-			require.Nil(t, err)
-			err = cursor.All(context.Background(), []bson.D{})
-			require.NotNil(t, err)
-		})
-
-		t.Run("fills slice with all documents", func(t *testing.T) {
-			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
-			require.Nil(t, err)
-
-			var docs []bson.D
-			err = cursor.All(context.Background(), &docs)
-			require.Nil(t, err)
-			require.Equal(t, 5, len(docs))
-
-			for index, doc := range docs {
-				require.Equal(t, doc, bson.D{{"foo", int32(index)}})
-			}
-		})
-
-		t.Run("decodes each document into slice type", func(t *testing.T) {
-			cursor, err := newCursor(newTestBatchCursor(1, 5), nil)
-			require.Nil(t, err)
-
-			type Document struct {
-				Foo int32 `bson:"foo"`
-			}
-			var docs []Document
-			err = cursor.All(context.Background(), &docs)
-			require.Nil(t, err)
-			require.Equal(t, 5, len(docs))
-
-			for index, doc := range docs {
-				require.Equal(t, doc, Document{Foo: int32(index)})
-			}
-		})
-
-		t.Run("multiple batches are included", func(t *testing.T) {
-			cursor, err := newCursor(newTestBatchCursor(2, 5), nil)
-			var docs []bson.D
-			err = cursor.All(context.Background(), &docs)
-			require.Nil(t, err)
-			require.Equal(t, 10, len(docs))
-
-			for index, doc := range docs {
-				require.Equal(t, doc, bson.D{{"foo", int32(index)}})
-			}
-		})
-	})
 }

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -60,4 +60,13 @@
 //
 // Additional examples can be found under the examples directory in the driver's repository and
 // on the MongoDB website.
+//
+// Potential DNS Issues
+//
+// Building with Go 1.11+ and using connection strings with the "mongodb+srv"[1] scheme is
+// incompatible with some DNS servers in the wild due to the change introduced in
+// https://github.com/golang/go/issues/10622. If you receive an error with the message "cannot
+// unmarshal DNS message" while running an operation, we suggest you use a different DNS server.
+//
+// [1] See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -35,12 +35,21 @@
 //    if err != nil { log.Fatal(err) }
 //    defer cur.Close(context.Background())
 //    for cur.Next(context.Background()) {
-//       raw, err := cur.DecodeBytes()
-//       if err != nil { log.Fatal(err) }
-//       // do something with elem....
+//      // To decode into a struct, use cursor.Decode()
+//      result := struct{
+//        Foo string
+//        Bar int32
+//      }{}
+//      err := cur.Decode(&result)
+//      if err != nil { log.Fatal(err) }
+//      // do something with result...
+//
+//      // To get the raw bson bytes use cursor.Current
+//      raw := cur.Current
+//      // do something with raw...
 //    }
 //    if err := cur.Err(); err != nil {
-//    		return err
+//      return err
 //    }
 //
 // Methods that only return a single document will return a *SingleResult, which works

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -41,6 +41,13 @@ func replaceErrors(err error) error {
 	if ce, ok := err.(command.Error); ok {
 		return CommandError{Code: ce.Code, Message: ce.Message, Labels: ce.Labels, Name: ce.Name}
 	}
+	if conv, ok := err.(driver.BulkWriteException); ok {
+		return BulkWriteException{
+			WriteConcernError: convertWriteConcernError(conv.WriteConcernError),
+			WriteErrors:       convertBulkWriteErrors(conv.WriteErrors),
+		}
+	}
+
 	return err
 }
 

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -354,7 +354,7 @@ func (b *Bucket) openDownloadStream(filter interface{}, opts ...*options.FindOpt
 	default:
 		fileLen = fileLenElem.Int64()
 	}
-	
+
 	if fileLen == 0 {
 		return newDownloadStream(nil, b.chunkSize, 0), nil
 	}

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -346,7 +347,14 @@ func (b *Bucket) openDownloadStream(filter interface{}, opts ...*options.FindOpt
 		return nil, err
 	}
 
-	fileLen := fileLenElem.Int64()
+	var fileLen int64
+	switch fileLenElem.Type {
+	case bsontype.Int32:
+		fileLen = int64(fileLenElem.Int32())
+	default:
+		fileLen = fileLenElem.Int64()
+	}
+	
 	if fileLen == 0 {
 		return newDownloadStream(nil, b.chunkSize, 0), nil
 	}

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -505,6 +505,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		if opt.ZlibLevel != nil {
 			c.ZlibLevel = opt.ZlibLevel
 		}
+		if opt.err != nil {
+			c.err = opt.err
+		}
 	}
 
 	return c

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -151,6 +151,18 @@ func TestClientOptions(t *testing.T) {
 				t.Errorf("Merged client options do not match. got %v; want %v", got, want)
 			}
 		})
+
+		// go-cmp dont support error comparisons (https://github.com/google/go-cmp/issues/24)
+		// Use specifique test for this
+		t.Run("MergeClientOptions/err", func(t *testing.T) {
+			opt1, opt2 := Client(), Client()
+			opt1.err = errors.New("Test error")
+
+			got := MergeClientOptions(nil, opt1, opt2)
+			if got.err.Error() != "Test error" {
+				t.Errorf("Merged client options do not match. got %v; want %v", got.err.Error(), opt1.err.Error())
+			}
+		})
 	})
 	t.Run("ApplyURI", func(t *testing.T) {
 		baseClient := func() *ClientOptions {

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -28,7 +28,7 @@ func TestClientOptions(t *testing.T) {
 	t.Run("ApplyURI/doesn't overwrite previous errors", func(t *testing.T) {
 		uri := "not-mongo-db-uri://"
 		want := internal.WrapErrorf(
-			errors.New(`scheme must be "mongodb" or "mongodb+srv"`), "error parsing uri (%s)", "not-mongo-db-uri://",
+			errors.New(`scheme must be "mongodb" or "mongodb+srv"`), "error parsing uri",
 		)
 		co := Client().ApplyURI(uri).ApplyURI("mongodb://localhost/")
 		got := co.Validate()
@@ -177,7 +177,7 @@ func TestClientOptions(t *testing.T) {
 				"ParseError",
 				"not-mongo-db-uri://",
 				&ClientOptions{err: internal.WrapErrorf(
-					errors.New(`scheme must be "mongodb" or "mongodb+srv"`), "error parsing uri (%s)", "not-mongo-db-uri://",
+					errors.New(`scheme must be "mongodb" or "mongodb+srv"`), "error parsing uri",
 				)},
 			},
 			{

--- a/mongo/sessions_test.go
+++ b/mongo/sessions_test.go
@@ -121,8 +121,6 @@ func createFuncMap(t *testing.T, dbName string, collName string, monitored bool)
 			res := coll.FindOneAndUpdate(mctx, emptyDoc, updateDoc)
 			return res.err
 		}},
-		{"DropCollection", coll, nil, func(mctx SessionContext) error { err := coll.Drop(mctx); return err }},
-		{"DropDatabase", coll, nil, func(mctx SessionContext) error { err := db.Drop(mctx); return err }},
 		{"ListCollections", coll, nil, func(mctx SessionContext) error { _, err := db.ListCollections(mctx, emptyDoc); return err }},
 		{"ListDatabases", coll, nil, func(mctx SessionContext) error { _, err := client.ListDatabases(mctx, emptyDoc); return err }},
 		{"CreateOneIndex", coll, nil, func(mctx SessionContext) error { _, err := iv.CreateOne(mctx, fooIndex); return err }},
@@ -130,6 +128,8 @@ func createFuncMap(t *testing.T, dbName string, collName string, monitored bool)
 		{"DropOneIndex", coll, &iv, func(mctx SessionContext) error { _, err := iv.DropOne(mctx, "barIndex"); return err }},
 		{"DropAllIndexes", coll, nil, func(mctx SessionContext) error { _, err := iv.DropAll(mctx); return err }},
 		{"ListIndexes", coll, nil, func(mctx SessionContext) error { _, err := iv.List(mctx); return err }},
+		{"DropCollection", coll, nil, func(mctx SessionContext) error { err := coll.Drop(mctx); return err }},
+		{"DropDatabase", coll, nil, func(mctx SessionContext) error { err := db.Drop(mctx); return err }},
 	}
 
 	return client, db, coll, functions

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -39,27 +39,11 @@ func (sr *SingleResult) Decode(v interface{}) error {
 	if sr.reg == nil {
 		return bson.ErrNilRegistry
 	}
-	switch {
-	case sr.rdr != nil:
-		if v == nil {
-			return nil
-		}
-		return bson.UnmarshalWithRegistry(sr.reg, sr.rdr, v)
-	case sr.cur != nil:
-		defer sr.cur.Close(context.TODO())
-		if !sr.cur.Next(context.TODO()) {
-			if err := sr.cur.Err(); err != nil {
-				return err
-			}
-			return ErrNoDocuments
-		}
-		if v == nil {
-			return nil
-		}
-		return sr.cur.Decode(v)
-	}
 
-	return ErrNoDocuments
+	if sr.err = sr.setRdrContents(); sr.err != nil {
+		return sr.err
+	}
+	return bson.UnmarshalWithRegistry(sr.reg, sr.rdr, v)
 }
 
 // DecodeBytes will return a copy of the document as a bson.Raw. If there was an
@@ -67,23 +51,37 @@ func (sr *SingleResult) Decode(v interface{}) error {
 // will be returned. If there were no returned documents, ErrNoDocuments is
 // returned.
 func (sr *SingleResult) DecodeBytes() (bson.Raw, error) {
+	if sr.err != nil {
+		return nil, sr.err
+	}
+
+	if sr.err = sr.setRdrContents(); sr.err != nil {
+		return nil, sr.err
+	}
+	return sr.rdr, nil
+}
+
+// setRdrContents will set the contents of rdr by iterating the underlying cursor if necessary.
+func (sr *SingleResult) setRdrContents() error {
 	switch {
 	case sr.err != nil:
-		return nil, sr.err
+		return sr.err
 	case sr.rdr != nil:
-		return sr.rdr, nil
+		return nil
 	case sr.cur != nil:
 		defer sr.cur.Close(context.TODO())
 		if !sr.cur.Next(context.TODO()) {
 			if err := sr.cur.Err(); err != nil {
-				return nil, err
+				return err
 			}
-			return nil, ErrNoDocuments
+
+			return ErrNoDocuments
 		}
-		return sr.cur.Current, nil
+		sr.rdr = sr.cur.Current
+		return nil
 	}
 
-	return nil, ErrNoDocuments
+	return ErrNoDocuments
 }
 
 // Err will return the error from the operation that created this SingleResult.

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -31,7 +31,7 @@ type SingleResult struct {
 // Decode will attempt to decode the first document into v. If there was an
 // error from the operation that created this SingleResult then the error
 // will be returned. If there were no returned documents, ErrNoDocuments is
-// returned.
+// returned. If v is nil or is a typed nil, an error will be returned.
 func (sr *SingleResult) Decode(v interface{}) error {
 	if sr.err != nil {
 		return sr.err

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo
+
+import (
+	"bytes"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSingleResult(t *testing.T) {
+	t.Run("TestDecode", func(t *testing.T) {
+		t.Run("DecodeTwice", func(t *testing.T) {
+			// Test that Decode and DecodeBytes can be called more than once
+			c, err := newCursor(newTestBatchCursor(1, 1), bson.DefaultRegistry)
+			if err != nil {
+				t.Fatalf("error creating cursor: %v", err)
+			}
+
+			sr := &SingleResult{cur: c, reg: bson.DefaultRegistry}
+			var firstDecode, secondDecode bson.Raw
+			if err = sr.Decode(&firstDecode); err != nil {
+				t.Fatalf("error on first Decode call: %v", err)
+			}
+			if err = sr.Decode(&secondDecode); err != nil {
+				t.Fatalf("error on second Decode call: %v", err)
+			}
+			decodeBytes, err := sr.DecodeBytes()
+			if err != nil {
+				t.Fatalf("error on DecodeBytes call: %v", err)
+			}
+
+			if !bytes.Equal(firstDecode, secondDecode) {
+				t.Fatalf("Decode contents do not match; first returned %v, second returned %v",
+					firstDecode, secondDecode)
+			}
+			if !bytes.Equal(firstDecode, decodeBytes) {
+				t.Fatalf("Decode and DecodeBytes contents do not match; Decode returned %v, DecodeBytes "+
+					"returned %v", firstDecode, decodeBytes)
+			}
+		})
+	})
+}

--- a/mongo/transactions_test.go
+++ b/mongo/transactions_test.go
@@ -142,7 +142,6 @@ func runTransactionTestFile(t *testing.T, filepath string) {
 
 func runTransactionsTestCase(t *testing.T, test *transTestCase, testfile transTestFile, dbAdmin *Database) {
 	t.Run(test.Description, func(t *testing.T) {
-
 		// kill sessions from previously failed tests
 		killSessions(t, dbAdmin.client)
 

--- a/version/version.go
+++ b/version/version.go
@@ -7,4 +7,4 @@
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.
-var Driver = "v1.0.0"
+var Driver = "v1.0.1"

--- a/version/version.go
+++ b/version/version.go
@@ -7,4 +7,4 @@
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.
-var Driver = "v1.0.1"
+var Driver = "v1.0.2+prerelease"

--- a/version/version.go
+++ b/version/version.go
@@ -7,4 +7,4 @@
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.
-var Driver = "v1.0.2+prerelease"
+var Driver = "v1.0.2"

--- a/version/version.go
+++ b/version/version.go
@@ -7,4 +7,4 @@
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.
-var Driver = "v1.0.2"
+var Driver = "v1.0.3+prerelease"

--- a/x/bsonx/bsoncore/document_sequence.go
+++ b/x/bsonx/bsoncore/document_sequence.go
@@ -83,9 +83,9 @@ func (ds *DocumentSequence) ResetIterator() {
 	ds.Pos = 0
 }
 
-// documents returns a slice of the documents. If nil either the Data field is also nil or could not
+// Documents returns a slice of the documents. If nil either the Data field is also nil or could not
 // be properly read.
-func (ds *DocumentSequence) documents() ([]Document, error) {
+func (ds *DocumentSequence) Documents() ([]Document, error) {
 	if ds == nil {
 		return nil, nil
 	}

--- a/x/bsonx/bsoncore/document_sequence.go
+++ b/x/bsonx/bsoncore/document_sequence.go
@@ -83,9 +83,9 @@ func (ds *DocumentSequence) ResetIterator() {
 	ds.Pos = 0
 }
 
-// Documents returns a slice of the documents. If nil either the Data field is also nil or could not
+// documents returns a slice of the documents. If nil either the Data field is also nil or could not
 // be properly read.
-func (ds *DocumentSequence) Documents() ([]Document, error) {
+func (ds *DocumentSequence) documents() ([]Document, error) {
 	if ds == nil {
 		return nil, nil
 	}

--- a/x/bsonx/bsoncore/document_sequence_test.go
+++ b/x/bsonx/bsoncore/document_sequence_test.go
@@ -103,7 +103,7 @@ func TestDocumentSequence(t *testing.T) {
 					Style: tc.style,
 					Data:  tc.data,
 				}
-				documents, err := ds.documents()
+				documents, err := ds.Documents()
 				if !cmp.Equal(documents, tc.documents) {
 					t.Errorf("Documents do not match. got %v; want %v", documents, tc.documents)
 				}
@@ -252,7 +252,7 @@ func TestDocumentSequence(t *testing.T) {
 					Style: tc.style,
 					Data:  tc.data,
 				}
-				docs, err := ds.documents()
+				docs, err := ds.Documents()
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -376,7 +376,7 @@ func TestDocumentSequence(t *testing.T) {
 		t.Run("Documents", func(t *testing.T) {
 			defer capturePanic()
 			var ds *DocumentSequence
-			_, _ = ds.documents()
+			_, _ = ds.Documents()
 		})
 		t.Run("Next", func(t *testing.T) {
 			defer capturePanic()

--- a/x/bsonx/bsoncore/document_sequence_test.go
+++ b/x/bsonx/bsoncore/document_sequence_test.go
@@ -103,7 +103,7 @@ func TestDocumentSequence(t *testing.T) {
 					Style: tc.style,
 					Data:  tc.data,
 				}
-				documents, err := ds.Documents()
+				documents, err := ds.documents()
 				if !cmp.Equal(documents, tc.documents) {
 					t.Errorf("Documents do not match. got %v; want %v", documents, tc.documents)
 				}
@@ -252,7 +252,7 @@ func TestDocumentSequence(t *testing.T) {
 					Style: tc.style,
 					Data:  tc.data,
 				}
-				docs, err := ds.Documents()
+				docs, err := ds.documents()
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -376,7 +376,7 @@ func TestDocumentSequence(t *testing.T) {
 		t.Run("Documents", func(t *testing.T) {
 			defer capturePanic()
 			var ds *DocumentSequence
-			_, _ = ds.Documents()
+			_, _ = ds.documents()
 		})
 		t.Run("Next", func(t *testing.T) {
 			defer capturePanic()

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -342,6 +342,13 @@ func (bc *BatchCursor) legacyGetMore(ctx context.Context) {
 	numToReturn := bc.batchSize
 	if bc.limit != 0 && bc.numReturned+bc.batchSize > bc.limit {
 		numToReturn = bc.limit - bc.numReturned
+		if numToReturn <= 0 {
+			err = bc.Close(ctx)
+			if err != nil {
+				bc.err = err
+			}
+			return
+		}
 	}
 	gm := wiremessage.GetMore{
 		FullCollectionName: bc.namespace.DB + "." + bc.namespace.Collection,

--- a/x/mongo/driver/bulk_write.go
+++ b/x/mongo/driver/bulk_write.go
@@ -90,6 +90,7 @@ func BulkWrite(
 		WriteErrors: make([]BulkWriteError, 0),
 	}
 
+	var lastErr error
 	var opIndex int64 // the operation index for the upsertedIDs map
 	continueOnError := !ordered
 	for _, batch := range batches {
@@ -109,16 +110,26 @@ func BulkWrite(
 
 		if !continueOnError && (err != nil || len(batchErr.WriteErrors) > 0 || batchErr.WriteConcernError != nil) {
 			if err != nil {
-				return result.BulkWrite{}, err
+				return bwRes, err
 			}
 
-			return result.BulkWrite{}, bwErr
+			return bwRes, bwErr
+		}
+
+		if err != nil {
+			lastErr = err
 		}
 
 		opIndex += int64(len(batch.models))
 	}
 
 	bwRes.MatchedCount -= bwRes.UpsertedCount
+	if lastErr != nil {
+		return bwRes, lastErr
+	}
+	if len(bwErr.WriteErrors) > 0 || bwErr.WriteConcernError != nil {
+		return bwRes, bwErr
+	}
 	return bwRes, nil
 }
 
@@ -225,8 +236,9 @@ func runInsert(
 		WriteConcern:    wc,
 	}
 
+	cmd.Opts = []bsonx.Elem{{"ordered", bsonx.Boolean(!continueOnError)}}
 	if bypassDocValidation != nil {
-		cmd.Opts = []bsonx.Elem{{"bypassDocumentValidation", bsonx.Boolean(*bypassDocValidation)}}
+		cmd.Opts = append(cmd.Opts, bsonx.Elem{"bypassDocumentValidation", bsonx.Boolean(*bypassDocValidation)})
 	}
 
 	if !retrySupported(topo, ss.Description(), cmd.Session, cmd.WriteConcern) || !retryWrite || !batch.canRetry {
@@ -295,6 +307,7 @@ func runDelete(
 		Clock:           clock,
 		WriteConcern:    wc,
 	}
+	cmd.Opts = []bsonx.Elem{{"ordered", bsonx.Boolean(!continueOnError)}}
 
 	if !retrySupported(topo, ss.Description(), cmd.Session, cmd.WriteConcern) || !retryWrite || !batch.canRetry {
 		if cmd.Session != nil {
@@ -366,9 +379,11 @@ func runUpdate(
 		Clock:           clock,
 		WriteConcern:    wc,
 	}
+
+	cmd.Opts = []bsonx.Elem{{"ordered", bsonx.Boolean(!continueOnError)}}
 	if bypassDocValidation != nil {
 		// TODO this is temporary!
-		cmd.Opts = []bsonx.Elem{{"bypassDocumentValidation", bsonx.Boolean(*bypassDocValidation)}}
+		cmd.Opts = append(cmd.Opts, bsonx.Elem{"bypassDocumentValidation", bsonx.Boolean(*bypassDocValidation)})
 		//cmd.Opts = []option.UpdateOptioner{option.OptBypassDocumentValidation(bypassDocValidation)}
 	}
 

--- a/x/mongo/driver/bulk_write.go
+++ b/x/mongo/driver/bulk_write.go
@@ -164,6 +164,7 @@ func runBatch(
 
 		batchRes.InsertedCount = int64(res.N)
 		writeErrors = res.WriteErrors
+		batchErr.WriteConcernError = res.WriteConcernError
 	case DeleteOneModel, DeleteManyModel:
 		res, err := runDelete(ctx, ns, topo, selector, ss, sess, clock, wc, retryWrite, batch, continueOnError, registry)
 		if err != nil {
@@ -172,6 +173,7 @@ func runBatch(
 
 		batchRes.DeletedCount = int64(res.N)
 		writeErrors = res.WriteErrors
+		batchErr.WriteConcernError = res.WriteConcernError
 	case ReplaceOneModel, UpdateOneModel, UpdateManyModel:
 		res, err := runUpdate(ctx, ns, topo, selector, ss, sess, clock, wc, retryWrite, batch, bypassDocValidation,
 			continueOnError, registry)
@@ -183,6 +185,7 @@ func runBatch(
 		batchRes.ModifiedCount = res.ModifiedCount
 		batchRes.UpsertedCount = int64(len(res.Upserted))
 		writeErrors = res.WriteErrors
+		batchErr.WriteConcernError = res.WriteConcernError
 		for _, upsert := range res.Upserted {
 			batchRes.UpsertedIDs[upsert.Index] = upsert.ID
 		}

--- a/x/mongo/driver/find.go
+++ b/x/mongo/driver/find.go
@@ -113,7 +113,13 @@ func Find(
 		cmd.Opts = append(cmd.Opts, hintElem)
 	}
 	if fo.Limit != nil {
-		cmd.Opts = append(cmd.Opts, bsonx.Elem{"limit", bsonx.Int64(*fo.Limit)})
+		limit := *fo.Limit
+		if limit < 0 {
+			cmd.Opts = append(cmd.Opts, bsonx.Elem{"singleBatch", bsonx.Boolean(true)})
+			limit = -1 * limit
+		}
+
+		cmd.Opts = append(cmd.Opts, bsonx.Elem{"limit", bsonx.Int64(limit)})
 	}
 	if fo.Max != nil {
 		maxElem, err := interfaceToElement("max", fo.Max, registry)

--- a/x/mongo/driver/kill_cursors.go
+++ b/x/mongo/driver/kill_cursors.go
@@ -32,7 +32,7 @@ func KillCursors(
 	}
 	defer conn.Close()
 
-	if desc.WireVersion.Max < 4 {
+	if desc.WireVersion == nil || desc.WireVersion.Max < 4 {
 		return result.KillCursors{}, legacyKillCursors(ctx, ns, cursorID, conn)
 	}
 

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -60,7 +60,7 @@ func (sc *sconn) processErr(err error) {
 		return
 	}
 
-	ne, ok := err.(connection.NetworkError)
+	ne, ok := err.(connection.Error)
 	if !ok {
 		return
 	}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -33,7 +33,7 @@ func (n netErr) Temporary() bool {
 }
 
 type connect struct {
-	err *connection.NetworkError
+	err *connection.Error
 }
 
 func (c connect) WriteWireMessage(ctx context.Context, wm wiremessage.WireMessage) error {
@@ -58,7 +58,7 @@ func (c connect) ID() string {
 // Test case for sconn processErr
 func TestConnectionProcessErrSpec(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewServer(address.Address("localhost"))
+	s, err := NewServer(address.Address("localhost"), nil)
 	require.NoError(t, err)
 
 	desc := s.Description()
@@ -67,7 +67,7 @@ func TestConnectionProcessErrSpec(t *testing.T) {
 	s.connectionstate = connected
 
 	innerErr := netErr{}
-	connectErr := connection.NetworkError{"blah", innerErr}
+	connectErr := connection.Error{ConnectionID: "blah", Wrapped: innerErr}
 	c := connect{&connectErr}
 	sc := sconn{c, s, 1}
 	err = sc.WriteWireMessage(ctx, nil)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -516,7 +516,7 @@ func (s *Server) String() string {
 		str += fmt.Sprintf(", Tag sets: %s", desc.Tags)
 	}
 	if connState == connected {
-		str += fmt.Sprintf(", Avergage RTT: %d", desc.AverageRTT)
+		str += fmt.Sprintf(", Average RTT: %d", desc.AverageRTT)
 	}
 	if desc.LastError != nil {
 		str += fmt.Sprintf(", Last error: %s", desc.LastError)

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -74,7 +74,7 @@ func TestServer(t *testing.T) {
 
 	for _, tt := range serverTestTable {
 		t.Run(tt.name, func(t *testing.T) {
-			s, err := NewServer(address.Address("localhost"))
+			s, err := NewServer(address.Address("localhost"), nil)
 			require.NoError(t, err)
 
 			var desc *description.Server
@@ -103,7 +103,7 @@ func TestServer(t *testing.T) {
 		})
 	}
 	t.Run("WriteConcernError", func(t *testing.T) {
-		s, err := NewServer(address.Address("localhost"))
+		s, err := NewServer(address.Address("localhost"), nil)
 		require.NoError(t, err)
 
 		var desc *description.Server
@@ -127,7 +127,7 @@ func TestServer(t *testing.T) {
 		require.Equal(t, drained, true)
 	})
 	t.Run("no WriteConcernError", func(t *testing.T) {
-		s, err := NewServer(address.Address("localhost"))
+		s, err := NewServer(address.Address("localhost"), nil)
 		require.NoError(t, err)
 
 		var desc *description.Server
@@ -147,5 +147,13 @@ func TestServer(t *testing.T) {
 		// pool should not be drained
 		drained := s.pool.(*pool).drainCalled.Load().(bool)
 		require.Equal(t, drained, false)
+	})
+	t.Run("update topology", func(t *testing.T) {
+		var updated bool
+		s, err := NewServer(address.Address("localhost"), func(description.Server) { updated = true })
+		require.NoError(t, err)
+		s.updateDescription(description.Server{Addr: s.address}, false)
+		require.True(t, updated)
+
 	})
 }

--- a/x/network/connstring/connstring.go
+++ b/x/network/connstring/connstring.go
@@ -26,7 +26,7 @@ func Parse(s string) (ConnString, error) {
 	var p parser
 	err := p.parse(s)
 	if err != nil {
-		err = internal.WrapErrorf(err, "error parsing uri (%s)", s)
+		err = internal.WrapErrorf(err, "error parsing uri")
 	}
 	return p.ConnString, err
 }

--- a/x/network/examples/server_monitoring/main.go
+++ b/x/network/examples/server_monitoring/main.go
@@ -21,6 +21,7 @@ func main() {
 	s, err := topology.ConnectServer(
 		context.Background(),
 		address.Address("localhost:27017"),
+		nil,
 		topology.WithHeartbeatInterval(func(time.Duration) time.Duration { return 2 * time.Second }),
 		topology.WithConnectionOptions(
 			func(opts ...connection.Option) []connection.Option {

--- a/x/network/integration/aggregate_test.go
+++ b/x/network/integration/aggregate_test.go
@@ -118,7 +118,7 @@ func TestCommandAggregate(t *testing.T) {
 	t.Run("MaxTime", func(t *testing.T) {
 		t.Skip("max time is flaky on the server")
 
-		server, err := topology.ConnectServer(context.Background(), address.Address(*host))
+		server, err := topology.ConnectServer(context.Background(), address.Address(*host), nil)
 		noerr(t, err)
 		conn, err := server.Connection(context.Background())
 		noerr(t, err)

--- a/x/network/integration/command_test.go
+++ b/x/network/integration/command_test.go
@@ -31,7 +31,7 @@ func TestCommand(t *testing.T) {
 	}
 	t.Parallel()
 
-	server, err := topology.ConnectServer(context.Background(), address.Address(*host), serveropts(t)...)
+	server, err := topology.ConnectServer(context.Background(), address.Address(*host), nil, serveropts(t)...)
 	noerr(t, err)
 
 	ctx := context.Background()

--- a/x/network/integration/server_test.go
+++ b/x/network/integration/server_test.go
@@ -31,7 +31,7 @@ func TestTopologyServer(t *testing.T) {
 	}
 
 	t.Run("After close, should not return new connection", func(t *testing.T) {
-		s, err := topology.ConnectServer(context.Background(), address.Address(*host), serveropts(t)...)
+		s, err := topology.ConnectServer(context.Background(), address.Address(*host), nil, serveropts(t)...)
 		noerr(t, err)
 		err = s.Disconnect(context.TODO())
 		noerr(t, err)
@@ -43,7 +43,7 @@ func TestTopologyServer(t *testing.T) {
 	t.Run("Shouldn't be able to get more than max connections", func(t *testing.T) {
 		t.Parallel()
 
-		s, err := topology.ConnectServer(context.Background(), address.Address(*host),
+		s, err := topology.ConnectServer(context.Background(), address.Address(*host), nil,
 			serveropts(
 				t,
 				topology.WithMaxConnections(func(uint16) uint16 { return 2 }),
@@ -83,7 +83,7 @@ func TestTopologyServer(t *testing.T) {
 		t.Run("Write network timeout", func(t *testing.T) {})
 	})
 	t.Run("Close should close all subscription channels", func(t *testing.T) {
-		s, err := topology.ConnectServer(context.Background(), address.Address(*host), serveropts(t)...)
+		s, err := topology.ConnectServer(context.Background(), address.Address(*host), nil, serveropts(t)...)
 		noerr(t, err)
 
 		var done1, done2 = make(chan struct{}), make(chan struct{})
@@ -124,7 +124,7 @@ func TestTopologyServer(t *testing.T) {
 		}
 	})
 	t.Run("Subscribe after Close should return an error", func(t *testing.T) {
-		s, err := topology.ConnectServer(context.Background(), address.Address(*host), serveropts(t)...)
+		s, err := topology.ConnectServer(context.Background(), address.Address(*host), nil, serveropts(t)...)
 		noerr(t, err)
 
 		sub, err := s.Subscribe()
@@ -142,7 +142,7 @@ func TestTopologyServer(t *testing.T) {
 	})
 	t.Run("Disconnect", func(t *testing.T) {
 		t.Run("cannot disconnect before connecting", func(t *testing.T) {
-			s, err := topology.NewServer(address.Address(*host), serveropts(t)...)
+			s, err := topology.NewServer(address.Address(*host), nil, serveropts(t)...)
 			noerr(t, err)
 
 			got := s.Disconnect(context.TODO())
@@ -151,7 +151,7 @@ func TestTopologyServer(t *testing.T) {
 			}
 		})
 		t.Run("cannot disconnect twice", func(t *testing.T) {
-			s, err := topology.NewServer(address.Address(*host), serveropts(t)...)
+			s, err := topology.NewServer(address.Address(*host), nil, serveropts(t)...)
 			noerr(t, err)
 			err = s.Connect(context.TODO())
 			noerr(t, err)
@@ -168,7 +168,7 @@ func TestTopologyServer(t *testing.T) {
 		t.Run("all open sockets should be closed after disconnect", func(t *testing.T) {
 			d := newdialer(&net.Dialer{})
 			s, err := topology.NewServer(
-				address.Address(*host),
+				address.Address(*host), nil,
 				serveropts(
 					t,
 					topology.WithConnectionOptions(func(opts ...connection.Option) []connection.Option {
@@ -203,7 +203,7 @@ func TestTopologyServer(t *testing.T) {
 	})
 	t.Run("Connect", func(t *testing.T) {
 		t.Run("can reconnect a disconnected server", func(t *testing.T) {
-			s, err := topology.NewServer(address.Address(*host), serveropts(t)...)
+			s, err := topology.NewServer(address.Address(*host), nil, serveropts(t)...)
 			noerr(t, err)
 			err = s.Connect(context.TODO())
 			noerr(t, err)
@@ -214,7 +214,7 @@ func TestTopologyServer(t *testing.T) {
 			noerr(t, err)
 		})
 		t.Run("cannot connect multiple times without disconnect", func(t *testing.T) {
-			s, err := topology.NewServer(address.Address(*host), serveropts(t)...)
+			s, err := topology.NewServer(address.Address(*host), nil, serveropts(t)...)
 			noerr(t, err)
 			err = s.Connect(context.TODO())
 			noerr(t, err)
@@ -229,7 +229,7 @@ func TestTopologyServer(t *testing.T) {
 			}
 		})
 		t.Run("can disconnect and reconnect multiple times", func(t *testing.T) {
-			s, err := topology.NewServer(address.Address(*host), serveropts(t)...)
+			s, err := topology.NewServer(address.Address(*host), nil, serveropts(t)...)
 			noerr(t, err)
 			err = s.Connect(context.TODO())
 			noerr(t, err)


### PR DESCRIPTION
I think that the method in the errors file is rewritten as a pointer object. I don't know if it is intentionally designed as a value object. I can't use type assertions when judging the type of error, such as: if err==err.(*CommandError){ domething.. ..}, only switch err.(type){case xxx:.......}.