### PR TITLE
GODRIVER-1349 implement mgocompat StructCodec options

### DIFF
--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -12,7 +12,9 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
+	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
@@ -31,24 +33,41 @@ type Zeroer interface {
 
 // StructCodec is the Codec used for struct values.
 type StructCodec struct {
-	cache  map[reflect.Type]*structDescription
-	l      sync.RWMutex
-	parser StructTagParser
+	cache                map[reflect.Type]*structDescription
+	l                    sync.RWMutex
+	parser               StructTagParser
+	DecodeZeroStruct     bool
+	DecodeDeepZeroInline bool
+	OmitDefaultStruct    bool
 }
 
 var _ ValueEncoder = &StructCodec{}
 var _ ValueDecoder = &StructCodec{}
 
 // NewStructCodec returns a StructCodec that uses p for struct tag parsing.
-func NewStructCodec(p StructTagParser) (*StructCodec, error) {
+func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) (*StructCodec, error) {
 	if p == nil {
 		return nil, errors.New("a StructTagParser must be provided to NewStructCodec")
 	}
 
-	return &StructCodec{
+	structOpt := bsonoptions.MergeStructCodecOptions(opts...)
+
+	codec := &StructCodec{
 		cache:  make(map[reflect.Type]*structDescription),
 		parser: p,
-	}, nil
+	}
+
+	if structOpt.DecodeZeroStruct != nil {
+		codec.DecodeZeroStruct = *structOpt.DecodeZeroStruct
+	}
+	if structOpt.DecodeDeepZeroInline != nil {
+		codec.DecodeDeepZeroInline = *structOpt.DecodeDeepZeroInline
+	}
+	if structOpt.OmitDefaultStruct != nil {
+		codec.OmitDefaultStruct = *structOpt.OmitDefaultStruct
+	}
+
+	return codec, nil
 }
 
 // EncodeValue handles encoding generic struct types.
@@ -136,6 +155,13 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr bsonrw.ValueReader, val r
 	sd, err := sc.describeStruct(r.Registry, val.Type())
 	if err != nil {
 		return err
+	}
+
+	if sc.DecodeZeroStruct {
+		val.Set(reflect.Zero(val.Type()))
+	}
+	if sc.DecodeDeepZeroInline && sd.inline {
+		val.Set(deepZero(val.Type()))
 	}
 
 	var decoder ValueDecoder
@@ -257,6 +283,23 @@ func (sc *StructCodec) isZero(i interface{}) bool {
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
+	case reflect.Struct:
+		if sc.OmitDefaultStruct {
+			vt := v.Type()
+			if vt == tTime {
+				return v.Interface().(time.Time).IsZero()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				if vt.Field(i).PkgPath != "" && !vt.Field(i).Anonymous {
+					continue // Private field
+				}
+				fld := v.Field(i)
+				if !sc.isZero(fld.Interface()) {
+					return false
+				}
+			}
+			return true
+		}
 	}
 
 	return false
@@ -266,6 +309,7 @@ type structDescription struct {
 	fm        map[string]fieldDescription
 	fl        []fieldDescription
 	inlineMap int
+	inline    bool
 }
 
 type fieldDescription struct {
@@ -328,6 +372,7 @@ func (sc *StructCodec) describeStruct(r *Registry, t reflect.Type) (*structDescr
 		description.truncate = stags.Truncate
 
 		if stags.Inline {
+			sd.inline = true
 			switch sfType.Kind() {
 			case reflect.Map:
 				if sd.inlineMap >= 0 {
@@ -415,4 +460,40 @@ func getInlineField(val reflect.Value, index []int) (reflect.Value, error) {
 	fParent.Set(reflect.New(fParent.Type().Elem()))
 
 	return fieldByIndexErr(val, index)
+}
+
+// DeepZero returns recursive zero object
+func deepZero(st reflect.Type) (result reflect.Value) {
+	result = reflect.Indirect(reflect.New(st))
+
+	if result.Kind() == reflect.Struct {
+		for i := 0; i < result.NumField(); i++ {
+			if f := result.Field(i); f.Kind() == reflect.Ptr {
+				if f.CanInterface() {
+					if ft := reflect.TypeOf(f.Interface()); ft.Elem().Kind() == reflect.Struct {
+						result.Field(i).Set(recursivePointerTo(deepZero(ft.Elem())))
+					}
+				}
+			}
+		}
+	}
+
+	return
+}
+
+// recursivePointerTo calls reflect.New(v.Type) but recursively for its fields inside
+func recursivePointerTo(v reflect.Value) reflect.Value {
+	v = reflect.Indirect(v)
+	result := reflect.New(v.Type())
+	if v.Kind() == reflect.Struct {
+		for i := 0; i < v.NumField(); i++ {
+			if f := v.Field(i); f.Kind() == reflect.Ptr {
+				if f.Elem().Kind() == reflect.Struct {
+					result.Elem().Field(i).Set(recursivePointerTo(f))
+				}
+			}
+		}
+	}
+
+	return result
 }

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -33,12 +33,12 @@ type Zeroer interface {
 
 // StructCodec is the Codec used for struct values.
 type StructCodec struct {
-	cache                map[reflect.Type]*structDescription
-	l                    sync.RWMutex
-	parser               StructTagParser
-	DecodeZeroStruct     bool
-	DecodeDeepZeroInline bool
-	OmitDefaultStruct    bool
+	cache                   map[reflect.Type]*structDescription
+	l                       sync.RWMutex
+	parser                  StructTagParser
+	DecodeZeroStruct        bool
+	DecodeDeepZeroInline    bool
+	EncodeOmitDefaultStruct bool
 }
 
 var _ ValueEncoder = &StructCodec{}
@@ -63,8 +63,8 @@ func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) 
 	if structOpt.DecodeDeepZeroInline != nil {
 		codec.DecodeDeepZeroInline = *structOpt.DecodeDeepZeroInline
 	}
-	if structOpt.OmitDefaultStruct != nil {
-		codec.OmitDefaultStruct = *structOpt.OmitDefaultStruct
+	if structOpt.EncodeOmitDefaultStruct != nil {
+		codec.EncodeOmitDefaultStruct = *structOpt.EncodeOmitDefaultStruct
 	}
 
 	return codec, nil
@@ -284,7 +284,7 @@ func (sc *StructCodec) isZero(i interface{}) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	case reflect.Struct:
-		if sc.OmitDefaultStruct {
+		if sc.EncodeOmitDefaultStruct {
 			vt := v.Type()
 			if vt == tTime {
 				return v.Interface().(time.Time).IsZero()

--- a/bson/bsonoptions/string_codec_options.go
+++ b/bson/bsonoptions/string_codec_options.go
@@ -8,7 +8,7 @@ package bsonoptions
 
 var defaultDecodeOIDAsHex = true
 
-// StringCodecOptions represents all possible options for time.Time encoding and decoding.
+// StringCodecOptions represents all possible options for string encoding and decoding.
 type StringCodecOptions struct {
 	DecodeObjectIDAsHex *bool // Specifies if we should decode ObjectID as the hex value. Defaults to true.
 }

--- a/bson/bsonoptions/struct_codec_options.go
+++ b/bson/bsonoptions/struct_codec_options.go
@@ -8,9 +8,9 @@ package bsonoptions
 
 // StructCodecOptions represents all possible options for struct encoding and decoding.
 type StructCodecOptions struct {
-	DecodeZeroStruct     *bool // Specifies if structs should be zeroed before decoding into them. Defaults to false.
-	DecodeDeepZeroInline *bool // Specifies if structs should be recursively zeroed when a inline value is decoded. Defaults to false.
-	OmitDefaultStruct    *bool // Specifies if default structs should be considered empty by omitempty. Defaults to false.
+	DecodeZeroStruct        *bool // Specifies if structs should be zeroed before decoding into them. Defaults to false.
+	DecodeDeepZeroInline    *bool // Specifies if structs should be recursively zeroed when a inline value is decoded. Defaults to false.
+	EncodeOmitDefaultStruct *bool // Specifies if default structs should be considered empty by omitempty. Defaults to false.
 }
 
 // StructCodec creates a new *StructCodecOptions
@@ -30,9 +30,10 @@ func (t *StructCodecOptions) SetDecodeDeepZeroInline(b bool) *StructCodecOptions
 	return t
 }
 
-// SetOmitDefaultStruct specifies if default structs should be considered empty by omitempty. Defaults to false.
-func (t *StructCodecOptions) SetOmitDefaultStruct(b bool) *StructCodecOptions {
-	t.OmitDefaultStruct = &b
+// SetEncodeOmitDefaultStruct specifies if default structs should be considered empty by omitempty. A default struct has all
+// its values set to their default value. Defaults to false.
+func (t *StructCodecOptions) SetEncodeOmitDefaultStruct(b bool) *StructCodecOptions {
+	t.EncodeOmitDefaultStruct = &b
 	return t
 }
 
@@ -50,8 +51,8 @@ func MergeStructCodecOptions(opts ...*StructCodecOptions) *StructCodecOptions {
 		if opt.DecodeDeepZeroInline != nil {
 			s.DecodeDeepZeroInline = opt.DecodeDeepZeroInline
 		}
-		if opt.OmitDefaultStruct != nil {
-			s.OmitDefaultStruct = opt.OmitDefaultStruct
+		if opt.EncodeOmitDefaultStruct != nil {
+			s.EncodeOmitDefaultStruct = opt.EncodeOmitDefaultStruct
 		}
 	}
 

--- a/bson/bsonoptions/struct_codec_options.go
+++ b/bson/bsonoptions/struct_codec_options.go
@@ -1,0 +1,59 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsonoptions
+
+// StructCodecOptions represents all possible options for struct encoding and decoding.
+type StructCodecOptions struct {
+	DecodeZeroStruct     *bool // Specifies if structs should be zeroed before decoding into them. Defaults to false.
+	DecodeDeepZeroInline *bool // Specifies if structs should be recursively zeroed when a inline value is decoded. Defaults to false.
+	OmitDefaultStruct    *bool // Specifies if default structs should be considered empty by omitempty. Defaults to false.
+}
+
+// StructCodec creates a new *StructCodecOptions
+func StructCodec() *StructCodecOptions {
+	return &StructCodecOptions{}
+}
+
+// SetDecodeZeroStruct specifies if structs should be zeroed before decoding into them. Defaults to false.
+func (t *StructCodecOptions) SetDecodeZeroStruct(b bool) *StructCodecOptions {
+	t.DecodeZeroStruct = &b
+	return t
+}
+
+// SetDecodeDeepZeroInline specifies if structs should be zeroed before decoding into them. Defaults to false.
+func (t *StructCodecOptions) SetDecodeDeepZeroInline(b bool) *StructCodecOptions {
+	t.DecodeDeepZeroInline = &b
+	return t
+}
+
+// SetOmitDefaultStruct specifies if default structs should be considered empty by omitempty. Defaults to false.
+func (t *StructCodecOptions) SetOmitDefaultStruct(b bool) *StructCodecOptions {
+	t.OmitDefaultStruct = &b
+	return t
+}
+
+// MergeStructCodecOptions combines the given *StructCodecOptions into a single *StructCodecOptions in a last one wins fashion.
+func MergeStructCodecOptions(opts ...*StructCodecOptions) *StructCodecOptions {
+	s := StructCodec()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.DecodeZeroStruct != nil {
+			s.DecodeZeroStruct = opt.DecodeZeroStruct
+		}
+		if opt.DecodeDeepZeroInline != nil {
+			s.DecodeDeepZeroInline = opt.DecodeDeepZeroInline
+		}
+		if opt.OmitDefaultStruct != nil {
+			s.OmitDefaultStruct = opt.OmitDefaultStruct
+		}
+	}
+
+	return s
+}

--- a/bson/mgocompat/bson_test.go
+++ b/bson/mgocompat/bson_test.go
@@ -204,16 +204,16 @@ func TestUnmarshalRawIncompatible(t *testing.T) {
 	assert.NotNil(t, err, "expected an error")
 }
 
-// func TestUnmarshalZeroesStruct(t *testing.T) {
-// 	data, err := bson.MarshalWithRegistry(mgoRegistry, bson.M{"b": 2})
-// 	assert.Nil(t, err, "expected nil error, got: %v", err)
-// 	type T struct{ A, B int }
-// 	v := T{A: 1}
-// 	err = bson.UnmarshalWithRegistry(mgoRegistry, data, &v)
-// 	assert.Nil(t, err, "expected nil error, got: %v", err)
-// 	assert.Equal(t, 0, v.A, "expected: 0, got: %v", v.A)
-// 	assert.Equal(t, 2, v.B, "expected: 2, got: %v", v.B)
-// }
+func TestUnmarshalZeroesStruct(t *testing.T) {
+	data, err := bson.MarshalWithRegistry(mgoRegistry, bson.M{"b": 2})
+	assert.Nil(t, err, "expected nil error, got: %v", err)
+	type T struct{ A, B int }
+	v := T{A: 1}
+	err = bson.UnmarshalWithRegistry(mgoRegistry, data, &v)
+	assert.Nil(t, err, "expected nil error, got: %v", err)
+	assert.Equal(t, 0, v.A, "expected: 0, got: %v", v.A)
+	assert.Equal(t, 2, v.B, "expected: 2, got: %v", v.B)
+}
 
 // func TestUnmarshalZeroesMap(t *testing.T) {
 // 	data, err := bson.MarshalWithRegistry(mgoRegistry, bson.M{"b": 2})
@@ -226,17 +226,17 @@ func TestUnmarshalRawIncompatible(t *testing.T) {
 // 	assert.True(t, reflect.DeepEqual(want, m), "expected: %v, got: %v", want, m)
 // }
 
-// func TestUnmarshalNonNilInterface(t *testing.T) {
-// 	data, err := bson.MarshalWithRegistry(mgoRegistry, bson.M{"b": 2})
-// 	assert.Nil(t, err, "expected nil error, got: %v", err)
-// 	m := bson.M{"a": 1}
-// 	var i interface{}
-// 	i = m
-// 	err = bson.UnmarshalWithRegistry(mgoRegistry, data, &i)
-// 	assert.Nil(t, err, "expected nil error, got: %v", err)
-// 	assert.True(t, reflect.DeepEqual(bson.M{"b": 2}, i), "expected: %v, got: %v", bson.M{"b": 2}, i)
-// 	assert.True(t, reflect.DeepEqual(bson.M{"a": 1}, i), "expected: %v, got: %v", bson.M{"a": 1}, i)
-// }
+func TestUnmarshalNonNilInterface(t *testing.T) {
+	data, err := bson.MarshalWithRegistry(mgoRegistry, bson.M{"b": 2})
+	assert.Nil(t, err, "expected nil error, got: %v", err)
+	m := bson.M{"a": 1}
+	var i interface{}
+	i = m
+	err = bson.UnmarshalWithRegistry(mgoRegistry, data, &i)
+	assert.Nil(t, err, "expected nil error, got: %v", err)
+	assert.True(t, reflect.DeepEqual(bson.M{"b": 2}, i), "expected: %v, got: %v", bson.M{"b": 2}, i)
+	assert.True(t, reflect.DeepEqual(bson.M{"a": 1}, m), "expected: %v, got: %v", bson.M{"a": 1}, m)
+}
 
 func TestPtrInline(t *testing.T) {
 	cases := []struct {
@@ -1354,12 +1354,12 @@ var twoWayCrossItems = []crossTypeItem{
 	// {&struct{ S string }{"ghi"}, &struct{ S primitive.Symbol }{"ghi"}},
 
 	// map <=> struct
-	// {&struct {
-	// 	A struct {
-	// 		B, C int
-	// 	}
-	// }{struct{ B, C int }{1, 2}},
-	// 	map[string]map[string]int{"a": {"b": 1, "c": 2}}},
+	{&struct {
+		A struct {
+			B, C int
+		}
+	}{struct{ B, C int }{1, 2}},
+		&map[string]map[string]int{"a": {"b": 1, "c": 2}}},
 
 	// {&struct{ A primitive.Symbol }{"abc"}, &map[string]string{"a": "abc"}},
 	// {&struct{ A primitive.Symbol }{"abc"}, &map[string][]byte{"a": []byte("abc")}},
@@ -1414,7 +1414,7 @@ var twoWayCrossItems = []crossTypeItem{
 	{&condTime{}, &map[string]string{}},
 
 	{&condStruct{struct{ A []int }{[]int{1}}}, &bson.M{"v": bson.M{"a": []interface{}{1}}}},
-	// {&condStruct{struct{ A []int }{}}, &bson.M{}},
+	{&condStruct{struct{ A []int }{}}, &bson.M{}},
 
 	// {&condRaw{bson.RawValue{Type: 0x0A, Value: []byte{}}},&bson.M{"v": nil}},
 	// {&condRaw{bson.RawValue{Type: 0x00}}, &bson.M{}},
@@ -1508,9 +1508,9 @@ var oneWayCrossItems = []crossTypeItem{
 	{&shortIface{int64(1) << 30}, &map[string]interface{}{"v": 1 << 30}},
 
 	// Ensure omitempty on struct with private fields works properly.
-	// {&struct {
-	// 	V struct{ v time.Time } `bson:",omitempty"`
-	// }{}, &map[string]interface{}{}},
+	{&struct {
+		V struct{ v time.Time } `bson:",omitempty"`
+	}{}, &map[string]interface{}{}},
 
 	// Attempt to marshal slice into RawD (issue #120).
 	// {bson.M{"x": []int{1, 2, 3}}, &struct{ X bson.Raw }{}},

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -38,7 +38,12 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 	bsoncodec.DefaultValueDecoders{}.RegisterDefaultDecoders(rb)
 	bson.PrimitiveCodecs{}.RegisterPrimitiveCodecs(rb)
 
+	structcodec, _ := bsoncodec.NewStructCodec(bsoncodec.DefaultStructTagParser,
+		bsonoptions.StructCodec().SetDecodeZeroStruct(true).SetDecodeDeepZeroInline(true).SetOmitDefaultStruct(true))
+
 	rb.RegisterDefaultDecoder(reflect.String, bsoncodec.NewStringCodec(bsonoptions.StringCodec().SetDecodeObjectIDAsHex(false))).
+		RegisterDefaultEncoder(reflect.Struct, structcodec).
+		RegisterDefaultDecoder(reflect.Struct, structcodec).
 		RegisterTypeMapEntry(bsontype.Int32, tInt).
 		RegisterTypeMapEntry(bsontype.Type(0), tM).
 		RegisterTypeMapEntry(bsontype.Binary, tByteSlice).

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -39,7 +39,7 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 	bson.PrimitiveCodecs{}.RegisterPrimitiveCodecs(rb)
 
 	structcodec, _ := bsoncodec.NewStructCodec(bsoncodec.DefaultStructTagParser,
-		bsonoptions.StructCodec().SetDecodeZeroStruct(true).SetDecodeDeepZeroInline(true).SetOmitDefaultStruct(true))
+		bsonoptions.StructCodec().SetDecodeZeroStruct(true).SetDecodeDeepZeroInline(true).SetEncodeOmitDefaultStruct(true))
 
 	rb.RegisterDefaultDecoder(reflect.String, bsoncodec.NewStringCodec(bsonoptions.StringCodec().SetDecodeObjectIDAsHex(false))).
 		RegisterDefaultEncoder(reflect.Struct, structcodec).


### PR DESCRIPTION
The lax decoding work was removed from the scope of this ticket, as it is impossible to add an option for mgobson's specific lax decoding behavior without backwards breaking changes.