### PR TITLE
Implement a proxy dialer for integration tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1381,6 +1381,20 @@ tasks:
           SSL: "ssl"
           MONGO_GO_DRIVER_COMPRESSOR: "zstd"
 
+  - name: test-sharded-auth-nossl
+    tags: ["test", "sharded", "authssl"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "auth"
+          SSL: "nossl"
+      - func: run-tests
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "auth"
+          SSL: "nossl"
+
   - name: test-enterprise-auth-plain
     tags: ["test", "enterprise-auth"]
     commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -838,6 +838,20 @@ tasks:
           AUTH: "auth"
           SSL: "ssl"
 
+  - name: test-standalone-auth-nossl
+    tags: ["test", "standalone", "authssl"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "auth"
+          SSL: "nossl"
+      - func: run-tests
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "auth"
+          SSL: "nossl"
+
   - name: test-standalone-auth-ssl-snappy-compression
     tags: ["test", "standalone", "authssl", "compression", "snappy"]
     commands:

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -7,15 +7,10 @@
 package integration
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"io"
-	"net"
 	"path"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +24,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
@@ -381,37 +375,31 @@ func TestClient(t *testing.T) {
 	})
 
 	testAppName := "foo"
-	hosts := options.Client().ApplyURI(mt.ConnString()).Hosts
-	appNameProxyDialer := newProxyDialer()
-	appNameDialerOpts := options.Client().
-		SetDialer(appNameProxyDialer).
-		SetHosts(hosts[:1]).
-		SetDirect(true).
+	appNameClientOpts := options.Client().
 		SetAppName(testAppName)
 	appNameMtOpts := mtest.NewOptions().
-		ClientOptions(appNameDialerOpts).
-		Topologies(mtest.Single).
-		Auth(false) // Can't run with auth because the proxy dialer won't work with TLS enabled.
+		ClientType(mtest.Proxy).
+		ClientOptions(appNameClientOpts).
+		Topologies(mtest.Single)
 	mt.RunOpts("app name is always sent", appNameMtOpts, func(mt *mtest.T) {
 		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)
 
-		msgPairs := appNameProxyDialer.messages
+		msgPairs := mt.GetProxiedMessages()
 		assert.True(mt, len(msgPairs) >= 2, "expected at least 2 events sent, got %v", len(msgPairs))
 
 		// First two messages should be connection handshakes: one for the heartbeat connection and the other for the
 		// application connection.
 		for idx, pair := range msgPairs[:2] {
-			cmd, err := drivertest.GetCommandFromQueryWireMessage(pair.sent)
-			assert.Nil(mt, err, "GetCommandFromQueryWireMessage error at index %d: %v", idx, err)
-			heartbeatCmdName := cmd.Index(0).Key()
-			assert.Equal(mt, "isMaster", heartbeatCmdName,
-				"expected command name isMaster at index %d, got %v", idx, heartbeatCmdName)
+			assert.Equal(mt, pair.CommandName, "isMaster", "expected command name isMaster at index %d, got %s", idx,
+				pair.CommandName)
 
-			appNameVal, err := cmd.LookupErr("client", "application", "name")
-			assert.Nil(mt, err, "expected command %s at index %d to contain app name", cmd, idx)
+			sent := pair.Sent
+			appNameVal, err := sent.Command.LookupErr("client", "application", "name")
+			assert.Nil(mt, err, "expected command %s at index %d to contain app name", sent.Command, idx)
 			appName := appNameVal.StringValue()
-			assert.Equal(mt, testAppName, appName, "expected app name %v at index %d, got %v", testAppName, idx, appName)
+			assert.Equal(mt, testAppName, appName, "expected app name %v at index %d, got %v", testAppName, idx,
+				appName)
 		}
 	})
 
