### PR TITLE
Remove version number from README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The MongoDB supported driver for Go.
 The recommended way to get started using the MongoDB Go driver is by using `dep` to install the dependency in your project.
 
 ```bash
-dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.1.0"
+dep ensure -add "go.mongodb.org/mongo-driver/mongo"
 ```
 
 -------------------------


### PR DESCRIPTION
`dep` will automatically fetch the latest released version so this PR removes the version number from our README instructions to avoid inconsistencies.