### PR TITLE
GODRIVER-1438 Add separate RegistryBuilder methods for types and hooks

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -40,28 +40,26 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 	}
 
 	rb.
-		RegisterDecoder(tBinary, ValueDecoderFunc(dvd.BinaryDecodeValue)).
-		RegisterDecoder(tUndefined, ValueDecoderFunc(dvd.UndefinedDecodeValue)).
-		RegisterDecoder(tDateTime, ValueDecoderFunc(dvd.DateTimeDecodeValue)).
-		RegisterDecoder(tNull, ValueDecoderFunc(dvd.NullDecodeValue)).
-		RegisterDecoder(tRegex, ValueDecoderFunc(dvd.RegexDecodeValue)).
-		RegisterDecoder(tDBPointer, ValueDecoderFunc(dvd.DBPointerDecodeValue)).
-		RegisterDecoder(tTimestamp, ValueDecoderFunc(dvd.TimestampDecodeValue)).
-		RegisterDecoder(tMinKey, ValueDecoderFunc(dvd.MinKeyDecodeValue)).
-		RegisterDecoder(tMaxKey, ValueDecoderFunc(dvd.MaxKeyDecodeValue)).
-		RegisterDecoder(tJavaScript, ValueDecoderFunc(dvd.JavaScriptDecodeValue)).
-		RegisterDecoder(tSymbol, ValueDecoderFunc(dvd.SymbolDecodeValue)).
-		RegisterDecoder(tByteSlice, defaultByteSliceCodec).
-		RegisterDecoder(tTime, defaultTimeCodec).
-		RegisterDecoder(tEmpty, defaultEmptyInterfaceCodec).
-		RegisterDecoder(tOID, ValueDecoderFunc(dvd.ObjectIDDecodeValue)).
-		RegisterDecoder(tDecimal, ValueDecoderFunc(dvd.Decimal128DecodeValue)).
-		RegisterDecoder(tJSONNumber, ValueDecoderFunc(dvd.JSONNumberDecodeValue)).
-		RegisterDecoder(tURL, ValueDecoderFunc(dvd.URLDecodeValue)).
-		RegisterDecoder(tValueUnmarshaler, ValueDecoderFunc(dvd.ValueUnmarshalerDecodeValue)).
-		RegisterDecoder(tUnmarshaler, ValueDecoderFunc(dvd.UnmarshalerDecodeValue)).
-		RegisterDecoder(tCoreDocument, ValueDecoderFunc(dvd.CoreDocumentDecodeValue)).
-		RegisterDecoder(tCodeWithScope, ValueDecoderFunc(dvd.CodeWithScopeDecodeValue)).
+		RegisterTypeDecoder(tBinary, ValueDecoderFunc(dvd.BinaryDecodeValue)).
+		RegisterTypeDecoder(tUndefined, ValueDecoderFunc(dvd.UndefinedDecodeValue)).
+		RegisterTypeDecoder(tDateTime, ValueDecoderFunc(dvd.DateTimeDecodeValue)).
+		RegisterTypeDecoder(tNull, ValueDecoderFunc(dvd.NullDecodeValue)).
+		RegisterTypeDecoder(tRegex, ValueDecoderFunc(dvd.RegexDecodeValue)).
+		RegisterTypeDecoder(tDBPointer, ValueDecoderFunc(dvd.DBPointerDecodeValue)).
+		RegisterTypeDecoder(tTimestamp, ValueDecoderFunc(dvd.TimestampDecodeValue)).
+		RegisterTypeDecoder(tMinKey, ValueDecoderFunc(dvd.MinKeyDecodeValue)).
+		RegisterTypeDecoder(tMaxKey, ValueDecoderFunc(dvd.MaxKeyDecodeValue)).
+		RegisterTypeDecoder(tJavaScript, ValueDecoderFunc(dvd.JavaScriptDecodeValue)).
+		RegisterTypeDecoder(tSymbol, ValueDecoderFunc(dvd.SymbolDecodeValue)).
+		RegisterTypeDecoder(tByteSlice, defaultByteSliceCodec).
+		RegisterTypeDecoder(tTime, defaultTimeCodec).
+		RegisterTypeDecoder(tEmpty, defaultEmptyInterfaceCodec).
+		RegisterTypeDecoder(tOID, ValueDecoderFunc(dvd.ObjectIDDecodeValue)).
+		RegisterTypeDecoder(tDecimal, ValueDecoderFunc(dvd.Decimal128DecodeValue)).
+		RegisterTypeDecoder(tJSONNumber, ValueDecoderFunc(dvd.JSONNumberDecodeValue)).
+		RegisterTypeDecoder(tURL, ValueDecoderFunc(dvd.URLDecodeValue)).
+		RegisterTypeDecoder(tCoreDocument, ValueDecoderFunc(dvd.CoreDocumentDecodeValue)).
+		RegisterTypeDecoder(tCodeWithScope, ValueDecoderFunc(dvd.CodeWithScopeDecodeValue)).
 		RegisterDefaultDecoder(reflect.Bool, ValueDecoderFunc(dvd.BooleanDecodeValue)).
 		RegisterDefaultDecoder(reflect.Int, ValueDecoderFunc(dvd.IntDecodeValue)).
 		RegisterDefaultDecoder(reflect.Int8, ValueDecoderFunc(dvd.IntDecodeValue)).
