### PR TITLE
GODRIVER-1473 Allow authSource without credentials

### DIFF
--- a/data/auth/connection-string.json
+++ b/data/auth/connection-string.json
@@ -352,10 +352,11 @@
       "credential": null
     },
     {
-      "description": "authSource without username is invalid (default mechanism)",
+      "description": "authSource without username doesn't create credential (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
-      "valid": false
-        },
+      "valid": true,
+      "credential": null
+    },
     {
       "description": "should recognise the mechanism (MONGODB-AWS)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS",

--- a/data/auth/connection-string.yml
+++ b/data/auth/connection-string.yml
@@ -288,9 +288,10 @@ tests:
         valid: true
         credential: ~
     -
-        description: "authSource without username is invalid (default mechanism)"
+        description: "authSource without username doesn't create credential (default mechanism)"
         uri: "mongodb://localhost/?authSource=foo"
-        valid: false
+        valid: true
+        credential: ~
     -
         description: "should recognise the mechanism (MONGODB-AWS)"
         uri: "mongodb://localhost/?authMechanism=MONGODB-AWS"

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -174,8 +174,10 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 		c.AppName = &cs.AppName
 	}
 
-	if cs.AuthMechanism != "" || cs.AuthMechanismProperties != nil || cs.AuthSource != "" ||
-		cs.Username != "" || cs.PasswordSet {
+	// Only create a Credential if there is a request for authentication via non-empty credentials in the URI.
+	// Per SPEC-1511, an auth source without other credentials is semantically valid and must not be interpreted as a
+	// request for authentication.
+	if cs.AuthMechanism != "" || cs.AuthMechanismProperties != nil || cs.Username != "" || cs.PasswordSet {
 		c.Auth = &Credential{
 			AuthMechanism:           cs.AuthMechanism,
 			AuthMechanismProperties: cs.AuthMechanismProperties,

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -175,9 +175,7 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 	}
 
 	// Only create a Credential if there is a request for authentication via non-empty credentials in the URI.
-	// Per SPEC-1511, an auth source without other credentials is semantically valid and must not be interpreted as a
-	// request for authentication.
-	if cs.AuthMechanism != "" || cs.AuthMechanismProperties != nil || cs.Username != "" || cs.PasswordSet {
+	if cs.HasAuthParameters() {
 		c.Auth = &Credential{
 			AuthMechanism:           cs.AuthMechanism,
 			AuthMechanismProperties: cs.AuthMechanismProperties,

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -241,13 +241,6 @@ func TestClientOptions(t *testing.T) {
 				}),
 			},
 			{
-				"AuthSourceNoUsername",
-				"mongodb://localhost/?authSource=random-database-example",
-				&ClientOptions{err: internal.WrapErrorf(
-					errors.New("authsource without username is invalid"), "error validating uri",
-				)},
-			},
-			{
 				"AuthSource",
 				"mongodb://foo@localhost/?authSource=random-database-example",
 				baseClient().SetAuth(Credential{AuthSource: "random-database-example", Username: "foo"}),

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -345,6 +345,7 @@ func (p *parser) setDefaultAuthParams(dbName string) error {
 			}
 		}
 	case "":
+		// Only set auth source if there is a request for authentication via non-empty credentials.
 		if p.AuthSource == "" && (p.AuthMechanismProperties != nil || p.Username != "" || p.PasswordSet) {
 			p.AuthSource = dbName
 			if p.AuthSource == "" {
@@ -433,9 +434,6 @@ func (p *parser) validateAuth() error {
 			return fmt.Errorf("SCRAM-SHA-256 cannot have mechanism properties")
 		}
 	case "":
-		if p.Username == "" && p.AuthSource != "" {
-			return fmt.Errorf("authsource without username is invalid")
-		}
 	default:
 		return fmt.Errorf("invalid auth mechanism")
 	}

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -130,6 +130,14 @@ func (u *ConnString) String() string {
 	return u.Original
 }
 
+// HasAuthParameters returns true if this ConnString has any authentication parameters set and therefore represents
+// a request for authentication.
+func (u *ConnString) HasAuthParameters() bool {
+	// Per SPEC-1511, an auth source without other credentials is semantically valid and must not be interpreted as a
+	// request for authentication.
+	return u.AuthMechanism != "" || u.AuthMechanismProperties != nil || u.Username != "" || u.PasswordSet
+}
+
 // Validate checks that the Auth and SSL parameters are valid values.
 func (u *ConnString) Validate() error {
 	p := parser{

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -133,8 +133,8 @@ func (u *ConnString) String() string {
 // HasAuthParameters returns true if this ConnString has any authentication parameters set and therefore represents
 // a request for authentication.
 func (u *ConnString) HasAuthParameters() bool {
-	// Per SPEC-1511, an auth source without other credentials is semantically valid and must not be interpreted as a
-	// request for authentication.
+	// Check all auth parameters except for AuthSource because an auth source without other credentials is semantically
+	// valid and must not be interpreted as a request for authentication.
 	return u.AuthMechanism != "" || u.AuthMechanismProperties != nil || u.Username != "" || u.PasswordSet
 }
 


### PR DESCRIPTION
The previous set of changes in SPEC-1270 made it so the "default db" in the URI is only treated as the auth source if there are other auth-related parameters in the URI. Otherwise, it is ignored. This makes it so `mongodb://localhost:27017/db` does not represent a request for auth.

This PR expands that so an explicit auth source is only treated as a request for auth if there are other auth-related parameters in the URI and is ignored if there are not. This makes it so `mongodb://localhost:27017/?authSource=db` does not represent a request for auth.

Spec commit: https://github.com/mongodb/specifications/commit/af6b8b14606d43f1938a2a8da23801f05c6cf4ab