### PR TITLE
GODRIVER-1466 Respect type map entries for bsontype.EmbeddedDocument

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -98,7 +98,7 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterTypeMapEntry(bsontype.Decimal128, tDecimal).
 		RegisterTypeMapEntry(bsontype.MinKey, tMinKey).
 		RegisterTypeMapEntry(bsontype.MaxKey, tMaxKey).
-		RegisterTypeMapEntry(bsontype.Type(0), tD).
+		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tD).
 		RegisterHookDecoder(tValueUnmarshaler, ValueDecoderFunc(dvd.ValueUnmarshalerDecodeValue)).
 		RegisterHookDecoder(tUnmarshaler, ValueDecoderFunc(dvd.UnmarshalerDecodeValue))
 }

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -98,6 +98,7 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterTypeMapEntry(bsontype.Decimal128, tDecimal).
 		RegisterTypeMapEntry(bsontype.MinKey, tMinKey).
 		RegisterTypeMapEntry(bsontype.MaxKey, tMaxKey).
+		RegisterTypeMapEntry(bsontype.Type(0), tD).
 		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tD).
 		RegisterHookDecoder(tValueUnmarshaler, ValueDecoderFunc(dvd.ValueUnmarshalerDecodeValue)).
 		RegisterHookDecoder(tUnmarshaler, ValueDecoderFunc(dvd.UnmarshalerDecodeValue))

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -2660,7 +2660,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		})
 	})
 
