### PR TITLE
GODRIVER-1534 Sync spec tests for incompatible server becoming compatible

### DIFF
--- a/data/server-discovery-and-monitoring/single/too_old_then_upgraded.json
+++ b/data/server-discovery-and-monitoring/single/too_old_then_upgraded.json
@@ -1,0 +1,54 @@
+{
+  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/data/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
+++ b/data/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
@@ -1,0 +1,46 @@
+description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6"
+uri: "mongodb://a"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    },
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: true
+        }
+    }
+]

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -426,8 +426,11 @@ func runTest(t *testing.T, directory string, filename string) {
 			applyErrors(t, topo, phase.ApplicationErrors)
 			if phase.Outcome.Compatible == nil || *phase.Outcome.Compatible {
 				assert.True(t, topo.fsm.compatible.Load().(bool), "Expected servers to be compatible")
+				assert.Nil(t, topo.fsm.compatibilityErr, "expected fsm.compatiblity to be nil, got %v",
+					topo.fsm.compatibilityErr)
 			} else {
 				assert.False(t, topo.fsm.compatible.Load().(bool), "Expected servers to not be compatible")
+				assert.NotNil(t, topo.fsm.compatibilityErr, "expected fsm.compatiblity error to be non-nil")
 				continue
 			}
 			desc := topo.Description()


### PR DESCRIPTION
I added an assertion to the SDAM spec test runner to ensure that `fsm.compatibilityError` is nil if the test expects the topology to be compatible and non-nil if not. This assertion is important to ensure that we won't keep around a stale compatibility error if an incompatible server later becomes compatible.