### PR TITLE
Lock `serversLock` in `Topology.String`.

### DIFF
--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -610,6 +610,8 @@ func (t *Topology) addServer(addr address.Address) error {
 func (t *Topology) String() string {
 	desc := t.Description()
 	str := fmt.Sprintf("Type: %s\nServers:\n", desc.Kind)
+	t.serversLock.Lock()
+	defer t.serversLock.Unlock()
 	for _, s := range t.servers {
 		str += s.String() + "\n"
 	}


### PR DESCRIPTION
GODRIVER-1302

The test for this seems slightly silly, but does reproduce the race with `go test -race`.