### PR TITLE
GODRIVER-1659 fail fast during server selection if incompatible WireVersion

### DIFF
--- a/x/mongo/driver/description/topology.go
+++ b/x/mongo/driver/description/topology.go
@@ -17,6 +17,7 @@ type Topology struct {
 	Servers               []Server
 	Kind                  TopologyKind
 	SessionTimeoutMinutes uint32
+	CompatibilityErr      error
 }
 
 // Server returns the server for the given address. Returns false if the server

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -99,7 +99,8 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					supportedWireVersions.Min,
 					minSupportedMongoDBVersion,
 				)
-				return description.Topology{CompatibilityErr: f.compatibilityErr}, s, f.compatibilityErr
+				f.Topology.CompatibilityErr = f.compatibilityErr
+				return f.Topology, s, f.compatibilityErr
 			}
 
 			if server.WireVersion.Min > supportedWireVersions.Max {
@@ -110,7 +111,8 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					server.WireVersion.Min,
 					supportedWireVersions.Max,
 				)
-				return description.Topology{CompatibilityErr: f.compatibilityErr}, s, f.compatibilityErr
+				f.Topology.CompatibilityErr = f.compatibilityErr
+				return f.Topology, s, f.compatibilityErr
 			}
 		}
 	}

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -349,7 +349,7 @@ func (f *fsm) findPrimary() (int, bool) {
 func (f *fsm) findServer(addr address.Address) (int, bool) {
 	canon := addr.Canonicalize()
 	for i, s := range f.Servers {
-		if canon == s.Addr.Canonicalize() {
+		if canon == s.Addr {
 			return i, true
 		}
 	}

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -99,7 +99,7 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					supportedWireVersions.Min,
 					minSupportedMongoDBVersion,
 				)
-				return description.Topology{}, s, f.compatibilityErr
+				return description.Topology{CompatibilityErr: f.compatibilityErr}, s, f.compatibilityErr
 			}
 
 			if server.WireVersion.Min > supportedWireVersions.Max {
@@ -110,7 +110,7 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					server.WireVersion.Min,
 					supportedWireVersions.Max,
 				)
-				return description.Topology{}, s, f.compatibilityErr
+				return description.Topology{CompatibilityErr: f.compatibilityErr}, s, f.compatibilityErr
 			}
 		}
 	}
@@ -349,7 +349,7 @@ func (f *fsm) findPrimary() (int, bool) {
 func (f *fsm) findServer(addr address.Address) (int, bool) {
 	canon := addr.Canonicalize()
 	for i, s := range f.Servers {
-		if canon == s.Addr {
+		if canon == s.Addr.Canonicalize() {
 			return i, true
 		}
 	}

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -100,7 +100,7 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					minSupportedMongoDBVersion,
 				)
 				f.Topology.CompatibilityErr = f.compatibilityErr
-				return f.Topology, s, f.compatibilityErr
+				return f.Topology, s, nil
 			}
 
 			if server.WireVersion.Min > supportedWireVersions.Max {
@@ -112,7 +112,7 @@ func (f *fsm) apply(s description.Server) (description.Topology, description.Ser
 					supportedWireVersions.Max,
 				)
 				f.Topology.CompatibilityErr = f.compatibilityErr
-				return f.Topology, s, f.compatibilityErr
+				return f.Topology, s, nil
 			}
 		}
 	}

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -298,11 +298,6 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 		return nil, ErrTopologyClosed
 	}
 
