### PR TITLE
GODRIVER-1663 setting cancelConext to nil to avoid context being pinned

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -109,22 +109,19 @@ func (c *connection) connect(ctx context.Context) {
 	}
 	defer close(c.connectDone)
 
-	var cancelFn context.CancelFunc
-
 	c.connectContextMutex.Lock()
 	ctx, c.cancelConnectContext = context.WithCancel(ctx)
 	c.connectContextMutex.Unlock()
 
 	defer func() {
+		var cancelFn context.CancelFunc
 		c.connectContextMutex.Lock()
-		defer func() {
-			c.connectContextMutex.Unlock()
-			if cancelFn != nil {
-				cancelFn()
-			}
-		}()
 		cancelFn = c.cancelConnectContext
 		c.cancelConnectContext = nil
+		c.connectContextMutex.Unlock()
+		if cancelFn != nil {
+			cancelFn()
+		}
 	}()
 
 	close(c.connectContextMade)

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -115,10 +115,12 @@ func (c *connection) connect(ctx context.Context) {
 
 	defer func() {
 		var cancelFn context.CancelFunc
+
 		c.connectContextMutex.Lock()
 		cancelFn = c.cancelConnectContext
 		c.cancelConnectContext = nil
 		c.connectContextMutex.Unlock()
+
 		if cancelFn != nil {
 			cancelFn()
 		}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -110,6 +110,19 @@ func TestConnection(t *testing.T) {
 				assert.NotNil(t, err, "expected connect error %v, got nil", want)
 				assert.Equal(t, want, got, "expected error %v, got %v", want, got)
 			})
+			t.Run("cancelConnectContext is nil after connect", func(t *testing.T) {
+				conn, got := newConnection(context.Background(), address.Address(""))
+
+				if got != nil {
+					t.Errorf("newConnection shouldn't error. got %v; want nil", got)
+				}
+				go func() {
+					conn.connect(context.Background())
+					assert.Nil(t, conn.cancelConnectContext, "expected nil, got context.CancelFunc")
+				}()
+				conn.closeConnectContext()
+				assert.Nil(t, conn.cancelConnectContext, "expected nil, got context.CancelFunc")
+			})
 		})
 		t.Run("writeWireMessage", func(t *testing.T) {
 			t.Run("closed connection", func(t *testing.T) {

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -111,11 +111,9 @@ func TestConnection(t *testing.T) {
 				assert.Equal(t, want, got, "expected error %v, got %v", want, got)
 			})
 			t.Run("cancelConnectContext is nil after connect", func(t *testing.T) {
-				conn, got := newConnection(context.Background(), address.Address(""))
+				conn, err := newConnection(context.Background(), address.Address(""))
+				assert.Nil(t, err, "newConnection shouldn't error. got %v; want nil", err)
 
-				if got != nil {
-					t.Errorf("newConnection shouldn't error. got %v; want nil", got)
-				}
 				go func() {
 					conn.connect(context.Background())
 					assert.Nil(t, conn.cancelConnectContext, "expected nil, got context.CancelFunc")

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -113,13 +113,18 @@ func TestConnection(t *testing.T) {
 			t.Run("cancelConnectContext is nil after connect", func(t *testing.T) {
 				conn, err := newConnection(context.Background(), address.Address(""))
 				assert.Nil(t, err, "newConnection shouldn't error. got %v; want nil", err)
+				var wg sync.WaitGroup
+				wg.Add(1)
 
 				go func() {
+					defer wg.Done()
 					conn.connect(context.Background())
 					assert.Nil(t, conn.cancelConnectContext, "expected nil, got context.CancelFunc")
 				}()
+
 				conn.closeConnectContext()
 				assert.Nil(t, conn.cancelConnectContext, "expected nil, got context.CancelFunc")
+				wg.Wait()
 			})
 		})
 		t.Run("writeWireMessage", func(t *testing.T) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/GODRIVER-1663