### PR TITLE
Fix Linux make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 
 .PHONY: check-fmt
 check-fmt:
-	@gofmt -l -s $(PKGS) | read; if [ $$? == 0 ]; then echo "gofmt check failed for:"; gofmt -l -s $(PKGS) | sed -e 's/^/ - /'; exit 1; fi
+	etc/check_fmt.sh $(PKGS)
 
 .PHONY: fmt
 fmt:

--- a/etc/check_env.sh
+++ b/etc/check_env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [[ ! $TOPOLOGY =~ ^(server|replica_set|sharded_cluster)$ ]]; then
     >&2 echo "Invalid value of TOPOLOGY. TOPOLOGY must be set to one of: server, replica_set, sharded_cluster"

--- a/etc/check_fmt.sh
+++ b/etc/check_fmt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+gofmt_out="$(gofmt -l -s "$@")"
+
+if [[ $gofmt_out ]]; then
+  echo "gofmt check failed for:";
+  sed -e 's/^/ - /' <<< "$gofmt_out";
+  exit 1;
+fi


### PR DESCRIPTION
Hi, I was speaking with @divjotarora during GopherCon and decided that I would try fixing the Makefile on Linux, since I ran into this issue before and I know one other person did too (forgot his name).

This fixes the issue with `check_env.sh` using `bash`-specific syntax on `sh`. This only works on OS X because OS X does not actually _have_ `sh`, it has `bash` that is linked as `sh`. On Linux systems, `sh` exists and does not support the full `bash` language.

I've also fixed essentially the same problem in some in-line shell script in the Makefile, which by default on Linux will probably run via GNU Make, which runs `sh` by default.

Thank you!

P.S. A subset of the Evergreen tasks are [here](https://evergreen.mongodb.com/version/5d3d32b80ae6067c15bb6a22).