### PR TITLE
GODRIVER-1489 Ensure server check is cancelled for network errors during handshake

### DIFF
--- a/mongo/integration/json_helpers_test.go
+++ b/mongo/integration/json_helpers_test.go
@@ -98,7 +98,7 @@ func createClientOptions(t testing.TB, opts bson.Raw) *options.ClientOptions {
 			clientOpts.SetConnectTimeout(ct)
 		case "serverSelectionTimeoutMS":
 			sst := convertValueToMilliseconds(t, opt)
-			clientOpts.SetConnectTimeout(sst)
+			clientOpts.SetServerSelectionTimeout(sst)
 		default:
 			t.Fatalf("unrecognized client option: %v", name)
 		}

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -276,6 +276,7 @@ func (s *Server) ProcessHandshakeError(err error, startingGenerationNumber uint6
 	// checking logic above has already determined that this description is not stale.
 	s.updateDescription(description.NewServerFromError(s.address, wrappedConnErr, nil))
 	s.pool.clear()
+	s.cancelCheck()
 }
 
 // Description returns a description of the server as of the last heartbeat.


### PR DESCRIPTION
We cancel the check when a network error happens during an operation after the
connection handshake, but not when one happens during a connection handshake.
This commit fixes that.