### PR TITLE
Added bson to import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ res, err := collection.InsertOne(ctx, bson.M{"name": "pi", "value": 3.14159})
 id := res.InsertedID
 ```
 
+To use `bson.M`, you will need to add `"go.mongodb.org/mongo-driver/mongo/bson"` to your imports.
+
+Your import statement should now look like this:
+
+```go
+import (
+    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/mongo/options"
+    "go.mongodb.org/mongo-driver/mongo/readpref"
+    "go.mongodb.org/mongo-driver/mongo/bson"
+)
+```
+
 Several query methods return a cursor, which can be used like this:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Your import statement should now look like this:
 
 ```go
 import (
+    "go.mongodb.org/mongo-driver/bson"
     "go.mongodb.org/mongo-driver/mongo"
     "go.mongodb.org/mongo-driver/mongo/options"
     "go.mongodb.org/mongo-driver/mongo/readpref"
-    "go.mongodb.org/mongo-driver/bson"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ res, err := collection.InsertOne(ctx, bson.M{"name": "pi", "value": 3.14159})
 id := res.InsertedID
 ```
 
-To use `bson.M`, you will need to add `"go.mongodb.org/mongo-driver/mongo/bson"` to your imports.
+To use `bson.M`, you will need to add `"go.mongodb.org/mongo-driver/bson"` to your imports.
 
 Your import statement should now look like this:
 
@@ -116,7 +116,7 @@ import (
     "go.mongodb.org/mongo-driver/mongo"
     "go.mongodb.org/mongo-driver/mongo/options"
     "go.mongodb.org/mongo-driver/mongo/readpref"
-    "go.mongodb.org/mongo-driver/mongo/bson"
+    "go.mongodb.org/mongo-driver/bson"
 )
 ```
 


### PR DESCRIPTION
This pull request updates the `README.md` with a reminder to the user to import the `"go.mongodb.org/mongo-driver/bson"` package when following the documentation. 