### PR TITLE
fix uint32 encode.

### DIFF
--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -149,12 +149,13 @@ func (dve DefaultValueEncoders) IntEncodeValue(ec EncodeContext, vw bsonrw.Value
 
 // UintEncodeValue is the ValueEncoderFunc for uint types.
 func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
-	switch val.Kind() {
+	valKind := val.Kind()
+	switch valKind {
 	case reflect.Uint8, reflect.Uint16:
 		return vw.WriteInt32(int32(val.Uint()))
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		u64 := val.Uint()
-		if ec.MinSize && u64 <= math.MaxInt32 {
+		if (ec.MinSize || valKind <= reflect.Uint32) && u64 <= math.MaxInt32 {
 			return vw.WriteInt32(int32(u64))
 		}
 		if u64 > math.MaxInt64 {


### PR DESCRIPTION
When encode a uint32 type, it will got NumberLong() in bson.



for example
```golang
type Data struct {
	Number uint32 `bson:"Number"`
}

func TestBson(t *testing.T) {
	data := &Data{
		Number: 100,
	}
	byteData, _ := bson.Marshal(data)
	fmt.Println(byteData)

	var after = &Data{}
	bson.Unmarshal(byteData, after)
	fmt.Printf("%d\n", after.Number)
}
```

Output is :
[21 0 0 0 18 78 117 109 98 101 114 0 100 0 0 0 0 0 0 0 0]

According to this description: http://bsonspec.org/spec.html
18 = "\x12", it means 64-bit integer type


so, the more right output should be:
[17 0 0 0 16 78 117 109 98 101 114 0 100 0 0 0 0]