### PR TITLE
Fix bsoncore overflow

### DIFF
--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -123,6 +123,9 @@ func ReadElement(src []byte) (Element, []byte, bool) {
 	if elemLength > len(src) {
 		return nil, src, false
 	}
+	if elemLength < 0 {
+		return nil, src, false
+	}
 	return src[:elemLength], src[elemLength:], true
 }
 
@@ -723,13 +726,18 @@ func appendi32(dst []byte, i32 int32) []byte {
 // ReadLength reads an int32 length from src and returns the length and the remaining bytes. If
 // there aren't enough bytes to read a valid length, src is returned unomdified and the returned
 // bool will be false.
-func ReadLength(src []byte) (int32, []byte, bool) { return readi32(src) }
+func ReadLength(src []byte) (int32, []byte, bool) {
+	ln, src, ok := readi32(src)
+	if ln < 0 {
+		return ln, src, false
+	}
+	return ln, src, ok
+}
 
 func readi32(src []byte) (int32, []byte, bool) {
 	if len(src) < 4 {
 		return 0, src, false
 	}
-
 	return (int32(src[0]) | int32(src[1])<<8 | int32(src[2])<<16 | int32(src[3])<<24), src[4:], true
 }
 


### PR DESCRIPTION
Hello,
we were fuzzing one of our libraries that depend on bsonx and found following panics
```
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
go.mongodb.org/mongo-driver/x/bsonx/bsoncore.Document.Validate(0x4381000, 0x4, 0x4, 0x12dad00, 0xc0000102c0)
	XXXX/mongo-driver/x/bsonx/bsoncore/document.go:373 +0x6e3
go.mongodb.org/mongo-driver/x/bsonx.(*Doc).UnmarshalBSON(0xc0000cbe08, 0x4381000, 0x4, 0x4, 0xc0000cbe08, 0x99c4e6fa)
	XXXX/mongo-driver/x/bsonx/document.go:225 +0xb6
go.mongodb.org/mongo-driver/x/bsonx.ReadDoc(0x4381000, 0x4, 0x4, 0xc0000cbe70, 0x1076066, 0x5dcdd198, 0xdc8138, 0x133fa99c4e6fa)

XXXXXXXXXXXXXXXX

exit status 2

----------

panic: runtime error: slice bounds out of range [:-2147483643]

goroutine 1 [running]:
go.mongodb.org/mongo-driver/x/bsonx/bsoncore.ReadElement(0x4221004, 0x6, 0x6, 0xc000000006, 0x4221004, 0x6, 0x6, 0x1, 0x9, 0x4221004)
	XXXX/mongo-driver/x/bsonx/bsoncore/bsoncore.go:126 +0x3c8
go.mongodb.org/mongo-driver/x/bsonx/bsoncore.Document.Validate(0x4221000, 0xa, 0xa, 0x12dad20, 0xc0000c20a0)
	XXXX/mongo-driver/x/bsonx/bsoncore/document.go:381 +0x208
go.mongodb.org/mongo-driver/x/bsonx.(*Doc).UnmarshalBSON(0xc0000cbe08, 0x4221000, 0xa, 0xa, 0xc0000cbe08, 0x87888daf)
	XXXX/mongo-driver/x/bsonx/document.go:225 +0xb6

XXXXXXXXXXXXXXXX

exit status 2
```
This PR should fix that.
