### PR TITLE
GODRIVER-1491 Change field name in Connstring for OCSP option

### DIFF
--- a/internal/testutil/helpers/helpers.go
+++ b/internal/testutil/helpers/helpers.go
@@ -175,7 +175,7 @@ func VerifyConnStringOptions(t *testing.T, cs connstring.ConnString, options map
 		case "zstdcompressionlevel":
 			require.Equal(t, value, float64(cs.ZstdLevel))
 		case "tlsdisableocspendpointcheck":
-			require.Equal(t, value, cs.SSLDisableEndpointChecking)
+			require.Equal(t, value, cs.SSLDisableOCSPEndpointChecking)
 		default:
 			opt, ok := cs.UnknownOptions[key]
 			require.True(t, ok)

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -107,8 +107,8 @@ type ConnString struct {
 	SSLInsecureSet                     bool
 	SSLCaFile                          string
 	SSLCaFileSet                       bool
-	SSLDisableEndpointChecking         bool
-	SSLDisableEndpointCheckingSet      bool
+	SSLDisableOCSPEndpointChecking     bool
+	SSLDisableOCSPEndpointCheckingSet  bool
 	WString                            string
 	WNumber                            int
 	WNumberSet                         bool
@@ -444,7 +444,7 @@ func (p *parser) validateSSL() error {
 		return errors.New("the tlsCertificateFile URI option must be provided if the tlsPrivateKeyFile option is specified")
 	}
 
-	if p.SSLInsecureSet && p.SSLDisableEndpointCheckingSet {
+	if p.SSLInsecureSet && p.SSLDisableOCSPEndpointCheckingSet {
 		return errors.New("the sslInsecure/tlsInsecure URI option cannot be provided along with " +
 			"tlsDisableOCSPEndpointCheck ")
 	}
@@ -709,13 +709,13 @@ func (p *parser) addOption(pair string) error {
 
 		switch value {
 		case "true":
-			p.SSLDisableEndpointChecking = true
+			p.SSLDisableOCSPEndpointChecking = true
 		case "false":
-			p.SSLDisableEndpointChecking = false
+			p.SSLDisableOCSPEndpointChecking = false
 		default:
 			return fmt.Errorf("invalid value for %s: %s", key, value)
 		}
-		p.SSLDisableEndpointCheckingSet = true
+		p.SSLDisableOCSPEndpointCheckingSet = true
 	case "w":
 		if w, err := strconv.Atoi(value); err == nil {
 			if w < 0 {


### PR DESCRIPTION
This PR changes the field name from `SSLDisableEndpointChecking` to `SSLDisableOCSPEndpointChecking` for clarity.