### PR TITLE
GODRIVER-1379 CRUD GoDoc examples

### DIFF
--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -333,7 +333,8 @@ func ExampleCollection_FindOne() {
 	var coll *mongo.Collection
 
 	// find at most one document in which the "name" field is "Bob"
-	// specify the Sort option to sort the documents by age before selecting one
+	// specify the Sort option to sort the documents by age
+	// the first document in the sorted order will be returned
 	opts := options.FindOne().SetSort(bson.D{{"age", 1}})
 	var result bson.M
 	err := coll.FindOne(context.TODO(), bson.D{{"name", "Bob"}}, opts).Decode(&result)
@@ -351,7 +352,8 @@ func ExampleCollection_FindOneAndDelete() {
 	var coll *mongo.Collection
 
 	// find and delete at most one document in which the "name" field is "Bob"
-	// specify the Sort option to sort the documents by age before selecting one to delete
+	// specify the Sort option to sort the documents by age
+	// the first document in the sorted order will be deleted
 	opts := options.FindOneAndDelete().SetSort(bson.D{{"age", 1}})
 	var deletedDocument bson.M
 	err := coll.FindOneAndDelete(context.TODO(), bson.D{{"name", "Bob"}}, opts).Decode(&deletedDocument)

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -52,11 +52,11 @@ func ExampleClient_ListDatabaseNames() {
 func ExampleClient_Watch() {
 	var client *mongo.Client
 
-	// specify a pipeline that will add a field with the key "newField" to each event returned
+	// specify a pipeline that will only match "insert" events
 	// specify the MaxAwaitTimeOption to have each attempt wait two seconds for new documents
-	addFieldsStage := bson.D{{"$addFields", bson.D{{"newField", "this is a new field"}}}}
+	matchStage := bson.D{{"$match", bson.D{{"operationType", "insert"}}}}
 	opts := options.ChangeStream().SetMaxAwaitTime(2 * time.Second)
-	changeStream, err := client.Watch(context.TODO(), mongo.Pipeline{addFieldsStage}, opts)
+	changeStream, err := client.Watch(context.TODO(), mongo.Pipeline{matchStage}, opts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func ExampleDatabase_Aggregate() {
 
 	// get a list of all returned documents and print them out
 	// see the mongo.Cursor documentation for more examples of using cursors
-	var results []bson.Raw
+	var results []bson.M
 	if err = cursor.All(context.TODO(), &results); err != nil {
 		log.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func ExampleDatabase_ListCollections() {
 
 	// get a list of all returned specifications and print them out
 	// see the mongo.Cursor documentation for more examples of using cursors
-	var results []bson.Raw
+	var results []bson.M
 	if err = cursor.All(context.TODO(), &results); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 // Client examples
@@ -62,15 +63,17 @@ func ExampleClient_Watch() {
 	// print out all change stream events in the order they're received
 	// see the mongo.ChangeStream documentation for more examples of using change streams
 	for changeStream.Next(context.TODO()) {
-		fmt.Printf("got event %v\n", changeStream.Current)
+		fmt.Println(changeStream.Current)
 	}
 }
+
+// Database examples
 
 func ExampleDatabase_Aggregate() {
 	var db *mongo.Database
 
 	// specify a pipeline that will list all sessions on the target server
-	// specify the MaxTime option to limit the amount of time the query can run on the server
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
 	localSessionsStage := bson.D{{"$listLocalSessions", bson.D{{"allUsers", true}}}}
 	opts := options.Aggregate().SetMaxTime(2 * time.Second)
 	cursor, err := db.Aggregate(context.TODO(), mongo.Pipeline{localSessionsStage}, opts)
@@ -113,6 +116,209 @@ func ExampleDatabase_ListCollections() {
 	}
 
 	// get a list of all returned specifications and print them out
+	// see the mongo.Cursor documentation for more examples of using cursors
+	var results []bson.M
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Fatal(err)
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}
+
+func ExampleDatabase_RunCommand() {
+	var db *mongo.Database
+
+	// create a capped collection named "capped-coll"
+	// specify the ReadPreference option to explicitly set the read preference to primary
+	command := bson.D{{"create", "capped-coll"}, {"capped", true}, {"size", 4096}}
+	opts := options.RunCmd().SetReadPreference(readpref.Primary())
+	var result bson.M
+	if err := db.RunCommand(context.TODO(), command, opts).Decode(&result); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(result)
+}
+
+func ExampleDatabase_RunCommandCursor() {
+	var db *mongo.Database
+
+	// run a find command against collection "foo"
+	// specify the ReadPreference option to explicitly set the read preference to primary
+	command := bson.D{{"find", "foo"}}
+	opts := options.RunCmd().SetReadPreference(readpref.Primary())
+	cursor, err := db.RunCommandCursor(context.TODO(), command, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of all returned documents and print them out
+	// see the mongo.Cursor documentation for more examples of using cursors
+	var results []bson.M
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Fatal(err)
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}
+
+func ExampleDatabase_Watch() {
+	var db *mongo.Database
+
+	// specify a pipeline that will only match "insert" events
+	// specify the MaxAwaitTimeOption to have each attempt wait two seconds for new documents
+	matchStage := bson.D{{"$match", bson.D{{"operationType", "insert"}}}}
+	opts := options.ChangeStream().SetMaxAwaitTime(2 * time.Second)
+	changeStream, err := db.Watch(context.TODO(), mongo.Pipeline{matchStage}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// print out all change stream events in the order they're received
+	// see the mongo.ChangeStream documentation for more examples of using change streams
+	for changeStream.Next(context.TODO()) {
+		fmt.Println(changeStream.Current)
+	}
+}
+
+// Collection examples
+
+func ExampleCollection_Aggregate() {
+	var coll *mongo.Collection
+
+	// specify a pipeline that will return the number of times each name appears in the collection
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
+	groupStage := bson.D{
+		{"$group", bson.D{
+			{"_id", "$name"},
+			{"numTimes", bson.D{
+				{"$sum", 1},
+			}},
+		}},
+	}
+	opts := options.Aggregate().SetMaxTime(2 * time.Second)
+	cursor, err := coll.Aggregate(context.TODO(), mongo.Pipeline{groupStage}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of all returned documents and print them out
+	// see the mongo.Cursor documentation for more examples of using cursors
+	var results []bson.M
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Fatal(err)
+	}
+	for _, result := range results {
+		fmt.Printf("name %v appears %v times\n", result["_id"], result["numTimes"])
+	}
+}
+
+func ExampleCollection_BulkWrite() {
+	var coll *mongo.Collection
+
+	// insert {name: "Alice"} and delete {name: "Bob"}
+	// set the Ordered option to false to allow both operations to happen even if one of them errors
+	models := []mongo.WriteModel{
+		mongo.NewInsertOneModel().SetDocument(bson.D{{"name", "Alice"}}),
+		mongo.NewDeleteOneModel().SetFilter(bson.D{{"name", "Bob"}}),
+	}
+	opts := options.BulkWrite().SetOrdered(false)
+	res, err := coll.BulkWrite(context.TODO(), models, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("inserted %v and deleted %v documents\n", res.InsertedCount, res.DeletedCount)
+}
+
+func ExampleCollection_CountDocuments() {
+	var coll *mongo.Collection
+
+	// count the number of times the name "Bob" appears in the collection
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
+	opts := options.Count().SetMaxTime(2 * time.Second)
+	count, err := coll.CountDocuments(context.TODO(), bson.D{{"name", "Bob"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("name Bob appears in %v documents", count)
+}
+
+func ExampleCollection_DeleteMany() {
+	var coll *mongo.Collection
+
+	// delete all documents in which the "name" field is "Bob" or "bob"
+	// specify the SetCollation option to provide a collation that will ignore case for string comparisons
+	opts := options.Delete().SetCollation(&options.Collation{
+		Locale:   "en_US",
+		Strength: 1,
+	})
+	res, err := coll.DeleteMany(context.TODO(), bson.D{{"name", "bob"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("deleted %v documents\n", res.DeletedCount)
+}
+
+func ExampleCollection_DeleteOne() {
+	var coll *mongo.Collection
+
+	// delete at most one documents in which the "name" field is "Bob" or "bob"
+	// specify the SetCollation option to provide a collation that will ignore case for string comparisons
+	opts := options.Delete().SetCollation(&options.Collation{
+		Locale:   "en_US",
+		Strength: 1,
+	})
+	res, err := coll.DeleteOne(context.TODO(), bson.D{{"name", "bob"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("deleted %v documents\n", res.DeletedCount)
+}
+
+func ExampleCollection_Distinct() {
+	var coll *mongo.Collection
+
+	// find all unique values for the "name" field for documents in which the "age" field is greater than 25
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
+	filter := bson.D{{"age", bson.D{{"$gt", 25}}}}
+	opts := options.Distinct().SetMaxTime(2 * time.Second)
+	values, err := coll.Distinct(context.TODO(), "name", filter, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, value := range values {
+		fmt.Println(value)
+	}
+}
+
+func ExampleCollection_EstimatedDocumentCount() {
+	var coll *mongo.Collection
+
+	// get and print an estimated of the number of documents in the collection
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
+	opts := options.EstimatedDocumentCount().SetMaxTime(2 * time.Second)
+	count, err := coll.EstimatedDocumentCount(context.TODO(), opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("estimated document count: %v", count)
+}
+
+func ExampleCollection_Find() {
+	var coll *mongo.Collection
+
+	// find all documents in which the "name" field is "Bob"
+	// specify the MaxTime option to limit the amount of time the operation can run on the server
+	opts := options.Find().SetMaxTime(2 * time.Second)
+	cursor, err := coll.Find(context.TODO(), bson.D{{"name", "Bob"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of all returned documents and print them out
 	// see the mongo.Cursor documentation for more examples of using cursors
 	var results []bson.M
 	if err = cursor.All(context.TODO(), &results); err != nil {

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -1,0 +1,128 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Client examples
+
+func ExampleClient_ListDatabases() {
+	var client *mongo.Client
+
+	// use a filter to only select the admin database
+	// specify the NameOnly option so the returned specificiations only have the name field populated
+	opts := options.ListDatabases().SetNameOnly(true)
+	result, err := client.ListDatabases(context.TODO(), bson.D{{"name", "admin"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, db := range result.Databases {
+		fmt.Println(db.Name)
+	}
+}
+
+func ExampleClient_ListDatabaseNames() {
+	var client *mongo.Client
+
+	// use a filter to only select the admin database
+	result, err := client.ListDatabaseNames(context.TODO(), bson.D{{"name", "admin"}})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, db := range result {
+		fmt.Println(db)
+	}
+}
+
+func ExampleClient_Watch() {
+	var client *mongo.Client
+
+	// specify a pipeline that will add a field with the key "newField" to each event returned
+	// specify the MaxAwaitTimeOption to have each attempt wait two seconds for new documents
+	addFieldsStage := bson.D{{"$addFields", bson.D{{"newField", "this is a new field"}}}}
+	opts := options.ChangeStream().SetMaxAwaitTime(2 * time.Second)
+	changeStream, err := client.Watch(context.TODO(), mongo.Pipeline{addFieldsStage}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// print out all change stream events in the order they're received
+	// see the mongo.ChangeStream documentation for more examples of using change streams
+	for changeStream.Next(context.TODO()) {
+		fmt.Printf("got event %v\n", changeStream.Current)
+	}
+}
+
+func ExampleDatabase_Aggregate() {
+	var db *mongo.Database
+
+	// specify a pipeline that will list all sessions on the target server
+	// specify the MaxTime option to limit the amount of time the query can run on the server
+	localSessionsStage := bson.D{{"$listLocalSessions", bson.D{{"allUsers", true}}}}
+	opts := options.Aggregate().SetMaxTime(2 * time.Second)
+	cursor, err := db.Aggregate(context.TODO(), mongo.Pipeline{localSessionsStage}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of all returned documents and print them out
+	// see the mongo.Cursor documentation for more examples of using cursors
+	var results []bson.Raw
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Fatal(err)
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}
+
+func ExampleDatabase_ListCollectionNames() {
+	var db *mongo.Database
+
+	// use a filter to only select the collection "foo"
+	result, err := db.ListCollectionNames(context.TODO(), bson.D{{"name", "foo"}})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, coll := range result {
+		fmt.Println(coll)
+	}
+}
+
+func ExampleDatabase_ListCollections() {
+	var db *mongo.Database
+
+	// use a filter to only select the collection "foo"
+	// specify the NameOnly option so the returned specificiations only have the name field populated
+	opts := options.ListCollections().SetNameOnly(true)
+	cursor, err := db.ListCollections(context.TODO(), bson.D{{"name", "foo"}}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of all returned specifications and print them out
+	// see the mongo.Cursor documentation for more examples of using cursors
+	var results []bson.Raw
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Fatal(err)
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+}

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -22,24 +22,22 @@ import (
 func ExampleClient_ListDatabases() {
 	var client *mongo.Client
 
-	// use a filter to only select the admin database
-	// specify the NameOnly option so the returned specificiations only have the name field populated
-	opts := options.ListDatabases().SetNameOnly(true)
-	result, err := client.ListDatabases(context.TODO(), bson.D{{"name", "admin"}}, opts)
+	// use a filter to select non-empty databases
+	result, err := client.ListDatabases(context.TODO(), bson.D{{"empty", false}})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for _, db := range result.Databases {
-		fmt.Println(db.Name)
+		fmt.Printf("db: %v, size: %v\n", db.Name, db.SizeOnDisk)
 	}
 }
 
 func ExampleClient_ListDatabaseNames() {
 	var client *mongo.Client
 
-	// use a filter to only select the admin database
-	result, err := client.ListDatabaseNames(context.TODO(), bson.D{{"name", "admin"}})
+	// use a filter to only select non-empty databases
+	result, err := client.ListDatabaseNames(context.TODO(), bson.D{{"empty", false}})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,8 +92,8 @@ func ExampleDatabase_Aggregate() {
 func ExampleDatabase_ListCollectionNames() {
 	var db *mongo.Database
 
-	// use a filter to only select the collection "foo"
-	result, err := db.ListCollectionNames(context.TODO(), bson.D{{"name", "foo"}})
+	// use a filter to only select capped collections
+	result, err := db.ListCollectionNames(context.TODO(), bson.D{{"options.capped", true}})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,10 +106,8 @@ func ExampleDatabase_ListCollectionNames() {
 func ExampleDatabase_ListCollections() {
 	var db *mongo.Database
 
-	// use a filter to only select the collection "foo"
-	// specify the NameOnly option so the returned specificiations only have the name field populated
-	opts := options.ListCollections().SetNameOnly(true)
-	cursor, err := db.ListCollections(context.TODO(), bson.D{{"name", "foo"}}, opts)
+	// use a filter to only select capped collections
+	cursor, err := db.ListCollections(context.TODO(), bson.D{{"options.capped", "true"}})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -147,8 +147,8 @@ func ExampleCollection_BulkWrite() {
 	firstUpdate := bson.D{{"$set", bson.D{{"email", "firstEmail@example.com"}}}}
 	secondUpdate := bson.D{{"$set", bson.D{{"email", "secondEmail@example.com"}}}}
 	models := []mongo.WriteModel{
-		mongo.NewUpdateOneModel().SetFilter(bson.D{{"_id", firstID}}).SetUpdate(firstUpdate),
-		mongo.NewUpdateOneModel().SetFilter(bson.D{{"_id", secondID}}).SetUpdate(secondUpdate),
+		mongo.NewUpdateOneModel().SetFilter(bson.D{{"_id", firstID}}).SetUpdate(firstUpdate).SetUpsert(true),
+		mongo.NewUpdateOneModel().SetFilter(bson.D{{"_id", secondID}}).SetUpdate(secondUpdate).SetUpsert(true),
 	}
 	opts := options.BulkWrite().SetOrdered(false)
 	res, err := coll.BulkWrite(context.TODO(), models, opts)

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -249,7 +249,7 @@ func ExampleCollection_DeleteMany() {
 	var coll *mongo.Collection
 
 	// delete all documents in which the "name" field is "Bob" or "bob"
-	// specify the SetCollation option to provide a collation that will ignore case for string comparisons
+	// specify the Collation option to provide a collation that will ignore case for string comparisons
 	opts := options.Delete().SetCollation(&options.Collation{
 		Locale:   "en_US",
 		Strength: 1,
@@ -264,7 +264,7 @@ func ExampleCollection_DeleteMany() {
 func ExampleCollection_DeleteOne() {
 	var coll *mongo.Collection
 
-	// delete at most one documents in which the "name" field is "Bob" or "bob"
+	// delete at most one document in which the "name" field is "Bob" or "bob"
 	// specify the SetCollation option to provide a collation that will ignore case for string comparisons
 	opts := options.Delete().SetCollation(&options.Collation{
 		Locale:   "en_US",
@@ -311,8 +311,8 @@ func ExampleCollection_Find() {
 	var coll *mongo.Collection
 
 	// find all documents in which the "name" field is "Bob"
-	// specify the MaxTime option to limit the amount of time the operation can run on the server
-	opts := options.Find().SetMaxTime(2 * time.Second)
+	// specify the Sort option to sort the returned documents by name in ascending order
+	opts := options.Find().SetSort(bson.D{{"name", 1}})
 	cursor, err := coll.Find(context.TODO(), bson.D{{"name", "Bob"}}, opts)
 	if err != nil {
 		log.Fatal(err)
@@ -332,9 +332,9 @@ func ExampleCollection_Find() {
 func ExampleCollection_FindOne() {
 	var coll *mongo.Collection
 
-	// find the document in which the "name" field is "Bob"
-	// specify the MaxTime option to limit the amount of time the operation can run on the server
-	opts := options.FindOne().SetMaxTime(2 * time.Second)
+	// find at most one document in which the "name" field is "Bob"
+	// specify the Sort option to sort the documents by age before selecting one
+	opts := options.FindOne().SetSort(bson.D{{"age", 1}})
 	var result bson.M
 	err := coll.FindOne(context.TODO(), bson.D{{"name", "Bob"}}, opts).Decode(&result)
 	if err != nil {
@@ -350,9 +350,9 @@ func ExampleCollection_FindOne() {
 func ExampleCollection_FindOneAndDelete() {
 	var coll *mongo.Collection
 
-	// find and delete the document in which the "name" field is "Bob"
-	// specify the MaxTime option to limit the amount of time the operation can run on the server
-	opts := options.FindOneAndDelete().SetMaxTime(2 * time.Second)
+	// find and delete at most one document in which the "name" field is "Bob"
+	// specify the Sort option to sort the documents by age before selecting one to delete
+	opts := options.FindOneAndDelete().SetSort(bson.D{{"age", 1}})
 	var deletedDocument bson.M
 	err := coll.FindOneAndDelete(context.TODO(), bson.D{{"name", "Bob"}}, opts).Decode(&deletedDocument)
 	if err != nil {
@@ -368,8 +368,8 @@ func ExampleCollection_FindOneAndDelete() {
 func ExampleCollection_FindOneAndReplace() {
 	var coll *mongo.Collection
 
-	// find and replace the document in which the "name" field is "Bob" with {name: "Alice"}
-	// specify the Upsert option to insert {name: "Alice"} if the {name: "Bob"} document isn't found
+	// find and replace at most one document in which the "name" field is "Bob" with {name: "Alice"}
+	// specify the Upsert option to insert {name: "Alice"} if a document matching the filter isn't found
 	opts := options.FindOneAndReplace().SetUpsert(true)
 	filter := bson.D{{"name", "Bob"}}
 	replacement := bson.D{{"name", "Alice"}}
@@ -388,8 +388,8 @@ func ExampleCollection_FindOneAndReplace() {
 func ExampleCollection_FindOneAndUpdate() {
 	var coll *mongo.Collection
 
-	// find the document in which the "name" field is "Bob" and set the name to "Alice"
-	// specify the Upsert option to insert {name: "Alice"} if the {name: "Bob"} document isn't found
+	// find at most one document in which the "name" field is "Bob" and set the name to "Alice"
+	// specify the Upsert option to insert {name: "Alice"} if a document matching the filter isn't found
 	opts := options.FindOneAndUpdate().SetUpsert(true)
 	filter := bson.D{{"name", "Bob"}}
 	update := bson.D{{"$set", bson.D{{"name", "Alice"}}}}
@@ -438,8 +438,8 @@ func ExampleCollection_InsertOne() {
 func ExampleCollection_ReplaceOne() {
 	var coll *mongo.Collection
 
-	// replace the document in which the "name" field is "Bob" with {name: "Alice"}
-	// specify the Upsert option to insert {name: "Alice"} if the {name: "Bob"} document isn't found
+	// replace at most one document in which the "name" field is "Bob" with {name: "Alice"}
+	// specify the Upsert option to insert {name: "Alice"} if a document matching the filter isn't found
 	opts := options.Replace().SetUpsert(true)
 	filter := bson.D{{"name", "Bob"}}
 	replacement := bson.D{{"name", "Alice"}}
@@ -461,12 +461,12 @@ func ExampleCollection_UpdateMany() {
 	var coll *mongo.Collection
 
 	// find all documents in which the "name" field is "Bob" and set the name to "Alice"
-	// specify the Upsert option to insert {name: "Alice"} if the {name: "Bob"} document isn't found
+	// specify the Upsert option to insert {name: "Alice"} if a document matching the filter isn't found
 	opts := options.Update().SetUpsert(true)
 	filter := bson.D{{"name", "Bob"}}
 	update := bson.D{{"$set", bson.D{{"name", "Alice"}}}}
 
-	result, err := coll.UpdateOne(context.TODO(), filter, update, opts)
+	result, err := coll.UpdateMany(context.TODO(), filter, update, opts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -483,8 +483,8 @@ func ExampleCollection_UpdateMany() {
 func ExampleCollection_UpdateOne() {
 	var coll *mongo.Collection
 
-	// find the document in which the "name" field is "Bob" and set the name to "Alice"
-	// specify the Upsert option to insert {name: "Alice"} if the {name: "Bob"} document isn't found
+	// find at most one document in which the "name" field is "Bob" and set the name to "Alice"
+	// specify the Upsert option to insert {name: "Alice"} if a document matching the filter isn't found
 	opts := options.Update().SetUpsert(true)
 	filter := bson.D{{"name", "Bob"}}
 	update := bson.D{{"$set", bson.D{{"name", "Alice"}}}}


### PR DESCRIPTION
I want to get an initial review of these before adding examples for the rest of the examples for `Database` and `Collection`. The general rules I've been following for these are:

1. Use a non-empty filter/update/replacement when applicable.
2. Specify an arbitrary option from the `options` package.
3. For methods that return an iterable or concrete result type (e.g. `[]string`, `InsertOneResult`), print out something to show the result.
4. For methods that return a `Cursor`, use the `All` method to capture all docs as `bson.Raw` and print out each document. Add a note to say that users should see the `Cursor` docs for more examples.
5. For methods that return a `ChangeStream`, print out each event in a loop. Add a note to say that users should see the `ChangeStream` docs for more examples.