@@ -445,102 +433,4 @@ type proxyMessage struct {
 	serverAddress string
 	sent          wiremessage.WireMessage
 	received      wiremessage.WireMessage
-}
-
-// proxyDialer is a ContextDialer implementation that wraps a net.Dialer and records the messages sent and received
-// using connections created through it.
-type proxyDialer struct {
-	*net.Dialer
-	sync.Mutex
-	messages []proxyMessage
-	sentMap  sync.Map
-}
-
-var _ options.ContextDialer = (*proxyDialer)(nil)
-
-func newProxyDialer() *proxyDialer {
-	return &proxyDialer{
-		Dialer: &net.Dialer{Timeout: 30 * time.Second},
-	}
-}
-
-// DialContext creates a new proxyConnection.
-func (p *proxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	netConn, err := p.Dialer.DialContext(ctx, network, address)
-	if err != nil {
-		return netConn, err
-	}
-
-	proxy := &proxyConn{
-		Conn:           netConn,
-		dialer:         p,
-		currentReading: bytes.NewBuffer(nil),
-	}
-	return proxy, nil
-}
-
-// storeSentMessage stores a copy of the wire message being sent to the server.
-func (p *proxyDialer) storeSentMessage(msg []byte) {
-	p.Lock()
-	defer p.Unlock()
-
-	msgCopy := make(wiremessage.WireMessage, len(msg))
-	copy(msgCopy, msg)
-
-	_, requestID, _, _, _, _ := wiremessage.ReadHeader(msgCopy)
-	p.sentMap.Store(requestID, msgCopy)
-}
-
-// storeReceivedMessage stores a copy of the wire message being received from the server.
-func (p *proxyDialer) storeReceivedMessage(msg []byte) {
-	p.Lock()
-	defer p.Unlock()
-
-	msgCopy := make(wiremessage.WireMessage, len(msg))
-	copy(msgCopy, msg)
-
-	_, _, responseTo, _, _, _ := wiremessage.ReadHeader(msgCopy)
-	sentMsg, _ := p.sentMap.Load(responseTo)
-	p.sentMap.Delete(responseTo)
-
-	proxyMsg := proxyMessage{
-		sent:     sentMsg.(wiremessage.WireMessage),
-		received: msgCopy,
-	}
-	p.messages = append(p.messages, proxyMsg)
-}
-
-// proxyConn is a net.Conn that wraps a network connection. All messages sent/received through a proxyConn are stored
-// in the associated proxyDialer and are forwarded over the wrapped connection.
-type proxyConn struct {
-	net.Conn
-	dialer         *proxyDialer
-	currentReading *bytes.Buffer // The current message being read.
-}
-
-// Write stores the given message in the proxyDialer associated with this connection and forwards the message to the
-// server.
-func (pc *proxyConn) Write(msg []byte) (n int, err error) {
-	pc.dialer.storeSentMessage(msg)
-	return pc.Conn.Write(msg)
-}
-
-// Read reads the message from the server into the given buffer and stores the read message in the proxyDialer
-// associated with this connection.
-func (pc *proxyConn) Read(buffer []byte) (int, error) {
-	n, err := pc.Conn.Read(buffer)
-	if err != nil {
-		return n, err
-	}
-
-	_, err = io.Copy(pc.currentReading, bytes.NewReader(buffer))
-	if err != nil {
-		return 0, fmt.Errorf("error copying to mock: %v", err)
-	}
-	if len(buffer) != 4 {
-		pc.dialer.storeReceivedMessage(pc.currentReading.Bytes())
-		pc.currentReading.Reset()
-	}
-
-	return n, err
 }

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -86,14 +86,15 @@ type T struct {
 	mockDeployment   *mockDeployment // nil if the test is not being run against a mock
 	mockResponses    []bson.D
 	createdColls     []*Collection // collections created in this test
+	proxyDialer      *proxyDialer
 	dbName, collName string
 	failPointNames   []string
 	minServerVersion string
 	maxServerVersion string
 	validTopologies  []TopologyKind
 	auth             *bool
-	ssl              *bool
 	enterprise       *bool
+	ssl              *bool
 	collCreateOpts   bson.D
 	connsCheckedOut  int // net number of connections checked out during test execution
 
@@ -342,6 +343,22 @@ func (t *T) FilterFailedEvents(filter func(*event.CommandFailedEvent) bool) {
 	t.failed = newEvents
 }
 
+// GetProxiedMessages does thing
+func (t *T) GetProxiedMessages() []*ProxyMessage {
+	if t.proxyDialer == nil {
+		return nil
+	}
+	return t.proxyDialer.messages
+}
+
+// GetRawProxiedMessages does thing
+func (t *T) GetRawProxiedMessages() []*RawProxyMessage {
+	if t.proxyDialer == nil {
+		return nil
+	}
+	return t.proxyDialer.rawMessages
+}
+
 // ClearEvents clears the existing command monitoring events.
 func (t *T) ClearEvents() {
 	t.started = t.started[:0]
@@ -580,14 +597,6 @@ func (t *T) createTestClient() {
 
 	var err error
 	switch t.clientType {
-	case Default:
-		// only specify URI if the deployment is not set to avoid setting topology/server options along with the deployment
-		var uriOpts *options.ClientOptions
-		if clientOpts.Deployment == nil {
-			uriOpts = options.Client().ApplyURI(testContext.connString.Original)
-		}
-		// Specify the URI-based options first so the test can override them.
-		t.Client, err = mongo.NewClient(uriOpts, clientOpts)
 	case Pinned:
 		// pin to first mongos
 		pinnedHostList := []string{testContext.connString.Hosts[0]}
@@ -598,6 +607,22 @@ func (t *T) createTestClient() {
 		clientOpts.PoolMonitor = nil
 		t.mockDeployment = newMockDeployment()
 		clientOpts.Deployment = t.mockDeployment
+		t.Client, err = mongo.NewClient(clientOpts)
+	case Proxy, RawProxy:
+		dialerFn := newProxyDialer
+		if t.clientType == RawProxy {
+			dialerFn = newRawProxyDialer
+		}
+		t.proxyDialer = dialerFn()
+		clientOpts.SetDialer(t.proxyDialer)
+
+		// After setting the Dialer, fall-through to the Default case to apply the correct URI
+		fallthrough
+	case Default:
+		// only specify URI if the deployment is not set to avoid setting topology/server options along with the deployment
+		if clientOpts.Deployment == nil {
+			clientOpts.ApplyURI(testContext.connString.Original)
+		}
 		t.Client, err = mongo.NewClient(clientOpts)
 	}
 	if err != nil {

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -619,11 +619,17 @@ func (t *T) createTestClient() {
 		// After setting the Dialer, fall-through to the Default case to apply the correct URI
 		fallthrough
 	case Default:
-		// only specify URI if the deployment is not set to avoid setting topology/server options along with the deployment
+		// Use a different set of options to specify the URI because clientOpts may already have a URI or host seedlist
+		// specified.
+		var uriOpts *options.ClientOptions
 		if clientOpts.Deployment == nil {
-			clientOpts.ApplyURI(testContext.connString.Original)
+			// Only specify URI if the deployment is not set to avoid setting topology/server options along with the
+			// deployment.
+			uriOpts = options.Client().ApplyURI(testContext.connString.Original)
 		}
-		t.Client, err = mongo.NewClient(clientOpts)
+
+		// Pass in uriOpts first so clientOpts wins if there are any conflicting settings.
+		t.Client, err = mongo.NewClient(uriOpts, clientOpts)
 	}
 	if err != nil {
 		t.Fatalf("error creating client: %v", err)

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -343,20 +343,13 @@ func (t *T) FilterFailedEvents(filter func(*event.CommandFailedEvent) bool) {
 	t.failed = newEvents
 }
 
-// GetProxiedMessages does thing
+// GetProxiedMessages returns the messages proxied to the server by the test. If the client type is not Proxy, this
+// returns nil.
 func (t *T) GetProxiedMessages() []*ProxyMessage {
 	if t.proxyDialer == nil {
 		return nil
 	}
 	return t.proxyDialer.messages
-}
-
-// GetRawProxiedMessages does thing
-func (t *T) GetRawProxiedMessages() []*RawProxyMessage {
-	if t.proxyDialer == nil {
-		return nil
-	}
-	return t.proxyDialer.rawMessages
 }
 
 // ClearEvents clears the existing command monitoring events.
@@ -608,12 +601,8 @@ func (t *T) createTestClient() {
 		t.mockDeployment = newMockDeployment()
 		clientOpts.Deployment = t.mockDeployment
 		t.Client, err = mongo.NewClient(clientOpts)
-	case Proxy, RawProxy:
-		dialerFn := newProxyDialer
-		if t.clientType == RawProxy {
-			dialerFn = newRawProxyDialer
-		}
-		t.proxyDialer = dialerFn()
+	case Proxy:
+		t.proxyDialer = newProxyDialer()
 		clientOpts.SetDialer(t.proxyDialer)
 
 		// After setting the Dialer, fall-through to the Default case to apply the correct URI

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -33,9 +33,11 @@ const (
 	Pinned
 	// Mock specifies a client that communicates with a mock deployment.
 	Mock
-	// Proxy specifies a client that proxies messages to the server and also stores parsed copies.
+	// Proxy specifies a client that proxies messages to the server and also stores parsed copies. The proxied
+	// messages can be retrieved via T.GetProxiedMessages or T.GetRawProxiedMessages.
 	Proxy
-	// RawProxy specifies a client that proxies messages to the server and stores raw copies.
+	// RawProxy specifies a client that proxies messages to the server and stores raw copies. The proxied messages can
+	// be retrieved via T.GetRawProxiedMessages.
 	RawProxy
 )
 

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -33,6 +33,14 @@ const (
 	Pinned
 	// Mock specifies a client that communicates with a mock deployment.
 	Mock
+	// Proxy specifies a client that proxies messages to the server and also stores parsed copies.
+	Proxy
+	// RawProxy specifies a client that proxies messages to the server and stores raw copies.
+	RawProxy
+)
+
+var (
+	falseBool = false
 )
 
 // RunOnBlock describes a constraint for a test.
@@ -125,10 +133,15 @@ func (op *Options) DatabaseName(dbName string) *Options {
 }
 
 // ClientType specifies the type of client that should be created for a test. This option will be propagated to all
-// sub-tests.
+// sub-tests. If the provided ClientType is Proxy or RawProxy, the SSL(false) option will be also be added because
+// the internal proxy dialer and connection types do not support SSL.
 func (op *Options) ClientType(ct ClientType) *Options {
 	op.optFuncs = append(op.optFuncs, func(t *T) {
 		t.clientType = ct
+
+		if ct == Proxy || ct == RawProxy {
+			t.ssl = &falseBool
+		}
 	})
 	return op
 }

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -36,9 +36,6 @@ const (
 	// Proxy specifies a client that proxies messages to the server and also stores parsed copies. The proxied
 	// messages can be retrieved via T.GetProxiedMessages or T.GetRawProxiedMessages.
 	Proxy
-	// RawProxy specifies a client that proxies messages to the server and stores raw copies. The proxied messages can
-	// be retrieved via T.GetRawProxiedMessages.
-	RawProxy
 )
 
 var (
@@ -135,13 +132,13 @@ func (op *Options) DatabaseName(dbName string) *Options {
 }
 
 // ClientType specifies the type of client that should be created for a test. This option will be propagated to all
-// sub-tests. If the provided ClientType is Proxy or RawProxy, the SSL(false) option will be also be added because
-// the internal proxy dialer and connection types do not support SSL.
+// sub-tests. If the provided ClientType is Proxy, the SSL(false) option will be also be added because the internal
+// proxy dialer and connection types do not support SSL.
 func (op *Options) ClientType(ct ClientType) *Options {
 	op.optFuncs = append(op.optFuncs, func(t *T) {
 		t.clientType = ct
 
-		if ct == Proxy || ct == RawProxy {
+		if ct == Proxy {
 			t.ssl = &falseBool
 		}
 	})

--- a/mongo/integration/mtest/proxy_dialer.go
+++ b/mongo/integration/mtest/proxy_dialer.go
@@ -1,0 +1,181 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
+)
+
+// ProxyMessage represents a sent/received pair of parsed wire messages.
+type ProxyMessage struct {
+	CommandName string
+	Sent        *SentMessage
+	Received    *ReceivedMessage
+}
+
+// RawProxyMessage represents a sent/received pair of raw wire messages.
+type RawProxyMessage struct {
+	Sent     wiremessage.WireMessage
+	Received wiremessage.WireMessage
+}
+
+// proxyDialer is a ContextDialer implementation that wraps a net.Dialer and records the messages sent and received
+// using connections created through it.
+type proxyDialer struct {
+	*net.Dialer
+	sync.Mutex
+	// sentMap temporarily stores the message sent to the server using the requestID so it can map requests to their
+	// responses.
+	sentMap     map[int32]*SentMessage
+	messages    []*ProxyMessage
+	rawMessages []*RawProxyMessage
+
+	rawMessagesOnly bool
+}
+
+var _ options.ContextDialer = (*proxyDialer)(nil)
+
+func newProxyDialer() *proxyDialer {
+	return &proxyDialer{
+		Dialer:  &net.Dialer{Timeout: 30 * time.Second},
+		sentMap: make(map[int32]*SentMessage),
+	}
+}
+
+func newRawProxyDialer() *proxyDialer {
+	pd := newProxyDialer()
+	pd.rawMessagesOnly = true
+	return pd
+}
+
+func newProxyError(err error) error {
+	return fmt.Errorf("proxy error: %v", err)
+}
+
+func newProxyErrorWithWireMsg(wm []byte, err error) error {
+	return fmt.Errorf("proxy error for wiremessage %v: %v", wm, err)
+}
+
+// DialContext creates a new proxyConnection.
+func (p *proxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	netConn, err := p.Dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return netConn, newProxyError(err)
+	}
+
+	proxy := &proxyConn{
+		Conn:   netConn,
+		dialer: p,
+	}
+	return proxy, nil
+}
+
+func (p *proxyDialer) storeSentMessage(wm []byte) error {
+	p.Lock()
+	defer p.Unlock()
+
+	parsed, err := parseSentMessage(wm, p.rawMessagesOnly)
+	if err != nil {
+		return err
+	}
+	p.sentMap[parsed.RequestID] = parsed
+	return nil
+}
+
+func (p *proxyDialer) storeReceivedMessage(msg []byte) error {
+	p.Lock()
+	defer p.Unlock()
+
+	// Parse the incoming message and get the corresponding outgoing message.
+	parsed, err := parseReceivedMessage(msg, p.rawMessagesOnly)
+	if err != nil {
+		return err
+	}
+	sent, ok := p.sentMap[parsed.ResponseTo]
+	if !ok {
+		return errors.New("no sent message found")
+	}
+	delete(p.sentMap, parsed.ResponseTo)
+
+	// Store the raw message pair.
+	rawMsgPair := &RawProxyMessage{
+		Sent:     sent.RawMessage,
+		Received: parsed.RawMessage,
+	}
+	p.rawMessages = append(p.rawMessages, rawMsgPair)
+	if p.rawMessagesOnly {
+		return nil
+	}
+
+	// Store the parsed message pair.
+	msgPair := &ProxyMessage{
+		// The command name is always the first key in the command document.
+		CommandName: sent.Command.Index(0).Key(),
+		Sent:        sent,
+		Received:    parsed,
+	}
+	p.messages = append(p.messages, msgPair)
+	return nil
+}
+
+// proxyConn is a net.Conn that wraps a network connection. All messages sent/received through a proxyConn are stored
+// in the associated proxyDialer and are forwarded over the wrapped connection. Errors encountered when parsing and
+// storing wire messages are wrapped to add context, while errors returned from the underlying network connection are
+// forwarded without wrapping.
+type proxyConn struct {
+	net.Conn
+	dialer *proxyDialer
+}
+
+// Write stores the given message in the proxyDialer associated with this connection and forwards the message to the
+// server.
+func (pc *proxyConn) Write(wm []byte) (n int, err error) {
+	if err := pc.dialer.storeSentMessage(wm); err != nil {
+		wrapped := fmt.Errorf("error storing sent message: %v", err)
+		return 0, newProxyErrorWithWireMsg(wm, wrapped)
+	}
+
+	return pc.Conn.Write(wm)
+}
+
+// Read reads the message from the server into the given buffer and stores the read message in the proxyDialer
+// associated with this connection.
+func (pc *proxyConn) Read(buffer []byte) (int, error) {
+	n, err := pc.Conn.Read(buffer)
+	if err != nil {
+		return n, err
+	}
+
+	// The driver reads wire messages in two phases: a four-byte read to get the length of the incoming wire message
+	// and a (length-4) byte read to get the message itself. There's nothing to be stored during the initial four-byte
+	// read because we can calculate the length from the rest of the message.
+	if len(buffer) == 4 {
+		return 4, nil
+	}
+
+	// The buffer contains the entire wire message except for the length bytes. Re-create the full message by appending
+	// buffer to the end of a four-byte slice and using UpdateLength to set the length bytes.
+	idx, wm := bsoncore.ReserveLength(nil)
+	wm = append(wm, buffer...)
+	wm = bsoncore.UpdateLength(wm, idx, int32(len(wm[idx:])))
+
+	if err := pc.dialer.storeReceivedMessage(wm); err != nil {
+		wrapped := fmt.Errorf("error storing received message: %v", err)
+		return 0, newProxyErrorWithWireMsg(wm, wrapped)
+	}
+
+	return n, nil
+}

--- a/mongo/integration/mtest/received_message.go
+++ b/mongo/integration/mtest/received_message.go
@@ -14,7 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
-// ReceivedMessage is thing
+// ReceivedMessage represents a message received from the server.
 type ReceivedMessage struct {
 	ResponseTo int32
 	RawMessage wiremessage.WireMessage
@@ -36,11 +36,7 @@ func getReceivedMessageParser(opcode wiremessage.OpCode) (receivedMsgParseFn, bo
 	}
 }
 
-func parseReceivedMessage(original []byte, parseRawOnly bool) (*ReceivedMessage, error) {
-	// Create a copy of the entire wire message and pass that around to helpers so no copies will be needed later in
-	// the code.
-	wm := copyBytes(original)
-
+func parseReceivedMessage(wm []byte, parseRawOnly bool) (*ReceivedMessage, error) {
 	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
 	_, _, responseTo, opcode, remaining, ok := wiremessage.ReadHeader(wm)
 	if !ok {

--- a/mongo/integration/mtest/received_message.go
+++ b/mongo/integration/mtest/received_message.go
@@ -36,19 +36,11 @@ func getReceivedMessageParser(opcode wiremessage.OpCode) (receivedMsgParseFn, bo
 	}
 }
 
-func parseReceivedMessage(wm []byte, parseRawOnly bool) (*ReceivedMessage, error) {
+func parseReceivedMessage(wm []byte) (*ReceivedMessage, error) {
 	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
 	_, _, responseTo, opcode, remaining, ok := wiremessage.ReadHeader(wm)
 	if !ok {
 		return nil, errors.New("failed to read wiremessage header")
-	}
-
-	if parseRawOnly {
-		rm := &ReceivedMessage{
-			ResponseTo: responseTo,
-			RawMessage: wm,
-		}
-		return rm, nil
 	}
 
 	parseFn, ok := getReceivedMessageParser(opcode)

--- a/mongo/integration/mtest/received_message.go
+++ b/mongo/integration/mtest/received_message.go
@@ -1,0 +1,136 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mtest
+
+import (
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
+)
+
+// ReceivedMessage is thing
+type ReceivedMessage struct {
+	ResponseTo int32
+	RawMessage wiremessage.WireMessage
+	Response   bsoncore.Document
+}
+
+type receivedMsgParseFn func([]byte) (*ReceivedMessage, error)
+
+func getReceivedMessageParser(opcode wiremessage.OpCode) (receivedMsgParseFn, bool) {
+	switch opcode {
+	case wiremessage.OpReply:
+		return parseOpReply, true
+	case wiremessage.OpMsg:
+		return parseReceivedOpMsg, true
+	case wiremessage.OpCompressed:
+		return parseReceivedOpCompressed, true
+	default:
+		return nil, false
+	}
+}
+
+func parseReceivedMessage(original []byte, parseRawOnly bool) (*ReceivedMessage, error) {
+	// Create a copy of the entire wire message and pass that around to helpers so no copies will be needed later in
+	// the code.
+	wm := copyBytes(original)
+
+	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
+	_, _, responseTo, opcode, remaining, ok := wiremessage.ReadHeader(wm)
+	if !ok {
+		return nil, errors.New("failed to read wiremessage header")
+	}
+
+	if parseRawOnly {
+		rm := &ReceivedMessage{
+			ResponseTo: responseTo,
+			RawMessage: wm,
+		}
+		return rm, nil
+	}
+
+	parseFn, ok := getReceivedMessageParser(opcode)
+	if !ok {
+		return nil, fmt.Errorf("unknown opcode: %s", opcode)
+	}
+	received, err := parseFn(remaining)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing wiremessage with opcode %s: %v", opcode, err)
+	}
+
+	received.ResponseTo = responseTo
+	received.RawMessage = wm
+	return received, nil
+}
+
+func parseOpReply(wm []byte) (*ReceivedMessage, error) {
+	var ok bool
+
+	if _, wm, ok = wiremessage.ReadReplyFlags(wm); !ok {
+		return nil, errors.New("failed to read reply flags")
+	}
+	if _, wm, ok = wiremessage.ReadReplyCursorID(wm); !ok {
+		return nil, errors.New("failed to read cursor ID")
+	}
+	if _, wm, ok = wiremessage.ReadReplyStartingFrom(wm); !ok {
+		return nil, errors.New("failed to read starting from")
+	}
+	if _, wm, ok = wiremessage.ReadReplyNumberReturned(wm); !ok {
+		return nil, errors.New("failed to read number returned")
+	}
+
+	var replyDocuments []bsoncore.Document
+	replyDocuments, wm, ok = wiremessage.ReadReplyDocuments(wm)
+	if !ok {
+		return nil, errors.New("failed to read reply documents")
+	}
+	if len(replyDocuments) == 0 {
+		return nil, errors.New("no documents in response")
+	}
+
+	rm := &ReceivedMessage{
+		Response: replyDocuments[0],
+	}
+	return rm, nil
+}
+
+func parseReceivedOpMsg(wm []byte) (*ReceivedMessage, error) {
+	var ok bool
+	var err error
+
+	if _, wm, ok = wiremessage.ReadMsgFlags(wm); !ok {
+		return nil, errors.New("failed to read flags")
+	}
+
+	if wm, err = assertMsgSectionType(wm, wiremessage.SingleDocument); err != nil {
+		return nil, fmt.Errorf("error verifying section type for response document: %v", err)
+	}
+
+	response, wm, ok := wiremessage.ReadMsgSectionSingleDocument(wm)
+	if !ok {
+		return nil, errors.New("failed to read response document")
+	}
+	rm := &ReceivedMessage{
+		Response: response,
+	}
+	return rm, nil
+}
+
+func parseReceivedOpCompressed(wm []byte) (*ReceivedMessage, error) {
+	originalOpcode, wm, err := parseOpCompressed(wm)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, ok := getReceivedMessageParser(originalOpcode)
+	if !ok {
+		return nil, fmt.Errorf("unknown original opcode %v", originalOpcode)
+	}
+	return parser(wm)
+}

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -47,11 +47,7 @@ func getSentMessageParser(opcode wiremessage.OpCode) (sentMsgParseFn, bool) {
 	}
 }
 
-func parseSentMessage(original []byte, parseRawOnly bool) (*SentMessage, error) {
-	// Create a copy of the entire wire message and pass that around to helpers so no copies will be needed later in
-	// the code.
-	wm := copyBytes(original)
-
+func parseSentMessage(wm []byte, parseRawOnly bool) (*SentMessage, error) {
 	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
 	_, requestID, _, opcode, remaining, ok := wiremessage.ReadHeader(wm)
 	if !ok {

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -1,0 +1,208 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mtest
+
+import (
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
+)
+
+// SentMessage represents a message sent by the driver to the server.
+type SentMessage struct {
+	RequestID  int32
+	RawMessage wiremessage.WireMessage
+	Command    bsoncore.Document
+
+	// The $readPreference document. This is separated into its own field even though it's included in the larger
+	// command document in both OP_QUERY and OP_MSG because OP_QUERY separates the command into a $query sub-document
+	// if there is a read preference. To unify OP_QUERY and OP_MSG, we pull this out into a separate field and set
+	// the Command field to the $query sub-document.
+	ReadPreference bsoncore.Document
+
+	// The documents sent for an insert, update, or delete command. This is separated into its own field because it's
+	// sent as part of the command document in OP_QUERY and as a document sequence outside the command document in
+	// OP_MSG.
+	DocumentSequence *bsoncore.DocumentSequence
+}
+
+type sentMsgParseFn func([]byte) (*SentMessage, error)
+
+func getSentMessageParser(opcode wiremessage.OpCode) (sentMsgParseFn, bool) {
+	switch opcode {
+	case wiremessage.OpQuery:
+		return parseOpQuery, true
+	case wiremessage.OpMsg:
+		return parseSentOpMsg, true
+	case wiremessage.OpCompressed:
+		return parseSentOpCompressed, true
+	default:
+		return nil, false
+	}
+}
+
+func parseSentMessage(original []byte, parseRawOnly bool) (*SentMessage, error) {
+	// Create a copy of the entire wire message and pass that around to helpers so no copies will be needed later in
+	// the code.
+	wm := copyBytes(original)
+
+	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
+	_, requestID, _, opcode, remaining, ok := wiremessage.ReadHeader(wm)
+	if !ok {
+		return nil, errors.New("failed to read wiremessage header")
+	}
+
+	if parseRawOnly {
+		sm := &SentMessage{
+			RequestID:  requestID,
+			RawMessage: wm,
+		}
+		return sm, nil
+	}
+
+	parseFn, ok := getSentMessageParser(opcode)
+	if !ok {
+		return nil, fmt.Errorf("unknown opcode: %v", opcode)
+	}
+	sent, err := parseFn(remaining)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing wiremessage with opcode %s: %v", opcode, err)
+	}
+
+	sent.RequestID = requestID
+	sent.RawMessage = wm
+	return sent, nil
+}
+
+func parseOpQuery(wm []byte) (*SentMessage, error) {
+	var ok bool
+
+	if _, wm, ok = wiremessage.ReadQueryFlags(wm); !ok {
+		return nil, errors.New("failed to read query flags")
+	}
+	if _, wm, ok = wiremessage.ReadQueryFullCollectionName(wm); !ok {
+		return nil, errors.New("failed to read full collection name")
+	}
+	if _, wm, ok = wiremessage.ReadQueryNumberToSkip(wm); !ok {
+		return nil, errors.New("failed to read number to skip")
+	}
+	if _, wm, ok = wiremessage.ReadQueryNumberToReturn(wm); !ok {
+		return nil, errors.New("failed to read number to return")
+	}
+
+	query, wm, ok := wiremessage.ReadQueryQuery(wm)
+	if !ok {
+		return nil, errors.New("failed to read query")
+	}
+
+	// If there is no read preference document, the command document is query.
+	// Otherwise, query is in the format {$query: <command document>, $readPreference: <read preference document>}.
+	commandDoc := query
+	var rpDoc bsoncore.Document
+
+	dollarQueryVal, err := query.LookupErr("$query")
+	if err == nil {
+		commandDoc = dollarQueryVal.Document()
+
+		rpVal, err := query.LookupErr("$readPreference")
+		if err != nil {
+			return nil, fmt.Errorf("query %s contains $query but not $readPreference fields", query)
+		}
+		rpDoc = rpVal.Document()
+	}
+
+	// For OP_QUERY, inserts, updates, and deletes are sent as a BSON array of documents inside the main command
+	// document. Pull these sequences out into an ArrayStyle DocumentSequence.
+	var docSequence *bsoncore.DocumentSequence
+	cmdElems, _ := commandDoc.Elements()
+	for _, elem := range cmdElems {
+		switch elem.Key() {
+		case "documents", "updates", "deletes":
+			docSequence = &bsoncore.DocumentSequence{
+				Style: bsoncore.ArrayStyle,
+				Data:  elem.Value().Array(),
+			}
+			break
+		}
+		if docSequence != nil {
+			// There can only be one of these arrays in a well-formed command, so we exit the loop once one is found.
+			break
+		}
+	}
+
+	sm := &SentMessage{
+		Command:          commandDoc,
+		ReadPreference:   rpDoc,
+		DocumentSequence: docSequence,
+	}
+	return sm, nil
+}
+
+func parseSentOpMsg(wm []byte) (*SentMessage, error) {
+	var ok bool
+	var err error
+
+	if _, wm, ok = wiremessage.ReadMsgFlags(wm); !ok {
+		return nil, errors.New("failed to read flags")
+	}
+
+	if wm, err = assertMsgSectionType(wm, wiremessage.SingleDocument); err != nil {
+		return nil, fmt.Errorf("error verifying section type for command document: %v", err)
+	}
+
+	var commandDoc bsoncore.Document
+	commandDoc, wm, ok = wiremessage.ReadMsgSectionSingleDocument(wm)
+	if !ok {
+		return nil, errors.New("failed to read command document")
+	}
+
+	var rpDoc bsoncore.Document
+	if rpVal, err := commandDoc.LookupErr("$readPreference"); err == nil {
+		rpDoc = rpVal.Document()
+	}
+
+	var docSequence *bsoncore.DocumentSequence
+	if len(wm) != 0 {
+		// If there are bytes remaining in the wire message, they must correspond to a DocumentSequence section.
+		if wm, err = assertMsgSectionType(wm, wiremessage.DocumentSequence); err != nil {
+			return nil, fmt.Errorf("error verifying section type for document sequence: %v", err)
+		}
+
+		var data []byte
+		_, data, wm, ok = wiremessage.ReadMsgSectionRawDocumentSequence(wm)
+		if !ok {
+			return nil, errors.New("failed to read document sequence")
+		}
+
+		docSequence = &bsoncore.DocumentSequence{
+			Style: bsoncore.SequenceStyle,
+			Data:  data,
+		}
+	}
+
+	sm := &SentMessage{
+		Command:          commandDoc,
+		ReadPreference:   rpDoc,
+		DocumentSequence: docSequence,
+	}
+	return sm, nil
+}
+
+func parseSentOpCompressed(wm []byte) (*SentMessage, error) {
+	originalOpcode, wm, err := parseOpCompressed(wm)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, ok := getSentMessageParser(originalOpcode)
+	if !ok {
+		return nil, fmt.Errorf("unknown original opcode %v", originalOpcode)
+	}
+	return parser(wm)
+}

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -47,19 +47,11 @@ func getSentMessageParser(opcode wiremessage.OpCode) (sentMsgParseFn, bool) {
 	}
 }
 
-func parseSentMessage(wm []byte, parseRawOnly bool) (*SentMessage, error) {
+func parseSentMessage(wm []byte) (*SentMessage, error) {
 	// Re-assign the wire message to "remaining" so "wm" continues to point to the entire message after parsing.
 	_, requestID, _, opcode, remaining, ok := wiremessage.ReadHeader(wm)
 	if !ok {
 		return nil, errors.New("failed to read wiremessage header")
-	}
-
-	if parseRawOnly {
-		sm := &SentMessage{
-			RequestID:  requestID,
-			RawMessage: wm,
-		}
-		return sm, nil
 	}
 
 	parseFn, ok := getSentMessageParser(opcode)

--- a/mongo/integration/mtest/wiremessage_helpers.go
+++ b/mongo/integration/mtest/wiremessage_helpers.go
@@ -1,0 +1,69 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mtest
+
+import (
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
+)
+
+func copyBytes(original []byte) []byte {
+	newSlice := make([]byte, len(original))
+	copy(newSlice, original)
+	return newSlice
+}
+
+// assertMsgSectionType asserts that the next section type in the OP_MSG wire message is equal to the provided type.
+// It returns the remainder of the wire message and an error if the section type could not be read or was not equal
+// to the expected type.
+func assertMsgSectionType(wm []byte, expected wiremessage.SectionType) ([]byte, error) {
+	var actual wiremessage.SectionType
+	var ok bool
+
+	actual, wm, ok = wiremessage.ReadMsgSectionType(wm)
+	if !ok {
+		return wm, errors.New("failed to read section type")
+	}
+	if expected != actual {
+		return wm, fmt.Errorf("unexpected section type %v; expected %v", actual, expected)
+	}
+	return wm, nil
+}
+
+func parseOpCompressed(wm []byte) (wiremessage.OpCode, []byte, error) {
+	// Store the original opcode to forward to another parser later.
+	originalOpcode, wm, ok := wiremessage.ReadCompressedOriginalOpCode(wm)
+	if !ok {
+		return originalOpcode, nil, errors.New("failed to read original opcode")
+	}
+
+	uncompressedSize, wm, ok := wiremessage.ReadCompressedUncompressedSize(wm)
+	if !ok {
+		return originalOpcode, nil, errors.New("failed to read uncompressed size")
+	}
+
+	compressorID, wm, ok := wiremessage.ReadCompressedCompressorID(wm)
+	if !ok {
+		return originalOpcode, nil, errors.New("failed to read compressor ID")
+	}
+
+	compressedMsg, wm, ok := wiremessage.ReadCompressedCompressedMessage(wm, int32(len(wm)))
+
+	opts := driver.CompressionOpts{
+		Compressor:       compressorID,
+		UncompressedSize: uncompressedSize,
+	}
+	decompressed, err := driver.DecompressPayload(compressedMsg, opts)
+	if err != nil {
+		return originalOpcode, nil, fmt.Errorf("error decompressing payload: %v", err)
+	}
+
+	return originalOpcode, decompressed, nil
+}

--- a/mongo/integration/operation_legacy_test.go
+++ b/mongo/integration/operation_legacy_test.go
@@ -63,11 +63,12 @@ func TestOperationLegacy(t *testing.T) {
 		}
 		for _, tc := range cases {
 			mt.RunOpts(tc.name, mtest.NewOptions().ClientOptions(testClientOpts), func(mt *mtest.T) {
-				// clear any messages written during test setup
+				// Clear any messages written during test setup. Each message written consumed one of the pre-loaded
+				// replies, so add a fakeOpReply to the ReadResp channel for each one.
 				for len(testConn.Written) > 0 {
 					<-testConn.Written
+					testConn.ReadResp <- fakeOpReply
 				}
-				testConn.ReadResp <- fakeOpReply
 				expectedQuery := tc.cmdFn(mt)
 
 				assert.NotEqual(mt, 0, len(testConn.Written), "no message written to connection")

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"bytes"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
@@ -116,49 +114,34 @@ func TestSessions(t *testing.T) {
 		}
 	})
 
-	clusterTimeDialer := newProxyDialer()
 	hosts := options.Client().ApplyURI(mt.ConnString()).Hosts
 	clusterTimeHandshakeOpts := options.Client().
-		SetDialer(clusterTimeDialer).
 		SetHosts(hosts[:1]).
 		SetDirect(true)
 	clusterTimeHandshakeMtOpts := mtest.NewOptions().
+		ClientType(mtest.Proxy).
 		ClientOptions(clusterTimeHandshakeOpts).
 		CreateCollection(false).
 		SSL(false) // The proxy dialer doesn't work for SSL connections.
 	mt.RunOpts("cluster time is updated from handshakes", clusterTimeHandshakeMtOpts, func(mt *mtest.T) {
-		// Compression uses a different opcode that the existing drivertest helpers can't handle and doesn't affect
-		// the functionality tested here, so we can skip the test if compression is enabled.
-		if len(os.Getenv("MONGO_GO_DRIVER_COMPRESSOR")) > 0 {
-			mt.Skip("skipping for compression")
-		}
-
 		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)
+		msgPairs := mt.GetProxiedMessages()
+		assert.True(mt, len(msgPairs) > 2, "expected more than two messages, got %d", len(msgPairs))
 
-		msgPairs := clusterTimeDialer.messages
-		for idx, pair := range msgPairs {
-			// Get the command sent to the server.
-			cmd, err := drivertest.GetCommandFromQueryWireMessage(pair.sent)
-			if err != nil {
-				cmd, err = drivertest.GetCommandFromMsgWireMessage(pair.sent)
-			}
-			if err != nil {
-				mt.Fatalf("error reading command document from wire message: %v", err)
-			}
-
+		for idx, pair := range mt.GetProxiedMessages() {
 			// Get the $clusterTime value sent to the server. The first two messages are the handshakes for the
 			// heartbeat and application connections. These should not contain $clusterTime because they happen on
 			// connections that don't know the server's wire version and therefore don't know if the server supports
 			// $clusterTime.
-			_, err = cmd.LookupErr("$clusterTime")
+			_, err = pair.Sent.Command.LookupErr("$clusterTime")
 			if idx <= 1 {
-				assert.NotNil(mt, err, "expected no $clusterTime field in command %s", cmd)
+				assert.NotNil(mt, err, "expected no $clusterTime field in command %s", pair.Sent.Command)
 				continue
 			}
 
 			// All messages after the first two should contain $clusterTime.
-			assert.Nil(mt, err, "expected $clusterTime field in command %s", cmd)
+			assert.Nil(mt, err, "expected $clusterTime field in command %s", pair.Sent.Command)
 		}
 	})
 

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -352,7 +352,8 @@ func ReadMsgSectionSingleDocument(src []byte) (doc bsoncore.Document, rem []byte
 	return bsoncore.ReadDocument(src)
 }
 
-// ReadMsgSectionDocumentSequence reads an identifier and document sequence from src.
+// ReadMsgSectionDocumentSequence reads an identifier and document sequence from src and returns the document sequence
+// data parsed into a slice of BSON documents.
 func ReadMsgSectionDocumentSequence(src []byte) (identifier string, docs []bsoncore.Document, rem []byte, ok bool) {
 	length, rem, ok := readi32(src)
 	if !ok || int(length) > len(src) {
@@ -380,6 +381,26 @@ func ReadMsgSectionDocumentSequence(src []byte) (identifier string, docs []bsonc
 	}
 
 	return identifier, docs, ret, true
+}
+
+// ReadMsgSectionRawDocumentSequence reads an identifier and document sequence from src and returns the raw document
+// sequence data.
+func ReadMsgSectionRawDocumentSequence(src []byte) (identifier string, data []byte, rem []byte, ok bool) {
+	length, rem, ok := readi32(src)
+	if !ok || int(length) > len(src) {
+		return "", nil, rem, false
+	}
+
+	// After these assignments, rem will be the data containing the identifer string + the document sequence bytes and
+	// rest will be the rest of the wire message after this document sequence.
+	rem, rest := rem[:length-4], rem[length-4:]
+
+	identifier, rem, ok = readcstring(rem)
+	if !ok {
+		return "", nil, rem, false
+	}
+
+	return identifier, rem, rest, true
 }
 
 // ReadMsgChecksum reads a checksum from src.


### PR DESCRIPTION
This is a POC I've been working on and the changes for GODRIVER-1405 gave me a good reason for integrating it into our testing library. A summary of the changes made:

1. `received_message.go`, `sent_message.go`, and `wiremessage_helpers.go` contain types and helper functions for parsing sent and received wire messages. The messages are parsed into a view that unifies OP_QUERY and OP_MSG, but a raw copy of the entire message is also stored so we can check exact bits if we want.

2. `proxy_dialer.go` contains the `ContextDialer` and `net.Conn` interface implementations. The `proxyDialer` stores pairs of messages rather than separate slices for sent and received because it can access the wire message RequestID and match them up to make things easier for developers. It stores messages in two slices: one of type `ProxyMessage`, which has a parsed version of the messages, and one of type `RawProxyMessage`, which has only a raw version. The dialer can be configured to operation in a "raw-only" mode so it will only store the `RawProxyMessage` variant. This might be useful for tests that only want to check exact bits and don't want to incur parsing overhead.

3. Changes to `mongotest.go` and `mtest/options.go` are to integrate the dialer into the testing library so we can opt-in to using it with `mtest.NewOptions().ClientType(mtest.Proxy)` (or `mtest.RawProxy` for a raw-only version).

4. The `proxyDialer` type currently doesn't work if SSL is enabled because it assumes that anything sent through it is a wire message, so it tries to parse the SSL handshake as well. I still think running this dialer in auth environments is useful despite this limitation, so I added a standalone-auth-nossl variant to our Evergreen config and ensured that tests using the proxy dialer are skipped if SSL is enabled.

I know this is a lot of code and it can totally sit for a while. Just wanted to get the PR up because the work is done. 