### PR TITLE
GODRIVER-1584 Ensure cluster time is updated from handshakes

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -324,6 +324,9 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 
 	// TODO(GODRIVER-814): Add tests for topology, server, and connection related options.
 
+	// ClusterClock
+	c.clock = new(session.ClusterClock)
+
 	// Pass down URI so topology can determine whether or not SRV polling is required
 	topologyOpts = append(topologyOpts, topology.WithURI(func(uri string) string {
 		return opts.GetURI()
@@ -368,7 +371,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 	}
 	// Handshaker
 	var handshaker = func(driver.Handshaker) driver.Handshaker {
-		return operation.NewIsMaster().AppName(appName).Compressors(comps)
+		return operation.NewIsMaster().AppName(appName).Compressors(comps).ClusterClock(c.clock)
 	}
 	// Auth & Database & Password & Username
 	if opts.Auth != nil {
@@ -399,6 +402,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			AppName:       appName,
 			Authenticator: authenticator,
 			Compressors:   comps,
+			ClusterClock:  c.clock,
 		}
 		if mechanism == "" {
 			// Required for SASL mechanism negotiation during handshake
@@ -552,9 +556,6 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			return err
 		}
 	}
-
-	// ClusterClock
-	c.clock = new(session.ClusterClock)
 
 	// OCSP cache
 	ocspCache := ocsp.NewCache()

--- a/mongo/integration/operation_legacy_test.go
+++ b/mongo/integration/operation_legacy_test.go
@@ -66,8 +66,8 @@ func TestOperationLegacy(t *testing.T) {
 				// clear any messages written during test setup
 				for len(testConn.Written) > 0 {
 					<-testConn.Written
+					testConn.ReadResp <- fakeOpReply
 				}
-				testConn.ReadResp <- fakeOpReply
 				expectedQuery := tc.cmdFn(mt)
 
 				assert.NotEqual(mt, 0, len(testConn.Written), "no message written to connection")

--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -69,6 +69,10 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 		}, options.RunCmd().SetReadPreference(readpref.Primary())).Err()
 		assert.Nil(mt, err, "replSetStepDown error: %v", err)
 
+		// Because this test forces the primary to step-down, run a write command using the global client so it can
+		// update its state and will not get NotMaster errors when executing operations for future tests.
+		mt.GlobalClient().Database(mtest.TestDb).RunCommand(mtest.Background, bson.M{"create": mt.Coll.Name()})
+
 		assert.True(mt, cur.Next(mtest.Background), "expected Next true, got false")
 		assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
 	})

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
 // AuthenticatorFactory constructs an authenticator.
@@ -56,6 +57,7 @@ type HandshakeOptions struct {
 	Compressors           []string
 	DBUser                string
 	PerformAuthentication func(description.Server) bool
+	ClusterClock          *session.ClusterClock
 }
 
 type authHandshaker struct {
@@ -74,7 +76,8 @@ func (ah *authHandshaker) GetDescription(ctx context.Context, addr address.Addre
 	op := operation.NewIsMaster().
 		AppName(ah.options.AppName).
 		Compressors(ah.options.Compressors).
-		SASLSupportedMechs(ah.options.DBUser)
+		SASLSupportedMechs(ah.options.DBUser).
+		ClusterClock(ah.options.ClusterClock)
 
 	if ah.options.Authenticator != nil {
 		if speculativeAuth, ok := ah.options.Authenticator.(SpeculativeAuthenticator); ok {


### PR DESCRIPTION
This commit also changes the testing library so the global client is used for creating collections and failpoints to ensure that commands which could change the test client's view of the deployment aren't executed.