@@ -100,7 +98,9 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterTypeMapEntry(bsontype.Decimal128, tDecimal).
 		RegisterTypeMapEntry(bsontype.MinKey, tMinKey).
 		RegisterTypeMapEntry(bsontype.MaxKey, tMaxKey).
-		RegisterTypeMapEntry(bsontype.Type(0), tD)
+		RegisterTypeMapEntry(bsontype.Type(0), tD).
+		RegisterHookDecoder(tValueUnmarshaler, ValueDecoderFunc(dvd.ValueUnmarshalerDecodeValue)).
+		RegisterHookDecoder(tUnmarshaler, ValueDecoderFunc(dvd.UnmarshalerDecodeValue))
 }
 
 // BooleanDecodeValue is the ValueDecoderFunc for bool types.

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -2808,7 +2808,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 						llc := &llCodec{t: t, err: want}
 						dc := DecodeContext{
 							Registry: NewRegistryBuilder().
-								RegisterDecoder(reflect.TypeOf(tc.val), llc).
+								RegisterTypeDecoder(reflect.TypeOf(tc.val), llc).
 								RegisterTypeMapEntry(tc.bsontype, reflect.TypeOf(tc.val)).
 								Build(),
 						}
@@ -2823,7 +2823,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 						llc := &llCodec{t: t, decodeval: tc.val}
 						dc := DecodeContext{
 							Registry: NewRegistryBuilder().
-								RegisterDecoder(reflect.TypeOf(tc.val), llc).
+								RegisterTypeDecoder(reflect.TypeOf(tc.val), llc).
 								RegisterTypeMapEntry(tc.bsontype, reflect.TypeOf(tc.val)).
 								Build(),
 						}

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -67,29 +67,26 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		panic(errors.New("argument to RegisterDefaultEncoders must not be nil"))
 	}
 	rb.
