### PR TITLE
Disable change stream test.

### DIFF
--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -88,6 +88,9 @@ func runChangeStreamTestFile(mt *mtest.T, file string) {
 	assert.Nil(mt, err, "UnmarshalExtJSONWithRegistry error: %v", err)
 
 	for _, test := range testFile.Tests {
+		if test.Description == "Change Stream should error when _id is projected out" {
+			mt.Skip("skipping until SPEC-1505")
+		}
 		runChangeStreamTest(mt, test, testFile)
 	}
 }

--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -88,9 +88,6 @@ func runChangeStreamTestFile(mt *mtest.T, file string) {
 	assert.Nil(mt, err, "UnmarshalExtJSONWithRegistry error: %v", err)
 
 	for _, test := range testFile.Tests {
-		if test.Description == "Change Stream should error when _id is projected out" {
-			mt.Skip("skipping until SPEC-1505")
-		}
 		runChangeStreamTest(mt, test, testFile)
 	}
 }
@@ -98,6 +95,11 @@ func runChangeStreamTestFile(mt *mtest.T, file string) {
 func runChangeStreamTest(mt *mtest.T, test changeStreamTest, testFile changeStreamTestFile) {
 	mtOpts := mtest.NewOptions().MinServerVersion(test.MinServerVersion).MaxServerVersion(test.MaxServerVersion).
 		Topologies(test.Topology...).DatabaseName(testFile.DatabaseName).CollectionName(testFile.CollectionName)
+	if test.Description == "Change Stream should error when _id is projected out" {
+		// Skip on latest server variant until SPEC-1505 is done
+		mtOpts.MaxServerVersion("4.2")
+	}
+
 	mt.RunOpts(test.Description, mtOpts, func(mt *mtest.T) {
 		test.nsMap = make(map[string]struct{})
 


### PR DESCRIPTION
- The test is failing on the latest server variant because SERVER-45505 was merged.
- The test will be re-enabled or removed after SPEC-1505 is resolved.