### PR TITLE
GODRIVER-1511 Test that SDAM flow is always run

### DIFF
--- a/data/server-discovery-and-monitoring/rs/repeated.json
+++ b/data/server-discovery-and-monitoring/rs/repeated.json
@@ -1,0 +1,140 @@
+{
+  "description": "Repeated ismaster response must be processed",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/data/server-discovery-and-monitoring/rs/repeated.yml
+++ b/data/server-discovery-and-monitoring/rs/repeated.yml
@@ -1,0 +1,101 @@
+description: Repeated ismaster response must be processed
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases:
+  # Phase 1 - a says it's not primary and suggests c may be the primary
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 2 - c says it's a standalone, is removed
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 3 - response from a is repeated, and must be processed; c added again
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 4 - c is now a primary
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "c:27017":
+          type: RSPrimary
+          setName: rs
+      topologyType: "ReplicaSetWithPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"


### PR DESCRIPTION
We were already running the SDAM flow for every new server description, regardless of equality, so the only changes here are spec test resyncs.