### PR TITLE
GODRIVER-1688 Remove UnixNano call from NewDateTimeFromTime

### DIFF
--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -252,7 +252,8 @@ func (dve DefaultValueEncoders) TimeEncodeValue(ec EncodeContext, vw bsonrw.Valu
 		return ValueEncoderError{Name: "TimeEncodeValue", Types: []reflect.Type{tTime}, Received: val}
 	}
 	tt := val.Interface().(time.Time)
-	return vw.WriteDateTime(tt.Unix()*1000 + int64(tt.Nanosecond()/1e6))
+	dt := primitive.NewDateTimeFromTime(tt)
+	return vw.WriteDateTime(int64(dt))
 }
 
 // ByteSliceEncodeValue is the ValueEncoderFunc for []byte.

--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 const (
@@ -101,5 +102,6 @@ func (tc *TimeCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val re
 		return ValueEncoderError{Name: "TimeEncodeValue", Types: []reflect.Type{tTime}, Received: val}
 	}
 	tt := val.Interface().(time.Time)
-	return vw.WriteDateTime(tt.Unix()*1000 + int64(tt.Nanosecond()/1e6))
+	dt := primitive.NewDateTimeFromTime(tt)
+	return vw.WriteDateTime(int64(dt))
 }

--- a/bson/bsonrw/extjson_wrappers.go
+++ b/bson/bsonrw/extjson_wrappers.go
@@ -217,7 +217,7 @@ func parseDatetimeString(data string) (int64, error) {
 		return 0, fmt.Errorf("invalid $date value string: %s", data)
 	}
 
-	return t.Unix()*1e3 + int64(t.Nanosecond())/1e6, nil
+	return int64(primitive.NewDateTimeFromTime(t)), nil
 }
 
 func parseDatetimeObject(data *extJSONObject) (d int64, err error) {

--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -73,7 +73,7 @@ func (d DateTime) Time() time.Time {
 
 // NewDateTimeFromTime creates a new DateTime from a Time.
 func NewDateTimeFromTime(t time.Time) DateTime {
-	return DateTime(t.UnixNano() / 1000000)
+	return DateTime(t.Unix()*1e3 + int64(t.Nanosecond())/1e6)
 }
 
 // Null represents the BSON null value.

--- a/bson/primitive/primitive_test.go
+++ b/bson/primitive/primitive_test.go
@@ -9,6 +9,7 @@ package primitive
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
@@ -100,6 +101,20 @@ func TestDateTime(t *testing.T) {
 			err := json.Unmarshal(jsonBytes, &dt)
 			assert.Nil(t, err, "Unmarshal error: %v", err)
 			assert.Equal(t, DateTime(0), dt, "expected DateTime value to be 0, got %v", dt)
+		})
+	})
+	t.Run("NewDateTimeFromTime", func(t *testing.T) {
+		t.Run("range is not limited", func(t *testing.T) {
+			// If the implementation internally calls time.Time.UnixNano(), the constructor cannot handle times after
+			// the year 2262.
+
+			timeFormat := "2006-01-02T15:04:05.999Z07:00"
+			timeString := "3001-01-01T00:00:00Z"
+			tt, err := time.Parse(timeFormat, timeString)
+			assert.Nil(t, err, "Parse error: %v", err)
+
+			dt := NewDateTimeFromTime(tt)
+			assert.True(t, dt > 0, "expected a valid DateTime greater than 0, got %v", dt)
 		})
 	})
 }


### PR DESCRIPTION
I also went through and changed places that were directly converting `time.Time` to int64 to use `NewDateTimeFromTime` instead.