### PR TITLE
GODRIVER-1520 Fix panics for lone scope

### DIFF
--- a/bson/bsonrw/extjson_parser.go
+++ b/bson/bsonrw/extjson_parser.go
@@ -115,7 +115,8 @@ func (ejp *extJSONParser) peekType() (bsontype.Type, error) {
 		case jpsSawKey:
 			t = wrapperKeyBSONType(ejp.k)
 
-			if t == bsontype.JavaScript {
+			switch t {
+			case bsontype.JavaScript:
 				// just saw $code, need to check for $scope at same level
 				_, err := ejp.readValue(bsontype.JavaScript)
 
@@ -137,6 +138,8 @@ func (ejp *extJSONParser) peekType() (bsontype.Type, error) {
 				default:
 					err = ErrInvalidJSON
 				}
+			case bsontype.CodeWithScope:
+				err = errors.New("invalid extended JSON: code with $scope must contain $code before $scope")
 			}
 		}
 	}

--- a/bson/bsonrw/extjson_parser_test.go
+++ b/bson/bsonrw/extjson_parser_test.go
@@ -7,7 +7,6 @@
 package bsonrw
 
 import (
-	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -159,7 +158,6 @@ func TestExtJSONParserPeekType(t *testing.T) {
 				errF := tc.errFs[i]
 
 				typ, err := ejp.peekType()
-				fmt.Printf("err: %v\n", err)
 				errF(t, err, tc.desc)
 				if err != nil {
 					// Don't inspect the type if there was an error
@@ -345,7 +343,6 @@ func TestExtJSONParserReadKeyReadValue(t *testing.T) {
 
 				k, typ, err := ejp.readKey()
 				readKeyDiff(t, eKey, k, eTyp, typ, err, keyErrF, tc.desc)
-				fmt.Printf("key: %s, err: %v\n", k, err)
 
 				v, err := ejp.readValue(typ)
 				readValueDiff(t, eVal, v, err, valErrF, tc.desc)

--- a/bson/bsonrw/extjson_parser_test.go
+++ b/bson/bsonrw/extjson_parser_test.go
@@ -160,8 +160,13 @@ func TestExtJSONParserPeekType(t *testing.T) {
 
 				typ, err := ejp.peekType()
 				fmt.Printf("err: %v\n", err)
-				typDiff(t, eTyp, typ, tc.desc)
 				errF(t, err, tc.desc)
+				if err != nil {
+					// Don't inspect the type if there was an error
+					return
+				}
+
+				typDiff(t, eTyp, typ, tc.desc)
 			}
 		})
 	}


### PR DESCRIPTION
While doing this, I also made the relevant test functions in extjson_parser_test.go run table-driven tests as subtests so I could easily isolate the tests I wanted to run.