### PR TITLE
GODRIVER-1636 Ensure SNI is always enabled

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -513,16 +513,15 @@ var notMasterCodes = []int32{10107, 13435}
 var recoveringCodes = []int32{11600, 11602, 13436, 189, 91}
 
 func configureTLS(ctx context.Context, nc net.Conn, addr address.Address, config *tls.Config, ocspOpts *ocsp.VerifyOptions) (net.Conn, error) {
-	if !config.InsecureSkipVerify {
-		hostname := addr.String()
-		colonPos := strings.LastIndex(hostname, ":")
-		if colonPos == -1 {
-			colonPos = len(hostname)
-		}
-
-		hostname = hostname[:colonPos]
-		config.ServerName = hostname
+	// Ensure config.ServerName is always set for SNI.
+	hostname := addr.String()
+	colonPos := strings.LastIndex(hostname, ":")
+	if colonPos == -1 {
+		colonPos = len(hostname)
 	}
+
+	hostname = hostname[:colonPos]
+	config.ServerName = hostname
 
 	client := tls.Client(nc, config)
 


### PR DESCRIPTION
Testing this exact change would require having a mock server that can assert
SNI is always enabled on incoming connections. Instead, I modified our Atlas
connectivity tests to run both with and without TLS verification because
the bug was only present when tlsInsecure was set and Atlas shared tiers error
if SNI is not enabled.