### PR TITLE
GODRIVER-1158 Enhance Decimal128 and fix bug

### DIFF
--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -290,11 +290,7 @@ var (
 // ParseDecimal128FromBigInt attempts to parse the given significand and exponent into a valid Decimal128 value.
 func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	//copy
-	if bi == nil {
-		bi = new(big.Int)
-	} else {
-		bi = new(big.Int).Set(bi)
-	}
+	bi = new(big.Int).Set(bi)
 
 	q := new(big.Int)
 	r := new(big.Int)

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -11,8 +11,14 @@ package primitive
 
 import (
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
+)
+
+const (
+	MaxDecimal128Exp = 6111
+	MinDecimal128Exp = -6176
 )
 
 // Decimal128 holds decimal128 BSON values.
@@ -25,7 +31,7 @@ func NewDecimal128(h, l uint64) Decimal128 {
 	return Decimal128{h: h, l: l}
 }
 
-// GetBytes returns the underlying bytes of the BSON decimal value as two uint16 values. The first
+// GetBytes returns the underlying bytes of the BSON decimal value as two uint64 values. The first
 // contains the most first 8 bytes of the value and the second contains the latter.
 func (d Decimal128) GetBytes() (uint64, uint64) {
 	return d.h, d.l
@@ -52,13 +58,13 @@ func (d Decimal128) String() string {
 	if d.h>>61&3 == 3 {
 		// Bits: 1*sign 2*ignored 14*exponent 111*significand.
 		// Implicit 0b100 prefix in significand.
-		e = int(d.h>>47&(1<<14-1)) - 6176
+		e = int(d.h>>47&(1<<14-1)) + MinDecimal128Exp
 		//h = 4<<47 | d.h&(1<<47-1)
 		// Spec says all of these values are out of range.
 		h, l = 0, 0
 	} else {
 		// Bits: 1*sign 14*exponent 113*significand
-		e = int(d.h>>49&(1<<14-1)) - 6176
+		e = int(d.h>>49&(1<<14-1)) + MinDecimal128Exp
 		h = d.h & (1<<49 - 1)
 	}
 
@@ -114,6 +120,80 @@ Loop:
 	return string(repr[last+pos:])
 }
 
+// BigInt returns significand as big.Int and exponent, bi * 10 ^ exp.
+func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
+	h, l := d.GetBytes()
+	var pos int // positive sign
+
+	if h>>63&1 == 0 {
+		pos = 1
+	}
+
+	switch h >> 58 & (1<<5 - 1) {
+	case 0x1F:
+		return nil, 0, fmt.Errorf("cannot parse NaN as a *big.Int")
+	case 0x1E:
+		return nil, 0, fmt.Errorf("cannot parse %s as a *big.Int", "-Infinity"[pos:])
+	}
+
+	if h>>61&3 == 3 {
+		// Bits: 1*sign 2*ignored 14*exponent 111*significand.
+		// Implicit 0b100 prefix in significand.
+		exp = int(h>>47&(1<<14-1)) + MinDecimal128Exp
+		//h = 4<<47 | d.h&(1<<47-1)
+		// Spec says all of these values are out of range.
+		h, l = 0, 0
+	} else {
+		// Bits: 1*sign 14*exponent 113*significand
+		exp = int(h>>49&(1<<14-1)) + MinDecimal128Exp
+		h = h & (1<<49 - 1)
+	}
+
+	// Would be handled by the logic below, but that's trivial and common.
+	if h == 0 && l == 0 && exp == 0 {
+		if pos == 1 {
+			return new(big.Int), 0, nil
+		}
+		return new(big.Int), 0, nil
+	}
+
+	bi = big.NewInt(0)
+	const host32bit = ^uint(0)>>32 == 0
+	if host32bit {
+		bi.SetBits([]big.Word{big.Word(l), big.Word(l >> 32), big.Word(h), big.Word(h >> 32)})
+	} else {
+		bi.SetBits([]big.Word{big.Word(l), big.Word(h)})
+	}
+
+	if pos == 0 {
+		return bi.Neg(bi), exp, nil
+	}
+	return
+}
+
+// IsNaN returns whether d is NaN.
+func (d Decimal128) IsNaN() bool {
+	return d.h>>58&(1<<5-1) == 0x1F
+}
+
+// IsInf returns:
+//
+//   +1 d == Infinity
+//    0 other case
+//   -1 d == -Infinity
+//
+func (d Decimal128) IsInf() int {
+	if d.h>>58&(1<<5-1) != 0x1E {
+		return 0
+	}
+
+	if d.h>>63&1 == 0 {
+		return 1
+	} else {
+		return -1
+	}
+}
+
 func divmod(h, l uint64, div uint32) (qh, ql uint64, rem uint32) {
 	div64 := uint64(div)
 	a := h >> 32
@@ -139,7 +219,7 @@ func dErr(s string) (Decimal128, error) {
 	return dNaN, fmt.Errorf("cannot parse %q as a decimal128", s)
 }
 
-//ParseDecimal128 takes the given string and attempts to parse it into a valid
+// ParseDecimal128 takes the given string and attempts to parse it into a valid
 // Decimal128 value.
 func ParseDecimal128(s string) (Decimal128, error) {
 	orig := s
@@ -250,10 +330,10 @@ func ParseDecimal128(s string) (Decimal128, error) {
 			n = -n
 		}
 		e += n
-		for e < -6176 {
+		for e < MinDecimal128Exp {
 			// Subnormal.
 			var div uint32 = 1
-			for div < 1e9 && e < -6176 {
+			for div < 1e9 && e < MinDecimal128Exp {
 				div *= 10
 				e++
 			}
@@ -263,10 +343,10 @@ func ParseDecimal128(s string) (Decimal128, error) {
 				return dErr(orig)
 			}
 		}
-		for e > 6111 {
+		for e > MaxDecimal128Exp {
 			// Clamped.
 			var mul uint32 = 1
-			for mul < 1e9 && e > 6111 {
+			for mul < 1e9 && e > MaxDecimal128Exp {
 				mul *= 10
 				e--
 			}
@@ -275,7 +355,7 @@ func ParseDecimal128(s string) (Decimal128, error) {
 				return dErr(orig)
 			}
 		}
-		if e < -6176 || e > 6111 {
+		if e < MinDecimal128Exp || e > MaxDecimal128Exp {
 			return dErr(orig)
 		}
 	}
@@ -284,7 +364,7 @@ func ParseDecimal128(s string) (Decimal128, error) {
 		return dErr(orig)
 	}
 
-	h |= uint64(e+6176) & uint64(1<<14-1) << 49
+	h |= uint64(e-MinDecimal128Exp) & uint64(1<<14-1) << 49
 	if neg {
 		h |= 1 << 63
 	}
@@ -304,4 +384,64 @@ func muladd(h, l uint64, mul uint32, add uint32) (resh, resl uint64, overflow ui
 	d = d&(1<<32-1) + c>>32
 
 	return (d<<32 | c&(1<<32-1)), (b<<32 | a&(1<<32-1)), uint32(d >> 32)
+}
+
+var (
+	ten  = big.NewInt(10)
+	zero = new(big.Int)
+	maxS = new(big.Int).SetBytes([]byte{0x1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}) // 14 bits
+)
+
+// ParseDecimal128FromBigInt attempts to parse the given significand and exponent into a valid Decimal128 value.
+func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
+	//copy
+	bi = new(big.Int).Set(bi)
+
+	q := new(big.Int)
+	r := new(big.Int)
+
+	for bi.CmpAbs(maxS) == 1 {
+		bi, _ = q.QuoRem(bi, ten, r)
+		if r.Cmp(zero) != 0 {
+			return Decimal128{}, false
+		}
+		exp++
+		if exp > MaxDecimal128Exp {
+			return Decimal128{}, false
+		}
+	}
+
+	for exp < MinDecimal128Exp {
+		// Subnormal.
+		bi, _ = q.QuoRem(bi, ten, r)
+		if r.Cmp(zero) != 0 {
+			return Decimal128{}, false
+		}
+		exp++
+	}
+	for exp > MaxDecimal128Exp {
+		// Clamped.
+		bi.Mul(bi, ten)
+		if bi.CmpAbs(maxS) == 1 {
+			return Decimal128{}, false
+		}
+		exp--
+	}
+
+	b := bi.Bytes()
+	var h, l uint64
+	for i := 0; i < len(b); i++ {
+		if i < len(b)-8 {
+			h = h<<8 | uint64(b[i])
+		} else {
+			l = l<<8 | uint64(b[i])
+		}
+	}
+
+	h |= uint64(exp-MinDecimal128Exp) & uint64(1<<14-1) << 49
+	if bi.Sign() == -1 {
+		h |= 1 << 63
+	}
+
+	return Decimal128{h: h, l: l}, true
 }

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -280,7 +280,11 @@ var (
 // ParseDecimal128FromBigInt attempts to parse the given significand and exponent into a valid Decimal128 value.
 func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	//copy
-	bi = new(big.Int).Set(bi)
+	if bi == nil {
+		bi = new(big.Int)
+	} else {
+		bi = new(big.Int).Set(bi)
+	}
 
 	q := new(big.Int)
 	r := new(big.Int)

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -66,22 +66,8 @@ var bigIntTestCases = []bigIntTestCase{
 	{s: "99999999999999999999999999999.99999", h: 3474506263649159104, l: 4003012203950112767, bi: bi9_34, exp: -5},
 	{s: "-99999999999999999999999999999.99999", h: 12697878300503934912, l: 4003012203950112767, bi: biN9_34, exp: -5},
 
-	{s: "10384593717069655257060992658440191", h: 0x3041ffffffffffff, l: 1<<64 - 1, bi: biMaxS},
-	{s: "-10384593717069655257060992658440191", h: 0xb041ffffffffffff, l: 1<<64 - 1, bi: biNMaxS},
-
-	{s: "1.0384593717069655257060992658440191E+6145", h: 0x5fffffffffffffff, l: 1<<64 - 1, bi: biMaxS, exp: MaxDecimal128Exp},
-	{s: "-1.0384593717069655257060992658440191E+6145", h: 0xdfffffffffffffff, l: 1<<64 - 1, bi: biNMaxS, exp: MaxDecimal128Exp},
-	{s: "1.0384593717069655257060992658440191E-6142", h: 0x1ffffffffffff, l: 1<<64 - 1, bi: biMaxS, exp: MinDecimal128Exp},
-	{s: "-1.0384593717069655257060992658440191E-6142", h: 0x8001ffffffffffff, l: 1<<64 - 1, bi: biNMaxS, exp: MinDecimal128Exp},
-
-	{s: "1.0384593717069655257060992658440191E+6145", remark: "rounding", h: 0x5fffffffffffffff, l: 1<<64 - 1, bi: new(big.Int).Mul(biMaxS, ten), exp: MaxDecimal128Exp - 1},
-	{s: "-1.0384593717069655257060992658440191E+6145", remark: "rounding", h: 0xdfffffffffffffff, l: 1<<64 - 1, bi: new(big.Int).Mul(biNMaxS, ten), exp: MaxDecimal128Exp - 1},
-
 	{s: "1.038459371706965525706099265844019E-6143", remark: "subnormal", h: 0x333333333333, l: 0x3333333333333333, bi: parseBigInt("10384593717069655257060992658440190"), exp: MinDecimal128Exp - 1},
 	{s: "-1.038459371706965525706099265844019E-6143", remark: "subnormal", h: 0x8000333333333333, l: 0x3333333333333333, bi: parseBigInt("-10384593717069655257060992658440190"), exp: MinDecimal128Exp - 1},
-
-	{s: "1.0384593717069655257060992658440190E+6145", remark: "clamped", h: 0x5fffffffffffffff, l: 1<<64 - 2, bi: parseBigInt("1038459371706965525706099265844019"), exp: MaxDecimal128Exp + 1},
-	{s: "-1.0384593717069655257060992658440190E+6145", remark: "clamped", h: 0xdfffffffffffffff, l: 1<<64 - 2, bi: parseBigInt("-1038459371706965525706099265844019"), exp: MaxDecimal128Exp + 1},
 
 	{s: "rounding overflow 1", remark: "overflow", bi: parseBigInt("103845937170696552570609926584401910"), exp: MaxDecimal128Exp},
 	{s: "rounding overflow 2", remark: "overflow", bi: parseBigInt("103845937170696552570609926584401910"), exp: MaxDecimal128Exp},
@@ -137,8 +123,6 @@ func TestParseDecimal128FromBigInt(t *testing.T) {
 func TestParseDecimal128(t *testing.T) {
 	cases := append(bigIntTestCases,
 		[]bigIntTestCase{
-			{s: "0.10000000000000000000000000000000000000000000", h: 0x2ffbed09bead87c0, l: 0x378d8e6400000000},
-			{s: "-000001.0000000000000000000000000000000000000000000", h: 0xaffded09bead87c0, l: 0x378d8e6400000000},
 			{s: "-0001231.453454000000565600000000E-21", h: 0xafe6000003faa269, l: 0x81cfeceaabdb1800},
 			{s: "12345E+21", h: 0x306a000000000000, l: 12345},
 			{s: "0.10000000000000000000000000000000000000000001", remark: "parse fail"},

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -142,6 +142,9 @@ func TestParseDecimal128(t *testing.T) {
 			{s: "-0001231.453454000000565600000000E-21", h: 0xafe6000003faa269, l: 0x81cfeceaabdb1800},
 			{s: "12345E+21", h: 0x306a000000000000, l: 12345},
 			{s: "0.10000000000000000000000000000000000000000001", remark: "parse fail"},
+			{s: ".125e1", h: 0x303c000000000000, l: 125},
+			{s: ".125", h: 0x303a000000000000, l: 125},
+			{s: "", remark: "parse fail"},
 		}...)
 	for _, c := range cases {
 		switch c.remark {

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -1,0 +1,135 @@
+package primitive
+
+import (
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+type bigIntTestCase struct {
+	s string
+
+	h uint64
+	l uint64
+
+	bi  *big.Int
+	exp int
+
+	remark string
+}
+
+func parseBigInt(s string) *big.Int {
+	bi, _ := new(big.Int).SetString(s, 10)
+	return bi
+}
+
+var (
+	one = big.NewInt(1)
+
+	biMaxS  = new(big.Int).SetBytes([]byte{0x1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	biNMaxS = new(big.Int).Neg(biMaxS)
+
+	biOverflow  = new(big.Int).Add(biMaxS, one)
+	biNOverflow = new(big.Int).Neg(biOverflow)
+
+	bi12345  = parseBigInt("12345")
+	biN12345 = parseBigInt("-12345")
+
+	bi9_14  = parseBigInt("90123456789012")
+	biN9_14 = parseBigInt("-90123456789012")
+
+	bi9_34  = parseBigInt("9999999999999999999999999999999999")
+	biN9_34 = parseBigInt("-9999999999999999999999999999999999")
+)
+
+var bigIntTestCases = []bigIntTestCase{
+	{s: "12345", h: 0x3040000000000000, l: 12345, bi: bi12345},
+	{s: "-12345", h: 0xB040000000000000, l: 12345, bi: biN12345},
+
+	{s: "90123456.789012", h: 0x3034000000000000, l: 90123456789012, bi: bi9_14, exp: -6},
+	{s: "-90123456.789012", h: 0xB034000000000000, l: 90123456789012, bi: biN9_14, exp: -6},
+	{s: "9.0123456789012E+22", h: 0x3052000000000000, l: 90123456789012, bi: bi9_14, exp: 9},
+	{s: "-9.0123456789012E+22", h: 0xB052000000000000, l: 90123456789012, bi: biN9_14, exp: 9},
+	{s: "9.0123456789012E-8", h: 0x3016000000000000, l: 90123456789012, bi: bi9_14, exp: -21},
+	{s: "-9.0123456789012E-8", h: 0xB016000000000000, l: 90123456789012, bi: biN9_14, exp: -21},
+
+	{s: "9999999999999999999999999999999999", h: 3477321013416265664, l: 4003012203950112767, bi: bi9_34},
+	{s: "-9999999999999999999999999999999999", h: 12700693050271041472, l: 4003012203950112767, bi: biN9_34},
+	{s: "0.9999999999999999999999999999999999", h: 3458180714999941056, l: 4003012203950112767, bi: bi9_34, exp: -34},
+	{s: "-0.9999999999999999999999999999999999", h: 12681552751854716864, l: 4003012203950112767, bi: biN9_34, exp: -34},
+	{s: "99999999999999999.99999999999999999", h: 3467750864208103360, l: 4003012203950112767, bi: bi9_34, exp: -17},
+	{s: "-99999999999999999.99999999999999999", h: 12691122901062879168, l: 4003012203950112767, bi: biN9_34, exp: -17},
+	{s: "9.999999999999999999999999999999999E+35", h: 3478446913323108288, l: 4003012203950112767, bi: bi9_34, exp: 2},
+	{s: "-9.999999999999999999999999999999999E+35", h: 12701818950177884096, l: 4003012203950112767, bi: biN9_34, exp: 2},
+	{s: "9.999999999999999999999999999999999E+40", h: 3481261663090214848, l: 4003012203950112767, bi: bi9_34, exp: 7},
+	{s: "-9.999999999999999999999999999999999E+40", h: 12704633699944990656, l: 4003012203950112767, bi: biN9_34, exp: 7},
+	{s: "99999999999999999999999999999.99999", h: 3474506263649159104, l: 4003012203950112767, bi: bi9_34, exp: -5},
+	{s: "-99999999999999999999999999999.99999", h: 12697878300503934912, l: 4003012203950112767, bi: biN9_34, exp: -5},
+
+	{s: "10384593717069655257060992658440191", h: 0x3041ffffffffffff, l: 1<<64 - 1, bi: biMaxS},
+	{s: "-10384593717069655257060992658440191", h: 0xb041ffffffffffff, l: 1<<64 - 1, bi: biNMaxS},
+
+	{s: "1.0384593717069655257060992658440191E+6145", h: 0x5fffffffffffffff, l: 1<<64 - 1, bi: biMaxS, exp: MaxDecimal128Exp},
+	{s: "-1.0384593717069655257060992658440191E+6145", h: 0xdfffffffffffffff, l: 1<<64 - 1, bi: biNMaxS, exp: MaxDecimal128Exp},
+	{s: "1.0384593717069655257060992658440191E-6142", h: 0x1ffffffffffff, l: 1<<64 - 1, bi: biMaxS, exp: MinDecimal128Exp},
+	{s: "-1.0384593717069655257060992658440191E-6142", h: 0x8001ffffffffffff, l: 1<<64 - 1, bi: biNMaxS, exp: MinDecimal128Exp},
+
+	{s: "1.0384593717069655257060992658440191E+6145", remark: "rounding", h: 0x5fffffffffffffff, l: 1<<64 - 1, bi: new(big.Int).Mul(biMaxS, ten), exp: MaxDecimal128Exp - 1},
+	{s: "-1.0384593717069655257060992658440191E+6145", remark: "rounding", h: 0xdfffffffffffffff, l: 1<<64 - 1, bi: new(big.Int).Mul(biNMaxS, ten), exp: MaxDecimal128Exp - 1},
+
+	{s: "1.038459371706965525706099265844019E-6143", remark: "subnormal", h: 0x333333333333, l: 0x3333333333333333, bi: parseBigInt("10384593717069655257060992658440190"), exp: MinDecimal128Exp - 1},
+	{s: "-1.038459371706965525706099265844019E-6143", remark: "subnormal", h: 0x8000333333333333, l: 0x3333333333333333, bi: parseBigInt("-10384593717069655257060992658440190"), exp: MinDecimal128Exp - 1},
+
+	{s: "1.0384593717069655257060992658440190E+6145", remark: "clamped", h: 0x5fffffffffffffff, l: 1<<64 - 2, bi: parseBigInt("1038459371706965525706099265844019"), exp: MaxDecimal128Exp + 1},
+	{s: "-1.0384593717069655257060992658440190E+6145", remark: "clamped", h: 0xdfffffffffffffff, l: 1<<64 - 2, bi: parseBigInt("-1038459371706965525706099265844019"), exp: MaxDecimal128Exp + 1},
+
+	{s: "rounding overflow 1", remark: "overflow", bi: parseBigInt("103845937170696552570609926584401910"), exp: MaxDecimal128Exp},
+	{s: "rounding overflow 2", remark: "overflow", bi: parseBigInt("103845937170696552570609926584401910"), exp: MaxDecimal128Exp},
+
+	{s: "subnormal overflow 1", remark: "overflow", bi: biMaxS, exp: MinDecimal128Exp - 1},
+	{s: "subnormal overflow 2", remark: "overflow", bi: biNMaxS, exp: MinDecimal128Exp - 1},
+
+	{s: "clamped overflow 1", remark: "overflow", bi: biMaxS, exp: MaxDecimal128Exp + 1},
+	{s: "clamped overflow 2", remark: "overflow", bi: biNMaxS, exp: MaxDecimal128Exp + 1},
+
+	{s: "biMaxS+1 overflow", remark: "overflow", bi: biOverflow, exp: MaxDecimal128Exp},
+	{s: "biNMaxS-1 overflow", remark: "overflow", bi: biNOverflow, exp: MaxDecimal128Exp},
+
+	{s: "NaN", h: 0x7c00000000000000, l: 0, remark: "NaN"},
+	{s: "Infinity", h: 0x7800000000000000, l: 0, remark: "Infinity"},
+	{s: "-Infinity", h: 0xf800000000000000, l: 0, remark: "-Infinity"},
+}
+
+func TestDecimal128_BigInt(t *testing.T) {
+	for _, c := range bigIntTestCases {
+		switch c.remark {
+		case "NaN", "Infinity", "-Infinity":
+			d128 := NewDecimal128(c.h, c.l)
+			_, _, err := d128.BigInt()
+			require.Error(t, err, "case %s", c.s)
+		case "":
+			d128 := NewDecimal128(c.h, c.l)
+			bi, e, err := d128.BigInt()
+			require.NoError(t, err, "case %s", c.s)
+			require.Equal(t, 0, c.bi.Cmp(bi), "case %s e:%s a:%s", c.s, c.bi.String(), bi.String())
+			require.Equal(t, c.exp, e, "case %s", c.s, d128.String())
+		}
+	}
+}
+
+func TestParseDecimal128FromBigInt(t *testing.T) {
+	for _, c := range bigIntTestCases {
+		switch c.remark {
+		case "overflow":
+			d128, ok := ParseDecimal128FromBigInt(c.bi, c.exp)
+			require.Equal(t, false, ok, "case %s %s", c.s, d128.String(), c.remark)
+		case "", "rounding", "subnormal", "clamped":
+			d128, ok := ParseDecimal128FromBigInt(c.bi, c.exp)
+			require.Equal(t, true, ok, "case %s", c.s)
+			require.Equal(t, c.s, d128.String(), "case %s", c.s)
+
+			require.Equal(t, c.h, d128.h, "case %s", c.s, d128.l)
+			require.Equal(t, c.l, d128.l, "case %s", c.s, d128.h)
+		}
+	}
+}

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -133,3 +133,27 @@ func TestParseDecimal128FromBigInt(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDecimal128(t *testing.T) {
+	cases := append(bigIntTestCases,
+		[]bigIntTestCase{
+			{s: "0.10000000000000000000000000000000000000000000", h: 0x2ffbed09bead87c0, l: 0x378d8e6400000000},
+			{s: "-000001.0000000000000000000000000000000000000000000", h: 0xaffded09bead87c0, l: 0x378d8e6400000000},
+			{s: "-0001231.453454000000565600000000E-21", h: 0xafe6000003faa269, l: 0x81cfeceaabdb1800},
+			{s: "12345E+21", h: 0x306a000000000000, l: 12345},
+			{s: "0.10000000000000000000000000000000000000000001", remark: "parse fail"},
+		}...)
+	for _, c := range cases {
+		switch c.remark {
+		case "overflow", "parse fail":
+			_, err := ParseDecimal128(c.s)
+			require.Error(t, err)
+		case "", "rounding", "subnormal", "clamped", "NaN", "Infinity", "-Infinity":
+			d128, err := ParseDecimal128(c.s)
+			require.NoError(t, err)
+
+			require.Equal(t, c.h, d128.h, "case %s", c.s, d128.l)
+			require.Equal(t, c.l, d128.l, "case %s", c.s, d128.h)
+		}
+	}
+}


### PR DESCRIPTION
Enhance Decimal128 with support parse from or to big.Int. Refactor ParseDecimal128 base on math/big to fix boundary bug like "-NaN","10384593717069655257060992658440191"