### PR TITLE
GODRIVER-1576 fix non-addr type with pointer implementation for bson

### DIFF
--- a/bson/bsoncodec/cond_addr_codec.go
+++ b/bson/bsoncodec/cond_addr_codec.go
@@ -1,0 +1,63 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+)
+
+// CondAddrEncoder is the encoder used when a pointer to the encoding value has an encoder.
+type CondAddrEncoder struct {
+	canAddrEnc ValueEncoder
+	elseEnc    ValueEncoder
+}
+
+var _ ValueEncoder = &CondAddrEncoder{}
+
+// NewCondAddrEncoder returns an CondAddrEncoder.
+func NewCondAddrEncoder(canAddrEnc, elseEnc ValueEncoder) *CondAddrEncoder {
+	encoder := CondAddrEncoder{canAddrEnc: canAddrEnc, elseEnc: elseEnc}
+	return &encoder
+}
+
+// EncodeValue is the ValueEncoderFunc for a value that may be addressable.
+func (cae *CondAddrEncoder) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if val.CanAddr() {
+		return cae.canAddrEnc.EncodeValue(ec, vw, val)
+	}
+	if cae.elseEnc != nil {
+		return cae.elseEnc.EncodeValue(ec, vw, val)
+	}
+	return ErrNoEncoder{Type: val.Type()}
+}
+
+// CondAddrDecoder is the decoder used when a pointer to the value has a decoder.
+type CondAddrDecoder struct {
+	canAddrDec ValueDecoder
+	elseDec    ValueDecoder
+}
+
+var _ ValueDecoder = &CondAddrDecoder{}
+
+// NewCondAddrDecoder returns an CondAddrDecoder.
+func NewCondAddrDecoder(canAddrDec, elseDec ValueDecoder) *CondAddrDecoder {
+	decoder := CondAddrDecoder{canAddrDec: canAddrDec, elseDec: elseDec}
+	return &decoder
+}
+
+// DecodeValue is the ValueDecoderFunc for a value that may be addressable.
+func (cad *CondAddrDecoder) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if val.CanAddr() {
+		return cad.canAddrDec.DecodeValue(dc, vr, val)
+	}
+	if cad.elseDec != nil {
+		return cad.elseDec.DecodeValue(dc, vr, val)
+	}
+	return ErrNoDecoder{Type: val.Type()}
+}

--- a/bson/bsoncodec/cond_addr_codec.go
+++ b/bson/bsoncodec/cond_addr_codec.go
@@ -12,22 +12,22 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 )
 
