### PR TITLE
Fix PKG_CONFIG_PATH and LD_LIBRARY_PATH for Evergreen tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -140,9 +140,8 @@ functions:
               export TMPDIR="$MONGO_ORCHESTRATION_HOME/db"
               export PATH="$PATH"
               export PROJECT="$PROJECT"
-              export PKG_CONFIG_PATH=$BSON_INSTALL_PATH/lib/pkgconfig:$LIBMONGOCRYPT_INSTALL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH
-              export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install/mongo-c-driver/lib/pkgconfig
-              export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
+              export PKG_CONFIG_PATH=$BSON_INSTALL_PATH/lib/pkgconfig:$LIBMONGOCRYPT_INSTALL_PATH/lib/pkgconfig:$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install/mongo-c-driver/lib/pkgconfig
+              export LD_LIBRARY_PATH=$BSON_INSTALL_PATH/lib:$LIBMONGOCRYPT_INSTALL_PATH/lib:$(pwd)/install/libmongocrypt/lib
            EOT
            # See what we've done
            cat expansion.yml


### PR DESCRIPTION
Updated the linked patch build to run a full build with the same variants that are run on the waterfall so we can make sure no weird errors are happening.