### PR TITLE
GODRIVER-1467 Add tests for all combinations

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -480,6 +480,46 @@ functions:
           -v \
           --fault revoked
 
+  run-valid-delegate-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          /opt/mongodbtoolchain/v3/bin/python3 -m venv ./venv
+          ./venv/bin/pip3 install -r ${PROJECT_DIRECTORY}/.evergreen/ocsp-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          nohup ./venv/bin/python3 ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
+          -p 8100 -v
+
+  run-revoked-delegate-ocsp-server:
+    - command: shell.exec
+      params:
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+          /opt/mongodbtoolchain/v3/bin/python3 -m venv ./venv
+          ./venv/bin/pip3 install -r ${PROJECT_DIRECTORY}/.evergreen/ocsp-requirements.txt
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
+
+          nohup ./venv/bin/python3 ocsp_mock.py \
+          --ca_file ${OCSP_ALGORITHM}/ca.pem \
+          --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
+          --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
+          -p 8100 \
+          -v \
+          --fault revoked
+
 pre:
   - func: fetch-source
   - func: prepare-resources
@@ -753,6 +793,238 @@ tasks:
       - func: run-ocsp-test
         vars:
           OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-rsa-delegate-valid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "rsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "rsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-rsa-delegate-valid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "rsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-rsa-delegate-invalid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "rsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-rsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "rsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "rsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "rsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-valid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-ecdsa-invalid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-valid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-ecdsa-invalid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-soft-fail
+    tags: ["ocsp"]
+    commands:
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-ecdsa-malicious-invalid-cert-mustStaple-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-malicious-no-responder-mustStaple-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-staples
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-delegate-valid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-valid-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "true"
+
+  - name: test-ocsp-ecdsa-delegate-invalid-cert-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+          OCSP_TLS_SHOULD_SUCCEED: "false"
+
+  - name: test-ocsp-ecdsa-delegate-malicious-invalid-cert-mustStaple-server-does-not-staple
+    tags: ["ocsp"]
+    commands:
+      - func: run-revoked-delegate-ocsp-server
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
+      - func: ocsp-bootstrap-mongo-orchestration
+        vars:
+          ORCHESTRATION_FILE: "ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json"
+      - func: run-ocsp-test
+        vars:
+          OCSP_ALGORITHM: "ecdsa"
           OCSP_TLS_SHOULD_SUCCEED: "false"
 
   - name: test-replicaset-noauth-nossl
@@ -1078,6 +1350,16 @@ buildvariants:
     tasks:
       - name: "atlas-test"
 
+  - name: ocsp-test
+    display_name: "OCSP Tests"
+    run_on:
+      - ubuntu1604-build
+    expansions:
+      GO_DIST: "/opt/golang/go1.12"
+    tasks:
+      - name: ".ocsp"
+    cron: "@every 336h"
+
   - matrix_name: "tests-legacy-auth-ssl"
     matrix_spec: { version: ["2.6", "3.0"], os-ssl-legacy: "*" }
     display_name: "${version} ${os-ssl-legacy}"
@@ -1119,9 +1401,3 @@ buildvariants:
     display_name: "Enterprise Auth - ${os-ssl-32}"
     tasks:
       - name: ".test .enterprise-auth"
-
-  - matrix_name: "ocsp-tests"
-    matrix_spec: { version: ["latest"], os-ssl-32: ["ubuntu1604-64-go-1-12"] }
-    display_name: "OCSP ${version} ${os-ssl-32}"
-    tasks:
-      - name: ".ocsp"


### PR DESCRIPTION
The first commit for GODRIVER-1467 added tests for RSA certificates.
This commit adds the following sets of tests:

- RSA certificates + OCSP responses signed by delegates
- ECDSA certificates
- ECDSA certificates + OCSP responses signed by delegates

This commit also uses a buildvariant instead of a matrix for OCSP tests
in Evergreen and uses cron to set the variant to only run every 14 days
on the waterfall.