### PR TITLE
GODRIVER-1368 Add GoDoc examples for client side encryption

### DIFF
--- a/mongo/client_side_encryption_examples_test.go
+++ b/mongo/client_side_encryption_examples_test.go
@@ -1,0 +1,129 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func Example_clientSideEncryption() {
+	// This would have to be the same master key that was used to create the encryption key
+	localKey := make([]byte, 96)
+	if _, err := rand.Read(localKey); err != nil {
+		log.Fatal(err)
+	}
+	kmsProviders := map[string]map[string]interface{}{
+		"local": {
+			"key": localKey,
+		},
+	}
+	keyVaultNamespace := "admin.datakeys"
+
+	uri := "mongodb://localhost:27017"
+	autoEncryptionOpts := options.AutoEncryption().
+		SetKeyVaultNamespace(keyVaultNamespace).
+		SetKmsProviders(kmsProviders)
+	clientOpts := options.Client().ApplyURI(uri).SetAutoEncryptionOptions(autoEncryptionOpts)
+	client, err := Connect(context.TODO(), clientOpts)
+	if err != nil {
+		log.Fatalf("Connect error: %v", err)
+	}
+	defer client.Disconnect(context.TODO())
+
+	collection := client.Database("test").Collection("coll")
+	if err := collection.Drop(context.TODO()); err != nil {
+		log.Fatalf("Collection.Drop error: %v", err)
+	}
+
+	if _, err = collection.InsertOne(context.TODO(), bson.D{{"encryptedField", "123456789"}}); err != nil {
+		log.Fatalf("InsertOne error: %v", err)
+	}
+	res, err := collection.FindOne(context.TODO(), bson.D{}).DecodeBytes()
+	if err != nil {
+		log.Fatalf("FindOne error: %v", err)
+	}
+	fmt.Println(res)
+}
+
+func Example_clientSideEncryptionCreateKey() {
+	keyVaultNamespace := "admin.datakeys"
+	uri := "mongodb://localhost:27017"
+	// kmsProviders would have to be populated with the correct KMS provider information before it's used
+	var kmsProviders map[string]map[string]interface{}
+
+	// Create Client and ClientEncryption
+	clientEncryptionOpts := options.ClientEncryption().
+		SetKeyVaultNamespace(keyVaultNamespace).
+		SetKmsProviders(kmsProviders)
+	keyVaultClient, err := Connect(context.TODO(), options.Client().ApplyURI(uri))
+	if err != nil {
+		log.Fatalf("Connect error for keyVaultClient: %v", err)
+	}
+	clientEnc, err := NewClientEncryption(keyVaultClient, clientEncryptionOpts)
+	if err != nil {
+		log.Fatalf("NewClientEncryption error: %v", err)
+	}
+	defer clientEnc.Close(context.TODO()) // this will disconnect the keyVaultClient as well
+
+	// Create a new data key and encode it as base64
+	dataKeyID, err := clientEnc.CreateDataKey(context.TODO(), "local")
+	if err != nil {
+		log.Fatalf("CreateDataKey error: %v", err)
+	}
+	dataKeyBase64 := base64.StdEncoding.EncodeToString(dataKeyID.Data)
+
+	// Create a JSON schema using the new data key. This schema could also be written in a separate file and read in
+	// using I/O functions.
+	schema := `{
+		"properties": {
+			"encryptedField": {
+				"encrypt": {
+					"keyId": [{
+						"$binary": {
+							"base64": "%s",
+							"subType": "04"
+						}
+					}],
+					"bsonType": "string",
+					"algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+				}
+			}
+		},
+		"bsonType": "object"
+	}`
+	schema = fmt.Sprintf(schema, dataKeyBase64)
+	var schemaDoc bson.Raw
+	if err = bson.UnmarshalExtJSON([]byte(schema), true, &schemaDoc); err != nil {
+		log.Fatalf("UnmarshalExtJSON error: %v", err)
+	}
+
+	// Configure a Client with auto encryption using the new schema
+	dbName := "test"
+	collName := "coll"
+	schemaMap := map[string]interface{}{
+		dbName + collName: schemaDoc,
+	}
+	autoEncryptionOpts := options.AutoEncryption().
+		SetKmsProviders(kmsProviders).
+		SetKeyVaultNamespace(keyVaultNamespace).
+		SetSchemaMap(schemaMap)
+	client, err := Connect(context.TODO(), options.Client().ApplyURI(uri).SetAutoEncryptionOptions(autoEncryptionOpts))
+	if err != nil {
+		log.Fatalf("Connect error for encrypted client: %v", err)
+	}
+
+	// Use client for operations.
+
+	_ = client.Disconnect(context.TODO())
+}

