### PR TITLE
GODRIVER-1135  bson decode 0x09 flag data to time.Time

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -78,6 +78,24 @@ func TestNonNullTimeRoundTrip(t *testing.T) {
 	if !cmp.Equal(val, rtval) {
 		t.Errorf("Did not round trip properly. got %v; want %v", val, rtval)
 	}
+
+	beforeTimeVal := time.Now()
+	beforeTimeMap := map[string]interface{}{"ts": beforeTimeVal}
+	before, err := Marshal(beforeTimeMap)
+	noerr(t, err)
+
+	afterTimeMap := map[string]interface{}{}
+	err = Unmarshal(before, &afterTimeMap)
+	noerr(t, err)
+	afterTime, ok := afterTimeMap["ts"].(time.Time)
+	if !ok {
+		t.Errorf("after time format error. after time info:%#v", afterTimeMap)
+		return
+	}
+	if afterTime.Unix() != beforeTimeVal.Unix() {
+		t.Errorf("after time not equal before time. befere:%#v, after:%#v", beforeTimeVal.UnixNano(), afterTime.UnixNano())
+		return
+	}
 }
 
 func TestD(t *testing.T) {

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -88,7 +88,8 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterTypeMapEntry(bsontype.Undefined, tUndefined).
 		RegisterTypeMapEntry(bsontype.ObjectID, tOID).
 		RegisterTypeMapEntry(bsontype.Boolean, tBool).
-		RegisterTypeMapEntry(bsontype.DateTime, tDateTime).
+		//decode 0x09 to time.Time, not primitive.DateTime.
+		RegisterTypeMapEntry(bsontype.DateTime, tTime).
 		RegisterTypeMapEntry(bsontype.Regex, tRegex).
 		RegisterTypeMapEntry(bsontype.DBPointer, tDBPointer).
 		RegisterTypeMapEntry(bsontype.JavaScript, tJavaScript).


### PR DESCRIPTION

### feature
-  bson decode 0x09 to time.Time



### description:

- reason:
 bson encode time.Time format data,  decode is not time.Time format, but double type data.

- achieve:

bson.Encode time.Time to  primitive.DateTime. (data type flag:0x09)

bson.Decode  data type flag 0x09 to time.Time  

