### PR TITLE
Make error formatting consistent

### DIFF
--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -16,7 +16,7 @@ import (
 
 // ErrNoDocuments is returned by SingleResult methods when the operation that created the SingleResult did not return
 // any documents.
-var ErrNoDocuments = errors.New("mongo: no documents in result")
+var ErrNoDocuments = errors.New("no documents in result")
 
 // SingleResult represents a single document returned from an operation. If the operation resulted in an error, all
 // SingleResult methods will return that error. If the operation did not return any documents, all SingleResult methods


### PR DESCRIPTION
Only `ErrNoDocuments` is namespaced, so the namespace may be dropped in order to bring consistency to exported errors.

<img src="https://i.imgur.com/F1q97rf.jpg" width="650px" />