### PR TITLE
Document default encoding/decoding behavior for Go to BSON

### DIFF
--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -22,7 +22,7 @@ const (
 
 var defaultTimeCodec = NewTimeCodec()
 
-// TimeCodec is the Codec used for struct values.
+// TimeCodec is the Codec used for time.Time values.
 type TimeCodec struct {
 	UseLocalTimeZone bool
 }

--- a/bson/doc.go
+++ b/bson/doc.go
@@ -123,5 +123,5 @@
 //     30. string encodes to a BSON string. Strings can be decoded from a BSON string, ObjectId, or symbol. See
 //     StringCodec in bsoncodec for more information.
 //
-//     31. Structs encode to BSON subdocuments. See StructCodec in bsoncodec for more information.
+//     31. Structs encode to a BSON document. See StructCodec in bsoncodec for more information.
 package bson

--- a/bson/doc.go
+++ b/bson/doc.go
@@ -39,4 +39,89 @@
 // 		err = bson.Unmarshal(b, &fooer)
 // 		if err != nil { return err }
 // 		// do something with fooer...
+//
+// The default encoding/decoding mappings for Go to BSON types are:
+//
+//     1. []byte encodes to a BSON binary with subtype 0. See DefaultValueEncoders.ByteSliceEncodeValue in bsoncodec for
+//     more information.
+//
+//     2. time.Time encodes to a BSON datetime. This can be decoded from a BSON datetime, string (in RFC-3339 format),
+//     int64, or timestamp. See TimeCodec in bsoncodec for more information.
+//
+//     3. interface{} encodes to any BSON type, depending on the underlying concrete type. When decoding, interface{} will
+//     default to bson.D. See DefaultValueEncoders.EmptyInterfaceEncodeValue in bsoncodec for more information.
+//
+//     4. primitive.ObjectID encodes to a BSON ObjectId. See DefaultValueEncoders.ObjectIDEncodeValue in bsoncodec for more
+//     information.
+//
+//     5. primitive.Decimal128 encodes to a BSON decimal128. See DefaultValueEncoders.Decimal128EncodeValue in bsoncodec for
+//     more information.
+//
+//     6. json.Number encodes to a BSON int64 or double depending on the number. See
+//     DefaultValueEncoders.JSONNumberEncodeValue in bsoncodec for more information.
+//
+//     7. url.URL encodes to a BSON string. See DefaultValueEncoders.URLEncodeValue in bsoncodec for more information.
+//
+//     8. primitive.JavaScript encodes to a BSON JavaScript code value. See DefaultValueEncoders.JavaScriptEncodeValue
+//     in bsoncodec for more information.
+//
+//     9. primitive.CodeWithScope encodes to a BSON code with scope value. See
+//     DefaultValueEncoders.CodeWWithScopeEncodeValue in bsoncodec for more information.
+//
+//     10. primitive.Symbol encodes to a BSON symbol value. See DefaultValueEncoders.SymbolEncodeValue in bsoncodec for more
+//     information.
+//
+//     11. primitive.Binary encodes to a BSON binary. See DefaultValueEncoders.BinaryEncodeValue in bsoncodec for more
+//     information.
+//
+//     12. primitive.Undefined encodes to a BSON undefined value. See DefaultValueEncoders.UndefinedEncodeValue in bsoncodec
+//     for more information.
+//
+//     13. primitive.DateTime encodes to BSON datetime. See DefaultValueEncoders.DateTimeEncodeValue in bsoncodec for more
+//     information.
+//
+//     14. primitive.Null encodes to a BSON null value. See DefaultValueEncoders.NullEncodeValue in bsoncodec for more
+//     information.
+//
+//     15. primitive.Regex encodes to a BSON regex. See DefaultValueEncoders.RegexEncodeValue in bsoncodec for more
+//     information.
+//
+//     16. primitive.DBPointer encodes to a BSON DBPointer. See DefaultValueEncoders.DBPointerEncodeValue in bsoncodec for
+//     more information.
+//
+//     17. primitive.Timestamp encodes to a BSON timestamp. See DefaultValueEncoders.TimestampEncodeValue in bsoncodec for
+//     more information.
+//
+//     18. primitive.MinKey encodes to a BSON min key value. See DefaultValueEncoders.MinKeyEncodeValue in bsoncodec for
+//     more information.
+//
+//     19. primitive.MaxKey encodes to a BSON max key value. See DefaultValueEncoders.MaxKeyEncodeValue in bsoncodec for
+//     more information.
+//
+//     20. bson.Raw encodes to a BSON document. See PrimitiveCodecs.RawEncodeValue for more information.
+//
+//     21. bson.D encodes to a BSON document. See DefaultValueEncoders.SliceEncodeValue in bsoncodec for more information.
+//
+//     22. Maps, such as bson.M, encode to a BSON document. Maps must have string keys. See
+//     DefaultValueEncoders.MapEncodeValue in bsoncodec for more information.
+//
+//     23. int8, int16, and int32 encode to a BSON int32. int encodes to a BSON int32 if it's between math.MinInt32 and
+//     math.MaxInt32, inclusive, and a BSON int64 otherwise. int64 encodes to a BSON int64. See
+//     DefaultValueEncoders.IntEncodeValue in bsoncodec for more information.
+//
+//     26. bool encodes to a BSON boolean. See DefaultValueEncoders.BooleanEncodeValue in bsoncodec for more information.
+//
+//     27. uint8 and uint16 encode to a BSON int32. uint, uint32, and uint64 encode to a BSON int64. See
+//     DefaultValueEncoders.UintEncodeValue in bsoncodec for more information.
+//
+//     28. float32 and float64 encode to a BSON double. See DefaultValueEncoders.FloatEncodeValue in bsoncodec for more
+//     information.
+//
+//     29. Arrays and slices encode to BSON arrays. Arrays and slices of primitive.E are treated as a primitive.D and encode
+//     to a BSON subdocument. See DefaultValueEncoders.ArrayEncodeValue in bsoncodec for more information.
+//
+//     30. string encodes to a BSON string. Strings can be decoded from a BSON string, ObjectId, or symbol. See
+//     StringCodec in bsoncodec for more information.
+//
+//     31. Structs encode to BSON subdocuments. See StructCodec in bsoncodec for more information.
 package bson


### PR DESCRIPTION
This PR is pre-work for BSON documentation. It enumerates the default mappings for Go <-> BSON types in a top-level `bson/doc.go` file. Once this is merged, we can start documenting the `Registry` type and the different types of encoders/decoders that can be registered to override these defaults.

I struggled with the wording for this PR. It's hard to have consistent wording because the types are so different (e.g. `interface{}` is a completely different concept from something like `[]byte`) so I'm open to any suggestions.