### PR TITLE
GODRIVER-1658 Fix connection updates to topology

### DIFF
--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -64,6 +64,9 @@ type FailPointData struct {
 	FailBeforeCommitExceptionCode int32                  `bson:"failBeforeCommitExceptionCode,omitempty"`
 	ErrorLabels                   *[]string              `bson:"errorLabels,omitempty"`
 	WriteConcernError             *WriteConcernErrorData `bson:"writeConcernError,omitempty"`
+	BlockConnection               bool                   `bson:"blockConnection,omitempty"`
+	BlockTimeMS                   int32                  `bson:"blockTimeMS,omitempty"`
+	AppName                       string                 `bson:"appName,omitempty"`
 }
 
 // WriteConcernErrorData is a representation of the FailPoint.Data.WriteConcern field.

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -25,10 +25,16 @@ func TestSDAMErrorHandling(t *testing.T) {
 		SetPoolMonitor(poolMonitor).
 		SetWriteConcern(mtest.MajorityWc)
 	baseMtOpts := func() *mtest.Options {
-		return mtest.NewOptions().
+		mtOpts := mtest.NewOptions().
 			Topologies(mtest.ReplicaSet). // Don't run on sharded clusters to avoid complexity of sharded failpoints.
 			MinServerVersion("4.0").      // 4.0+ is required to use failpoints on replica sets.
 			ClientOptions(clientOpts)
+
+		if mt.TopologyKind() == mtest.Sharded {
+			// Pin to a single mongos because the tests use failpoints.
+			mtOpts.ClientType(mtest.Pinned)
+		}
+		return mtOpts
 	}
 
 	// Set min server version of 4.4 because the during-handshake tests use failpoint features introduced in 4.4 like

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -24,44 +24,148 @@ func TestSDAMErrorHandling(t *testing.T) {
 		SetRetryWrites(false).
 		SetPoolMonitor(poolMonitor).
 		SetWriteConcern(mtest.MajorityWc)
-	mtOpts := mtest.NewOptions().
-		Topologies(mtest.ReplicaSet). // Don't run on sharded clusters to avoid complexity of sharded failpoints.
-		MinServerVersion("4.0").      // 4.0+ is required to use failpoints on replica sets.
-		ClientOptions(clientOpts)
+	baseMtOpts := func() *mtest.Options {
+		return mtest.NewOptions().
+			Topologies(mtest.ReplicaSet). // Don't run on sharded clusters to avoid complexity of sharded failpoints.
+			MinServerVersion("4.0").      // 4.0+ is required to use failpoints on replica sets.
+			ClientOptions(clientOpts)
+	}
 
-	mt.RunOpts("network errors", mtOpts, func(mt *mtest.T) {
-		mt.Run("pool cleared on non-timeout network error", func(mt *mtest.T) {
-			clearPoolChan()
-			mt.SetFailPoint(mtest.FailPoint{
-				ConfigureFailPoint: "failCommand",
-				Mode: mtest.FailPointMode{
-					Times: 1,
-				},
-				Data: mtest.FailPointData{
-					FailCommands:    []string{"insert"},
-					CloseConnection: true,
-				},
+	// Set min server version of 4.4 because the during-handshake tests use failpoint features introduced in 4.4 like
+	// blockConnection and appName.
+	mt.RunOpts("before handshake completes", baseMtOpts().Auth(true).MinServerVersion("4.4"), func(mt *mtest.T) {
+		mt.RunOpts("network errors", noClientOpts, func(mt *mtest.T) {
+			mt.Run("pool cleared on network timeout", func(mt *mtest.T) {
+				// Assert that the pool is cleared when a connection created by an application operation thread
+				// encounters a network timeout during handshaking. Unlike the non-timeout test below, we only test
+				// connections created in the foreground for timeouts because connections created by the pool
+				// maintenance routine can't be timed out using a context.
+
+				appName := "authNetworkTimeoutTest"
+				// Set failpoint on saslContinue instead of saslStart because saslStart isn't done when using
+				// speculative auth.
+				mt.SetFailPoint(mtest.FailPoint{
+					ConfigureFailPoint: "failCommand",
+					Mode: mtest.FailPointMode{
+						Times: 1,
+					},
+					Data: mtest.FailPointData{
+						FailCommands:    []string{"saslContinue"},
+						BlockConnection: true,
+						BlockTimeMS:     150,
+						AppName:         appName,
+					},
+				})
+
+				// Reset the client with the appName specified in the failpoint.
+				clientOpts := options.Client().
+					SetAppName(appName).
+					SetRetryWrites(false).
+					SetPoolMonitor(poolMonitor)
+				mt.ResetClient(clientOpts)
+				clearPoolChan()
+
+				// The saslContinue blocks for 150ms so run the InsertOne with a 100ms context to cause a network
+				// timeout during auth and assert that the pool was cleared.
+				timeoutCtx, cancel := context.WithTimeout(mtest.Background, 100*time.Millisecond)
+				defer cancel()
+				_, err := mt.Coll.InsertOne(timeoutCtx, bson.D{{"test", 1}})
+				assert.NotNil(mt, err, "expected InsertOne error, got nil")
+				assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
 			})
+			mt.RunOpts("pool cleared on non-timeout network error", noClientOpts, func(mt *mtest.T) {
+				mt.Run("background", func(mt *mtest.T) {
+					// Assert that the pool is cleared when a connection created by the background pool maintenance
+					// routine encounters a non-timeout network error during handshaking.
+					appName := "authNetworkErrorTestBackground"
 
-			_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"test", 1}})
-			assert.NotNil(mt, err, "expected InsertOne error, got nil")
-			assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
+					mt.SetFailPoint(mtest.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode: mtest.FailPointMode{
+							Times: 1,
+						},
+						Data: mtest.FailPointData{
+							FailCommands:    []string{"saslContinue"},
+							CloseConnection: true,
+							AppName:         appName,
+						},
+					})
+
+					clientOpts := options.Client().
+						SetAppName(appName).
+						SetMinPoolSize(5).
+						SetPoolMonitor(poolMonitor)
+					mt.ResetClient(clientOpts)
+					clearPoolChan()
+
+					time.Sleep(200 * time.Millisecond)
+					assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
+				})
+				mt.Run("foreground", func(mt *mtest.T) {
+					// Assert that the pool is cleared when a connection created by an application thread connection
+					// checkout encounters a non-timeout network error during handshaking.
+					appName := "authNetworkErrorTestForeground"
+
+					mt.SetFailPoint(mtest.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode: mtest.FailPointMode{
+							Times: 1,
+						},
+						Data: mtest.FailPointData{
+							FailCommands:    []string{"saslContinue"},
+							CloseConnection: true,
+							AppName:         appName,
+						},
+					})
+
+					clientOpts := options.Client().
+						SetAppName(appName).
+						SetPoolMonitor(poolMonitor)
+					mt.ResetClient(clientOpts)
+					clearPoolChan()
+
+					_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+					assert.NotNil(mt, err, "expected InsertOne error, got nil")
+					assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
+				})
+			})
 		})
-		mt.Run("pool not cleared on timeout network error", func(mt *mtest.T) {
-			clearPoolChan()
+	})
+	mt.RunOpts("after handshake completes", baseMtOpts(), func(mt *mtest.T) {
+		mt.RunOpts("network errors", noClientOpts, func(mt *mtest.T) {
+			mt.Run("pool cleared on non-timeout network error", func(mt *mtest.T) {
+				clearPoolChan()
+				mt.SetFailPoint(mtest.FailPoint{
+					ConfigureFailPoint: "failCommand",
+					Mode: mtest.FailPointMode{
+						Times: 1,
+					},
+					Data: mtest.FailPointData{
+						FailCommands:    []string{"insert"},
+						CloseConnection: true,
+					},
+				})
 
-			_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
-			assert.Nil(mt, err, "InsertOne error: %v", err)
+				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"test", 1}})
+				assert.NotNil(mt, err, "expected InsertOne error, got nil")
+				assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
+			})
+			mt.Run("pool not cleared on timeout network error", func(mt *mtest.T) {
+				clearPoolChan()
 
-			filter := bson.M{
-				"$where": "function() { sleep(1000); return false; }",
-			}
-			timeoutCtx, cancel := context.WithTimeout(mtest.Background, 100*time.Millisecond)
-			defer cancel()
-			_, err = mt.Coll.Find(timeoutCtx, filter)
-			assert.NotNil(mt, err, "expected Find error, got %v", err)
+				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+				assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
+				filter := bson.M{
+					"$where": "function() { sleep(1000); return false; }",
+				}
+				timeoutCtx, cancel := context.WithTimeout(mtest.Background, 100*time.Millisecond)
+				defer cancel()
+				_, err = mt.Coll.Find(timeoutCtx, filter)
+				assert.NotNil(mt, err, "expected Find error, got %v", err)
+
+				assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
+			})
 		})
 	})
 }

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -71,7 +71,11 @@ func TestSessions(t *testing.T) {
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
 
-	clusterTimeOpts := mtest.NewOptions().ClientOptions(options.Client().SetHeartbeatInterval(50 * time.Second)).
+	// Pin to a single mongos so heartbeats/handshakes to other mongoses won't cause errors.
+	// Pin to a single mongos so heartbeats/handshakes to other mongoses won't cause errors.
+	clusterTimeOpts := mtest.NewOptions().
+		ClientOptions(options.Client().SetHeartbeatInterval(50 * time.Second)).
+		ClientType(mtest.Pinned).
 		CreateClient(false)
 	mt.RunOpts("cluster time", clusterTimeOpts, func(mt *mtest.T) {
 		// $clusterTime included in commands

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -141,7 +141,6 @@ func (c *connection) connect(ctx context.Context) {
 
 	handshakeConn := initConnection{c}
 	c.desc, err = handshaker.GetDescription(ctx, c.addr, handshakeConn)
-	fmt.Printf("GetDesc err: %v\n", err)
 	if err == nil {
 		err = handshaker.FinishHandshake(ctx, handshakeConn)
 	}

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -8,7 +8,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/ocsp"
 )
 
@@ -50,9 +49,9 @@ type connectionConfig struct {
 	compressors              []string
 	zlibLevel                *int
 	zstdLevel                *int
-	descCallback             func(description.Server)
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
+	errorHandlingCallback    func(error)
 }
 
 func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
@@ -76,15 +75,15 @@ func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
 	return cfg, nil
 }
 
-func withServerDescriptionCallback(callback func(description.Server), opts ...ConnectionOption) []ConnectionOption {
-	return append(opts, ConnectionOption(func(c *connectionConfig) error {
-		c.descCallback = callback
-		return nil
-	}))
-}
-
 // ConnectionOption is used to configure a connection.
 type ConnectionOption func(*connectionConfig) error
+
+func withErrorHandlingCallback(fn func(error)) ConnectionOption {
+	return func(c *connectionConfig) error {
+		c.errorHandlingCallback = fn
+		return nil
+	}
+}
 
 // WithCompressors sets the compressors that can be used for communication.
 func WithCompressors(fn func([]string) []string) ConnectionOption {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -142,7 +142,6 @@ func NewServer(addr address.Address, opts ...ServerOption) (*Server, error) {
 	}
 	s.desc.Store(description.NewDefaultServer(addr))
 
-	callback := func(desc description.Server) { s.updateDescription(desc) }
 	pc := poolConfig{
 		Address:     addr,
 		MinPoolSize: cfg.minConns,
@@ -151,7 +150,8 @@ func NewServer(addr address.Address, opts ...ServerOption) (*Server, error) {
 		PoolMonitor: cfg.poolMonitor,
 	}
 
-	s.pool, err = newPool(pc, withServerDescriptionCallback(callback, cfg.connectionOpts...)...)
+	connectionOpts := append(cfg.connectionOpts, withErrorHandlingCallback(s.ProcessHandshakeError))
+	s.pool, err = newPool(pc, connectionOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -224,21 +224,28 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 
 	conn, err := s.pool.get(ctx)
 	if err != nil {
-		wrappedConnErr := unwrapConnectionError(err)
-		if wrappedConnErr == nil {
-			return nil, err
-		}
-
-		// Since the only kind of ConnectionError we receive from pool.Get will be an initialization
-		// error, we should set the description.Server appropriately.
-		desc := description.NewServerFromError(s.address, wrappedConnErr)
-		s.updateDescription(desc)
-		s.pool.clear()
-
+		// The error has already been handled by connection.connect, which calls Server.ProcessHandshakeError.
 		return nil, err
 	}
 
 	return &Connection{connection: conn, s: s}, nil
+}
+
+// ProcessHandshakeError implements SDAM error handling for errors that occur before a connection finishes handshaking.
+func (s *Server) ProcessHandshakeError(err error) {
+	if err == nil {
+		return
+	}
+	wrappedConnErr := unwrapConnectionError(err)
+	if wrappedConnErr == nil {
+		return
+	}
+
+	// Since the only kind of ConnectionError we receive from pool.Get will be an initialization error, we should set
+	// the description.Server appropriately.
+	desc := description.NewServerFromError(s.address, wrappedConnErr)
+	s.updateDescription(desc)
+	s.pool.clear()
 }
 
 // Description returns a description of the server as of the last heartbeat.


### PR DESCRIPTION
The change itself is simple: we no longer update the topology for successful connection handshakes because doing so doesn't gain us much and could actually hurt because it can cause resource contention if the applcation has many concurrent operations making connections, which would all try to update the topology even during steady-state. This PR also moves the SDAM error handling for connection handshakes to be earlier. Instead of doing it when a connection is checked out, we now do it inside `connection.connect` itself. This prevents an error from sitting around for a long time in the pool before it's actually processed and/or becomes stale.

@iwysiu This will probably require changes to your code for GODRIVER-1572 as well.