### PR TITLE
GODRIVER-1584 Ensure cluster time is updated from handshakes

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -838,20 +838,6 @@ tasks:
           AUTH: "auth"
           SSL: "ssl"
 
-  - name: test-standalone-auth-nossl
-    tags: ["test", "standalone", "authssl"]
-    commands:
-      - func: bootstrap-mongo-orchestration
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "auth"
-          SSL: "nossl"
-      - func: run-tests
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "auth"
-          SSL: "nossl"
-
   - name: test-standalone-auth-ssl-snappy-compression
     tags: ["test", "standalone", "authssl", "compression", "snappy"]
     commands:
@@ -1248,6 +1234,20 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
+
+  - name: test-replicaset-auth-nossl
+    tags: ["test", "replicaset", "authssl"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "replica_set"
+          AUTH: "auth"
+          SSL: "nossl"
+      - func: run-tests
+        vars:
+          TOPOLOGY: "replica_set"
+          AUTH: "auth"
+          SSL: "nossl"
 
   - name: test-sharded-noauth-nossl
     tags: ["test", "sharded"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -838,6 +838,20 @@ tasks:
           AUTH: "auth"
           SSL: "ssl"
 
+  - name: test-standalone-auth-nossl
+    tags: ["test", "standalone", "authssl"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "auth"
+          SSL: "nossl"
+      - func: run-tests
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "auth"
+          SSL: "nossl"
+
   - name: test-standalone-auth-ssl-snappy-compression
     tags: ["test", "standalone", "authssl", "compression", "snappy"]
     commands:

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -324,6 +324,9 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 
 	// TODO(GODRIVER-814): Add tests for topology, server, and connection related options.
 
+	// ClusterClock
+	c.clock = new(session.ClusterClock)
+
 	// Pass down URI so topology can determine whether or not SRV polling is required
 	topologyOpts = append(topologyOpts, topology.WithURI(func(uri string) string {
 		return opts.GetURI()
@@ -368,7 +371,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 	}
 	// Handshaker
 	var handshaker = func(driver.Handshaker) driver.Handshaker {
-		return operation.NewIsMaster().AppName(appName).Compressors(comps)
+		return operation.NewIsMaster().AppName(appName).Compressors(comps).ClusterClock(c.clock)
 	}
 	// Auth & Database & Password & Username
 	if opts.Auth != nil {
@@ -399,6 +402,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			AppName:       appName,
 			Authenticator: authenticator,
 			Compressors:   comps,
+			ClusterClock:  c.clock,
 		}
 		if mechanism == "" {
 			// Required for SASL mechanism negotiation during handshake
@@ -552,9 +556,6 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			return err
 		}
 	}
-
-	// ClusterClock
-	c.clock = new(session.ClusterClock)
 
 	// OCSP cache
 	ocspCache := ocsp.NewCache()

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -452,8 +452,12 @@ type proxyMessage struct {
 type proxyDialer struct {
 	*net.Dialer
 	sync.Mutex
-	messages            []proxyMessage
-	sentMap             sync.Map
+	messages []proxyMessage
+	sentMap  sync.Map
+
+	// addressTranslations maps dialed addresses to the remote addresses reported by the created connections if they
+	// differ. This can happen if a connection is dialed to a host name, in which case the reported remote address will
+	// be the resolved IP address.
 	addressTranslations sync.Map
 }
 

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -71,7 +71,7 @@ func TestClient(t *testing.T) {
 
 		assert.Equal(mt, int64(-10), got.ID, "expected ID -10, got %v", got.ID)
 	})
-	mt.RunOpts("tls connection", mtest.NewOptions().MinServerVersion("3.0").Auth(true), func(mt *mtest.T) {
+	mt.RunOpts("tls connection", mtest.NewOptions().MinServerVersion("3.0").SSL(true), func(mt *mtest.T) {
 		var result bson.Raw
 		err := mt.Coll.Database().RunCommand(mtest.Background, bson.D{
 			{"serverStatus", 1},
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 		_, found = security.Document().LookupErr("SSLServerHasCertificateAuthority")
 		assert.Nil(mt, found, "SSLServerHasCertificateAuthority not found in result")
 	})
-	mt.RunOpts("x509", mtest.NewOptions().Auth(true), func(mt *mtest.T) {
+	mt.RunOpts("x509", mtest.NewOptions().Auth(true).SSL(true), func(mt *mtest.T) {
 		const user = "C=US,ST=New York,L=New York City,O=MongoDB,OU=other,CN=external"
 		db := mt.Client.Database("$external")
 

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -92,6 +92,7 @@ type T struct {
 	maxServerVersion string
 	validTopologies  []TopologyKind
 	auth             *bool
+	ssl              *bool
 	enterprise       *bool
 	collCreateOpts   bson.D
 	connsCheckedOut  int // net number of connections checked out during test execution
@@ -493,6 +494,11 @@ func (t *T) AuthEnabled() bool {
 	return testContext.authEnabled
 }
 
+// SSLEnabled returns whether or not this test is running in an environment with SSL.
+func (t *T) SSLEnabled() bool {
+	return testContext.sslEnabled
+}
+
 // TopologyKind returns the topology kind of the environment
 func (t *T) TopologyKind() TopologyKind {
 	return testContext.topoKind
@@ -660,6 +666,9 @@ func (t *T) shouldSkip() bool {
 		return true
 	}
 	if t.auth != nil && *t.auth != testContext.authEnabled {
+		return true
+	}
+	if t.ssl != nil && *t.ssl != testContext.sslEnabled {
 		return true
 	}
 	if t.enterprise != nil && *t.enterprise != testContext.enterpriseServer {

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -184,6 +184,15 @@ func (op *Options) Auth(auth bool) *Options {
 	return op
 }
 
+// SSL specifies whether or not SSL should be enabled for this test to run. By default, a test will run regardless
+// of whether or not SSL is enabled.
+func (op *Options) SSL(ssl bool) *Options {
+	op.optFuncs = append(op.optFuncs, func(t *T) {
+		t.ssl = &ssl
+	})
+	return op
+}
+
 // Enterprise specifies whether or not this test should only be run on enterprise server variants. Defaults to false.
 func (op *Options) Enterprise(ent bool) *Options {
 	op.optFuncs = append(op.optFuncs, func(t *T) {

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -42,6 +42,7 @@ var testContext struct {
 	client           *mongo.Client // client used for setup and teardown
 	serverVersion    string
 	authEnabled      bool
+	sslEnabled       bool
 	enterpriseServer bool
 }
 
@@ -53,6 +54,14 @@ func setupClient(cs connstring.ConnString, opts *options.ClientOptions) (*mongo.
 // Setup initializes the current testing context.
 // This function must only be called one time and must be called before any tests run.
 func Setup() error {
+	defer func() {
+		fmt.Println("===Detected Details===")
+		fmt.Printf("%s\n\n", testContext.topo)
+		fmt.Printf("auth: %v\nssl: %v\n", testContext.authEnabled, testContext.sslEnabled)
+		fmt.Printf("connstring: %v\n", testContext.connString)
+		fmt.Println("==Detected Details===")
+	}()
+
 	var err error
 	testContext.connString, err = getConnString()
 	if err != nil {
@@ -121,7 +130,8 @@ func Setup() error {
 		}
 	}
 
-	testContext.authEnabled = len(os.Getenv("MONGO_GO_DRIVER_CA_FILE")) != 0
+	testContext.authEnabled = os.Getenv("AUTH") == "auth"
+	testContext.sslEnabled = os.Getenv("SSL") == "ssl"
 	biRes, err := testContext.client.Database("admin").RunCommand(Background, bson.D{{"buildInfo", 1}}).DecodeBytes()
 	if err != nil {
 		return fmt.Errorf("buildInfo error: %v", err)

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -54,14 +54,6 @@ func setupClient(cs connstring.ConnString, opts *options.ClientOptions) (*mongo.
 // Setup initializes the current testing context.
 // This function must only be called one time and must be called before any tests run.
 func Setup() error {
-	defer func() {
-		fmt.Println("===Detected Details===")
-		fmt.Printf("%s\n\n", testContext.topo)
-		fmt.Printf("auth: %v\nssl: %v\n", testContext.authEnabled, testContext.sslEnabled)
-		fmt.Printf("connstring: %v\n", testContext.connString)
-		fmt.Println("==Detected Details===")
-	}()
-
 	var err error
 	testContext.connString, err = getConnString()
 	if err != nil {

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -18,6 +19,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
@@ -113,6 +116,69 @@ func TestSessions(t *testing.T) {
 			})
 		}
 	})
+
+	clusterTimeDialer := newProxyDialer()
+	hosts := options.Client().ApplyURI(mt.ConnString()).Hosts
+	clusterTimeHandshakeOpts := options.Client().
+		SetDialer(clusterTimeDialer).
+		SetHosts(hosts[:1]).
+		SetDirect(true)
+	clusterTimeHandshakeMtOpts := mtest.NewOptions().
+		ClientOptions(clusterTimeHandshakeOpts).
+		CreateCollection(false).
+		SSL(false) // The proxy dialer doesn't work for SSL connections.
+	mt.RunOpts("cluster time is updated from handshakes", clusterTimeHandshakeMtOpts, func(mt *mtest.T) {
+		// Compression uses a different opcode that the existing drivertest helpers can't handle and doesn't affect
+		// the functionality tested here, so we can skip the test if compression is enabled.
+		if len(os.Getenv("MONGO_GO_DRIVER_COMPRESSOR")) > 0 {
+			mt.Skip("skipping for compression")
+		}
+
+		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
+		assert.Nil(mt, err, "Ping error: %v", err)
+
+		msgPairs := clusterTimeDialer.messages
+		var previousClusterTime bsoncore.Document
+		for idx, pair := range msgPairs {
+			// Get the command sent to the server.
+			cmd, err := drivertest.GetCommandFromQueryWireMessage(pair.sent)
+			if err != nil {
+				cmd, err = drivertest.GetCommandFromMsgWireMessage(pair.sent)
+			}
+			if err != nil {
+				mt.Fatalf("error reading command document from wire message: %v", err)
+			}
+
+			// Get the $clusterTime value sent to the server. The first two messages are the handshakes for the
+			// heartbeat and application connections. These should not contain $clusterTime because they happen on
+			// connections that don't know the server's wire version and therefore don't know if the server supports
+			// $clusterTime.
+			sentClusterTime, err := cmd.LookupErr("$clusterTime")
+			if idx <= 1 {
+				assert.NotNil(mt, err, "expected no $clusterTime field in command %s", cmd)
+
+				// Get the response document and record the $clusterTime value sent by the server.
+				response, err := drivertest.GetReplyFromOpReply(pair.received)
+				if err != nil {
+					response, err = drivertest.GetCommandFromMsgWireMessage(pair.received)
+				}
+				if err != nil {
+					mt.Fatalf("error reading response document from wire message: %v", err)
+				}
+
+				responseClusterTime, err := response.LookupErr("$clusterTime")
+				assert.Nil(mt, err, "expected $clusterTime in response %s", response)
+				previousClusterTime = responseClusterTime.Document()
+				continue
+			}
+
+			// All messages after the first two should contain $clusterTime.
+			assert.Nil(mt, err, "expected $clusterTime field in command %s", cmd)
+			assert.Equal(mt, previousClusterTime, sentClusterTime.Document(), "expected sent $clusterTime %s, got %s",
+				previousClusterTime, sentClusterTime.Document())
+		}
+	})
+
 	mt.RunOpts("explicit implicit session arguments", noClientOpts, func(mt *mtest.T) {
 		// lsid is included in commands with explicit and implicit sessions
 

--- a/x/mongo/driver/auth/conversation.go
+++ b/x/mongo/driver/auth/conversation.go
@@ -10,7 +10,6 @@ import (
 	"context"
 
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 // SpeculativeConversation represents an authentication conversation that can be merged with the initial connection
@@ -23,7 +22,7 @@ import (
 // authenticate the provided connection.
 type SpeculativeConversation interface {
 	FirstMessage() (bsoncore.Document, error)
-	Finish(ctx context.Context, firstResponse bsoncore.Document, conn driver.Connection) error
+	Finish(ctx context.Context, cfg *Config, firstResponse bsoncore.Document) error
 }
 
 // SpeculativeAuthenticator represents an authenticator that supports speculative authentication.

--- a/x/mongo/driver/auth/default.go
+++ b/x/mongo/driver/auth/default.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 )
 
@@ -49,11 +48,11 @@ func (a *DefaultAuthenticator) CreateSpeculativeConversation() (SpeculativeConve
 }
 
 // Auth authenticates the connection.
-func (a *DefaultAuthenticator) Auth(ctx context.Context, desc description.Server, conn driver.Connection) error {
+func (a *DefaultAuthenticator) Auth(ctx context.Context, cfg *Config) error {
 	var actual Authenticator
 	var err error
 
-	switch chooseAuthMechanism(desc) {
+	switch chooseAuthMechanism(cfg.Description) {
 	case SCRAMSHA256:
 		actual, err = newScramSHA256Authenticator(a.Cred)
 	case SCRAMSHA1:
@@ -66,7 +65,7 @@ func (a *DefaultAuthenticator) Auth(ctx context.Context, desc description.Server
 		return newAuthError("error creating authenticator", err)
 	}
 
-	return actual.Auth(ctx, desc, conn)
+	return actual.Auth(ctx, cfg)
 }
 
 // If a server provides a list of supported mechanisms, we choose

--- a/x/mongo/driver/auth/gssapi.go
+++ b/x/mongo/driver/auth/gssapi.go
@@ -14,9 +14,7 @@ import (
 	"fmt"
 	"net"
 
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/auth/internal/gssapi"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 )
 
 // GSSAPI is the mechanism name for GSSAPI.
@@ -44,8 +42,8 @@ type GSSAPIAuthenticator struct {
 }
 
 // Auth authenticates the connection.
-func (a *GSSAPIAuthenticator) Auth(ctx context.Context, desc description.Server, conn driver.Connection) error {
-	target := desc.Addr.String()
+func (a *GSSAPIAuthenticator) Auth(ctx context.Context, cfg *Config) error {
+	target := cfg.Description.Addr.String()
 	hostname, _, err := net.SplitHostPort(target)
 	if err != nil {
 		return newAuthError(fmt.Sprintf("invalid endpoint (%s) specified: %s", target, err), nil)
@@ -56,5 +54,5 @@ func (a *GSSAPIAuthenticator) Auth(ctx context.Context, desc description.Server,
 	if err != nil {
 		return newAuthError("error creating gssapi", err)
 	}
-	return ConductSaslConversation(ctx, conn, "$external", client)
+	return ConductSaslConversation(ctx, cfg, "$external", client)
 }

--- a/x/mongo/driver/auth/gssapi_test.go
+++ b/x/mongo/driver/auth/gssapi_test.go
@@ -31,9 +31,9 @@ func TestGSSAPIAuthenticator(t *testing.T) {
 		}
 		desc := description.Server{
 			WireVersion: &description.VersionRange{
-				Max:  6,
-				Addr: address.Address("foo:27017"),
+				Max: 6,
 			},
+			Addr: address.Address("foo:27017"),
 		}
 		err := authenticator.Auth(context.Background(), &Config{Description: desc})
 		if err == nil {

--- a/x/mongo/driver/auth/gssapi_test.go
+++ b/x/mongo/driver/auth/gssapi_test.go
@@ -29,12 +29,13 @@ func TestGSSAPIAuthenticator(t *testing.T) {
 				"SERVICE_HOST":           "localhost",
 			},
 		}
-		err := authenticator.Auth(context.Background(), description.Server{
+		desc := description.Server{
 			WireVersion: &description.VersionRange{
-				Max: 6,
+				Max:  6,
+				Addr: address.Address("foo:27017"),
 			},
-			Addr: address.Address("foo:27017"),
-		}, nil)
+		}
+		err := authenticator.Auth(context.Background(), &Config{Description: desc})
 		if err == nil {
 			t.Fatalf("expected err, got nil")
 		}

--- a/x/mongo/driver/auth/mongodbaws.go
+++ b/x/mongo/driver/auth/mongodbaws.go
@@ -8,9 +8,6 @@ package auth
 
 import (
 	"context"
-
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 )
 
 // MongoDBAWS is the mechanism name for MongoDBAWS.
@@ -37,7 +34,7 @@ type MongoDBAWSAuthenticator struct {
 }
 
 // Auth authenticates the connection.
-func (a *MongoDBAWSAuthenticator) Auth(ctx context.Context, _ description.Server, conn driver.Connection) error {
+func (a *MongoDBAWSAuthenticator) Auth(ctx context.Context, cfg *Config) error {
 	adapter := &awsSaslAdapter{
 		conversation: &awsConversation{
 			username: a.username,
@@ -45,7 +42,7 @@ func (a *MongoDBAWSAuthenticator) Auth(ctx context.Context, _ description.Server
 			token:    a.sessionToken,
 		},
 	}
-	err := ConductSaslConversation(ctx, conn, a.source, adapter)
+	err := ConductSaslConversation(ctx, cfg, a.source, adapter)
 	if err != nil {
 		return newAuthError("sasl conversation error", err)
 	}

--- a/x/mongo/driver/auth/mongodbcr.go
+++ b/x/mongo/driver/auth/mongodbcr.go
@@ -16,7 +16,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
 )
 
@@ -45,7 +44,7 @@ type MongoDBCRAuthenticator struct {
 // Auth authenticates the connection.
 //
 // The MONGODB-CR authentication mechanism is deprecated in MongoDB 4.0.
-func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, _ description.Server, conn driver.Connection) error {
+func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, cfg *Config) error {
 
 	db := a.DB
 	if db == "" {
@@ -53,7 +52,10 @@ func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, _ description.Server,
 	}
 
 	doc := bsoncore.BuildDocumentFromElements(nil, bsoncore.AppendInt32Element(nil, "getnonce", 1))
-	cmd := operation.NewCommand(doc).Database(db).Deployment(driver.SingleConnectionDeployment{conn})
+	cmd := operation.NewCommand(doc).
+		Database(db).
+		Deployment(driver.SingleConnectionDeployment{cfg.Connection}).
+		ClusterClock(cfg.ClusterClock)
 	err := cmd.Execute(ctx)
 	if err != nil {
 		return newError(err, MONGODBCR)
@@ -75,7 +77,10 @@ func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, _ description.Server,
 		bsoncore.AppendStringElement(nil, "nonce", getNonceResult.Nonce),
 		bsoncore.AppendStringElement(nil, "key", a.createKey(getNonceResult.Nonce)),
 	)
-	cmd = operation.NewCommand(doc).Database(db).Deployment(driver.SingleConnectionDeployment{conn})
+	cmd = operation.NewCommand(doc).
+		Database(db).
+		Deployment(driver.SingleConnectionDeployment{cfg.Connection}).
+		ClusterClock(cfg.ClusterClock)
 	err = cmd.Execute(ctx)
 	if err != nil {
 		return newError(err, MONGODBCR)

--- a/x/mongo/driver/auth/mongodbcr_test.go
+++ b/x/mongo/driver/auth/mongodbcr_test.go
@@ -46,7 +46,7 @@ func TestMongoDBCRAuthenticator_Fails(t *testing.T) {
 		Desc:     desc,
 	}
 
-	err := authenticator.Auth(context.Background(), desc, c)
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
 	if err == nil {
 		t.Fatalf("expected an error but got none")
 	}
@@ -85,7 +85,7 @@ func TestMongoDBCRAuthenticator_Succeeds(t *testing.T) {
 		Desc:     desc,
 	}
 
-	err := authenticator.Auth(context.Background(), desc, c)
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
 	if err != nil {
 		t.Fatalf("expected no error but got \"%s\"", err)
 	}

--- a/x/mongo/driver/auth/plain.go
+++ b/x/mongo/driver/auth/plain.go
@@ -8,9 +8,6 @@ package auth
 
 import (
 	"context"
-
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 )
 
 // PLAIN is the mechanism name for PLAIN.
@@ -30,8 +27,8 @@ type PlainAuthenticator struct {
 }
 
 // Auth authenticates the connection.
-func (a *PlainAuthenticator) Auth(ctx context.Context, _ description.Server, conn driver.Connection) error {
-	return ConductSaslConversation(ctx, conn, "$external", &plainSaslClient{
+func (a *PlainAuthenticator) Auth(ctx context.Context, cfg *Config) error {
+	return ConductSaslConversation(ctx, cfg, "$external", &plainSaslClient{
 		username: a.Username,
 		password: a.Password,
 	})

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -47,7 +47,7 @@ func TestPlainAuthenticator_Fails(t *testing.T) {
 		Desc:     desc,
 	}
 
-	err := authenticator.Auth(context.Background(), desc, c)
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
 	if err == nil {
 		t.Fatalf("expected an error but got none")
 	}
@@ -90,7 +90,7 @@ func TestPlainAuthenticator_Extra_server_message(t *testing.T) {
 		Desc:     desc,
 	}
 
-	err := authenticator.Auth(context.Background(), desc, c)
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
 	if err == nil {
 		t.Fatalf("expected an error but got none")
 	}
@@ -128,7 +128,7 @@ func TestPlainAuthenticator_Succeeds(t *testing.T) {
 		Desc:     desc,
 	}
 
-	err := authenticator.Auth(context.Background(), desc, c)
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
 	if err != nil {
 		t.Fatalf("expected no error but got \"%s\"", err)
 	}

--- a/x/mongo/driver/auth/scram.go
+++ b/x/mongo/driver/auth/scram.go
@@ -19,8 +19,6 @@ import (
 	"github.com/xdg/scram"
 	"github.com/xdg/stringprep"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 )
 
 const (
@@ -79,8 +77,8 @@ type ScramAuthenticator struct {
 var _ SpeculativeAuthenticator = (*ScramAuthenticator)(nil)
 
 // Auth authenticates the provided connection by conducting a full SASL conversation.
-func (a *ScramAuthenticator) Auth(ctx context.Context, _ description.Server, conn driver.Connection) error {
-	err := ConductSaslConversation(ctx, conn, a.source, a.createSaslClient())
+func (a *ScramAuthenticator) Auth(ctx context.Context, cfg *Config) error {
+	err := ConductSaslConversation(ctx, cfg, a.source, a.createSaslClient())
 	if err != nil {
 		return newAuthError("sasl conversation error", err)
 	}

--- a/x/mongo/driver/auth/scram_test.go
+++ b/x/mongo/driver/auth/scram_test.go
@@ -74,7 +74,7 @@ func TestSCRAM(t *testing.T) {
 					Desc:     desc,
 				}
 
-				err = authenticator.Auth(context.Background(), desc, conn)
+				err = authenticator.Auth(context.Background(), &Config{Description: desc, Connection: conn})
 				assert.Nil(t, err, "Auth error: %v\n", err)
 
 				// Verify that the first command sent is saslStart.

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -131,34 +131,3 @@ func GetCommandFromMsgWireMessage(wm []byte) (bsoncore.Document, error) {
 	}
 	return cmdDoc, nil
 }
-
-// GetReplyFromOpReply returns the response document received in an OP_REPLY wire message.
-func GetReplyFromOpReply(wm []byte) (bsoncore.Document, error) {
-	var ok bool
-
-	if _, _, _, _, wm, ok = wiremessage.ReadHeader(wm); !ok {
-		return nil, errors.New("could not read header")
-	}
-	if _, wm, ok = wiremessage.ReadReplyFlags(wm); !ok {
-		return nil, errors.New("failed to read reply flags")
-	}
-	if _, wm, ok = wiremessage.ReadReplyCursorID(wm); !ok {
-		return nil, errors.New("failed to read cursor ID")
-	}
-	if _, wm, ok = wiremessage.ReadReplyStartingFrom(wm); !ok {
-		return nil, errors.New("failed to read starting from")
-	}
-	if _, wm, ok = wiremessage.ReadReplyNumberReturned(wm); !ok {
-		return nil, errors.New("failed to read number returned")
-	}
-
-	var replyDocuments []bsoncore.Document
-	replyDocuments, wm, ok = wiremessage.ReadReplyDocuments(wm)
-	if !ok {
-		return nil, errors.New("failed to read reply documents")
-	}
-	if len(replyDocuments) == 0 {
-		return nil, errors.New("no documents in response")
-	}
-	return replyDocuments[0], nil
-}

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -107,3 +107,58 @@ func GetCommandFromQueryWireMessage(wm []byte) (bsoncore.Document, error) {
 	}
 	return query, nil
 }
+
+// GetCommandFromMsgWireMessage returns the command document sent in an OP_MSG wire message.
+func GetCommandFromMsgWireMessage(wm []byte) (bsoncore.Document, error) {
+	var ok bool
+	_, _, _, _, wm, ok = wiremessage.ReadHeader(wm)
+	if !ok {
+		return nil, errors.New("could not read header")
+	}
+
+	_, wm, ok = wiremessage.ReadMsgFlags(wm)
+	if !ok {
+		return nil, errors.New("could not read flags")
+	}
+	_, wm, ok = wiremessage.ReadMsgSectionType(wm)
+	if !ok {
+		return nil, errors.New("could not read section type")
+	}
+
+	cmdDoc, wm, ok := wiremessage.ReadMsgSectionSingleDocument(wm)
+	if !ok {
+		return nil, errors.New("could not read command document")
+	}
+	return cmdDoc, nil
+}
+
+// GetReplyFromOpReply returns the response document received in an OP_REPLY wire message.
+func GetReplyFromOpReply(wm []byte) (bsoncore.Document, error) {
+	var ok bool
+
+	if _, _, _, _, wm, ok = wiremessage.ReadHeader(wm); !ok {
+		return nil, errors.New("could not read header")
+	}
+	if _, wm, ok = wiremessage.ReadReplyFlags(wm); !ok {
+		return nil, errors.New("failed to read reply flags")
+	}
+	if _, wm, ok = wiremessage.ReadReplyCursorID(wm); !ok {
+		return nil, errors.New("failed to read cursor ID")
+	}
+	if _, wm, ok = wiremessage.ReadReplyStartingFrom(wm); !ok {
+		return nil, errors.New("failed to read starting from")
+	}
+	if _, wm, ok = wiremessage.ReadReplyNumberReturned(wm); !ok {
+		return nil, errors.New("failed to read number returned")
+	}
+
+	var replyDocuments []bsoncore.Document
+	replyDocuments, wm, ok = wiremessage.ReadReplyDocuments(wm)
+	if !ok {
+		return nil, errors.New("failed to read reply documents")
+	}
+	if len(replyDocuments) == 0 {
+		return nil, errors.New("no documents in response")
+	}
+	return replyDocuments[0], nil
+}


### PR DESCRIPTION
Testing this required adding a auth-nossl variant because the custom dialer can't handle SSL connections and I'm not sure there's any benefit in testing this with SSL, as that's a property of the networking layer and does not affect the wire messages we create/receieve.