### PR TITLE
GODRIVER-1405 Remove topology.WithConnectionAppName

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -337,9 +337,6 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		serverOpts = append(serverOpts, topology.WithServerAppName(func(string) string {
 			return appName
 		}))
-		connOpts = append(connOpts, topology.WithConnectionAppName(func(string) string {
-			return appName
-		}))
 	}
 	// Compressors & ZlibLevel
 	var comps []string

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -351,7 +351,8 @@ func TestClient(t *testing.T) {
 		SetAppName(testAppName)
 	appNameMtOpts := mtest.NewOptions().
 		ClientOptions(appNameDialerOpts).
-		Topologies(mtest.Single)
+		Topologies(mtest.Single).
+		Auth(false) // Can't run with auth because the proxy dialer won't work with TLS enabled.
 	mt.RunOpts("app name is always sent", appNameMtOpts, func(mt *mtest.T) {
 		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)

--- a/x/mongo/driver/examples/server_monitoring/main.go
+++ b/x/mongo/driver/examples/server_monitoring/main.go
@@ -20,11 +20,6 @@ func main() {
 		address.Address("localhost:27017"),
 		nil,
 		topology.WithHeartbeatInterval(func(time.Duration) time.Duration { return 2 * time.Second }),
-		topology.WithConnectionOptions(
-			func(opts ...topology.ConnectionOption) []topology.ConnectionOption {
-				return append(opts, topology.WithConnectionAppName(func(string) string { return "server monitoring test" }))
-			},
-		),
 	)
 	if err != nil {
 		log.Fatalf("could not start server: %v", err)

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -86,15 +86,6 @@ func withServerDescriptionCallback(callback func(description.Server), opts ...Co
 // ConnectionOption is used to configure a connection.
 type ConnectionOption func(*connectionConfig) error
 
-// WithConnectionAppName sets the application name which gets sent to MongoDB when it
-// first connects.
-func WithConnectionAppName(fn func(string) string) ConnectionOption {
-	return func(c *connectionConfig) error {
-		c.appName = fn(c.appName)
-		return nil
-	}
-}
-
 // WithCompressors sets the compressors that can be used for communication.
 func WithCompressors(fn func([]string) []string) ConnectionOption {
 	return func(c *connectionConfig) error {

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -65,7 +65,6 @@ func WithConnString(fn func(connstring.ConnString) connstring.ConnString) Option
 		var connOpts []ConnectionOption
 
 		if cs.AppName != "" {
-			connOpts = append(connOpts, WithConnectionAppName(func(string) string { return cs.AppName }))
 			c.serverOpts = append(c.serverOpts, WithServerAppName(func(string) string { return cs.AppName }))
 		}
 


### PR DESCRIPTION
This is a follow-up change for the bug fix in GODRIVER-1405. The topology.WithConnectionAppName ConnectionOption doesn't do anythhing because the app name for a connection is set through the handshaker, so it's safe to remove.