### PR TITLE
Update evergreen config to test compilation with go1.9.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -739,13 +739,13 @@ tasks:
             targets: "build"
             BUILD_ENV: "PATH=/opt/golang/go1.9/bin:$PATH GOROOT=/opt/golang/go1.9"
 
-    - name: go1.8-build-nocgo
+    - name: go1.9-build-nocgo
       tags: ["compile-check"]
       commands:
         - func: run-make
           vars:
             targets: "build"
-            BUILD_ENV: "CGO_ENABLED=0 PATH=/opt/golang/go1.8/bin:$PATH GOROOT=/opt/golang/go1.8"
+            BUILD_ENV: "CGO_ENABLED=0 PATH=/opt/golang/go1.9/bin:$PATH GOROOT=/opt/golang/go1.9"
 
     - name: go1.10-build
       tags: ["compile-check"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -731,13 +731,13 @@ tasks:
           vars:
             MONGO_GO_DRIVER_COMPRESSOR: "snappy"
 
-    - name: go1.8-build
+    - name: go1.9-build
       tags: ["compile-check"]
       commands:
         - func: run-make
           vars:
             targets: "build"
-            BUILD_ENV: "PATH=/opt/golang/go1.8/bin:$PATH GOROOT=/opt/golang/go1.8"
+            BUILD_ENV: "PATH=/opt/golang/go1.9/bin:$PATH GOROOT=/opt/golang/go1.9"
 
     - name: go1.8-build-nocgo
       tags: ["compile-check"]


### PR DESCRIPTION
We already successfully compile with go1.9, so there's no code changes needed. This PR updates our Evergreen config to test compilation on go1.9 instead of go1.8.