-// CondAddrEncoder is the encoder used when a pointer to the encoding value has an encoder.
-type CondAddrEncoder struct {
+// condAddrEncoder is the encoder used when a pointer to the encoding value has an encoder.
+type condAddrEncoder struct {
 	canAddrEnc ValueEncoder
 	elseEnc    ValueEncoder
 }
 
-var _ ValueEncoder = &CondAddrEncoder{}
+var _ ValueEncoder = &condAddrEncoder{}
 
-// NewCondAddrEncoder returns an CondAddrEncoder.
-func NewCondAddrEncoder(canAddrEnc, elseEnc ValueEncoder) *CondAddrEncoder {
-	encoder := CondAddrEncoder{canAddrEnc: canAddrEnc, elseEnc: elseEnc}
+// newCondAddrEncoder returns an condAddrEncoder.
+func newCondAddrEncoder(canAddrEnc, elseEnc ValueEncoder) *condAddrEncoder {
+	encoder := condAddrEncoder{canAddrEnc: canAddrEnc, elseEnc: elseEnc}
 	return &encoder
 }
 
 // EncodeValue is the ValueEncoderFunc for a value that may be addressable.
-func (cae *CondAddrEncoder) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (cae *condAddrEncoder) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if val.CanAddr() {
 		return cae.canAddrEnc.EncodeValue(ec, vw, val)
 	}
@@ -37,22 +37,22 @@ func (cae *CondAddrEncoder) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter,
 	return ErrNoEncoder{Type: val.Type()}
 }
 
-// CondAddrDecoder is the decoder used when a pointer to the value has a decoder.
-type CondAddrDecoder struct {
+// condAddrDecoder is the decoder used when a pointer to the value has a decoder.
+type condAddrDecoder struct {
 	canAddrDec ValueDecoder
 	elseDec    ValueDecoder
 }
 
-var _ ValueDecoder = &CondAddrDecoder{}
+var _ ValueDecoder = &condAddrDecoder{}
 
-// NewCondAddrDecoder returns an CondAddrDecoder.
-func NewCondAddrDecoder(canAddrDec, elseDec ValueDecoder) *CondAddrDecoder {
-	decoder := CondAddrDecoder{canAddrDec: canAddrDec, elseDec: elseDec}
+// newCondAddrDecoder returns an CondAddrDecoder.
+func newCondAddrDecoder(canAddrDec, elseDec ValueDecoder) *condAddrDecoder {
+	decoder := condAddrDecoder{canAddrDec: canAddrDec, elseDec: elseDec}
 	return &decoder
 }
 
 // DecodeValue is the ValueDecoderFunc for a value that may be addressable.
-func (cad *CondAddrDecoder) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (cad *condAddrDecoder) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if val.CanAddr() {
 		return cad.canAddrDec.DecodeValue(dc, vr, val)
 	}

--- a/bson/bsoncodec/cond_addr_codec.go
+++ b/bson/bsoncodec/cond_addr_codec.go
@@ -18,7 +18,7 @@ type condAddrEncoder struct {
 	elseEnc    ValueEncoder
 }
 
-var _ ValueEncoder = &condAddrEncoder{}
+var _ ValueEncoder = (*condAddrEncoder)(nil)
 
 // newCondAddrEncoder returns an condAddrEncoder.
 func newCondAddrEncoder(canAddrEnc, elseEnc ValueEncoder) *condAddrEncoder {
@@ -43,7 +43,7 @@ type condAddrDecoder struct {
 	elseDec    ValueDecoder
 }
 
-var _ ValueDecoder = &condAddrDecoder{}
+var _ ValueDecoder = (*condAddrDecoder)(nil)
 
 // newCondAddrDecoder returns an CondAddrDecoder.
 func newCondAddrDecoder(canAddrDec, elseDec ValueDecoder) *condAddrDecoder {

--- a/bson/bsoncodec/cond_addr_codec_test.go
+++ b/bson/bsoncodec/cond_addr_codec_test.go
@@ -22,7 +22,7 @@ func TestCondAddrCodec(t *testing.T) {
 	unaddressable := reflect.ValueOf(inner)
 	rw := &bsonrwtest.ValueReaderWriter{}
 
-	t.Run("Encode", func(t *testing.T) {
+	t.Run("addressEncode", func(t *testing.T) {
 		invoked := 0
 		encode1 := func(EncodeContext, bsonrw.ValueWriter, reflect.Value) error {
 			invoked = 1
@@ -45,7 +45,7 @@ func TestCondAddrCodec(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				err := condEncoder.EncodeValue(EncodeContext{}, rw, tc.val)
-				assert.Nil(t, err, "StringCodec.EncodeValue error: %v", err)
+				assert.Nil(t, err, "CondAddrEncoder error: %v", err)
 
 				assert.Equal(t, invoked, tc.invoked, "Expected function %v to be called, called %v", tc.invoked, invoked)
 			})
@@ -58,7 +58,7 @@ func TestCondAddrCodec(t *testing.T) {
 			assert.Equal(t, err, want, "expected error %v, got %v", want, err)
 		})
 	})
-	t.Run("Decode", func(t *testing.T) {
+	t.Run("addressDecode", func(t *testing.T) {
 		invoked := 0
 		decode1 := func(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 			invoked = 1
@@ -81,7 +81,7 @@ func TestCondAddrCodec(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				err := condDecoder.DecodeValue(DecodeContext{}, rw, tc.val)
-				assert.Nil(t, err, "StringCodec.DecodeValue error: %v", err)
+				assert.Nil(t, err, "CondAddrDecoder error: %v", err)
 
 				assert.Equal(t, invoked, tc.invoked, "Expected function %v to be called, called %v", tc.invoked, invoked)
 			})

--- a/bson/bsoncodec/cond_addr_codec_test.go
+++ b/bson/bsoncodec/cond_addr_codec_test.go
@@ -32,7 +32,7 @@ func TestCondAddrCodec(t *testing.T) {
 			invoked = 2
 			return nil
 		}
-		condEncoder := NewCondAddrEncoder(ValueEncoderFunc(encode1), ValueEncoderFunc(encode2))
+		condEncoder := newCondAddrEncoder(ValueEncoderFunc(encode1), ValueEncoderFunc(encode2))
 
 		testCases := []struct {
 			name    string
@@ -52,7 +52,7 @@ func TestCondAddrCodec(t *testing.T) {
 		}
 
 		t.Run("error", func(t *testing.T) {
-			errEncoder := NewCondAddrEncoder(ValueEncoderFunc(encode1), nil)
+			errEncoder := newCondAddrEncoder(ValueEncoderFunc(encode1), nil)
 			err := errEncoder.EncodeValue(EncodeContext{}, rw, unaddressable)
 			want := ErrNoEncoder{Type: unaddressable.Type()}
 			assert.Equal(t, err, want, "expected error %v, got %v", want, err)
@@ -68,7 +68,7 @@ func TestCondAddrCodec(t *testing.T) {
 			invoked = 2
 			return nil
 		}
-		condDecoder := NewCondAddrDecoder(ValueDecoderFunc(decode1), ValueDecoderFunc(decode2))
+		condDecoder := newCondAddrDecoder(ValueDecoderFunc(decode1), ValueDecoderFunc(decode2))
 
 		testCases := []struct {
 			name    string
@@ -88,7 +88,7 @@ func TestCondAddrCodec(t *testing.T) {
 		}
 
 		t.Run("error", func(t *testing.T) {
-			errDecoder := NewCondAddrDecoder(ValueDecoderFunc(decode1), nil)
+			errDecoder := newCondAddrDecoder(ValueDecoderFunc(decode1), nil)
 			err := errDecoder.DecodeValue(DecodeContext{}, rw, unaddressable)
 			want := ErrNoDecoder{Type: unaddressable.Type()}
 			assert.Equal(t, err, want, "expected error %v, got %v", want, err)

--- a/bson/bsoncodec/cond_addr_codec_test.go
+++ b/bson/bsoncodec/cond_addr_codec_test.go
@@ -1,0 +1,97 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"reflect"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+)
+
+func TestCondAddrCodec(t *testing.T) {
+	var inner int
+	canAddrVal := reflect.ValueOf(&inner)
+	addressable := canAddrVal.Elem()
+	unaddressable := reflect.ValueOf(inner)
+	rw := &bsonrwtest.ValueReaderWriter{}
+
+	t.Run("Encode", func(t *testing.T) {
+		invoked := 0
+		encode1 := func(EncodeContext, bsonrw.ValueWriter, reflect.Value) error {
+			invoked = 1
+			return nil
+		}
+		encode2 := func(EncodeContext, bsonrw.ValueWriter, reflect.Value) error {
+			invoked = 2
+			return nil
+		}
+		condEncoder := NewCondAddrEncoder(ValueEncoderFunc(encode1), ValueEncoderFunc(encode2))
+
+		testCases := []struct {
+			name    string
+			val     reflect.Value
+			invoked int
+		}{
+			{"canAddr", addressable, 1},
+			{"else", unaddressable, 2},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := condEncoder.EncodeValue(EncodeContext{}, rw, tc.val)
+				assert.Nil(t, err, "StringCodec.EncodeValue error: %v", err)
+
+				assert.Equal(t, invoked, tc.invoked, "Expected function %v to be called, called %v", tc.invoked, invoked)
+			})
+		}
+
+		t.Run("error", func(t *testing.T) {
+			errEncoder := NewCondAddrEncoder(ValueEncoderFunc(encode1), nil)
+			err := errEncoder.EncodeValue(EncodeContext{}, rw, unaddressable)
+			want := ErrNoEncoder{Type: unaddressable.Type()}
+			assert.Equal(t, err, want, "expected error %v, got %v", want, err)
+		})
+	})
+	t.Run("Decode", func(t *testing.T) {
+		invoked := 0
+		decode1 := func(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+			invoked = 1
+			return nil
+		}
+		decode2 := func(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+			invoked = 2
+			return nil
+		}
+		condDecoder := NewCondAddrDecoder(ValueDecoderFunc(decode1), ValueDecoderFunc(decode2))
+
+		testCases := []struct {
+			name    string
+			val     reflect.Value
+			invoked int
+		}{
+			{"canAddr", addressable, 1},
+			{"else", unaddressable, 2},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := condDecoder.DecodeValue(DecodeContext{}, rw, tc.val)
+				assert.Nil(t, err, "StringCodec.DecodeValue error: %v", err)
+
+				assert.Equal(t, invoked, tc.invoked, "Expected function %v to be called, called %v", tc.invoked, invoked)
+			})
+		}
+
+		t.Run("error", func(t *testing.T) {
+			errDecoder := NewCondAddrDecoder(ValueDecoderFunc(decode1), nil)
+			err := errDecoder.DecodeValue(DecodeContext{}, rw, unaddressable)
+			want := ErrNoDecoder{Type: unaddressable.Type()}
+			assert.Equal(t, err, want, "expected error %v, got %v", want, err)
+		})
+	})
+}

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -322,30 +322,14 @@ func (r *Registry) LookupEncoder(t reflect.Type) (ValueEncoder, error) {
 		if enc == nil {
 			return nil, ErrNoEncoder{Type: t}
 		}
-		// if dec is a condAddrEncoder, we still need to fill in elseEnc
-		if _, ok := enc.(*condAddrEncoder); !ok {
-			return enc, nil
-		}
+		return enc, nil
 	}
 
-	if !found {
-		enc, found = r.lookupInterfaceEncoder(t, true)
-		if found {
-			r.mu.Lock()
-			r.typeEncoders[t] = enc
-			r.mu.Unlock()
-		}
-	}
-
-	// fill in elseEnc for condAddrEncoder
-	if cae, ok := enc.(*condAddrEncoder); ok {
-		defaultEnc, innerFound := r.lookupInterfaceEncoder(t, false)
-		if !innerFound {
-			defaultEnc, _ = r.kindEncoders[t.Kind()]
-		}
-		cae.elseEnc = defaultEnc
-	}
+	enc, found = r.lookupInterfaceEncoder(t, true)
 	if found {
+		r.mu.Lock()
+		r.typeEncoders[t] = enc
+		r.mu.Unlock()
 		return enc, nil
 	}
 
@@ -417,30 +401,14 @@ func (r *Registry) LookupDecoder(t reflect.Type) (ValueDecoder, error) {
 		if dec == nil {
 			return nil, ErrNoDecoder{Type: t}
 		}
-		// if dec is a condAddrDecoder, we still need to fill in elseDec
-		if _, ok := dec.(*condAddrDecoder); !ok {
-			return dec, nil
-		}
+		return dec, nil
 	}
 
-	if !found {
-		dec, found = r.lookupInterfaceDecoder(t, true)
-		if found {
-			r.mu.Lock()
-			r.typeDecoders[t] = dec
-			r.mu.Unlock()
-		}
-	}
-
-	// fill in elseDec for condAddrDecoder
-	if cad, ok := dec.(*condAddrDecoder); ok {
-		defaultDec, innerFound := r.lookupInterfaceDecoder(t, false)
-		if !innerFound {
-			defaultDec, _ = r.kindDecoders[t.Kind()]
-		}
-		cad.elseDec = defaultDec
-	}
+	dec, found = r.lookupInterfaceDecoder(t, true)
 	if found {
+		r.mu.Lock()
+		r.typeDecoders[t] = dec
+		r.mu.Unlock()
 		return dec, nil
 	}
 
@@ -469,7 +437,11 @@ func (r *Registry) lookupInterfaceDecoder(t reflect.Type, allowAddr bool) (Value
 			return idec.vd, true
 		}
 		if allowAddr && t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(idec.i) {
-			return newCondAddrDecoder(idec.vd, nil), true
+			defaultDec, found := r.lookupInterfaceDecoder(t, false)
+			if !found {
+				defaultDec, _ = r.kindDecoders[t.Kind()]
+			}
+			return newCondAddrDecoder(idec.vd, defaultDec), true
 		}
 	}
 	return nil, false

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -368,6 +368,8 @@ func (r *Registry) lookupInterfaceEncoder(t reflect.Type, allowAddr bool) (Value
 			return ienc.ve, true
 		}
 		if allowAddr && t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(ienc.i) {
+			// if *t implements an interface, this will catch if t implements an interface further ahead
+			// in interfaceEncoders
 			defaultEnc, found := r.lookupInterfaceEncoder(t, false)
 			if !found {
 				defaultEnc, _ = r.kindEncoders[t.Kind()]
@@ -437,6 +439,8 @@ func (r *Registry) lookupInterfaceDecoder(t reflect.Type, allowAddr bool) (Value
 			return idec.vd, true
 		}
 		if allowAddr && t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(idec.i) {
+			// if *t implements an interface, this will catch if t implements an interface further ahead
+			// in interfaceDecoders
 			defaultDec, found := r.lookupInterfaceDecoder(t, false)
 			if !found {
 				defaultDec, _ = r.kindDecoders[t.Kind()]

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 )
 
 func TestRegistry(t *testing.T) {
@@ -252,15 +253,6 @@ func TestRegistry(t *testing.T) {
 					false,
 				},
 				{
-					// lookup a type whose pointer implements an interface and expect that the registered hook is
-					// returned
-					"interface implementation with hook (pointer)",
-					ti3Impl,
-					fc3,
-					nil,
-					false,
-				},
-				{
 					// lookup a pointer to a type where the pointer implements an interface and expect that the
 					// registered hook is returned
 					"interface pointer to implementation with hook (pointer)",
@@ -351,6 +343,36 @@ func TestRegistry(t *testing.T) {
 					})
 				})
 			}
+			// lookup a type whose pointer implements an interface and expect that the registered hook is
+			// returned
+			t.Run("interface implementation with hook (pointer)", func(t *testing.T) {
+				t.Run("Encoder", func(t *testing.T) {
+					gotEnc, err := reg.LookupEncoder(ti3Impl)
+					assert.Nil(t, err, "LookupEncoder error: %v", err)
+
+					cae, ok := gotEnc.(*CondAddrEncoder)
+					assert.True(t, ok, "Expected CondAddrEncoder, got %T", gotEnc)
+					if !cmp.Equal(cae.canAddrEnc, fc3, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("expected canAddrEnc %v, got %v", cae.canAddrEnc, fc3)
+					}
+					if !cmp.Equal(cae.elseEnc, fsc, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("expected elseEnc %v, got %v", cae.elseEnc, fsc)
+					}
+				})
+				t.Run("Decoder", func(t *testing.T) {
+					gotDec, err := reg.LookupDecoder(ti3Impl)
+					assert.Nil(t, err, "LookupDecoder error: %v", err)
+
+					cad, ok := gotDec.(*CondAddrDecoder)
+					assert.True(t, ok, "Expected CondAddrDecoder, got %T", gotDec)
+					if !cmp.Equal(cad.canAddrDec, fc3, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("expected canAddrDec %v, got %v", cad.canAddrDec, fc3)
+					}
+					if !cmp.Equal(cad.elseDec, fsc, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("expected elseDec %v, got %v", cad.elseDec, fsc)
+					}
+				})
+			})
 		})
 	})
 	t.Run("Type Map", func(t *testing.T) {

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -350,7 +350,7 @@ func TestRegistry(t *testing.T) {
 					gotEnc, err := reg.LookupEncoder(ti3Impl)
 					assert.Nil(t, err, "LookupEncoder error: %v", err)
 
-					cae, ok := gotEnc.(*CondAddrEncoder)
+					cae, ok := gotEnc.(*condAddrEncoder)
 					assert.True(t, ok, "Expected CondAddrEncoder, got %T", gotEnc)
 					if !cmp.Equal(cae.canAddrEnc, fc3, allowunexported, cmp.Comparer(comparepc)) {
 						t.Errorf("expected canAddrEnc %v, got %v", cae.canAddrEnc, fc3)
@@ -363,7 +363,7 @@ func TestRegistry(t *testing.T) {
 					gotDec, err := reg.LookupDecoder(ti3Impl)
 					assert.Nil(t, err, "LookupDecoder error: %v", err)
 
-					cad, ok := gotDec.(*CondAddrDecoder)
+					cad, ok := gotDec.(*condAddrDecoder)
 					assert.True(t, ok, "Expected CondAddrDecoder, got %T", gotDec)
 					if !cmp.Equal(cad.canAddrDec, fc3, allowunexported, cmp.Comparer(comparepc)) {
 						t.Errorf("expected canAddrDec %v, got %v", cad.canAddrDec, fc3)


### PR DESCRIPTION
Right now this doesn't store CondAddrEncoders in the typeEncoders map. Would it make sense to store half-filled CondAddrEncoders?