### PR TITLE
GODRIVER-1522 Ignore read preference for aggregations with output stages

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -735,8 +735,24 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 		Crypt:          a.client.crypt,
 	}
 
-	op := operation.NewAggregate(pipelineArr).Session(sess).WriteConcern(wc).ReadConcern(rc).ReadPreference(a.readPreference).CommandMonitor(a.client.monitor).
-		ServerSelector(selector).ClusterClock(a.client.clock).Database(a.db).Collection(a.col).Deployment(a.client.deployment).Crypt(a.client.crypt)
+	op := operation.NewAggregate(pipelineArr).
+		Session(sess).
+		WriteConcern(wc).
+		ReadConcern(rc).
+		CommandMonitor(a.client.monitor).
+		ServerSelector(selector).
+		ClusterClock(a.client.clock).
+		Database(a.db).
+		Collection(a.col).
+		Deployment(a.client.deployment).
+		Crypt(a.client.crypt)
+	if !hasOutputStage {
+		// Only pass the user-specified read preference if the aggregation doesn't have a $out or $merge stage.
+		// Otherwise, the read preference could be forwarded to a mongos, which would error if the aggregation were
+		// executed against a non-primary node.
+		op.ReadPreference(a.readPreference)
+	}
+
 	if ao.AllowDiskUse != nil {
 		op.AllowDiskUse(*ao.AllowDiskUse)
 	}

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -185,9 +185,9 @@ func TestAggregateSecondaryPreferredReadPreference(t *testing.T) {
 		SetWriteConcern(mtest.MajorityWc).
 		SetReadPreference(readpref.SecondaryPreferred()).
 		SetReadConcern(mtest.MajorityRc)
-    mtOpts := mtest.NewOptions().
-        ClientOptions(secondaryPrefClientOpts).
-        MinServerVersion(4.1.0) // Consistent with tests in aggregate-out-readConcern.json
+	mtOpts := mtest.NewOptions().
+		ClientOptions(secondaryPrefClientOpts).
+		MinServerVersion("4.1.0") // Consistent with tests in aggregate-out-readConcern.json
 
 	mt := mtest.New(t, mtOpts)
 	mt.Run("aggregate $out with read preference secondary", func(mt *mtest.T) {

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -183,8 +183,13 @@ func TestAggregateSecondaryPreferredReadPreference(t *testing.T) {
 	// one-node shards, so a secondary read preference is not satisfiable.
 	secondaryPrefClientOpts := options.Client().
 		SetWriteConcern(mtest.MajorityWc).
-		SetReadPreference(readpref.SecondaryPreferred())
-	mt := mtest.New(t, mtest.NewOptions().ClientOptions(secondaryPrefClientOpts))
+		SetReadPreference(readpref.SecondaryPreferred()).
+		SetReadConcern(mtest.MajorityRc)
+    mtOpts := mtest.NewOptions().
+        ClientOptions(secondaryPrefClientOpts).
+        MinServerVersion(4.1.0) // Consistent with tests in aggregate-out-readConcern.json
+
+	mt := mtest.New(t, mtOpts)
 	mt.Run("aggregate $out with read preference secondary", func(mt *mtest.T) {
 		doc, err := bson.Marshal(bson.D{
 			{"_id", 1},

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -184,7 +184,7 @@ func TestAggregateSecondaryPreferredReadPreference(t *testing.T) {
 	secondaryPrefClientOpts := options.Client().
 		SetWriteConcern(mtest.MajorityWc).
 		SetReadPreference(readpref.SecondaryPreferred())
-	mt := mtest.New(t, mtest.NewOptions().ClientOptions(secondaryPrefClientOpts)
+	mt := mtest.New(t, mtest.NewOptions().ClientOptions(secondaryPrefClientOpts))
 	mt.Run("aggregate $out with read preference secondary", func(mt *mtest.T) {
 		doc, err := bson.Marshal(bson.D{
 			{"_id", 1},

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -183,10 +183,8 @@ func TestAggregateSecondaryPreferredReadPreference(t *testing.T) {
 	// one-node shards, so a secondary read preference is not satisfiable.
 	secondaryPrefClientOpts := options.Client().
 		SetWriteConcern(mtest.MajorityWc).
-		SetReadPreference(readpref.SecondaryPreferred()).
-		SetReadConcern(mtest.MajorityRc)
-	// Use min server version 3.2 because read concern is not supported on lower versions.
-	mt := mtest.New(t, mtest.NewOptions().ClientOptions(secondaryPrefClientOpts).MinServerVersion("3.2"))
+		SetReadPreference(readpref.SecondaryPreferred())
+	mt := mtest.New(t, mtest.NewOptions().ClientOptions(secondaryPrefClientOpts)
 	mt.Run("aggregate $out with read preference secondary", func(mt *mtest.T) {
 		doc, err := bson.Marshal(bson.D{
 			{"_id", 1},


### PR DESCRIPTION
I added a test for now so this will continue to be tested on the release branch. The hope is to remove the test on master before 1.4.0 and replace it with spec tests when we do the work for $out/$merge to secondaries.