### PR TITLE
Remove usages of CmpAbs

### DIFF
--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -359,15 +359,15 @@ func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	return Decimal128{h: h, l: l}, true
 }
 
-// computes big.Int.Cmp(absoluteValue(x), absouteValue(y))
+// bigIntCmpAbs computes big.Int.Cmp(absoluteValue(x), absoluteValue(y)).
 func bigIntCmpAbs(x, y *big.Int) int {
 	xAbs := bigIntAbsValue(x)
 	yAbs := bigIntAbsValue(y)
 	return xAbs.Cmp(yAbs)
 }
 
-// returns a big.Int containing the absolute value of b
-// if b is already a non-negative number, it is returned without any changes or copies
+// bigIntAbsValue returns a big.Int containing the absolute value of b.
+// If b is already a non-negative number, it is returned without any changes or copies.
 func bigIntAbsValue(b *big.Int) *big.Int {
 	if b.Sign() >= 0 {
 		return b // already positive

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -313,7 +313,7 @@ func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	q := new(big.Int)
 	r := new(big.Int)
 
-	for bi.CmpAbs(maxS) == 1 {
+	for bigIntCmpAbs(bi, maxS) == 1 {
 		bi, _ = q.QuoRem(bi, ten, r)
 		if r.Cmp(zero) != 0 {
 			return Decimal128{}, false
@@ -335,7 +335,7 @@ func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	for exp > MaxDecimal128Exp {
 		// Clamped.
 		bi.Mul(bi, ten)
-		if bi.CmpAbs(maxS) == 1 {
+		if bigIntCmpAbs(bi, maxS) == 1 {
 			return Decimal128{}, false
 		}
 		exp--
@@ -357,4 +357,20 @@ func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	}
 
 	return Decimal128{h: h, l: l}, true
+}
+
+// computes big.Int.Comp(absoluteValue(x), absouteValue(y))
+func bigIntCmpAbs(x, y *big.Int) int {
+	xAbs := bigIntAbsValue(x)
+	yAbs := bigIntAbsValue(y)
+	return xAbs.Cmp(yAbs)
+}
+
+// returns a big.Int containing the absolute value of b
+// if b is already a non-negative number, it is returned without any changes or copies
+func bigIntAbsValue(b *big.Int) *big.Int {
+	if b.Sign() >= 0 {
+		return b // already positive
+	}
+	return new(big.Int).Abs(b)
 }

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -359,7 +359,7 @@ func ParseDecimal128FromBigInt(bi *big.Int, exp int) (Decimal128, bool) {
 	return Decimal128{h: h, l: l}, true
 }
 
-// computes big.Int.Comp(absoluteValue(x), absouteValue(y))
+// computes big.Int.Cmp(absoluteValue(x), absouteValue(y))
 func bigIntCmpAbs(x, y *big.Int) int {
 	xAbs := bigIntAbsValue(x)
 	yAbs := bigIntAbsValue(y)


### PR DESCRIPTION
The PR for GODRIVER-1158 used the `big.Int.CmpAbs` function, which compares the absolute value of 2 `big.Int` instances. This function is only available for go1.10, so this PR removes uses of that function to maintain go1.9 compatibility.