-	desc := t.Description()
-	if desc.CompatibilityErr != nil {
-		return nil, desc.CompatibilityErr
-	}
-
 	var ssTimeoutCh <-chan time.Time
 
 	if t.cfg.serverSelectionTimeout > 0 {
@@ -317,6 +312,11 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 	for {
 		var suitable []description.Server
 		var selectErr error
+
+		desc := t.Description()
+		if desc.CompatibilityErr != nil {
+			return nil, desc.CompatibilityErr
+		}
 
 		if !doneOnce {
 			// for the first pass, select a server from the current description.
@@ -618,7 +618,7 @@ func (t *Topology) apply(ctx context.Context, desc description.Server) descripti
 	var err error
 	current, desc, err = t.fsm.apply(desc)
 
-	if err != nil && current.CompatibilityErr != nil {
+	if current.CompatibilityErr != nil {
 		updatedDesc := t.Description()
 		updatedDesc.CompatibilityErr = err
 		t.desc.Store(updatedDesc)

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -370,11 +370,6 @@ func (t *Topology) SelectServerLegacy(ctx context.Context, ss description.Server
 		return nil, ErrTopologyClosed
 	}
 
-	desc := t.Description()
-	if desc.CompatibilityErr != nil {
-		return nil, desc.CompatibilityErr
-	}
-
 	var ssTimeoutCh <-chan time.Time
 
 	if t.cfg.serverSelectionTimeout > 0 {
@@ -466,6 +461,10 @@ func (t *Topology) selectServerFromDescription(desc description.Topology,
 
 	// Unlike selectServerFromSubscription, this code path does not check ctx.Done or selectionState.timeoutChan because
 	// selecting a server from a description is not a blocking operation.
+
+	if desc.CompatibilityErr != nil {
+		return nil, desc.CompatibilityErr
+	}
 
 	var allowed []description.Server
 	for _, s := range desc.Servers {

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -313,11 +313,6 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 		var suitable []description.Server
 		var selectErr error
 
-		desc := t.Description()
-		if desc.CompatibilityErr != nil {
-			return nil, desc.CompatibilityErr
-		}
-
 		if !doneOnce {
 			// for the first pass, select a server from the current description.
 			// this improves selection speed for up-to-date topology descriptions.
@@ -617,10 +612,8 @@ func (t *Topology) apply(ctx context.Context, desc description.Server) descripti
 	var err error
 	current, desc, err = t.fsm.apply(desc)
 
-	if current.CompatibilityErr != nil {
-		updatedDesc := t.Description()
-		updatedDesc.CompatibilityErr = err
-		t.desc.Store(updatedDesc)
+	if err != nil {
+		t.desc.Store(current)
 		return desc
 	}
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -618,7 +618,7 @@ func (t *Topology) apply(ctx context.Context, desc description.Server) descripti
 	var err error
 	current, desc, err = t.fsm.apply(desc)
 
-	if err != nil {
+	if err != nil && current.CompatibilityErr != nil {
 		updatedDesc := t.Description()
 		updatedDesc.CompatibilityErr = err
 		t.desc.Store(updatedDesc)

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -611,9 +611,7 @@ func (t *Topology) apply(ctx context.Context, desc description.Server) descripti
 	var current description.Topology
 	var err error
 	current, desc, err = t.fsm.apply(desc)
-
 	if err != nil {
-		t.desc.Store(current)
 		return desc
 	}
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -297,7 +297,6 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 	if atomic.LoadInt32(&t.connectionstate) != connected {
 		return nil, ErrTopologyClosed
 	}
-
 	var ssTimeoutCh <-chan time.Time
 
 	if t.cfg.serverSelectionTimeout > 0 {
@@ -364,7 +363,6 @@ func (t *Topology) SelectServerLegacy(ctx context.Context, ss description.Server
 	if atomic.LoadInt32(&t.connectionstate) != connected {
 		return nil, ErrTopologyClosed
 	}
-
 	var ssTimeoutCh <-chan time.Time
 
 	if t.cfg.serverSelectionTimeout > 0 {

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -103,7 +103,6 @@ func TestServerSelection(t *testing.T) {
 			supportedWireVersions.Max,
 		)
 		desc.CompatibilityErr = want
-		topo.fsm.Servers = desc.Servers
 		atomic.StoreInt32(&topo.connectionstate, connected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
@@ -129,7 +128,6 @@ func TestServerSelection(t *testing.T) {
 			minSupportedMongoDBVersion,
 		)
 		desc.CompatibilityErr = want
-		topo.fsm.Servers = desc.Servers
 		atomic.StoreInt32(&topo.connectionstate, connected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -91,9 +91,9 @@ func TestServerSelection(t *testing.T) {
 		desc := description.Topology{
 			Kind: description.Single,
 			Servers: []description.Server{
-				{Addr: address.Address("one"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 11, Min: 11}},
-				{Addr: address.Address("two"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
-				{Addr: address.Address("three"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
+				{Addr: address.Address("one:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 11, Min: 11}},
+				{Addr: address.Address("two:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
+				{Addr: address.Address("three:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
 			},
 		}
 		serverDesc := description.Server{Addr: address.Address("two"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}}
@@ -116,9 +116,9 @@ func TestServerSelection(t *testing.T) {
 		desc := description.Topology{
 			Kind: description.Single,
 			Servers: []description.Server{
-				{Addr: address.Address("one"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 1, Min: 1}},
-				{Addr: address.Address("two"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
-				{Addr: address.Address("three"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
+				{Addr: address.Address("one:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 1, Min: 1}},
+				{Addr: address.Address("two:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
+				{Addr: address.Address("three:27017"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}},
 			},
 		}
 		serverDesc := description.Server{Addr: address.Address("two"), Kind: description.Standalone, WireVersion: &description.VersionRange{Max: 9, Min: 2}}

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -107,7 +107,7 @@ func TestServerSelection(t *testing.T) {
 		atomic.StoreInt32(&topo.connectionstate, connected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
-		assert.Equal(t, err, want, "expected %v, got %v\n", want, err)
+		assert.Equal(t, err, want, "expected %v, got %v", want, err)
 	})
 	t.Run("Compatibility Error Max Version Too Low", func(t *testing.T) {
 		topo, err := New()


### PR DESCRIPTION
https://jira.mongodb.org/browse/GODRIVER-1659

This pull request will ensure that if any server has an incompatible `WireVersion`, it will fail fast during server selection and return the appropriate error in order to be consistent with the spec. 