### PR TITLE
Fixes unexpected Panic from invalid JSON payloads

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -101,7 +101,10 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 	var err error
 	switch len(b) {
 	case 12:
-		copy(id[:], b)
+		_, err := hex.Decode(buf[:], b)
+		if err != nil {
+			return err
+		}
 	default:
 		// Extended JSON
 		var res interface{}

--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -101,8 +101,7 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 	var err error
 	switch len(b) {
 	case 12:
-		_, err := hex.Decode(buf[:], b)
-		if err != nil {
+		if _, err := hex.Decode(buf[:], b); err != nil {
 			return err
 		}
 	default:

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -11,6 +11,7 @@ import (
 
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -147,4 +148,19 @@ func TestCounterOverflow(t *testing.T) {
 	objectIDCounter = 0xFFFFFFFF
 	NewObjectID()
 	require.Equal(t, uint32(0), objectIDCounter)
+}
+
+func TestInvalid12BytesJSON(t *testing.T) {
+	p := map[string]interface{}{
+		"id": map[string]interface{}{
+			"$oid": 123,
+		},
+	}
+
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	expected := "encoding/hex: invalid byte: U+007B '{'"
+	err := json.Unmarshal(b, &struct{}{})
+	require.Equal(t, expected, err)
 }

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -161,6 +161,6 @@ func TestInvalid12BytesJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := "encoding/hex: invalid byte: U+007B '{'"
-	err := json.Unmarshal(b, &struct{}{})
+	err := json.Unmarshal(b, &struct{ ID ObjectID }{})
 	require.Equal(t, expected, err)
 }


### PR DESCRIPTION
I ran across an unexpected panic. As the code is currently written, if a JSON payload is unmarshalled with an invalid 12 byte objectId, a panic occurs. I found this with an invalid extended JSON which happened to be 12 bytes. A panic should never occur due to a JSON payload. This PR returns an error instead. See the test case I added for an example