### PR TITLE
GODRIVER-1565 Consolidate IndexView helpers and improve docs

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -45,8 +44,9 @@ type IndexView struct {
 
 // IndexModel represents a new index to be created.
 type IndexModel struct {
-	// A document describing which keys should be used for the index. It cannot be nil. See
-	// https://docs.mongodb.com/manual/indexes/#indexes for examples of valid documents.
+	// A document describing which keys should be used for the index. It cannot be nil. This must be an order-preserving
+	// type such as bson.D. Map types such as bson.M are not valid. See https://docs.mongodb.com/manual/indexes/#indexes
+	// for examples of valid documents.
 	Keys interface{}
 
 	// The options to use to create the index.
@@ -164,17 +164,17 @@ func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ..
 			return nil, fmt.Errorf("index model keys cannot be nil")
 		}
 
-		name, err := getOrGenerateIndexName(iv.coll.registry, model)
+		keys, err := transformBsoncoreDocument(iv.coll.registry, model.Keys)
+		if err != nil {
+			return nil, err
+		}
+
+		name, err := getOrGenerateIndexName(keys, model)
 		if err != nil {
 			return nil, err
 		}
 
 		names = append(names, name)
-
-		keys, err := transformBsoncoreDocument(iv.coll.registry, model.Keys)
-		if err != nil {
-			return nil, err
-		}
 
 		var iidx int32
 		iidx, indexes = bsoncore.AppendDocumentElementStart(indexes, strconv.Itoa(i))
@@ -421,7 +421,7 @@ func (iv IndexView) DropAll(ctx context.Context, opts ...*options.DropIndexesOpt
 	return iv.drop(ctx, "*", opts...)
 }
 
-func getOrGenerateIndexName(registry *bsoncodec.Registry, model IndexModel) (string, error) {
+func getOrGenerateIndexName(keySpecDocument bsoncore.Document, model IndexModel) (string, error) {
 	if model.Options != nil && model.Options.Name != nil {
 		return *model.Options.Name, nil
 	}
@@ -429,11 +429,11 @@ func getOrGenerateIndexName(registry *bsoncodec.Registry, model IndexModel) (str
 	name := bytes.NewBufferString("")
 	first := true
 
-	keys, err := transformDocument(registry, model.Keys)
+	elems, err := keySpecDocument.Elements()
 	if err != nil {
 		return "", err
 	}
-	for _, elem := range keys {
+	for _, elem := range elems {
 		if !first {
 			_, err := name.WriteRune('_')
 			if err != nil {
@@ -441,7 +441,7 @@ func getOrGenerateIndexName(registry *bsoncodec.Registry, model IndexModel) (str
 			}
 		}
 
-		_, err := name.WriteString(elem.Key)
+		_, err := name.WriteString(elem.Key())
 		if err != nil {
 			return "", err
 		}
@@ -453,13 +453,14 @@ func getOrGenerateIndexName(registry *bsoncodec.Registry, model IndexModel) (str
 
 		var value string
 
-		switch elem.Value.Type() {
+		bsonValue := elem.Value()
+		switch bsonValue.Type {
 		case bsontype.Int32:
-			value = fmt.Sprintf("%d", elem.Value.Int32())
+			value = fmt.Sprintf("%d", bsonValue.Int32())
 		case bsontype.Int64:
-			value = fmt.Sprintf("%d", elem.Value.Int64())
+			value = fmt.Sprintf("%d", bsonValue.Int64())
 		case bsontype.String:
-			value = elem.Value.StringValue()
+			value = bsonValue.StringValue()
 		default:
 			return "", ErrInvalidIndexValue
 		}

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type index struct {
-	Key  map[string]int
+	Key  bson.D
 	Name string
 }
 
@@ -29,35 +29,44 @@ func TestIndexView(t *testing.T) {
 
 	mt.Run("list", func(mt *mtest.T) {
 		verifyIndexExists(mt, mt.Coll.Indexes(), index{
-			Key: map[string]int{
-				"_id": 1,
-			},
+			Key:  bson.D{{"_id", int32(1)}},
 			Name: "_id_",
 		})
 	})
 	mt.RunOpts("create one", noClientOpts, func(mt *mtest.T) {
-		mt.Run("success", func(mt *mtest.T) {
+		mt.Run("name not specified", func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
+			keysDoc := bson.D{
+				{"foo", int32(1)},
+				{"bar", int32(-1)},
+			}
+			expectedName := "foo_1_bar_-1"
+
 			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
-				Keys: bson.D{{"foo", -1}},
+				Keys: keysDoc,
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
+			assert.Equal(mt, expectedName, indexName, "expected name %q, got %q", expectedName, indexName)
 
 			verifyIndexExists(mt, iv, index{
-				Key:  map[string]int{"foo": -1},
+				Key:  keysDoc,
 				Name: indexName,
 			})
 		})
 		mt.Run("specify name", func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
+			keysDoc := bson.D{{"foo", int32(-1)}}
+			name := "testname"
+
 			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
-				Keys:    bson.D{{"foo", -1}},
-				Options: options.Index().SetName("testname"),
+				Keys:    keysDoc,
+				Options: options.Index().SetName(name),
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
+			assert.Equal(mt, name, indexName, "expected returned name %q, got %q", name, indexName)
 
 			verifyIndexExists(mt, iv, index{
-				Key:  map[string]int{"foo": -1},
+				Key:  keysDoc,
 				Name: indexName,
 			})
 		})
@@ -110,7 +119,7 @@ func TestIndexView(t *testing.T) {
 				})
 				assert.Nil(mt, err, "CreateOne error: %v", err)
 				verifyIndexExists(mt, iv, index{
-					Key:  map[string]int{"$**": 1},
+					Key:  keysDoc,
 					Name: indexName,
 				})
 			})
@@ -195,23 +204,26 @@ func TestIndexView(t *testing.T) {
 	mt.Run("create many", func(mt *mtest.T) {
 		mt.Run("success", func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
+			firstKeysDoc := bson.D{{"foo", int32(-1)}}
+			secondKeysDoc := bson.D{{"bar", int32(1)}, {"baz", int32(-1)}}
+			expectedNames := []string{"foo_-1", "bar_1_baz_-1"}
 			indexNames, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
 				{
-					Keys: bson.D{{"foo", -1}},
+					Keys: firstKeysDoc,
 				},
 				{
-					Keys: bson.D{{"bar", 1}, {"baz", -1}},
+					Keys: secondKeysDoc,
 				},
 			})
 			assert.Nil(mt, err, "CreateMany error: %v", err)
-			assert.Equal(mt, 2, len(indexNames), "expected 2 index names, got %v", len(indexNames))
+			assert.Equal(mt, expectedNames, indexNames, "expected returned names %v, got %v", expectedNames, indexNames)
 
 			verifyIndexExists(mt, iv, index{
-				Key:  map[string]int{"foo": -1},
+				Key:  firstKeysDoc,
 				Name: indexNames[0],
 			})
 			verifyIndexExists(mt, iv, index{
-				Key:  map[string]int{"bar": 1, "baz": -1},
+				Key:  secondKeysDoc,
 				Name: indexNames[1],
 			})
 		})


### PR DESCRIPTION
The current code converts `IndexModel.Keys` into `bsoncore.Document` twice: once to generate the key specification document and another time in `getOrGenerateIndexName` to iterate the document and generarte the name. This PR cleans up that logic to first generate the key spec and pass that into `getOrGenerateIndexName` to avoid doubling the marshalling cost. I've also updated the documentation for `IndexModel.Keys` to say that it should be order-preserving.