### PR TITLE
Improve clarity of incomplete read error message

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -243,7 +243,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 	if err != nil {
 		// We closeConnection the connection because we don't know if there are other bytes left to read.
 		c.close()
-		return nil, ConnectionError{ConnectionID: c.id, Wrapped: err, message: "unable to decode message length"}
+		return nil, ConnectionError{ConnectionID: c.id, Wrapped: err, message: "incomplete read of message header"}
 	}
 
 	// read the length as an int32
@@ -262,7 +262,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 	if err != nil {
 		// We closeConnection the connection because we don't know if there are other bytes left to read.
 		c.close()
-		return nil, ConnectionError{ConnectionID: c.id, Wrapped: err, message: "unable to read full message"}
+		return nil, ConnectionError{ConnectionID: c.id, Wrapped: err, message: "incomplete read of full message"}
 	}
 
 	c.bumpIdleDeadline()

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -259,7 +259,7 @@ func TestConnection(t *testing.T) {
 			})
 			t.Run("Read (size)", func(t *testing.T) {
 				err := errors.New("Read error")
-				want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "unable to decode message length"}
+				want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "incomplete read of message header"}
 				tnc := &testNetConn{readerr: err}
 				conn := &connection{id: "foobar", nc: tnc, connected: connected}
 				_, got := conn.readWireMessage(context.Background(), []byte{})
@@ -272,7 +272,7 @@ func TestConnection(t *testing.T) {
 			})
 			t.Run("Read (wire message)", func(t *testing.T) {
 				err := errors.New("Read error")
-				want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "unable to read full message"}
+				want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "incomplete read of full message"}
 				tnc := &testNetConn{readerr: err, buf: []byte{0x11, 0x00, 0x00, 0x00}}
 				conn := &connection{id: "foobar", nc: tnc, connected: connected}
 				_, got := conn.readWireMessage(context.Background(), []byte{})


### PR DESCRIPTION
Previously, the error message for being unable to read a document was
confusing because it mentioned "decoding" when no such decoding was
occuring.  E.g.:

> unable to decode message length: read tcp 10.148.11.183:42418->63.35.244.142:27017: i/o timeout

This commit changes this and a related message to clarify that the
problem is an incomplete read, either of the message header or the full
message.  (These terms are also not quite accurate, but are likely to be
better-understood by end-users reading the message.)  After the change,
the message above would appear as follows:

> incomplete read of message header: read tcp 10.148.11.183:42418->63.35.244.142:27017: i/o timeout