### PR TITLE
GODRIVER-1613 Improve stability of flaky test

### DIFF
--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -706,7 +706,7 @@ func assertConnectionsClosed(t *testing.T, dialer *dialer, expectedClosedCount i
 
 	callback := func() error {
 		for {
-			if dialer.lenclosed() == 3 {
+			if dialer.lenclosed() == expectedClosedCount {
 				return nil
 			}
 


### PR DESCRIPTION
I think this is the same issue that we ran into when first implementing this ticket, but for a different test, so I moved the `assert.RunWithTimeout` logic into a helper.

Example failure in Evergreen: https://evergreen.mongodb.com/test_log/5ee118211e2d17189bc97d0a#L14607