### PR TITLE
Don't mutate inputs in `DiffTopology` or `Topology.DiffHostlist`.

### DIFF
--- a/x/mongo/driver/description/topology_test.go
+++ b/x/mongo/driver/description/topology_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) MongoDB, Inc. 2019-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package description
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffTopology(t *testing.T) {
+	s1 := Server{Addr: "1.0.0.0:27017"}
+	s2 := Server{Addr: "2.0.0.0:27017"}
+	s3 := Server{Addr: "3.0.0.0:27017"}
+	s4 := Server{Addr: "4.0.0.0:27017"}
+	s5 := Server{Addr: "5.0.0.0:27017"}
+	s6 := Server{Addr: "6.0.0.0:27017"}
+
+	t1 := Topology{
+		Servers: []Server{s6, s1, s3, s2},
+	}
+	t2 := Topology{
+		Servers: []Server{s2, s4, s3, s5},
+	}
+
+	diff := DiffTopology(t1, t2)
+
+	assert.ElementsMatch(t, []Server{s4, s5}, diff.Added)
+	assert.ElementsMatch(t, []Server{s1, s6}, diff.Removed)
+
+	// Ensure that original topology servers were not reordered.
+	assert.EqualValues(t, []Server{s6, s1, s3, s2}, t1.Servers)
+	assert.EqualValues(t, []Server{s2, s4, s3, s5}, t2.Servers)
+}
+
+func TestTopology_DiffHostlist(t *testing.T) {
+	h1 := "1.0.0.0:27017"
+	h2 := "2.0.0.0:27017"
+	h3 := "3.0.0.0:27017"
+	h4 := "4.0.0.0:27017"
+	h5 := "5.0.0.0:27017"
+	h6 := "6.0.0.0:27017"
+	s1 := Server{Addr: "1.0.0.0:27017"}
+	s2 := Server{Addr: "2.0.0.0:27017"}
+	s3 := Server{Addr: "3.0.0.0:27017"}
+	s6 := Server{Addr: "6.0.0.0:27017"}
+
+	topo := Topology{
+		Servers: []Server{s6, s1, s3, s2},
+	}
+	hostlist := []string{h2, h4, h3, h5}
+
+	diff := topo.DiffHostlist(hostlist)
+
+	assert.ElementsMatch(t, []string{h4, h5}, diff.Added)
+	assert.ElementsMatch(t, []string{h1, h6}, diff.Removed)
+
+	// Ensure that original topology servers and hostlist were not reordered.
+	assert.EqualValues(t, []Server{s6, s1, s3, s2}, topo.Servers)
+	assert.EqualValues(t, []string{h2, h4, h3, h5}, hostlist)
+}

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -108,14 +108,17 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 		t.Fatalf("Number of hosts in topology does not match expected value. Got %v; want %v.", len(received), len(expected))
 	}
 
-	actual := serverSorter(received)
+	// Take a copy of servers so we don't risk a data race similar to GODRIVER-1301.
+	servers := make([]description.Server, len(received))
+	copy(servers, received)
+	actual := serverSorter(servers)
 	sort.Sort(actual)
 	sort.Strings(expected)
 
-	for i := range received {
-		if received[i].Addr.String() != expected[i] {
+	for i := range servers {
+		if servers[i].Addr.String() != expected[i] {
 			t.Errorf("Hosts in topology differ from expected values. Got %v; want %v.",
-				received[i].Addr.String(), expected[i])
+				servers[i].Addr.String(), expected[i])
 		}
 	}
 }


### PR DESCRIPTION
GODRIVER-1301

One caveat is that this does not return added/removed servers in sorted ordered.  Neither of these functions were documented to do so, and afaict nothing in the driver actually requires that.  Similarly, since inputs are no longer sorted, I assume that topology servers will also not be sorted.