-		RegisterEncoder(tByteSlice, defaultByteSliceCodec).
-		RegisterEncoder(tTime, defaultTimeCodec).
-		RegisterEncoder(tEmpty, defaultEmptyInterfaceCodec).
-		RegisterEncoder(tOID, ValueEncoderFunc(dve.ObjectIDEncodeValue)).
-		RegisterEncoder(tDecimal, ValueEncoderFunc(dve.Decimal128EncodeValue)).
-		RegisterEncoder(tJSONNumber, ValueEncoderFunc(dve.JSONNumberEncodeValue)).
-		RegisterEncoder(tURL, ValueEncoderFunc(dve.URLEncodeValue)).
-		RegisterEncoder(tValueMarshaler, ValueEncoderFunc(dve.ValueMarshalerEncodeValue)).
-		RegisterEncoder(tMarshaler, ValueEncoderFunc(dve.MarshalerEncodeValue)).
-		RegisterEncoder(tProxy, ValueEncoderFunc(dve.ProxyEncodeValue)).
-		RegisterEncoder(tJavaScript, ValueEncoderFunc(dve.JavaScriptEncodeValue)).
-		RegisterEncoder(tSymbol, ValueEncoderFunc(dve.SymbolEncodeValue)).
-		RegisterEncoder(tBinary, ValueEncoderFunc(dve.BinaryEncodeValue)).
-		RegisterEncoder(tUndefined, ValueEncoderFunc(dve.UndefinedEncodeValue)).
-		RegisterEncoder(tDateTime, ValueEncoderFunc(dve.DateTimeEncodeValue)).
-		RegisterEncoder(tNull, ValueEncoderFunc(dve.NullEncodeValue)).
-		RegisterEncoder(tRegex, ValueEncoderFunc(dve.RegexEncodeValue)).
-		RegisterEncoder(tDBPointer, ValueEncoderFunc(dve.DBPointerEncodeValue)).
-		RegisterEncoder(tTimestamp, ValueEncoderFunc(dve.TimestampEncodeValue)).
-		RegisterEncoder(tMinKey, ValueEncoderFunc(dve.MinKeyEncodeValue)).
-		RegisterEncoder(tMaxKey, ValueEncoderFunc(dve.MaxKeyEncodeValue)).
-		RegisterEncoder(tCoreDocument, ValueEncoderFunc(dve.CoreDocumentEncodeValue)).
-		RegisterEncoder(tCodeWithScope, ValueEncoderFunc(dve.CodeWithScopeEncodeValue)).
+		RegisterTypeEncoder(tByteSlice, defaultByteSliceCodec).
+		RegisterTypeEncoder(tTime, defaultTimeCodec).
+		RegisterTypeEncoder(tEmpty, defaultEmptyInterfaceCodec).
+		RegisterTypeEncoder(tOID, ValueEncoderFunc(dve.ObjectIDEncodeValue)).
+		RegisterTypeEncoder(tDecimal, ValueEncoderFunc(dve.Decimal128EncodeValue)).
+		RegisterTypeEncoder(tJSONNumber, ValueEncoderFunc(dve.JSONNumberEncodeValue)).
+		RegisterTypeEncoder(tURL, ValueEncoderFunc(dve.URLEncodeValue)).
+		RegisterTypeEncoder(tJavaScript, ValueEncoderFunc(dve.JavaScriptEncodeValue)).
+		RegisterTypeEncoder(tSymbol, ValueEncoderFunc(dve.SymbolEncodeValue)).
+		RegisterTypeEncoder(tBinary, ValueEncoderFunc(dve.BinaryEncodeValue)).
+		RegisterTypeEncoder(tUndefined, ValueEncoderFunc(dve.UndefinedEncodeValue)).
+		RegisterTypeEncoder(tDateTime, ValueEncoderFunc(dve.DateTimeEncodeValue)).
+		RegisterTypeEncoder(tNull, ValueEncoderFunc(dve.NullEncodeValue)).
+		RegisterTypeEncoder(tRegex, ValueEncoderFunc(dve.RegexEncodeValue)).
+		RegisterTypeEncoder(tDBPointer, ValueEncoderFunc(dve.DBPointerEncodeValue)).
+		RegisterTypeEncoder(tTimestamp, ValueEncoderFunc(dve.TimestampEncodeValue)).
+		RegisterTypeEncoder(tMinKey, ValueEncoderFunc(dve.MinKeyEncodeValue)).
+		RegisterTypeEncoder(tMaxKey, ValueEncoderFunc(dve.MaxKeyEncodeValue)).
+		RegisterTypeEncoder(tCoreDocument, ValueEncoderFunc(dve.CoreDocumentEncodeValue)).
+		RegisterTypeEncoder(tCodeWithScope, ValueEncoderFunc(dve.CodeWithScopeEncodeValue)).
 		RegisterDefaultEncoder(reflect.Bool, ValueEncoderFunc(dve.BooleanEncodeValue)).
 		RegisterDefaultEncoder(reflect.Int, ValueEncoderFunc(dve.IntEncodeValue)).
 		RegisterDefaultEncoder(reflect.Int8, ValueEncoderFunc(dve.IntEncodeValue)).
