### PR TITLE
Propagate errors in unified test runner rather than failing

### DIFF
--- a/mongo/integration/crud_spec_test.go
+++ b/mongo/integration/crud_spec_test.go
@@ -96,7 +96,8 @@ func verifyCrudError(mt *mtest.T, outcome crudOutcome, err error) {
 	if opError == nil {
 		return
 	}
-	verifyError(mt, opError, err)
+	verificationErr := verifyError(opError, err)
+	assert.Nil(mt, verificationErr, "error mismatch: %v", verificationErr)
 }
 
 // run a CRUD operation and verify errors and outcomes.


### PR DESCRIPTION
This commit changes the runOperation function in the unified
test runner to return an error rather than failing the test
so that errors can be reported with more context at a higher
level.

Note that this still isn't perfect because functions like `executeCollectionOperation` will fail the test if the operation result doesn't match the expected result (e.g. the `UpsertedCount` field is different in an `Update*` test), but the errors we usually see on Evergreen are when a test gets an unexpected error, which is handled by this PR. Ideally, we should get to a point where any helpers called from `runSpecTestCase` return an error and never internally call `mt.Fatalf`.