### PR TITLE
GODRIVER-1398 Add tests to ensure default write concern is omitted.

### DIFF
--- a/data/read-write-concern/README.rst
+++ b/data/read-write-concern/README.rst
@@ -10,13 +10,7 @@ Version
 -------
 
 Files in the "specifications" repository have no version scheme. They are not
-tied to a MongoDB server version, and it is our intention that each
-specification moves from "draft" to "final" with no further versions; it is
-superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target. As test files
-evolve they will be occasionally tagged like "uri-tests-tests-2015-07-16", until
-the spec is final.
+tied to a MongoDB server version.
 
 Format
 ------
@@ -50,7 +44,6 @@ Each YAML file contains an object with a single ``tests`` key. This key is an
 array of test case objects, each of which have the following keys:
 
 - ``description``: A string describing the test.
-- ``uri``: A string containing the URI to be parsed.
 - ``valid:``: a boolean indicating if the write concern created from the document is valid.
 - ``writeConcern:`` A document indicating the write concern to use.
 - ``writeConcernDocument:`` A document indicating the write concern to be sent to the server.
@@ -58,6 +51,25 @@ array of test case objects, each of which have the following keys:
 - ``readConcernDocument:`` A document indicating the read concern to be sent to the server.
 - ``isServerDefault:`` Indicates whether the read or write concern is considered the server's default.
 - ``isAcknowledged:`` Indicates if the write concern should be considered acknowledged.
+
+Operation
+~~~~~~~~~
+
+These tests check that the default write concern is omitted in operations.
+
+The spec test format is an extension of `transactions spec tests <https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst>`_ with the following additions:
+
+- ``writeConcern`` in the ``databaseOptions`` or ``collectionOptions`` may be an empty document to indicate a `server default write concern <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#servers-default-writeconcern>`_. For example, in libmongoc:
+
+    .. code:: c
+
+       /* Create a default write concern, and set on a collection object. */
+       mongoc_write_concern_t *wc = mongoc_write_concern_new ();
+       mongoc_collection_set_write_concern (collection, wc);
+
+    If the driver has no way to explicitly set a default write concern on a database or collection, ignore the empty ``writeConcern`` document and continue with the test.
+- The operations ``createIndex``, ``dropIndex`` are introduced.
+
 
 Use as unit tests
 =================

