### PR TITLE
GODRIVER-1369 Resync retryable reads tests for listIndexNames

### DIFF
--- a/data/retryable-reads/listIndexNames.json
+++ b/data/retryable-reads/listIndexNames.json
@@ -30,7 +30,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }
@@ -61,7 +61,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }
@@ -69,7 +69,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }
@@ -104,7 +104,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }
@@ -136,7 +136,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }
@@ -144,7 +144,7 @@
         {
           "command_started_event": {
             "command": {
-              "listIndexNames": "coll"
+              "listIndexes": "coll"
             },
             "database_name": "retryable-reads-tests"
           }

--- a/data/retryable-reads/listIndexNames.yml
+++ b/data/retryable-reads/listIndexNames.yml
@@ -22,7 +22,7 @@ tests:
             -  &retryable_command_started_event
                 command_started_event:
                     command:
-                        listIndexNames: *collection_name
+                        listIndexes: *collection_name
                     database_name: *database_name
     -
         description: "ListIndexNames succeeds on second attempt"


### PR DESCRIPTION
We don't run these tests as we don't have a `ListIndexNames` helper but I figured it's worth doing this ticket anyway so we're in sync with the specs repo.