@@ -108,7 +105,10 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		RegisterDefaultEncoder(reflect.Slice, defaultSliceCodec).
 		RegisterDefaultEncoder(reflect.String, defaultStringCodec).
 		RegisterDefaultEncoder(reflect.Struct, defaultStructCodec).
-		RegisterDefaultEncoder(reflect.Ptr, NewPointerCodec())
+		RegisterDefaultEncoder(reflect.Ptr, NewPointerCodec()).
+		RegisterHookEncoder(tValueMarshaler, ValueEncoderFunc(dve.ValueMarshalerEncodeValue)).
+		RegisterHookEncoder(tMarshaler, ValueEncoderFunc(dve.MarshalerEncodeValue)).
+		RegisterHookEncoder(tProxy, ValueEncoderFunc(dve.ProxyEncodeValue))
 }
 
 // BooleanEncodeValue is the ValueEncoderFunc for bool types.

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -8,6 +8,7 @@ package bsoncodec
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -134,10 +135,12 @@ func (rb *RegistryBuilder) RegisterTypeEncoder(t reflect.Type, enc ValueEncoder)
 
 // RegisterHookEncoder will register an encoder for the provided interface type t. This encoder will be called when
 // marshalling a type if the type implements t or a pointer to the type implements t. If the provided type is not