--- a/data/read-write-concern/operation/default-write-concern-2.6.json
+++ b/data/read-write-concern/operation/default-write-concern-2.6.json
@@ -1,0 +1,545 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "other_collection_name": "other_collection_name",
+  "runOn": [
+    {
+      "minServerVersion": "2.6"
+    }
+  ],
+  "tests": [
+    {
+      "description": "DeleteOne omits default write concern",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "DeleteMany omits default write concern",
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {}
+          },
+          "result": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite with all models omits default write concern",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "ordered": true,
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {}
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 2
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "x": 2
+                  }
+                }
+              },
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 3
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 3
+                    }
+                  }
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 3
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 0
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "x": 2
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 3
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "InsertOne and InsertMany omit default write concern",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default_write_concern_coll",
+              "documents": [
+                {
+                  "_id": 4
+                },
+                {
+                  "_id": 5
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne, UpdateMany, and ReplaceOne omit default write concern",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "update": {
+              "$set": {
+                "x": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 3
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            },
+            {
+              "_id": 2,
+              "x": 3
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 1
+                    }
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 2
+                    }
+                  },
+                  "multi": true
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "default_write_concern_coll",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "u": {
+                    "x": 3
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-2.6.json
+++ b/data/read-write-concern/operation/default-write-concern-2.6.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "2.6"

--- a/data/read-write-concern/operation/default-write-concern-2.6.yml
+++ b/data/read-write-concern/operation/default-write-concern-2.6.yml
@@ -7,7 +7,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "2.6"

--- a/data/read-write-concern/operation/default-write-concern-2.6.yml
+++ b/data/read-write-concern/operation/default-write-concern-2.6.yml
@@ -1,0 +1,216 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 2.6+ server.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+other_collection_name: &other_collection_name other_collection_name
+
+runOn:
+    - minServerVersion: "2.6"
+
+tests:
+  - description: DeleteOne omits default write concern
+    operations:
+      - name: deleteOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {}
+        result:
+          deletedCount: 1
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+            writeConcern: null
+  - description: DeleteMany omits default write concern
+    operations:
+      - name: deleteMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {}
+        result:
+          deletedCount: 2
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {}, limit: 0}]
+            writeConcern: null
+  - description: BulkWrite with all models omits default write concern
+    operations:
+      - name: bulkWrite
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          ordered: true
+          requests:
+            - name: deleteMany
+              arguments:
+                filter: {}
+            - name: insertOne
+              arguments:
+                document: {_id: 1}
+            - name: updateOne
+              arguments:
+                filter: {_id: 1}
+                update: {$set: {x: 1}}
+            - name: insertOne
+              arguments:
+                document: {_id: 2}
+            - name: replaceOne
+              arguments:
+                filter: {_id: 1}
+                replacement: {x: 2}
+            - name: insertOne
+              arguments:
+                document: {_id: 3}
+            - name: updateMany
+              arguments:
+                filter: {_id: 1}
+                update: {$set: {x: 3}}
+            - name: deleteOne
+              arguments:
+                filter: {_id: 3}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 3}
+          - {_id: 2}
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {}, limit: 0}]
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 1}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {$set: {x: 1}}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {x: 2}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 3}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates: 
+              - {q: {_id: 1}, u: {$set: {x: 3}}, multi: true}
+            writeConcern: null
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes: [{q: {_id: 3}, limit: 1}]
+            writeConcern: null
+  - description: 'InsertOne and InsertMany omit default write concern'
+    operations:
+      - name: insertOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          document: {_id: 3}
+      - name: insertMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          documents:
+            - {_id: 4}
+            - {_id: 5}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+          - {_id: 3}
+          - {_id: 4}
+          - {_id: 5}
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 3}
+            writeConcern: null
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 4}
+              - {_id: 5}
+            writeConcern: null
+  - description: 'UpdateOne, UpdateMany, and ReplaceOne omit default write concern'
+    operations:
+      - name: updateOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 1}
+          update: {$set: {x: 1}}
+      - name: updateMany
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          update: {$set: {x: 2}}
+      - name: replaceOne
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          replacement: {x: 3}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 1}
+          - {_id: 2, x: 3}
+    expectations:
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 1}, u: {$set: {x: 1}}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 2}, u: {$set: {x: 2}}, multi: true}
+            writeConcern: null
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - {q: {_id: 2}, u: {x: 3}}
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-3.2.json
+++ b/data/read-write-concern/operation/default-write-concern-3.2.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "3.2"

--- a/data/read-write-concern/operation/default-write-concern-3.2.json
+++ b/data/read-write-concern/operation/default-write-concern-3.2.json
@@ -1,0 +1,126 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "other_collection_name": "other_collection_name",
+  "runOn": [
+    {
+      "minServerVersion": "3.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "findAndModify operations omit default write concern",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "replacement": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "filter": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "default_write_concern_coll",
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$set": {
+                  "x": 1
+                }
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "update": {
+                "x": 2
+              },
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "default_write_concern_coll",
+              "query": {
+                "_id": 2
+              },
+              "remove": true,
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-3.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.2.yml
@@ -1,0 +1,59 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 3.2+ server, where findAndModify started
+# to accept a write concern.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+other_collection_name: &other_collection_name other_collection_name
+
+runOn:
+    - minServerVersion: "3.2"
+
+tests:
+  - description: 'findAndModify operations omit default write concern'
+    operations:
+      - name: findOneAndUpdate
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 1}
+          update: {$set: {x: 1}}
+      - name: findOneAndReplace
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+          replacement: {x: 2}
+      - name: findOneAndDelete
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          filter: {_id: 2}
+    outcome:
+      collection:
+        name: *collection_name
+        data:
+          - {_id: 1, x: 1}
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$set: {x: 1}}
+            writeConcern: null
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 2}
+            update: {x: 2}
+            writeConcern: null
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 2}
+            remove: true
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-3.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.2.yml
@@ -8,7 +8,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "3.2"

