### PR TITLE
GODRIVER-1536 Ensure errInfo is propagated

### DIFF
--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -71,6 +71,7 @@ type WriteConcernErrorData struct {
 	Name        string    `bson:"codeName"`
 	Errmsg      string    `bson:"errmsg"`
 	ErrorLabels *[]string `bson:"errorLabels,omitempty"`
+	ErrInfo     bson.Raw  `bson:"errInfo,omitempty"`
 }
 
 // T is a wrapper around testing.T.


### PR DESCRIPTION
Relevant spec change: https://github.com/mongodb/specifications/commit/7745234f93039a83ae42589a6c0cdbefcffa32fa

We were already parsing the `errInfo` field for the `WriteConcernError.Details` document, so the only change here is adding a test.