-// an interface (i.e. t.Kind() != reflect.Interface), it is ignored and the RegistryBuilder is not modified.
+// an interface (i.e. t.Kind() != reflect.Interface), this method will panic.
 func (rb *RegistryBuilder) RegisterHookEncoder(t reflect.Type, enc ValueEncoder) *RegistryBuilder {
 	if t.Kind() != reflect.Interface {
-		return rb
+		panicStr := fmt.Sprintf("RegisterHookEncoder expects a type with kind reflect.Interface, "+
+			"got type %s with kind %s", t, t.Kind())
+		panic(panicStr)
 	}
 
 	for idx, encoder := range rb.interfaceEncoders {
@@ -165,10 +168,12 @@ func (rb *RegistryBuilder) RegisterTypeDecoder(t reflect.Type, dec ValueDecoder)
 
 // RegisterHookDecoder will register an decoder for the provided interface type t. This decoder will be called when
 // unmarshalling into a type if the type implements t or a pointer to the type implements t. If the provided type is not
-// an interface (i.e. t.Kind() != reflect.Interface), it is ignored and the RegistryBuilder is not modified.
+// an interface (i.e. t.Kind() != reflect.Interface), this method will panic.
 func (rb *RegistryBuilder) RegisterHookDecoder(t reflect.Type, dec ValueDecoder) *RegistryBuilder {
 	if t.Kind() != reflect.Interface {
-		return rb
+		panicStr := fmt.Sprintf("RegisterHookDecoder expects a type with kind reflect.Interface, "+
+			"got type %s with kind %s", t, t.Kind())
+		panic(panicStr)
 	}
 
 	for idx, decoder := range rb.interfaceDecoders {

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -35,7 +35,7 @@ func TestRegistry(t *testing.T) {
 			}
 			rb := NewRegistryBuilder()
 			for _, ip := range ips {
-				rb.RegisterEncoder(ip.i, ip.ve)
+				rb.RegisterHookEncoder(ip.i, ip.ve)
 			}
 			got := rb.interfaceEncoders
 			if !cmp.Equal(got, want, cmp.AllowUnexported(interfaceValueEncoder{}, fakeCodec{}), cmp.Comparer(typeComparer)) {
@@ -45,10 +45,10 @@ func TestRegistry(t *testing.T) {
 		t.Run("type", func(t *testing.T) {
 			ft1, ft2, ft4 := fakeType1{}, fakeType2{}, fakeType4{}
 			rb := NewRegistryBuilder().
-				RegisterEncoder(reflect.TypeOf(ft1), fc1).
-				RegisterEncoder(reflect.TypeOf(ft2), fc2).
-				RegisterEncoder(reflect.TypeOf(ft1), fc3).
-				RegisterEncoder(reflect.TypeOf(ft4), fc4)
+				RegisterTypeEncoder(reflect.TypeOf(ft1), fc1).
+				RegisterTypeEncoder(reflect.TypeOf(ft2), fc2).
+				RegisterTypeEncoder(reflect.TypeOf(ft1), fc3).
+				RegisterTypeEncoder(reflect.TypeOf(ft4), fc4)
 			want := []struct {
 				t reflect.Type
 				c ValueEncoder
@@ -164,29 +164,41 @@ func TestRegistry(t *testing.T) {
 			ft1 := reflect.PtrTo(reflect.TypeOf(fakeType1{}))
 			ft2 := reflect.TypeOf(fakeType2{})
 			ft3 := reflect.TypeOf(fakeType5(func(string, string) string { return "fakeType5" }))
+			ti1 := reflect.TypeOf((*testInterface1)(nil)).Elem()
 			ti2 := reflect.TypeOf((*testInterface2)(nil)).Elem()
-			fc1, fc2, fc4 := fakeCodec{num: 1}, fakeCodec{num: 2}, fakeCodec{num: 4}
+			ti1Impl := reflect.TypeOf(testInterface1Impl{})
+			ti2Impl := reflect.TypeOf(testInterface2Impl{})
+			ti3 := reflect.TypeOf((*testInterface3)(nil)).Elem()
+			ti3Impl := reflect.TypeOf(testInterface3Impl{})
+			ti3ImplPtr := reflect.TypeOf((*testInterface3Impl)(nil))
+			fc1, fc2 := fakeCodec{num: 1}, fakeCodec{num: 2}
 			fsc, fslcc, fmc := new(fakeStructCodec), new(fakeSliceCodec), new(fakeMapCodec)
 			pc := NewPointerCodec()
+
 			reg := NewRegistryBuilder().
-				RegisterEncoder(ft1, fc1).
-				RegisterEncoder(ft2, fc2).
-				RegisterEncoder(ti2, fc4).
+				RegisterTypeEncoder(ft1, fc1).
+				RegisterTypeEncoder(ft2, fc2).
+				RegisterTypeEncoder(ti1, fc1).
 				RegisterDefaultEncoder(reflect.Struct, fsc).
 				RegisterDefaultEncoder(reflect.Slice, fslcc).
 				RegisterDefaultEncoder(reflect.Array, fslcc).
 				RegisterDefaultEncoder(reflect.Map, fmc).
 				RegisterDefaultEncoder(reflect.Ptr, pc).
-				RegisterDecoder(ft1, fc1).
-				RegisterDecoder(ft2, fc2).
-				RegisterDecoder(ti2, fc4).
+				RegisterTypeDecoder(ft1, fc1).
+				RegisterTypeDecoder(ft2, fc2).
+				RegisterTypeDecoder(ti1, fc1). // values whose exact type is testInterface1 will use fc1 encoder
 				RegisterDefaultDecoder(reflect.Struct, fsc).
 				RegisterDefaultDecoder(reflect.Slice, fslcc).
 				RegisterDefaultDecoder(reflect.Array, fslcc).
 				RegisterDefaultDecoder(reflect.Map, fmc).
 				RegisterDefaultDecoder(reflect.Ptr, pc).
+				RegisterHookEncoder(ti2, fc2).
+				RegisterHookDecoder(ti2, fc2).
+				RegisterHookEncoder(ti3, fc3).
+				RegisterHookDecoder(ti3, fc3).
 				Build()
 
+			// TODO add test for hook encoder/decoder
 			testCases := []struct {
 				name      string
 				t         reflect.Type
@@ -209,11 +221,54 @@ func TestRegistry(t *testing.T) {
 					false,
 				},
 				{
-					"interface registry",
-					ti2,
-					fc4,
+					// lookup an interface type and expect that the registered encoder is returned
+					"interface with type encoder",
+					ti1,
+					fc1,
 					nil,
 					true,
+				},
+				{
+					// lookup a type that implements an interface and expect that the default struct codec is returned
+					"interface implementation with type encoder",
+					ti1Impl,
+					fsc,
+					nil,
+					false,
+				},
+				{
+					// lookup an interface type and expect that the registered hook is returned
+					"interface with hook",
+					ti2,
+					fc2,
+					nil,
+					false,
+				},
+				{
+					// lookup a type that implements an interface and expect that the registered hook is returned
+					"interface implementation with hook",
+					ti2Impl,
+					fc2,
+					nil,
+					false,
+				},
+				{
+					// lookup a type whose pointer implements an interface and expect that the registered hook is
+					// returned
+					"interface implementation with hook (pointer)",
+					ti3Impl,
+					fc3,
+					nil,
+					false,
+				},
+				{
+					// lookup a pointer to a type where the pointer implements an interface and expect that the
+					// registered hook is returned
+					"interface pointer to implementation with hook (pointer)",
+					ti3ImplPtr,
+					fc3,
+					nil,
+					false,
 				},
 				{
 					"default struct codec (pointer)",
@@ -355,5 +410,23 @@ type testInterface1 interface{ test1() }
 type testInterface2 interface{ test2() }
 type testInterface3 interface{ test3() }
 type testInterface4 interface{ test4() }
+
+type testInterface1Impl struct{}
+
+var _ testInterface1 = testInterface1Impl{}
+
+func (testInterface1Impl) test1() {}
+
+type testInterface2Impl struct{}
+
+var _ testInterface2 = testInterface2Impl{}
+
+func (testInterface2Impl) test2() {}
+
+type testInterface3Impl struct{}
+
+var _ testInterface3 = (*testInterface3Impl)(nil)
+
+func (*testInterface3Impl) test3() {}
 
 func typeComparer(i1, i2 reflect.Type) bool { return i1 == i2 }

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -198,7 +198,6 @@ func TestRegistry(t *testing.T) {
 				RegisterHookDecoder(ti3, fc3).
 				Build()
 
-			// TODO add test for hook encoder/decoder
 			testCases := []struct {
 				name      string
 				t         reflect.Type

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -60,20 +60,20 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 			SetDecodeZerosMap(true).
 			SetEncodeNilAsEmpty(true))
 
-	rb.RegisterDecoder(tEmpty, emptyInterCodec).
-		RegisterDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue)).
+	rb.RegisterTypeDecoder(tEmpty, emptyInterCodec).
 		RegisterDefaultDecoder(reflect.String, bsoncodec.NewStringCodec(bsonoptions.StringCodec().SetDecodeObjectIDAsHex(false))).
 		RegisterDefaultDecoder(reflect.Struct, structcodec).
 		RegisterDefaultDecoder(reflect.Map, mapCodec).
-		RegisterEncoder(tByteSlice, bsoncodec.NewByteSliceCodec(bsonoptions.ByteSliceCodec().SetEncodeNilAsEmpty(true))).
-		RegisterEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
+		RegisterTypeEncoder(tByteSlice, bsoncodec.NewByteSliceCodec(bsonoptions.ByteSliceCodec().SetEncodeNilAsEmpty(true))).
 		RegisterDefaultEncoder(reflect.Struct, structcodec).
 		RegisterDefaultEncoder(reflect.Slice, bsoncodec.NewSliceCodec(bsonoptions.SliceCodec().SetEncodeNilAsEmpty(true))).
 		RegisterDefaultEncoder(reflect.Map, mapCodec).
 		RegisterTypeMapEntry(bsontype.Int32, tInt).
 		RegisterTypeMapEntry(bsontype.Type(0), tM).
 		RegisterTypeMapEntry(bsontype.DateTime, tTime).
-		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice)
+		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice).
+		RegisterHookEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
+		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue))
 
 	return rb
 }

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -28,10 +28,10 @@ func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder)
 	}
 
 	rb.
-		RegisterEncoder(tRawValue, bsoncodec.ValueEncoderFunc(pc.RawValueEncodeValue)).
-		RegisterEncoder(tRaw, bsoncodec.ValueEncoderFunc(pc.RawEncodeValue)).
-		RegisterDecoder(tRawValue, bsoncodec.ValueDecoderFunc(pc.RawValueDecodeValue)).
-		RegisterDecoder(tRaw, bsoncodec.ValueDecoderFunc(pc.RawDecodeValue))
+		RegisterTypeEncoder(tRawValue, bsoncodec.ValueEncoderFunc(pc.RawValueEncodeValue)).
+		RegisterTypeEncoder(tRaw, bsoncodec.ValueEncoderFunc(pc.RawEncodeValue)).
+		RegisterTypeDecoder(tRawValue, bsoncodec.ValueDecoderFunc(pc.RawValueDecodeValue)).
+		RegisterTypeDecoder(tRaw, bsoncodec.ValueDecoderFunc(pc.RawDecodeValue))
 }
 
 // RawValueEncodeValue is the ValueEncoderFunc for RawValue.

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -149,7 +149,7 @@ var directories = []string{
 var checkOutcomeOpts = options.Collection().SetReadPreference(readpref.Primary()).SetReadConcern(readconcern.Local())
 var specTestRegistry = bson.NewRegistryBuilder().
 	RegisterTypeMapEntry(bson.TypeEmbeddedDocument, reflect.TypeOf(bson.Raw{})).
-	RegisterDecoder(reflect.TypeOf(testData{}), bsoncodec.ValueDecoderFunc(decodeTestData)).Build()
+	RegisterTypeDecoder(reflect.TypeOf(testData{}), bsoncodec.ValueDecoderFunc(decodeTestData)).Build()
 
 func TestUnifiedSpecs(t *testing.T) {
 	for _, specDir := range directories {

--- a/x/bsonx/primitive_codecs.go
+++ b/x/bsonx/primitive_codecs.go
@@ -36,14 +36,14 @@ func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder)
 	}
 
 	rb.
-		RegisterEncoder(tDocument, bsoncodec.ValueEncoderFunc(pc.DocumentEncodeValue)).
-		RegisterEncoder(tArray, bsoncodec.ValueEncoderFunc(pc.ArrayEncodeValue)).
-		RegisterEncoder(tValue, bsoncodec.ValueEncoderFunc(pc.ValueEncodeValue)).
-		RegisterEncoder(tElementSlice, bsoncodec.ValueEncoderFunc(pc.ElementSliceEncodeValue)).
-		RegisterDecoder(tDocument, bsoncodec.ValueDecoderFunc(pc.DocumentDecodeValue)).
-		RegisterDecoder(tArray, bsoncodec.ValueDecoderFunc(pc.ArrayDecodeValue)).
-		RegisterDecoder(tValue, bsoncodec.ValueDecoderFunc(pc.ValueDecodeValue)).
-		RegisterDecoder(tElementSlice, bsoncodec.ValueDecoderFunc(pc.ElementSliceDecodeValue))
+		RegisterTypeEncoder(tDocument, bsoncodec.ValueEncoderFunc(pc.DocumentEncodeValue)).
+		RegisterTypeEncoder(tArray, bsoncodec.ValueEncoderFunc(pc.ArrayEncodeValue)).
+		RegisterTypeEncoder(tValue, bsoncodec.ValueEncoderFunc(pc.ValueEncodeValue)).
+		RegisterTypeEncoder(tElementSlice, bsoncodec.ValueEncoderFunc(pc.ElementSliceEncodeValue)).
+		RegisterTypeDecoder(tDocument, bsoncodec.ValueDecoderFunc(pc.DocumentDecodeValue)).
+		RegisterTypeDecoder(tArray, bsoncodec.ValueDecoderFunc(pc.ArrayDecodeValue)).
+		RegisterTypeDecoder(tValue, bsoncodec.ValueDecoderFunc(pc.ValueDecodeValue)).
+		RegisterTypeDecoder(tElementSlice, bsoncodec.ValueDecoderFunc(pc.ElementSliceDecodeValue))
 }
 
 // DocumentEncodeValue is the ValueEncoderFunc for *Document.


### PR DESCRIPTION
- Deprecate RegisterEncoder and replace with RegisterTypeEncoder and RegisterHookEncoder
- Deprecate RegisterDecoder and replace with RegisterTypeDecoder and RegisterHookDecoder