--- a/data/read-write-concern/operation/default-write-concern-3.4.json
+++ b/data/read-write-concern/operation/default-write-concern-3.4.json
@@ -1,0 +1,217 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "other_collection_name": "other_collection_name",
+  "runOn": [
+    {
+      "minServerVersion": "3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_collection_name"
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_collection_name"
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "RunCommand with a write command omits default write concern (runCommand should never inherit write concern)",
+      "operations": [
+        {
+          "object": "database",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "name": "runCommand",
+          "command_name": "delete",
+          "arguments": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "default_write_concern_coll",
+              "deletes": [
+                {
+                  "q": {},
+                  "limit": 1
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateIndex and dropIndex omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "createIndex",
+          "arguments": {
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "dropIndex",
+          "arguments": {
+            "name": "x_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "default_write_concern_coll",
+              "indexes": [
+                {
+                  "name": "x_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "dropIndexes": "default_write_concern_coll",
+              "index": "x_1",
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "MapReduce omits default write concern",
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "mapReduce": "default_write_concern_coll",
+              "map": {
+                "$code": "function inc() { return emit(0, this.x + 1) }"
+              },
+              "reduce": {
+                "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+              },
+              "out": {
+                "inline": 1
+              },
+              "writeConcern": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-3.4.json
+++ b/data/read-write-concern/operation/default-write-concern-3.4.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "3.4"

--- a/data/read-write-concern/operation/default-write-concern-3.4.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.4.yml
@@ -8,7 +8,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "3.4"
@@ -22,7 +21,7 @@ tests:
         arguments:
           pipeline: &out_pipeline
             - $match: {_id: {$gt: 1}}
-            - $out: *other_collection_name
+            - $out: &other_collection_name "other_collection_name"
     outcome:
       collection:
         name: *other_collection_name

--- a/data/read-write-concern/operation/default-write-concern-3.4.yml
+++ b/data/read-write-concern/operation/default-write-concern-3.4.yml
@@ -1,0 +1,96 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 3.4+ server, where all commands started
+# to accept a write concern.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+other_collection_name: &other_collection_name other_collection_name
+
+runOn:
+    - minServerVersion: "3.4"
+
+tests:
+  - description: Aggregate with $out omits default write concern
+    operations:
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: aggregate
+        arguments:
+          pipeline: &out_pipeline
+            - $match: {_id: {$gt: 1}}
+            - $out: *other_collection_name
+    outcome:
+      collection:
+        name: *other_collection_name
+        data:
+          - {_id: 2, x: 22}
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *out_pipeline
+            writeConcern: null
+  - description: RunCommand with a write command omits default write concern (runCommand should never inherit write concern)
+    operations:
+      - object: database
+        databaseOptions: {writeConcern: {}}
+        name: runCommand
+        command_name: delete
+        arguments:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - {q: {}, limit: 1}
+            writeConcern: null
+  - description: CreateIndex and dropIndex omits default write concern 
+    operations:
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: createIndex
+        arguments:
+          keys: {x: 1}
+      - object: collection
+        collectionOptions: {writeConcern: {}}
+        name: dropIndex
+        arguments:
+          name: x_1
+    expectations:
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: x_1
+                key: {x: 1}
+            writeConcern: null
+      - command_started_event:
+          command:
+            dropIndexes: *collection_name
+            index: x_1
+            writeConcern: null
+  - description: MapReduce omits default write concern
+    operations:
+      - name: mapReduce
+        object: collection
+        collectionOptions: {writeConcern: {}}
+        arguments:
+          map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
+          reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
+          out: { inline: 1 }
+    expectations:
+      - command_started_event:
+          command:
+            mapReduce: *collection_name
+            map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
+            reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
+            out: { inline: 1 }
+            writeConcern: null

--- a/data/read-write-concern/operation/default-write-concern-4.2.json
+++ b/data/read-write-concern/operation/default-write-concern-4.2.json
@@ -1,0 +1,88 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "default_write_concern_coll",
+  "database_name": "default_write_concern_db",
+  "other_collection_name": "other_collection_name",
+  "runOn": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $merge omits default write concern",
+      "operations": [
+        {
+          "object": "collection",
+          "databaseOptions": {
+            "writeConcern": {}
+          },
+          "collectionOptions": {
+            "writeConcern": {}
+          },
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_collection_name"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "default_write_concern_coll",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_collection_name"
+                  }
+                }
+              ],
+              "writeConcern": null
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_collection_name",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/data/read-write-concern/operation/default-write-concern-4.2.json
+++ b/data/read-write-concern/operation/default-write-concern-4.2.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "4.2"

--- a/data/read-write-concern/operation/default-write-concern-4.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-4.2.yml
@@ -7,7 +7,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "4.2"
@@ -22,7 +21,7 @@ tests:
         arguments:
           pipeline: &merge_pipeline
             - $match: {_id: {$gt: 1}}
-            - $merge: {into: *other_collection_name}
+            - $merge: {into: &other_collection_name "other_collection_name" }
     expectations:
       - command_started_event:
           command:

--- a/data/read-write-concern/operation/default-write-concern-4.2.yml
+++ b/data/read-write-concern/operation/default-write-concern-4.2.yml
@@ -1,0 +1,37 @@
+# Test that setting a default write concern does not add a write concern
+# to the command sent over the wire.
+# Test operations that require 4.2+ server.
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+collection_name: &collection_name default_write_concern_coll
+database_name: &database_name default_write_concern_db
+other_collection_name: &other_collection_name other_collection_name
+
+runOn:
+    - minServerVersion: "4.2"
+
+tests:
+  - description: Aggregate with $merge omits default write concern
+    operations:
+      - object: collection
+        databaseOptions: {writeConcern: {}}
+        collectionOptions: {writeConcern: {}}
+        name: aggregate
+        arguments:
+          pipeline: &merge_pipeline
+            - $match: {_id: {$gt: 1}}
+            - $merge: {into: *other_collection_name}
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *merge_pipeline
+            # "null" fields will be checked for non-existence
+            writeConcern: null
+    outcome:
+      collection:
+        name: *other_collection_name
+        data:
+          - {_id: 2, x: 22}

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -56,7 +56,7 @@ func createUpdate(mt *mtest.T, updateVal bson.RawValue) interface{} {
 }
 
 // returns true if err is a mongo.CommandError containing a code that is expected from a killAllSessions command.
-func isExepctedKillAllSessionsError(err error) bool {
+func isExpectedKillAllSessionsError(err error) bool {
 	cmdErr, ok := err.(mongo.CommandError)
 	if !ok {
 		return false
@@ -78,7 +78,7 @@ func killSessions(mt *mtest.T) {
 		return
 	}
 
-	if !isExepctedKillAllSessionsError(err) {
+	if !isExpectedKillAllSessionsError(err) {
 		mt.Fatalf("killAllSessions error: %v", err)
 	}
 }

--- a/mongo/integration/json_helpers_test.go
+++ b/mongo/integration/json_helpers_test.go
@@ -227,6 +227,8 @@ func createDatabaseOptions(t testing.TB, opts bson.Raw) *options.DatabaseOptions
 		switch name {
 		case "readConcern":
 			do.SetReadConcern(createReadConcern(opt))
+		case "writeConcern":
+			do.SetWriteConcern(createWriteConcern(t, opt))
 		default:
 			t.Fatalf("unrecognized database option: %v", name)
 		}

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -35,15 +35,14 @@ const (
 )
 
 type testFile struct {
-	RunOn               []mtest.RunOnBlock `bson:"runOn"`
-	DatabaseName        string             `bson:"database_name"`
-	CollectionName      string             `bson:"collection_name"`
-	OtherCollectionName string             `bson:"other_collection_name"` // Specified in read/write concern tests
-	BucketName          string             `bson:"bucket_name"`
-	Data                testData           `bson:"data"`
-	JSONSchema          bson.Raw           `bson:"json_schema"`
-	KeyVaultData        []bson.Raw         `bson:"key_vault_data"`
-	Tests               []*testCase        `bson:"tests"`
+	RunOn          []mtest.RunOnBlock `bson:"runOn"`
+	DatabaseName   string             `bson:"database_name"`
+	CollectionName string             `bson:"collection_name"`
+	BucketName     string             `bson:"bucket_name"`
+	Data           testData           `bson:"data"`
+	JSONSchema     bson.Raw           `bson:"json_schema"`
+	KeyVaultData   []bson.Raw         `bson:"key_vault_data"`
+	Tests          []*testCase        `bson:"tests"`
 }
 
 type testData struct {


### PR DESCRIPTION
No logic changes needed! The test format for the spec changes added a field called `other_collection_name` which from what I can tell is used to specify the name of the outcome collection. However, the CRUD v2 tests already have this functionality for operations like aggregate with `$merge` and do not have this field, so I'm going to ask tomorrow if the field can be removed in a follow-up PR or the CRUD tests can be updated to match.