### PR TITLE
readme: fix missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.0"
 To get started with the driver, import the `mongo` package, create a `mongo.Client`:
 
 ```go
-import "go.mongodb.org/mongo-driver/mongo"
+import (
+    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/mongo/options"
+)
 
 client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
 ```


### PR DESCRIPTION
If I follow the very first snippet in the Usage section, this is what I'll get:
```
$ go build
./main.go:12:36: undefined: options
```

This PR fixes the import statement to include the `options` module.