### PR TITLE
Make Atlas connectivity tests more robust

### DIFF
--- a/mongo/testatlas/main.go
+++ b/mongo/testatlas/main.go
@@ -9,56 +9,60 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 )
 
 func main() {
 	flag.Parse()
 	uris := flag.Args()
+	ctx := context.Background()
+	wcMajority := writeconcern.New(writeconcern.WMajority())
+	rcLocal := readconcern.Local()
 
-	for _, uri := range uris {
-		ctx := context.Background()
-
-		client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	for idx, uri := range uris {
+		client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri).SetWriteConcern(wcMajority).
+			SetReadConcern(rcLocal))
 		if err != nil {
-			log.Fatalf("failed creating and connecting to client: %v", err)
+			panic(createErrorMessage(idx, "Connect error: %v", err))
 		}
 
 		db := client.Database("test")
 		defer func() {
-			err := db.Drop(ctx)
-			if err != nil {
-				log.Fatalf("failed dropping database: %v", err)
+			if err = db.Drop(ctx); err != nil {
+				panic(createErrorMessage(idx, "Drop error: %v", err))
 			}
 
-			err = client.Disconnect(ctx)
-			if err != nil {
-				log.Fatalf("failed disconnecting from client: %v", err)
+			if err = client.Disconnect(ctx); err != nil {
+				panic(createErrorMessage(idx, "Disconnect error: %v", err))
 			}
 		}()
-
-		coll := db.Collection("test")
 
 		err = db.RunCommand(
 			ctx,
 			bson.D{{"isMaster", 1}},
 		).Err()
 		if err != nil {
-			log.Fatalf("failed executing isMaster command: %v", err)
+			panic(createErrorMessage(idx, "isMaster error: %v", err))
 		}
 
-		_, err = coll.InsertOne(ctx, bson.D{{"x", 1}})
-		if err != nil {
-			log.Fatalf("failed executing insertOne command: %v", err)
+		coll := db.Collection("test")
+		if _, err = coll.InsertOne(ctx, bson.D{{"x", 1}}); err != nil {
+			panic(createErrorMessage(idx, "InsertOne error: %v", err))
 		}
 
-		res := coll.FindOne(ctx, bson.D{{"x", 1}})
-		if res.Err() != nil {
-			log.Fatalf("failed executing findOne command: %v", res.Err())
+		if err = coll.FindOne(ctx, bson.D{{"x", 1}}).Err(); err != nil {
+			panic(createErrorMessage(idx, "FindOne error: %v", err))
 		}
 	}
+}
+
+func createErrorMessage(idx int, msg string, args ...interface{}) string {
+	msg = fmt.Sprintf(msg, args...)
+	return fmt.Sprintf("error for URI at index %d: %s", idx, msg)
 }


### PR DESCRIPTION
I've seen these tests fail sometimes with because the inserted document isn't found, so I added write concern majority and read concern local (I tried read concern majority but I believe some of these are running against older servers that weren't started with `--enableMajorityReadConcern`).

Also, the current tests use `log.Fatalf` which calls `os.Exit` in a failure. This means that `defer` functions do not run, so the created client isn't closed in failure cases. I changed these to `panic` instead and added the URI index to the error messages so we can easily find the cluster URI if we have failures that aren't transient.