### PR TITLE
GODRIVER-1390 Add support for shorter SCRAM conversation

### DIFF
--- a/x/mongo/driver/auth/sasl.go
+++ b/x/mongo/driver/auth/sasl.go
@@ -44,10 +44,14 @@ func ConductSaslConversation(ctx context.Context, conn driver.Connection, db str
 		return newError(err, mech)
 	}
 
+	optionsDoc := bsoncore.BuildDocumentFromElements(nil,
+		bsoncore.AppendBooleanElement(nil, "skipEmptyExchange", true),
+	)
 	doc := bsoncore.BuildDocumentFromElements(nil,
 		bsoncore.AppendInt32Element(nil, "saslStart", 1),
 		bsoncore.AppendStringElement(nil, "mechanism", mech),
 		bsoncore.AppendBinaryElement(nil, "payload", 0x00, payload),
+		bsoncore.AppendDocumentElement(nil, "options", optionsDoc),
 	)
 	saslStartCmd := operation.NewCommand(doc).Database(db).Deployment(driver.SingleConnectionDeployment{conn})
 


### PR DESCRIPTION
Still figuring out if/how we can test this. I considered using a mock deployment, but I don't think we have the ability to control the randomized parts of the SCRAM conversation, so I can't hardcode the server responses ahead of time. We can't use command monitoring either, as that doesn't publish any security-related commands. @xdg thoughts?