### PR TITLE
GODRIVER-1502 Fix variable shadowing in parsing

### DIFF
--- a/bson/bsonrw/extjson_parser.go
+++ b/bson/bsonrw/extjson_parser.go
@@ -118,8 +118,8 @@ func (ejp *extJSONParser) peekType() (bsontype.Type, error) {
 			switch t {
 			case bsontype.JavaScript:
 				// just saw $code, need to check for $scope at same level
-				_, tempErr := ejp.readValue(bsontype.JavaScript)
-				if tempErr != nil {
+				_, err = ejp.readValue(bsontype.JavaScript)
+				if err != nil {
 					break
 				}
 

--- a/bson/bsonrw/extjson_parser.go
+++ b/bson/bsonrw/extjson_parser.go
@@ -118,9 +118,8 @@ func (ejp *extJSONParser) peekType() (bsontype.Type, error) {
 			switch t {
 			case bsontype.JavaScript:
 				// just saw $code, need to check for $scope at same level
-				_, err := ejp.readValue(bsontype.JavaScript)
-
-				if err != nil {
+				_, tempErr := ejp.readValue(bsontype.JavaScript)
+				if tempErr != nil {
 					break
 				}
 
@@ -128,6 +127,7 @@ func (ejp *extJSONParser) peekType() (bsontype.Type, error) {
 				case jpsSawEndObject: // type is TypeJavaScript
 				case jpsSawComma:
 					ejp.advanceState()
+
 					if ejp.s == jpsSawKey && ejp.k == "$scope" {
 						t = bsontype.CodeWithScope
 					} else {

--- a/bson/bsonrw/extjson_parser_test.go
+++ b/bson/bsonrw/extjson_parser_test.go
@@ -148,6 +148,8 @@ func TestExtJSONParserPeekType(t *testing.T) {
 			errFs: []expectedErrorFunc{expectNoError, expectError},
 		},
 		makeInvalidTestCase("lone $scope", `{"$scope": {}}`, expectError),
+		makeInvalidTestCase("empty code with unknown extra key", `{"$code":"", "0":""}`, expectError),
+		makeInvalidTestCase("non-empty code with unknown extra key", `{"$code":"foobar", "0":""}`, expectError),
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This is based on top of the branch for GODRIVER-1520 because the test helpers I added in that commit are useful here. Please review that one first so I can rebase and push in the correct order.