### PR TITLE
mgocompat ObjectID, interface{}, slice, []byte, and symbol changes

### DIFF
--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -17,7 +17,7 @@ import (
 
 var defaultByteSliceCodec = NewByteSliceCodec()
 
-// ByteSliceCodec is the Codec used for []slice values.
+// ByteSliceCodec is the Codec used for []byte values.
 type ByteSliceCodec struct {
 	EncodeNilAsEmpty bool
 }
@@ -52,7 +52,6 @@ func (bsc *ByteSliceCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, 
 	}
 
 	var data []byte
-	var subtype byte
 	var err error
 	switch vr.Type() {
 	case bsontype.String:
@@ -68,6 +67,7 @@ func (bsc *ByteSliceCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, 
 		}
 		data = []byte(sym)
 	case bsontype.Binary:
+		var subtype byte
 		data, subtype, err = vr.ReadBinary()
 		if err != nil {
 			return err

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -1,0 +1,87 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsonoptions"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+)
+
+var defaultByteSliceCodec = NewByteSliceCodec()
+
+// ByteSliceCodec is the Codec used for []slice values.
+type ByteSliceCodec struct {
+	EncodeNilAsEmpty bool
+}
+
+var _ ValueCodec = &ByteSliceCodec{}
+
+// NewByteSliceCodec returns a StringCodec with options opts.
+func NewByteSliceCodec(opts ...*bsonoptions.ByteSliceCodecOptions) *ByteSliceCodec {
+	byteSliceOpt := bsonoptions.MergeByteSliceCodecOptions(opts...)
+	codec := ByteSliceCodec{}
+	if byteSliceOpt.EncodeNilAsEmpty != nil {
+		codec.EncodeNilAsEmpty = *byteSliceOpt.EncodeNilAsEmpty
+	}
+	return &codec
+}
+
+// EncodeValue is the ValueEncoder for []byte.
+func (bsc *ByteSliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Type() != tByteSlice {
+		return ValueEncoderError{Name: "ByteSliceEncodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
+	}
+	if val.IsNil() && !bsc.EncodeNilAsEmpty {
+		return vw.WriteNull()
+	}
+	return vw.WriteBinary(val.Interface().([]byte))
+}
+
+// DecodeValue is the ValueDecoder for []byte.
+func (bsc *ByteSliceCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Type() != tByteSlice {
+		return ValueDecoderError{Name: "ByteSliceDecodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
+	}
+
+	var data []byte
+	var subtype byte
+	var err error
+	switch vr.Type() {
+	case bsontype.String:
+		str, err := vr.ReadString()
+		if err != nil {
+			return err
+		}
+		data = []byte(str)
+	case bsontype.Symbol:
+		sym, err := vr.ReadSymbol()
+		if err != nil {
+			return err
+		}
+		data = []byte(sym)
+	case bsontype.Binary:
+		data, subtype, err = vr.ReadBinary()
+		if err != nil {
+			return err
+		}
+		if subtype != bsontype.BinaryGeneric && subtype != bsontype.BinaryBinaryOld {
+			return fmt.Errorf("ByteSliceDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, subtype)
+		}
+	case bsontype.Null:
+		val.Set(reflect.Zero(val.Type()))
+		return vr.ReadNull()
+	default:
+		return fmt.Errorf("cannot decode %v into a []byte", vr.Type())
+	}
+
+	val.Set(reflect.ValueOf(data))
+	return nil
+}

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -51,9 +51,9 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterDecoder(tMaxKey, ValueDecoderFunc(dvd.MaxKeyDecodeValue)).
 		RegisterDecoder(tJavaScript, ValueDecoderFunc(dvd.JavaScriptDecodeValue)).
 		RegisterDecoder(tSymbol, ValueDecoderFunc(dvd.SymbolDecodeValue)).
-		RegisterDecoder(tByteSlice, ValueDecoderFunc(dvd.ByteSliceDecodeValue)).
+		RegisterDecoder(tByteSlice, defaultByteSliceCodec).
 		RegisterDecoder(tTime, defaultTimeCodec).
-		RegisterDecoder(tEmpty, ValueDecoderFunc(dvd.EmptyInterfaceDecodeValue)).
+		RegisterDecoder(tEmpty, defaultEmptyInterfaceCodec).
 		RegisterDecoder(tOID, ValueDecoderFunc(dvd.ObjectIDDecodeValue)).
 		RegisterDecoder(tDecimal, ValueDecoderFunc(dvd.Decimal128DecodeValue)).
 		RegisterDecoder(tJSONNumber, ValueDecoderFunc(dvd.JSONNumberDecodeValue)).
@@ -77,7 +77,7 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterDefaultDecoder(reflect.Float64, ValueDecoderFunc(dvd.FloatDecodeValue)).
 		RegisterDefaultDecoder(reflect.Array, ValueDecoderFunc(dvd.ArrayDecodeValue)).
 		RegisterDefaultDecoder(reflect.Map, defaultMapCodec).
-		RegisterDefaultDecoder(reflect.Slice, ValueDecoderFunc(dvd.SliceDecodeValue)).
+		RegisterDefaultDecoder(reflect.Slice, defaultSliceCodec).
 		RegisterDefaultDecoder(reflect.String, defaultStringCodec).
 		RegisterDefaultDecoder(reflect.Struct, defaultStructCodec).
 		RegisterDefaultDecoder(reflect.Ptr, NewPointerCodec()).
@@ -400,13 +400,30 @@ func (DefaultValueDecoders) SymbolDecodeValue(dctx DecodeContext, vr bsonrw.Valu
 		return ValueDecoderError{Name: "SymbolDecodeValue", Types: []reflect.Type{tSymbol}, Received: val}
 	}
 
-	if vr.Type() != bsontype.Symbol {
+	var symbol string
+	var err error
+	switch vr.Type() {
+	case bsontype.String:
+		symbol, err = vr.ReadString()
+		if err != nil {
+			return err
+		}
+	case bsontype.Symbol:
+		symbol, err = vr.ReadSymbol()
+		if err != nil {
+			return err
+		}
+	case bsontype.Binary:
+		data, subtype, err := vr.ReadBinary()
+		if err != nil {
+			return err
+		}
+		if subtype != bsontype.BinaryGeneric && subtype != bsontype.BinaryBinaryOld {
+			return fmt.Errorf("SymbolDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, subtype)
+		}
+		symbol = string(data)
+	default:
 		return fmt.Errorf("cannot decode %v into a primitive.Symbol", vr.Type())
-	}
-
-	symbol, err := vr.ReadSymbol()
-	if err != nil {
-		return err
 	}
 
 	val.SetString(symbol)
@@ -452,10 +469,24 @@ func (dvd DefaultValueDecoders) ObjectIDDecodeValue(dc DecodeContext, vr bsonrw.
 		return ValueDecoderError{Name: "ObjectIDDecodeValue", Types: []reflect.Type{tOID}, Received: val}
 	}
 
-	if vr.Type() != bsontype.ObjectID {
+	var oid primitive.ObjectID
+	var err error
+	switch vr.Type() {
+	case bsontype.ObjectID:
+		oid, err = vr.ReadObjectID()
+	case bsontype.String:
+		str, err := vr.ReadString()
+		if err != nil {
+			return err
+		}
+		if len(str) != 12 {
+			return fmt.Errorf("An ObjectID string must be exactly 12 bytes long (got %v)", len(str))
+		}
+		byteArr := []byte(str)
+		copy(oid[:], byteArr)
+	default:
 		return fmt.Errorf("cannot decode %v into an ObjectID", vr.Type())
 	}
-	oid, err := vr.ReadObjectID()
 	val.Set(reflect.ValueOf(oid))
 	return err
 }
@@ -762,6 +793,26 @@ func (dvd DefaultValueDecoders) ArrayDecodeValue(dc DecodeContext, vr bsonrw.Val
 		if val.Type().Elem() != tE {
 			return fmt.Errorf("cannot decode document into %s", val.Type())
 		}
+	case bsontype.Binary:
+		if val.Type().Elem() != tByte {
+			return fmt.Errorf("ArrayDecodeValue can only be used to decode binary into a byte array, got %v", vr.Type())
+		}
+		data, subtype, err := vr.ReadBinary()
+		if err != nil {
+			return err
+		}
+		if subtype != bsontype.BinaryGeneric && subtype != bsontype.BinaryBinaryOld {
+			return fmt.Errorf("ArrayDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, subtype)
+		}
+
+		if len(data) > val.Len() {
+			return fmt.Errorf("more elements returned in array than can fit inside %s", val.Type())
+		}
+
+		for idx, elem := range data {
+			val.Index(idx).Set(reflect.ValueOf(elem))
+		}
+		return nil
 	default:
 		return fmt.Errorf("cannot decode %v into an array", vr.Type())
 	}

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -831,7 +831,7 @@ func (dvd DefaultValueDecoders) ArrayDecodeValue(dc DecodeContext, vr bsonrw.Val
 	}
 
 	if len(elems) > val.Len() {
-		return fmt.Errorf("more elements returned in array than can fit inside %s", val.Type())
+		return fmt.Errorf("more elements returned in array than can fit inside %s, got %v elements", val.Type(), len(elems))
 	}
 
 	for idx, elem := range elems {

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -2042,7 +2042,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		_, vr, err := dr.ReadElement()
 		noerr(t, err)
 		var val [1]string
-		want := fmt.Errorf("more elements returned in array than can fit inside %T", val)
+		want := fmt.Errorf("more elements returned in array than can fit inside %T, got 2 elements", val)
 
 		dc := DecodeContext{Registry: buildDefaultRegistry()}
 		got := dvd.ArrayDecodeValue(dc, vr, reflect.ValueOf(val))

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -703,14 +703,14 @@ func TestDefaultValueDecoders(t *testing.T) {
 		},
 		{
 			"TimeDecodeValue",
-			ValueDecoderFunc(dvd.TimeDecodeValue),
+			defaultTimeCodec,
 			[]subtest{
 				{
 					"wrong type",
 					wrong,
 					nil,
 					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.DateTime, Return: int64(0)},
-					bsonrwtest.ReadDateTime,
+					bsonrwtest.Nothing,
 					ValueDecoderError{Name: "TimeDecodeValue", Types: []reflect.Type{tTime}, Received: reflect.ValueOf(wrong)},
 				},
 				{
@@ -741,7 +741,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		},
 		{
 			"MapDecodeValue",
-			ValueDecoderFunc(dvd.MapDecodeValue),
+			defaultMapCodec,
 			[]subtest{
 				{
 					"wrong kind",
@@ -753,15 +753,11 @@ func TestDefaultValueDecoders(t *testing.T) {
 				},
 				{
 					"wrong kind (non-string key)",
-					map[int]interface{}{},
-					nil,
+					map[bool]interface{}{},
+					&DecodeContext{Registry: buildDefaultRegistry()},
 					&bsonrwtest.ValueReaderWriter{},
-					bsonrwtest.Nothing,
-					ValueDecoderError{
-						Name:     "MapDecodeValue",
-						Kinds:    []reflect.Kind{reflect.Map},
-						Received: reflect.ValueOf(map[int]interface{}{}),
-					},
+					bsonrwtest.ReadElement,
+					fmt.Errorf("BSON map must have string or decimal keys. Got:%v", reflect.ValueOf(map[bool]interface{}{}).Type()),
 				},
 				{
 					"ReadDocument Error",
@@ -885,7 +881,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		},
 		{
 			"SliceDecodeValue",
-			ValueDecoderFunc(dvd.SliceDecodeValue),
+			defaultSliceCodec,
 			[]subtest{
 				{
 					"wrong kind",
@@ -907,9 +903,9 @@ func TestDefaultValueDecoders(t *testing.T) {
 					"Not Type Array",
 					[]interface{}{},
 					nil,
-					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.String},
+					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Int32},
 					bsonrwtest.Nothing,
-					errors.New("cannot decode string into a slice"),
+					errors.New("cannot decode 32-bit integer into a slice"),
 				},
 				{
 					"ReadArray Error",
@@ -977,9 +973,9 @@ func TestDefaultValueDecoders(t *testing.T) {
 					"type not objectID",
 					primitive.ObjectID{},
 					nil,
-					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.String},
+					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Int32},
 					bsonrwtest.Nothing,
-					fmt.Errorf("cannot decode %v into an ObjectID", bsontype.String),
+					fmt.Errorf("cannot decode %v into an ObjectID", bsontype.Int32),
 				},
 				{
 					"ReadObjectID Error",
@@ -1006,6 +1002,17 @@ func TestDefaultValueDecoders(t *testing.T) {
 						Return:   primitive.ObjectID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 					},
 					bsonrwtest.ReadObjectID,
+					nil,
+				},
+				{
+					"success/string",
+					primitive.ObjectID{0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61, 0x62},
+					nil,
+					&bsonrwtest.ValueReaderWriter{
+						BSONType: bsontype.String,
+						Return:   "0123456789ab",
+					},
+					bsonrwtest.ReadString,
 					nil,
 				},
 			},
@@ -1190,11 +1197,11 @@ func TestDefaultValueDecoders(t *testing.T) {
 		},
 		{
 			"ByteSliceDecodeValue",
-			ValueDecoderFunc(dvd.ByteSliceDecodeValue),
+			defaultByteSliceCodec,
 			[]subtest{
 				{
 					"wrong type",
-					wrong,
+					[]byte{},
 					nil,
 					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Int32},
 					bsonrwtest.Nothing,
@@ -1228,7 +1235,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 						},
 					},
 					bsonrwtest.ReadBinary,
-					fmt.Errorf("ByteSliceDecodeValue can only be used to decode subtype 0x00 for %s, got %v", bsontype.Binary, byte(0xFF)),
+					fmt.Errorf("ByteSliceDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, byte(0xFF)),
 				},
 				{
 					"can set false",
@@ -1761,9 +1768,9 @@ func TestDefaultValueDecoders(t *testing.T) {
 					"type not Symbol",
 					primitive.Symbol(""),
 					nil,
-					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.String},
+					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Int32},
 					bsonrwtest.Nothing,
-					fmt.Errorf("cannot decode %v into a primitive.Symbol", bsontype.String),
+					fmt.Errorf("cannot decode %v into a primitive.Symbol", bsontype.Int32),
 				},
 				{
 					"ReadSymbol Error",

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -202,7 +202,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		},
 		{
 			"TimeEncodeValue",
-			ValueEncoderFunc(dve.TimeEncodeValue),
+			defaultTimeCodec,
 			[]subtest{
 				{
 					"wrong type",
@@ -375,7 +375,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		},
 		{
 			"SliceEncodeValue",
-			ValueEncoderFunc(dve.SliceEncodeValue),
+			defaultSliceCodec,
 			[]subtest{
 				{
 					"wrong kind",
@@ -539,7 +539,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		},
 		{
 			"ByteSliceEncodeValue",
-			ValueEncoderFunc(dve.ByteSliceEncodeValue),
+			defaultByteSliceCodec,
 			[]subtest{
 				{
 					"wrong type",
@@ -555,7 +555,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		},
 		{
 			"EmptyInterfaceEncodeValue",
-			ValueEncoderFunc(dve.EmptyInterfaceEncodeValue),
+			defaultEmptyInterfaceCodec,
 			[]subtest{
 				{
 					"wrong type",

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -1,0 +1,100 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsonoptions"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var defaultEmptyInterfaceCodec = NewEmptyInterfaceCodec()
+
+// EmptyInterfaceCodec is the Codec used for interface{} values.
+type EmptyInterfaceCodec struct {
+	DecodeDefaultType  reflect.Type
+	DecodeUnpackBinary bool
+}
+
+var _ ValueCodec = &EmptyInterfaceCodec{}
+
+// NewEmptyInterfaceCodec returns a EmptyInterfaceCodec with options opts.
+func NewEmptyInterfaceCodec(opts ...*bsonoptions.EmptyInterfaceCodecOptions) *EmptyInterfaceCodec {
+	interfaceOpt := bsonoptions.MergeEmptyInterfaceCodecOptions(opts...)
+
+	codec := EmptyInterfaceCodec{
+		DecodeDefaultType: *interfaceOpt.DecodeDefaultType,
+	}
+	if interfaceOpt.DecodeUnpackBinary != nil {
+		codec.DecodeUnpackBinary = *interfaceOpt.DecodeUnpackBinary
+	}
+	return &codec
+}
+
+// EncodeValue is the ValueEncoderFunc for interface{}.
+func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Type() != tEmpty {
+		return ValueEncoderError{Name: "EmptyInterfaceEncodeValue", Types: []reflect.Type{tEmpty}, Received: val}
+	}
+
+	if val.IsNil() {
+		return vw.WriteNull()
+	}
+	encoder, err := ec.LookupEncoder(val.Elem().Type())
+	if err != nil {
+		return err
+	}
+
+	return encoder.EncodeValue(ec, vw, val.Elem())
+}
+
+// DecodeValue is the ValueDecoderFunc for interface{}.
+func (eic EmptyInterfaceCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Type() != tEmpty {
+		return ValueDecoderError{Name: "EmptyInterfaceDecodeValue", Types: []reflect.Type{tEmpty}, Received: val}
+	}
+
+	rtype, err := dc.LookupTypeMapEntry(vr.Type())
+	if err != nil {
+		switch vr.Type() {
+		case bsontype.EmbeddedDocument:
+			if dc.Ancestor != nil {
+				rtype = dc.Ancestor
+				break
+			}
+			rtype = eic.DecodeDefaultType
+		case bsontype.Null:
+			val.Set(reflect.Zero(val.Type()))
+			return vr.ReadNull()
+		default:
+			return err
+		}
+	}
+
+	decoder, err := dc.LookupDecoder(rtype)
+	if err != nil {
+		return err
+	}
+
+	elem := reflect.New(rtype).Elem()
+	err = decoder.DecodeValue(dc, vr, elem)
+	if err != nil {
+		return err
+	}
+	if eic.DecodeUnpackBinary && rtype == tBinary {
+		binElem := elem.Interface().(primitive.Binary)
+		if binElem.Subtype == bsontype.BinaryGeneric || binElem.Subtype == bsontype.BinaryBinaryOld {
+			elem = reflect.ValueOf(binElem.Data)
+		}
+	}
+
+	val.Set(elem)
+	return nil
+}

--- a/bson/bsoncodec/slice_codec.go
+++ b/bson/bsoncodec/slice_codec.go
@@ -1,0 +1,196 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsonoptions"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var defaultSliceCodec = NewSliceCodec()
+
+// SliceCodec is the Codec used for slice values.
+type SliceCodec struct {
+	EncodeNilAsEmpty bool
+}
+
+var _ ValueCodec = &MapCodec{}
+
+// NewSliceCodec returns a MapCodec with options opts.
+func NewSliceCodec(opts ...*bsonoptions.SliceCodecOptions) *SliceCodec {
+	sliceOpt := bsonoptions.MergeSliceCodecOptions(opts...)
+
+	codec := SliceCodec{}
+	if sliceOpt.EncodeNilAsEmpty != nil {
+		codec.EncodeNilAsEmpty = *sliceOpt.EncodeNilAsEmpty
+	}
+	return &codec
+}
+
+// EncodeValue is the ValueEncoder for slice types.
+func (sc SliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Kind() != reflect.Slice {
+		return ValueEncoderError{Name: "SliceEncodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
+	}
+
+	if val.IsNil() && !sc.EncodeNilAsEmpty {
+		return vw.WriteNull()
+	}
+
+	// If we have a []byte we want to treat it as a binary instead of as an array.
+	if val.Type().Elem() == tByte {
+		var byteSlice []byte
+		for idx := 0; idx < val.Len(); idx++ {
+			byteSlice = append(byteSlice, val.Index(idx).Interface().(byte))
+		}
+		return vw.WriteBinary(byteSlice)
+	}
+
+	// If we have a []primitive.E we want to treat it as a document instead of as an array.
+	if val.Type().ConvertibleTo(tD) {
+		d := val.Convert(tD).Interface().(primitive.D)
+
+		dw, err := vw.WriteDocument()
+		if err != nil {
+			return err
+		}
+
+		for _, e := range d {
+			err = encodeElement(ec, dw, e)
+			if err != nil {
+				return err
+			}
+		}
+
+		return dw.WriteDocumentEnd()
+	}
+
+	aw, err := vw.WriteArray()
+	if err != nil {
+		return err
+	}
+
+	elemType := val.Type().Elem()
+	encoder, err := ec.LookupEncoder(elemType)
+	if err != nil && elemType.Kind() != reflect.Interface {
+		return err
+	}
+
+	for idx := 0; idx < val.Len(); idx++ {
+		currEncoder, currVal, lookupErr := defaultValueEncoders.lookupElementEncoder(ec, encoder, val.Index(idx))
+		if lookupErr != nil && lookupErr != errInvalidValue {
+			return lookupErr
+		}
+
+		vw, err := aw.WriteArrayElement()
+		if err != nil {
+			return err
+		}
+
+		if lookupErr == errInvalidValue {
+			err = vw.WriteNull()
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		err = currEncoder.EncodeValue(ec, vw, currVal)
+		if err != nil {
+			return err
+		}
+	}
+	return aw.WriteArrayEnd()
+}
+
+// DecodeValue is the ValueDecoder for slice types.
+func (sc *SliceCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Kind() != reflect.Slice {
+		return ValueDecoderError{Name: "SliceDecodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
+	}
+
+	switch vr.Type() {
+	case bsontype.Array:
+	case bsontype.Null:
+		val.Set(reflect.Zero(val.Type()))
+		return vr.ReadNull()
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+		if val.Type().Elem() != tE {
+			return fmt.Errorf("cannot decode document into %s", val.Type())
+		}
+	case bsontype.Binary:
+		if val.Type().Elem() != tByte {
+			return fmt.Errorf("SliceDecodeValue can only decode a binary into a byte array, got %v", vr.Type())
+		}
+		data, subtype, err := vr.ReadBinary()
+		if err != nil {
+			return err
+		}
+		if subtype != bsontype.BinaryGeneric && subtype != bsontype.BinaryBinaryOld {
+			return fmt.Errorf("SliceDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, subtype)
+		}
+
+		if val.IsNil() {
+			val.Set(reflect.MakeSlice(val.Type(), 0, len(data)))
+		}
+
+		val.SetLen(0)
+		for _, elem := range data {
+			val.Set(reflect.Append(val, reflect.ValueOf(elem)))
+		}
+		return nil
+	case bsontype.String:
+		if val.Type().Elem() != tByte {
+			return fmt.Errorf("SliceDecodeValue can only decode a string into a byte array, got %v", vr.Type())
+		}
+		str, err := vr.ReadString()
+		if err != nil {
+			return err
+		}
+		byteStr := []byte(str)
+
+		if val.IsNil() {
+			val.Set(reflect.MakeSlice(val.Type(), 0, len(byteStr)))
+		}
+
+		val.SetLen(0)
+		for _, elem := range byteStr {
+			val.Set(reflect.Append(val, reflect.ValueOf(elem)))
+		}
+		return nil
+	default:
+		return fmt.Errorf("cannot decode %v into a slice", vr.Type())
+	}
+
+	var elemsFunc func(DecodeContext, bsonrw.ValueReader, reflect.Value) ([]reflect.Value, error)
+	switch val.Type().Elem() {
+	case tE:
+		dc.Ancestor = val.Type()
+		elemsFunc = defaultValueDecoders.decodeD
+	default:
+		elemsFunc = defaultValueDecoders.decodeDefault
+	}
+
+	elems, err := elemsFunc(dc, vr, val)
+	if err != nil {
+		return err
+	}
+
+	if val.IsNil() {
+		val.Set(reflect.MakeSlice(val.Type(), 0, len(elems)))
+	}
+
+	val.SetLen(0)
+	val.Set(reflect.Append(val, elems...))
+
+	return nil
+}

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -72,6 +72,16 @@ func (sc *StringCodec) DecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, va
 		if err != nil {
 			return err
 		}
+	case bsontype.Binary:
+		data, subtype, err := vr.ReadBinary()
+		if err != nil {
+			return err
+		}
+		if subtype == bsontype.BinaryGeneric || subtype == bsontype.BinaryBinaryOld {
+			str = string(data)
+			break
+		}
+		fallthrough
 	default:
 		return fmt.Errorf("cannot decode %v into a string type", vr.Type())
 	}

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -77,11 +77,10 @@ func (sc *StringCodec) DecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, va
 		if err != nil {
 			return err
 		}
-		if subtype == bsontype.BinaryGeneric || subtype == bsontype.BinaryBinaryOld {
-			str = string(data)
-			break
+		if subtype != bsontype.BinaryGeneric && subtype != bsontype.BinaryBinaryOld {
+			return fmt.Errorf("SliceDecodeValue can only be used to decode subtype 0x00 or 0x02 for %s, got %v", bsontype.Binary, subtype)
 		}
-		fallthrough
+		str = string(data)
 	default:
 		return fmt.Errorf("cannot decode %v into a string type", vr.Type())
 	}

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -240,6 +240,7 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr bsonrw.ValueReader, val r
 			}
 
 			elem := reflect.New(inlineMap.Type().Elem()).Elem()
+			r.Ancestor = inlineMap.Type()
 			err = decoder.DecodeValue(r, vr, elem)
 			if err != nil {
 				return err

--- a/bson/bsoncodec/types.go
+++ b/bson/bsoncodec/types.go
@@ -74,6 +74,7 @@ var tDecimal = reflect.TypeOf(primitive.Decimal128{})
 var tMinKey = reflect.TypeOf(primitive.MinKey{})
 var tMaxKey = reflect.TypeOf(primitive.MaxKey{})
 var tD = reflect.TypeOf(primitive.D{})
+var tM = reflect.TypeOf(primitive.M{})
 var tA = reflect.TypeOf(primitive.A{})
 var tE = reflect.TypeOf(primitive.E{})
 

--- a/bson/bsonoptions/byte_slice_codec_options.go
+++ b/bson/bsonoptions/byte_slice_codec_options.go
@@ -1,0 +1,38 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsonoptions
+
+// ByteSliceCodecOptions represents all possible options for byte slice encoding and decoding.
+type ByteSliceCodecOptions struct {
+	EncodeNilAsEmpty *bool // Specifies if a nil byte slice should encode as an empty binary instead of null. Defaults to false.
+}
+
+// ByteSliceCodec creates a new *ByteSliceCodecOptions
+func ByteSliceCodec() *ByteSliceCodecOptions {
+	return &ByteSliceCodecOptions{}
+}
+
+// SetEncodeNilAsEmpty specifies  if a nil byte slice should encode as an empty binary instead of null. Defaults to false.
+func (bs *ByteSliceCodecOptions) SetEncodeNilAsEmpty(b bool) *ByteSliceCodecOptions {
+	bs.EncodeNilAsEmpty = &b
+	return bs
+}
+
+// MergeByteSliceCodecOptions combines the given *ByteSliceCodecOptions into a single *ByteSliceCodecOptions in a last one wins fashion.
+func MergeByteSliceCodecOptions(opts ...*ByteSliceCodecOptions) *ByteSliceCodecOptions {
+	bs := ByteSliceCodec()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if opt.EncodeNilAsEmpty != nil {
+			bs.EncodeNilAsEmpty = opt.EncodeNilAsEmpty
+		}
+	}
+
+	return bs
+}

--- a/bson/bsonoptions/empty_interface_codec_options.go
+++ b/bson/bsonoptions/empty_interface_codec_options.go
@@ -1,0 +1,58 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsonoptions
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var defaultDecodeType = reflect.TypeOf(primitive.D{})
+
+// EmptyInterfaceCodecOptions represents all possible options for interface{} encoding and decoding.
+type EmptyInterfaceCodecOptions struct {
+	DecodeDefaultType  *reflect.Type // Specifies if the default type for decoding. Defaults to bson.D.
+	DecodeUnpackBinary *bool         // Specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
+}
+
+// EmptyInterfaceCodec creates a new *EmptyInterfaceCodecOptions
+func EmptyInterfaceCodec() *EmptyInterfaceCodecOptions {
+	return &EmptyInterfaceCodecOptions{}
+}
+
+// SetDecodeDefaultType specifies if the default type for decoding. Defaults to bson.D.
+func (e *EmptyInterfaceCodecOptions) SetDecodeDefaultType(t reflect.Type) *EmptyInterfaceCodecOptions {
+	e.DecodeDefaultType = &t
+	return e
+}
+
+// SetDecodeUnpackBinary specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
+func (e *EmptyInterfaceCodecOptions) SetDecodeUnpackBinary(b bool) *EmptyInterfaceCodecOptions {
+	e.DecodeUnpackBinary = &b
+	return e
+}
+
+// MergeEmptyInterfaceCodecOptions combines the given *EmptyInterfaceCodecOptions into a single *EmptyInterfaceCodecOptions in a last one wins fashion.
+func MergeEmptyInterfaceCodecOptions(opts ...*EmptyInterfaceCodecOptions) *EmptyInterfaceCodecOptions {
+	e := &EmptyInterfaceCodecOptions{
+		DecodeDefaultType: &defaultDecodeType,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if opt.DecodeDefaultType != nil {
+			e.DecodeDefaultType = opt.DecodeDefaultType
+		}
+		if opt.DecodeUnpackBinary != nil {
+			e.DecodeUnpackBinary = opt.DecodeUnpackBinary
+		}
+	}
+
+	return e
+}

--- a/bson/bsonoptions/empty_interface_codec_options.go
+++ b/bson/bsonoptions/empty_interface_codec_options.go
@@ -6,18 +6,10 @@
 
 package bsonoptions
 
-import (
-	"reflect"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
-)
-
-var defaultDecodeType = reflect.TypeOf(primitive.D{})
-
 // EmptyInterfaceCodecOptions represents all possible options for interface{} encoding and decoding.
 type EmptyInterfaceCodecOptions struct {
-	DecodeDefaultType  *reflect.Type // Specifies if the default type for decoding. Defaults to bson.D.
-	DecodeUnpackBinary *bool         // Specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
+	DecodeAsMap         *bool // Specifies if the default type for decoding should be a bson.M instead of a bson.D. Defaults to false.
+	DecodeBinaryAsSlice *bool // Specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
 }
 
 // EmptyInterfaceCodec creates a new *EmptyInterfaceCodecOptions
@@ -25,32 +17,30 @@ func EmptyInterfaceCodec() *EmptyInterfaceCodecOptions {
 	return &EmptyInterfaceCodecOptions{}
 }
 
-// SetDecodeDefaultType specifies if the default type for decoding. Defaults to bson.D.
-func (e *EmptyInterfaceCodecOptions) SetDecodeDefaultType(t reflect.Type) *EmptyInterfaceCodecOptions {
-	e.DecodeDefaultType = &t
+// SetDecodeAsMap specifies if the default type for decoding should be a bson.M instead of a bson.D. Defaults to false.
+func (e *EmptyInterfaceCodecOptions) SetDecodeAsMap(t bool) *EmptyInterfaceCodecOptions {
+	e.DecodeAsMap = &t
 	return e
 }
 
-// SetDecodeUnpackBinary specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
-func (e *EmptyInterfaceCodecOptions) SetDecodeUnpackBinary(b bool) *EmptyInterfaceCodecOptions {
-	e.DecodeUnpackBinary = &b
+// SetDecodeBinaryAsSlice specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
+func (e *EmptyInterfaceCodecOptions) SetDecodeBinaryAsSlice(b bool) *EmptyInterfaceCodecOptions {
+	e.DecodeBinaryAsSlice = &b
 	return e
 }
 
 // MergeEmptyInterfaceCodecOptions combines the given *EmptyInterfaceCodecOptions into a single *EmptyInterfaceCodecOptions in a last one wins fashion.
 func MergeEmptyInterfaceCodecOptions(opts ...*EmptyInterfaceCodecOptions) *EmptyInterfaceCodecOptions {
-	e := &EmptyInterfaceCodecOptions{
-		DecodeDefaultType: &defaultDecodeType,
-	}
+	e := EmptyInterfaceCodec()
 	for _, opt := range opts {
 		if opt == nil {
 			continue
 		}
-		if opt.DecodeDefaultType != nil {
-			e.DecodeDefaultType = opt.DecodeDefaultType
+		if opt.DecodeAsMap != nil {
+			e.DecodeAsMap = opt.DecodeAsMap
 		}
-		if opt.DecodeUnpackBinary != nil {
-			e.DecodeUnpackBinary = opt.DecodeUnpackBinary
+		if opt.DecodeBinaryAsSlice != nil {
+			e.DecodeBinaryAsSlice = opt.DecodeBinaryAsSlice
 		}
 	}
 

--- a/bson/bsonoptions/map_codec_options.go
+++ b/bson/bsonoptions/map_codec_options.go
@@ -8,7 +8,8 @@ package bsonoptions
 
 // MapCodecOptions represents all possible options for map encoding and decoding.
 type MapCodecOptions struct {
-	DecodeZerosMap *bool // Specifies if the map should be zeroed before decoding into it. Defaults to false.
+	DecodeZerosMap   *bool // Specifies if the map should be zeroed before decoding into it. Defaults to false.
+	EncodeNilAsEmpty *bool // Specifies if a nil map should encode as an empty document instead of null. Defaults to false.
 }
 
 // MapCodec creates a new *MapCodecOptions
@@ -22,6 +23,12 @@ func (t *MapCodecOptions) SetDecodeZerosMap(b bool) *MapCodecOptions {
 	return t
 }
 
+// SetEncodeNilAsEmpty specifies  if a nil map should encode as an empty document instead of null. Defaults to false.
+func (t *MapCodecOptions) SetEncodeNilAsEmpty(b bool) *MapCodecOptions {
+	t.EncodeNilAsEmpty = &b
+	return t
+}
+
 // MergeMapCodecOptions combines the given *MapCodecOptions into a single *MapCodecOptions in a last one wins fashion.
 func MergeMapCodecOptions(opts ...*MapCodecOptions) *MapCodecOptions {
 	s := MapCodec()
@@ -31,6 +38,9 @@ func MergeMapCodecOptions(opts ...*MapCodecOptions) *MapCodecOptions {
 		}
 		if opt.DecodeZerosMap != nil {
 			s.DecodeZerosMap = opt.DecodeZerosMap
+		}
+		if opt.EncodeNilAsEmpty != nil {
+			s.EncodeNilAsEmpty = opt.EncodeNilAsEmpty
 		}
 	}
 

--- a/bson/bsonoptions/slice_codec_options.go
+++ b/bson/bsonoptions/slice_codec_options.go
@@ -1,0 +1,38 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsonoptions
+
+// SliceCodecOptions represents all possible options for slice encoding and decoding.
+type SliceCodecOptions struct {
+	EncodeNilAsEmpty *bool // Specifies if a nil slice should encode as an empty array instead of null. Defaults to false.
+}
+
+// SliceCodec creates a new *SliceCodecOptions
+func SliceCodec() *SliceCodecOptions {
+	return &SliceCodecOptions{}
+}
+
+// SetEncodeNilAsEmpty specifies  if a nil slice should encode as an empty array instead of null. Defaults to false.
+func (s *SliceCodecOptions) SetEncodeNilAsEmpty(b bool) *SliceCodecOptions {
+	s.EncodeNilAsEmpty = &b
+	return s
+}
+
+// MergeSliceCodecOptions combines the given *SliceCodecOptions into a single *SliceCodecOptions in a last one wins fashion.
+func MergeSliceCodecOptions(opts ...*SliceCodecOptions) *SliceCodecOptions {
+	s := SliceCodec()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if opt.EncodeNilAsEmpty != nil {
+			s.EncodeNilAsEmpty = opt.EncodeNilAsEmpty
+		}
+	}
+
+	return s
+}

--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -373,7 +373,7 @@ func (vr *valueReader) ReadBinary() (b []byte, btype byte, err error) {
 		return nil, 0, err
 	}
 
-	if btype == 0x02 {
+	if btype == 0x02 && length > 4 {
 		length, err = vr.readLength()
 		if err != nil {
 			return nil, 0, err

--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -373,6 +373,7 @@ func (vr *valueReader) ReadBinary() (b []byte, btype byte, err error) {
 		return nil, 0, err
 	}
 
+	// Check length in case it is an old binary without a length.
 	if btype == 0x02 && length > 4 {
 		length, err = vr.readLength()
 		if err != nil {

--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -31,6 +31,14 @@ const (
 	Decimal128       Type = 0x13
 	MinKey           Type = 0xFF
 	MaxKey           Type = 0x7F
+
+	BinaryGeneric     byte = 0x00
+	BinaryFunction    byte = 0x01
+	BinaryBinaryOld   byte = 0x02
+	BinaryUUIDOld     byte = 0x03
+	BinaryUUID        byte = 0x04
+	BinaryMD5         byte = 0x05
+	BinaryUserDefined byte = 0x80
 )
 
 // Type represents a BSON type.

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -47,8 +47,8 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 			SetAllowUnexportedFields(true))
 	emptyInterCodec := bsoncodec.NewEmptyInterfaceCodec(
 		bsonoptions.EmptyInterfaceCodec().
-			SetDecodeDefaultType(tM).
-			SetDecodeUnpackBinary(true))
+			SetDecodeAsMap(true).
+			SetDecodeBinaryAsSlice(true))
 	mapCodec := bsoncodec.NewMapCodec(
 		bsonoptions.MapCodec().
 			SetDecodeZerosMap(true).


### PR DESCRIPTION
GODRIVER-1354
GODRIVER-1362
GODRIVER-1421
GODRIVER-1429
GODRIVER-1430