### PR TITLE
Handle null strings

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -315,6 +315,8 @@ func (dvd DefaultValueDecoders) StringDecodeValue(dctx DecodeContext, vr bsonrw.
 		if err != nil {
 			return err
 		}
+	case bsontype.Null:
+		str = ""
 	default:
 		return fmt.Errorf("cannot decode %v into a string type", vr.Type())
 	}


### PR DESCRIPTION
Right now, trying to decode a null from a document into a string will return a `cannot decode null into a string type`. While converting a null to an empty string is not ideal, it has the fewer downsides: it makes decoding more resilient, and is not that different from decoding undefined into an empty string.

I tried to add in a test, but I'll admit I'm having trouble understanding the test structure, and I couldn't find any test for the StringDecodeValue in `default_value_decoders_test.go` anyway. Sorry about that.