### PR TITLE
GODRIVER-1349 fix omitEmpty for interface{}

### DIFF
--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -132,6 +132,7 @@ func (sc *StructCodec) EncodeValue(r EncodeContext, vw bsonrw.ValueWriter, val r
 		if cz, ok := encoder.(CodecZeroer); ok {
 			isZero = cz.IsTypeZero(rvInterface)
 		} else if rv.Kind() == reflect.Interface {
+			// sc.isZero will not treat an interface rv as an interface, so we need to check for the zero interface separately.
 			isZero = rv.IsNil()
 		} else {
 			isZero = sc.isZero(rvInterface)

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -127,12 +127,16 @@ func (sc *StructCodec) EncodeValue(r EncodeContext, vw bsonrw.ValueWriter, val r
 
 		encoder := desc.encoder
 
-		iszero := sc.isZero
-		if iz, ok := encoder.(CodecZeroer); ok {
-			iszero = iz.IsTypeZero
+		var isZero bool
+		rvInterface := rv.Interface()
+		if cz, ok := encoder.(CodecZeroer); ok {
+			isZero = cz.IsTypeZero(rvInterface)
+		} else if rv.Kind() == reflect.Interface {
+			isZero = rv.IsNil()
+		} else {
+			isZero = sc.isZero(rvInterface)
 		}
-
-		if desc.omitEmpty && iszero(rv.Interface()) {
+		if desc.omitEmpty && isZero {
 			continue
 		}
 

--- a/bson/mgocompat/bson_test.go
+++ b/bson/mgocompat/bson_test.go
@@ -1404,7 +1404,7 @@ var twoWayCrossItems = []crossTypeItem{
 	{&condMap{map[string]int{"k": 1}}, bson.M{"v": bson.M{"k": 1}}},
 	{&condMap{}, map[string][]string{}},
 	{&condIface{"yo"}, map[string]string{"v": "yo"}},
-	// {&condIface{""}, map[string]string{"v": ""}},
+	{&condIface{""}, map[string]string{"v": ""}},
 	{&condIface{}, map[string]string{}},
 	{&condPtr{&truevar}, map[string]bool{"v": true}},
 	{&condPtr{&falsevar}, map[string]bool{"v": false}},


### PR DESCRIPTION
I realized I forgot to enable one of the mgocompat tests for structcodecs when I did that work.