-	t.Run("EmptyInterfaceDecodeValue", func(t *testing.T) {
+	t.Run("defaultEmptyInterfaceCodec", func(t *testing.T) {
 		t.Run("DecodeValue", func(t *testing.T) {
 			testCases := []struct {
 				name     string
@@ -2777,7 +2777,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 						val := reflect.New(tEmpty).Elem()
 						dc := DecodeContext{Registry: NewRegistryBuilder().Build()}
 						want := ErrNoTypeMapEntry{Type: tc.bsontype}
-						got := dvd.EmptyInterfaceDecodeValue(dc, llvr, val)
+						got := defaultEmptyInterfaceCodec.DecodeValue(dc, llvr, val)
 						if !compareErrors(got, want) {
 							t.Errorf("Errors are not equal. got %v; want %v", got, want)
 						}
@@ -2794,7 +2794,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 								Build(),
 						}
 						want := ErrNoDecoder{Type: reflect.TypeOf(tc.val)}
-						got := dvd.EmptyInterfaceDecodeValue(dc, llvr, val)
+						got := defaultEmptyInterfaceCodec.DecodeValue(dc, llvr, val)
 						if !compareErrors(got, want) {
 							t.Errorf("Errors are not equal. got %v; want %v", got, want)
 						}
@@ -2812,7 +2812,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 								RegisterTypeMapEntry(tc.bsontype, reflect.TypeOf(tc.val)).
 								Build(),
 						}
-						got := dvd.EmptyInterfaceDecodeValue(dc, llvr, reflect.New(tEmpty).Elem())
+						got := defaultEmptyInterfaceCodec.DecodeValue(dc, llvr, reflect.New(tEmpty).Elem())
 						if !compareErrors(got, want) {
 							t.Errorf("Errors are not equal. got %v; want %v", got, want)
 						}
@@ -2828,7 +2828,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 								Build(),
 						}
 						got := reflect.New(tEmpty).Elem()
-						err := dvd.EmptyInterfaceDecodeValue(dc, llvr, got)
+						err := defaultEmptyInterfaceCodec.DecodeValue(dc, llvr, got)
 						noerr(t, err)
 						if !cmp.Equal(got.Interface(), want, cmp.Comparer(compareDecimal128)) {
 							t.Errorf("Did not receive expected value. got %v; want %v", got.Interface(), want)
@@ -2841,7 +2841,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		t.Run("non-interface{}", func(t *testing.T) {
 			val := uint64(1234567890)
 			want := ValueDecoderError{Name: "EmptyInterfaceDecodeValue", Types: []reflect.Type{tEmpty}, Received: reflect.ValueOf(val)}
-			got := dvd.EmptyInterfaceDecodeValue(DecodeContext{}, nil, reflect.ValueOf(val))
+			got := defaultEmptyInterfaceCodec.DecodeValue(DecodeContext{}, nil, reflect.ValueOf(val))
 			if !compareErrors(got, want) {
 				t.Errorf("Errors are not equal. got %v; want %v", got, want)
 			}
@@ -2850,7 +2850,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		t.Run("nil *interface{}", func(t *testing.T) {
 			var val interface{}
 			want := ValueDecoderError{Name: "EmptyInterfaceDecodeValue", Types: []reflect.Type{tEmpty}, Received: reflect.ValueOf(val)}
-			got := dvd.EmptyInterfaceDecodeValue(DecodeContext{}, nil, reflect.ValueOf(val))
+			got := defaultEmptyInterfaceCodec.DecodeValue(DecodeContext{}, nil, reflect.ValueOf(val))
 			if !compareErrors(got, want) {
 				t.Errorf("Errors are not equal. got %v; want %v", got, want)
 			}
@@ -2860,7 +2860,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 			llvr := &bsonrwtest.ValueReaderWriter{BSONType: bsontype.Double}
 			want := ErrNoTypeMapEntry{Type: bsontype.Double}
 			val := reflect.New(tEmpty).Elem()
-			got := dvd.EmptyInterfaceDecodeValue(DecodeContext{Registry: NewRegistryBuilder().Build()}, llvr, val)
+			got := defaultEmptyInterfaceCodec.DecodeValue(DecodeContext{Registry: NewRegistryBuilder().Build()}, llvr, val)
 			if !compareErrors(got, want) {
 				t.Errorf("Errors are not equal. got %v; want %v", got, want)
 			}
@@ -2871,10 +2871,78 @@ func TestDefaultValueDecoders(t *testing.T) {
 			want := primitive.D{{"pi", 3.14159}}
 			var got interface{}
 			val := reflect.ValueOf(&got).Elem()
-			err := dvd.EmptyInterfaceDecodeValue(DecodeContext{Registry: buildDefaultRegistry()}, vr, val)
+			err := defaultEmptyInterfaceCodec.DecodeValue(DecodeContext{Registry: buildDefaultRegistry()}, vr, val)
 			noerr(t, err)
 			if !cmp.Equal(got, want) {
 				t.Errorf("Did not get correct result. got %v; want %v", got, want)
+			}
+		})
+		t.Run("custom type map entry", func(t *testing.T) {
+			// registering a custom type map entry for bsontype.EmbeddedDocument should cause top-level document
+			// to decode to registered type when unmarshalling to interface{}
+
+			rb := NewRegistryBuilder()
+			defaultValueEncoders.RegisterDefaultEncoders(rb)
+			defaultValueDecoders.RegisterDefaultDecoders(rb)
+			rb.RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(primitive.M{}))
+			reg := rb.Build()
+
+			// create doc {"nested": {"foo": 1}}
+			innerDoc := bsoncore.BuildDocument(
+				nil,
+				bsoncore.AppendInt32Element(nil, "foo", 1),
+			)
+			doc := bsoncore.BuildDocument(
+				nil,
+				bsoncore.AppendDocumentElement(nil, "nested", innerDoc),
+			)
+
+			want := primitive.M{
+				"nested": primitive.M{
+					"foo": int32(1),
+				},
+			}
+			var got interface{}
+			vr := bsonrw.NewBSONDocumentReader(doc)
+			val := reflect.ValueOf(&got).Elem()
+			err := defaultEmptyInterfaceCodec.DecodeValue(DecodeContext{Registry: reg}, vr, val)
+			noerr(t, err)
+			if !cmp.Equal(got, want) {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		})
+		t.Run("top level document with type map entry", func(t *testing.T) {
+			// If a type map entry is registered for bsontype.EmbeddedDocument, the decoder should use ancestor
+			// information if available instead of the registered entry.
+
+			rb := NewRegistryBuilder()
+			defaultValueEncoders.RegisterDefaultEncoders(rb)
+			defaultValueDecoders.RegisterDefaultDecoders(rb)
+			rb.RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(primitive.M{}))
+			reg := rb.Build()
+
+			// build document {"nested": {"foo": 10}}
+			inner := bsoncore.BuildDocument(
+				nil,
+				bsoncore.AppendInt32Element(nil, "foo", 10),
+			)
+			doc := bsoncore.BuildDocument(
+				nil,
+				bsoncore.AppendDocumentElement(nil, "nested", inner),
+			)
+			want := primitive.D{
+				{"nested", primitive.D{
+					{"foo", int32(10)},
+				}},
+			}
+
+			var got primitive.D
+			vr := bsonrw.NewBSONDocumentReader(doc)
+			val := reflect.ValueOf(&got).Elem()
+			err := defaultSliceCodec.DecodeValue(DecodeContext{Registry: reg}, vr, val)
+			noerr(t, err)
+			if !cmp.Equal(got, want) {
+				t.Fatalf("got %v, want %v", got, want)
 			}
 		})
 	})

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -255,11 +255,10 @@ func (rb *RegistryBuilder) RegisterDefaultDecoder(kind reflect.Kind, dec ValueDe
 // mapping is decoding situations where an empty interface is used and a default type needs to be
 // created and decoded into.
 //
-// NOTE: It is unlikely that registering a type for BSON Embedded Document is actually desired. By
-// registering a type map entry for BSON Embedded Document the type registered will be used in any
-// case where a BSON Embedded Document will be decoded into an empty interface. For example, if you
-// register primitive.M, the EmptyInterface decoder will always use primitive.M, even if an ancestor
-// was a primitive.D.
+// By default, BSON documents will decode as bson.D using interface{}. To change the default type for BSON documents, a
+// type map entry for bsontype.EmbeddedDocument should be registered. For example, to force BSON documents to decode to
+// bson.Raw, use the following code:
+//	rb.RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(bson.Raw{}))
 func (rb *RegistryBuilder) RegisterTypeMapEntry(bt bsontype.Type, rt reflect.Type) *RegistryBuilder {
 	rb.typeMap[bt] = rt
 	return rb

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -255,9 +255,9 @@ func (rb *RegistryBuilder) RegisterDefaultDecoder(kind reflect.Kind, dec ValueDe
 // mapping is decoding situations where an empty interface is used and a default type needs to be
 // created and decoded into.
 //
-// By default, BSON documents will decode as bson.D using interface{}. To change the default type for BSON documents, a
-// type map entry for bsontype.EmbeddedDocument should be registered. For example, to force BSON documents to decode to
-// bson.Raw, use the following code:
+// By default, BSON documents will decode into interface{} values as bson.D. To change the default type for BSON
+// documents, a type map entry for bsontype.EmbeddedDocument should be registered. For example, to force BSON documents
+// to decode to bson.Raw, use the following code:
 //	rb.RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(bson.Raw{}))
 func (rb *RegistryBuilder) RegisterTypeMapEntry(bt bsontype.Type, rt reflect.Type) *RegistryBuilder {
 	rb.typeMap[bt] = rt

--- a/bson/bsonoptions/empty_interface_codec_options.go
+++ b/bson/bsonoptions/empty_interface_codec_options.go
@@ -8,19 +8,12 @@ package bsonoptions
 
 // EmptyInterfaceCodecOptions represents all possible options for interface{} encoding and decoding.
 type EmptyInterfaceCodecOptions struct {
-	DecodeAsMap         *bool // Specifies if the default type for decoding should be a bson.M instead of a bson.D. Defaults to false.
 	DecodeBinaryAsSlice *bool // Specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
 }
 
 // EmptyInterfaceCodec creates a new *EmptyInterfaceCodecOptions
 func EmptyInterfaceCodec() *EmptyInterfaceCodecOptions {
 	return &EmptyInterfaceCodecOptions{}
-}
-
-// SetDecodeAsMap specifies if the default type for decoding should be a bson.M instead of a bson.D. Defaults to false.
-func (e *EmptyInterfaceCodecOptions) SetDecodeAsMap(t bool) *EmptyInterfaceCodecOptions {
-	e.DecodeAsMap = &t
-	return e
 }
 
 // SetDecodeBinaryAsSlice specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
@@ -35,9 +28,6 @@ func MergeEmptyInterfaceCodecOptions(opts ...*EmptyInterfaceCodecOptions) *Empty
 	for _, opt := range opts {
 		if opt == nil {
 			continue
-		}
-		if opt.DecodeAsMap != nil {
-			e.DecodeAsMap = opt.DecodeAsMap
 		}
 		if opt.DecodeBinaryAsSlice != nil {
 			e.DecodeBinaryAsSlice = opt.DecodeBinaryAsSlice

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -75,9 +75,9 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 		RegisterTypeMapEntry(bsontype.Int32, tInt).
 		RegisterTypeMapEntry(bsontype.DateTime, tTime).
 		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice).
+		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tM).
 		RegisterHookEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
-		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue)).
-		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tM)
+		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue))
 
 	return rb
 }

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 var (
@@ -52,7 +53,6 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 			SetAllowUnexportedFields(true))
 	emptyInterCodec := bsoncodec.NewEmptyInterfaceCodec(
 		bsonoptions.EmptyInterfaceCodec().
-			SetDecodeAsMap(true).
 			SetDecodeBinaryAsSlice(true))
 	mapCodec := bsoncodec.NewMapCodec(
 		bsonoptions.MapCodec().
@@ -78,7 +78,8 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 		RegisterTypeMapEntry(bsontype.DateTime, tTime).
 		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice).
 		RegisterHookEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
-		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue))
+		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue)).
+		RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(primitive.M{}))
 
 	return rb
 }

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -15,7 +15,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 var (
@@ -74,12 +73,11 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 		RegisterDefaultEncoder(reflect.Uint32, uintcodec).
 		RegisterDefaultEncoder(reflect.Uint64, uintcodec).
 		RegisterTypeMapEntry(bsontype.Int32, tInt).
-		RegisterTypeMapEntry(bsontype.Type(0), tM).
 		RegisterTypeMapEntry(bsontype.DateTime, tTime).
 		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice).
 		RegisterHookEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
 		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue)).
-		RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(primitive.M{}))
+		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tM)
 
 	return rb
 }

--- a/bson/mgocompat/registry.go
+++ b/bson/mgocompat/registry.go
@@ -75,6 +75,7 @@ func newRegistryBuilder() *bsoncodec.RegistryBuilder {
 		RegisterTypeMapEntry(bsontype.Int32, tInt).
 		RegisterTypeMapEntry(bsontype.DateTime, tTime).
 		RegisterTypeMapEntry(bsontype.Array, tInterfaceSlice).
+		RegisterTypeMapEntry(bsontype.Type(0), tM).
 		RegisterTypeMapEntry(bsontype.EmbeddedDocument, tM).
 		RegisterHookEncoder(tGetter, bsoncodec.ValueEncoderFunc(GetterEncodeValue)).
 		RegisterHookDecoder(tSetter, bsoncodec.ValueDecoderFunc(SetterDecodeValue))


### PR DESCRIPTION
- Change empty interface decoding so that type map entries registered for bsontype.EmbeddedDocument are used for top level documents as well.
- Remove the DecodeAsMap option for EmptyInterfaceCodec and replace the functionality by registering a type map entry for bsontype.EmbeddedDocument to bson.M.