### PR TITLE
GODRIVER-1581 Transform network errors into context.DeadlineExceeded

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -47,7 +47,10 @@ func replaceErrors(err error) error {
 	}
 	if qe, ok := err.(driver.QueryFailureError); ok {
 		// qe.Message is "command failure"
-		ce := CommandError{Name: qe.Message}
+		ce := CommandError{
+			Name:    qe.Message,
+			Wrapped: qe.Wrapped,
+		}
 
 		dollarErr, err := qe.Response.LookupErr("$err")
 		if err == nil {

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -76,8 +76,8 @@ func TestErrors(t *testing.T) {
 
 			evt := mt.GetStartedEvent()
 			assert.Equal(mt, "find", evt.CommandName, "expected command 'find', got %q", evt.CommandName)
-			assert.True(mt, errors.Is(err, context.DeadlineExceeded), "expected error %v, got %v",
-				context.DeadlineExceeded, err)
+			assert.True(mt, errors.Is(err, context.DeadlineExceeded),
+				"errors.Is failure: expected error %v to be %v", err, context.DeadlineExceeded)
 		})
 
 		socketTimeoutOpts := options.Client().
@@ -98,10 +98,10 @@ func TestErrors(t *testing.T) {
 			assert.Equal(mt, "find", evt.CommandName, "expected command 'find', got %q", evt.CommandName)
 
 			assert.False(mt, errors.Is(err, context.DeadlineExceeded),
-				"expected error %v to not be context.DeadlineExceeded", err)
+				"errors.Is failure: expected error %v to not be %v", err, context.DeadlineExceeded)
 			var netErr net.Error
 			ok := errors.As(err, &netErr)
-			assert.True(mt, ok, "expected error %v to be a net.Error", err)
+			assert.True(mt, ok, "errors.As failure: expected error %v to be a net.Error", err)
 			assert.True(mt, netErr.Timeout(), "expected error %v to be a network timeout", err)
 		})
 	})

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -68,7 +68,7 @@ func TestErrors(t *testing.T) {
 
 			mt.ClearEvents()
 			filter := bson.M{
-				"$where": "function() { sleep(5000); return false; }",
+				"$where": "function() { sleep(1000); return false; }",
 			}
 			timeoutCtx, cancel := context.WithTimeout(mtest.Background, 100*time.Millisecond)
 			defer cancel()
@@ -90,7 +90,7 @@ func TestErrors(t *testing.T) {
 
 			mt.ClearEvents()
 			filter := bson.M{
-				"$where": "function() { sleep(5000); return false; }",
+				"$where": "function() { sleep(1000); return false; }",
 			}
 			_, err = mt.Coll.Find(mtest.Background, filter)
 

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -44,11 +44,17 @@ var (
 type QueryFailureError struct {
 	Message  string
 	Response bsoncore.Document
+	Wrapped  error
 }
 
 // Error implements the error interface.
 func (e QueryFailureError) Error() string {
 	return fmt.Sprintf("%s: %v", e.Message, e.Response)
+}
+
+// Unwrap returns the underlying error.
+func (e QueryFailureError) Unwrap() error {
+	return e.Wrapped
 }
 
 // ResponseError is an error parsing the response to a command.

--- a/x/mongo/driver/operation_legacy.go
+++ b/x/mongo/driver/operation_legacy.go
@@ -648,12 +648,12 @@ func (op Operation) roundTripLegacyCursor(ctx context.Context, wm []byte, srvr S
 func (op Operation) roundTripLegacy(ctx context.Context, conn Connection, wm []byte) ([]byte, error) {
 	err := conn.WriteWireMessage(ctx, wm)
 	if err != nil {
-		return nil, Error{Message: err.Error(), Labels: []string{TransientTransactionError, NetworkError}}
+		return nil, Error{Message: err.Error(), Labels: []string{TransientTransactionError, NetworkError}, Wrapped: err}
 	}
 
 	wm, err = conn.ReadWireMessage(ctx, wm[:0])
 	if err != nil {
-		err = Error{Message: err.Error(), Labels: []string{TransientTransactionError, NetworkError}}
+		err = Error{Message: err.Error(), Labels: []string{TransientTransactionError, NetworkError}, Wrapped: err}
 	}
 	return wm, err
 }


### PR DESCRIPTION
If a context is translated to a network read/write deadline and the
read/write call returns a timeout error, this commit will swallow
that error and replace it with context.DeadlineExceeded so the
resulting error will return true for
errors.Is(err, context.DeadlineExceeded).