--- a/mongo/client_side_encryption_examples_test.go
+++ b/mongo/client_side_encryption_examples_test.go
@@ -39,7 +39,11 @@ func Example_clientSideEncryption() {
 	if err != nil {
 		log.Fatalf("Connect error: %v", err)
 	}
-	defer client.Disconnect(context.TODO())
+	defer func() {
+		if err = client.Disconnect(context.TODO()); err != nil {
+			log.Fatalf("Disconnect error: %v", err)
+		}
+	}()
 
 	collection := client.Database("test").Collection("coll")
 	if err := collection.Drop(context.TODO()); err != nil {
@@ -74,7 +78,12 @@ func Example_clientSideEncryptionCreateKey() {
 	if err != nil {
 		log.Fatalf("NewClientEncryption error: %v", err)
 	}
-	defer clientEnc.Close(context.TODO()) // this will disconnect the keyVaultClient as well
+	defer func() {
+		// this will disconnect the keyVaultClient as well
+		if err = clientEnc.Close(context.TODO()); err != nil {
+			log.Fatalf("Close error: %v", err)
+		}
+	}()
 
 	// Create a new data key and encode it as base64
 	dataKeyID, err := clientEnc.CreateDataKey(context.TODO(), "local")
@@ -125,5 +134,7 @@ func Example_clientSideEncryptionCreateKey() {
 
 	// Use client for operations.
 
-	_ = client.Disconnect(context.TODO())
+	if err = client.Disconnect(context.TODO()); err != nil {
+		log.Fatalf("Disconnect error: %v", err)
+	}
 }

--- a/mongo/client_side_encryption_examples_test.go
+++ b/mongo/client_side_encryption_examples_test.go
@@ -112,7 +112,7 @@ func Example_clientSideEncryptionCreateKey() {
 	dbName := "test"
 	collName := "coll"
 	schemaMap := map[string]interface{}{
-		dbName + collName: schemaDoc,
+		dbName + "." + collName: schemaDoc,
 	}
 	autoEncryptionOpts := options.AutoEncryption().
 		SetKmsProviders(kmsProviders).

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -113,7 +113,8 @@
 //    }
 //    aeo.SetExtraOptions(mongocryptdOpts)
 // To specify a process URI for mongocryptd, the "mongocryptdURI" option can be passed in the ExtraOptions map as well.
-// More information about mongocryptd will soon be available from the official documentation.
+// More information about mongocryptd will soon be available from the official documentation. See the
+// ClientSideEncryption and ClientSideEncryptionCreateKey examples below for code samples about using this feature.
 //
 // [1] See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -79,7 +79,8 @@
 //
 // Client Side Encryption
 //
-// Client-side encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted.
+// Client-side encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
+// feature requires specifying the "cse" build tag during compilation.
 //
 // Important: This feature is beta. The API for both automatic and explicit encryption/decryption does not have any
 // stability guarantees and backwards-breaking changes may be made before the final release.

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -114,8 +114,8 @@
 //    }
 //    aeo.SetExtraOptions(mongocryptdOpts)
 // To specify a process URI for mongocryptd, the "mongocryptdURI" option can be passed in the ExtraOptions map as well.
-// More information about mongocryptd will soon be available from the official documentation. See the
-// ClientSideEncryption and ClientSideEncryptionCreateKey examples below for code samples about using this feature.
+// See the ClientSideEncryption and ClientSideEncryptionCreateKey examples below for code samples about using this
+// feature.
 //
 // [1] See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo


### PR DESCRIPTION
For reference, these examples are supposed to mimic the Java ones at https://mongodb.github.io/mongo-java-driver/3.11/driver/tutorials/client-side-encryption/ as per the DRIVERS-752.