### PR TITLE
Improve perf and reduce allocs in `bsoncore.Document.LookupErr`.

### DIFF
--- a/benchmark/harness.go
+++ b/benchmark/harness.go
@@ -38,6 +38,7 @@ func WrapCase(bench BenchCase) BenchFunction {
 	return func(b *testing.B) {
 		ctx := context.Background()
 		b.ResetTimer()
+		b.ReportAllocs()
 		err := bench(ctx, b, b.N)
 		require.NoError(b, err, "case='%s'", name)
 	}

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -181,7 +181,8 @@ func (d Document) LookupErr(key ...string) (Value, error) {
 		if !ok {
 			return Value{}, NewInsufficientBytesError(d, rem)
 		}
-		if elem.Key() != key[0] {
+		// We use `KeyBytes` rather than `Key` to avoid a needless string alloc.
+		if string(elem.KeyBytes()) != key[0] {
 			continue
 		}
 		if len(key) > 1 {


### PR DESCRIPTION
Calling `elem.Key()` causes a string to be needlessly allocated for every key in the document (until the key is found).

```
Before:
BenchmarkMultiInsertSmallDocument-8       137404          7895 ns/op        4401 B/op         85 allocs/op
BenchmarkMultiInsertLargeDocument-8           28      40820770 ns/op    56993558 B/op     519048 allocs/op
BenchmarkSingleRunCommand-8                15486         77255 ns/op        8703 B/op        145 allocs/op
BenchmarkSingleFindOneByID-8               12741        108356 ns/op        6398 B/op         68 allocs/op
BenchmarkSingleInsertSmallDocument-8       11641        103208 ns/op        5769 B/op        129 allocs/op
BenchmarkSingleInsertLargeDocument-8          24      41890824 ns/op    49652546 B/op     519096 allocs/op

After:
BenchmarkMultiInsertSmallDocument-8       135732          7664 ns/op        4288 B/op         72 allocs/op
BenchmarkMultiInsertLargeDocument-8           30      37820538 ns/op    55949030 B/op     424690 allocs/op
BenchmarkSingleRunCommand-8                15766         75572 ns/op        7685 B/op         92 allocs/op
BenchmarkSingleFindOneByID-8               12685         94377 ns/op        6350 B/op         57 allocs/op
BenchmarkSingleInsertSmallDocument-8       11562        103031 ns/op        5657 B/op        111 allocs/op
BenchmarkSingleInsertLargeDocument-8          25      40179867 ns/op    48142948 B/op     424736 allocs/op
```