### PR TITLE
GODRIVER-1506 Fix error checking for invalid extjson timestamp values

### DIFF
--- a/bson/bsonrw/extjson_wrappers.go
+++ b/bson/bsonrw/extjson_wrappers.go
@@ -430,17 +430,20 @@ func (ejv *extJSONValue) parseTimestamp() (t, i uint32, err error) {
 
 		switch val.t {
 		case bsontype.Int32:
-			if val.v.(int32) < 0 {
-				return 0, fmt.Errorf("$timestamp %s number should be uint32: %s", key, string(val.v.(int32)))
+			value := val.v.(int32)
+
+			if value < 0 {
+				return 0, fmt.Errorf("$timestamp %s number should be uint32: %d", key, value)
 			}
 
-			return uint32(val.v.(int32)), nil
+			return uint32(value), nil
 		case bsontype.Int64:
-			if val.v.(int64) < 0 || uint32(val.v.(int64)) > math.MaxUint32 {
-				return 0, fmt.Errorf("$timestamp %s number should be uint32: %s", key, string(val.v.(int32)))
+			value := val.v.(int64)
+			if value < 0 || value > int64(math.MaxUint32) {
+				return 0, fmt.Errorf("$timestamp %s number should be uint32: %d", key, value)
 			}
 
-			return uint32(val.v.(int64)), nil
+			return uint32(value), nil
 		default:
 			return 0, fmt.Errorf("$timestamp %s value should be uint32, but instead is %s", key, val.t)
 		}

--- a/bson/extjson_prose_test.go
+++ b/bson/extjson_prose_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bson
+
+import (
+	"fmt"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+)
+
+func TestExtJSON(t *testing.T) {
+	timestampNegativeInt32Err := fmt.Errorf("$timestamp i number should be uint32: -1")
+	timestampNegativeInt64Err := fmt.Errorf("$timestamp i number should be uint32: -2147483649")
+	timestampLargeValueErr := fmt.Errorf("$timestamp i number should be uint32: 4294967296")
+
+	testCases := []struct {
+		name      string
+		input     string
+		canonical bool
+		err       error
+	}{
+		{"timestamp - negative int32 value", `{"":{"$timestamp":{"t":0,"i":-1}}}`, false, timestampNegativeInt32Err},
+		{"timestamp - negative int64 value", `{"":{"$timestamp":{"t":0,"i":-2147483649}}}`, false, timestampNegativeInt64Err},
+		{"timestamp - value overflows uint32", `{"":{"$timestamp":{"t":0,"i":4294967296}}}`, false, timestampLargeValueErr},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var res Raw
+			err := UnmarshalExtJSON([]byte(tc.input), tc.canonical, &res)
+			if tc.err == nil {
+				assert.Nil(t, err, "UnmarshalExtJSON error: %v", err)
+				return
+			}
+
+			assert.NotNil(t, err, "expected error %v, got nil", tc.err)
+			assert.Equal(t, tc.err.Error(), err.Error(), "expected error %v, got %v", tc.err, err)
+		})
+	}
+}


### PR DESCRIPTION
We didn't have a great place to put prose tests before, so I added a new extjson_prose_test.go file.