### PR TITLE
GODRIVER-1662 Respect context.Cancellation for network operations

### DIFF
--- a/internal/cancellation_listener.go
+++ b/internal/cancellation_listener.go
@@ -24,19 +24,14 @@ func NewCancellationListener() *CancellationListener {
 // detects that the context has been cancelled (i.e. ctx.Err() == context.Canceled), the provided callback is called to
 // abort in-progress work. Even if the context expires, this function will block until StopListening is called.
 func (c *CancellationListener) Listen(ctx context.Context, abortFn func()) {
-	for {
-		select {
-		case <-ctx.Done():
-			if ctx.Err() != context.Canceled {
-				continue
-			}
-
+	select {
+	case <-ctx.Done():
+		if ctx.Err() == context.Canceled {
 			abortFn()
-			<-c.done
-			return
-		case <-c.done:
-			return
 		}
+
+		<-c.done
+	case <-c.done:
 	}
 }
 

--- a/internal/cancellation_listener.go
+++ b/internal/cancellation_listener.go
@@ -1,0 +1,46 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import "context"
+
+// CancellationListener listens for context cancellation in a loop until the context expires or the listener is aborted.
+type CancellationListener struct {
+	done chan struct{}
+}
+
+// NewCancellationListener constructs a CancellationListener.
+func NewCancellationListener() *CancellationListener {
+	return &CancellationListener{
+		done: make(chan struct{}),
+	}
+}
+
+// Listen loops until the provided context is cancelled or listening is aborted via the StopListening function. If this
+// detects that the context has been cancelled (i.e. ctx.Err() == context.Canceled), the provided callback is called to
+// abort in-progress work. Even if the context expires, this function will block until StopListening is called.
+func (c *CancellationListener) Listen(ctx context.Context, abortFn func()) {
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() != context.Canceled {
+				continue
+			}
+
+			abortFn()
+			<-c.done
+			return
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// StopListening stops the in-progress Listen call. This function will block if there is no in-progress Listen call.
+func (c *CancellationListener) StopListening() {
+	c.done <- struct{}{}
+}

--- a/internal/cancellation_listener.go
+++ b/internal/cancellation_listener.go
@@ -20,7 +20,7 @@ func NewCancellationListener() *CancellationListener {
 	}
 }
 
-// Listen loops until the provided context is cancelled or listening is aborted via the StopListening function. If this
+// Listen blocks until the provided context is cancelled or listening is aborted via the StopListening function. If this
 // detects that the context has been cancelled (i.e. ctx.Err() == context.Canceled), the provided callback is called to
 // abort in-progress work. Even if the context expires, this function will block until StopListening is called.
 func (c *CancellationListener) Listen(ctx context.Context, abortFn func()) {

--- a/x/mongo/driver/topology/cancellation_listener.go
+++ b/x/mongo/driver/topology/cancellation_listener.go
@@ -10,5 +10,5 @@ import "context"
 
 type cancellationListener interface {
 	Listen(context.Context, func())
-	StopListening()
+	StopListening() bool
 }

--- a/x/mongo/driver/topology/cancellation_listener.go
+++ b/x/mongo/driver/topology/cancellation_listener.go
@@ -1,0 +1,14 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package topology
+
+import "context"
+
+type cancellationListener interface {
+	Listen(context.Context, func())
+	StopListening()
+}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -404,6 +404,8 @@ func TestConnection(t *testing.T) {
 				want := ConnectionError{ConnectionID: conn.id, Wrapped: context.Canceled, message: "unable to read server response"}
 				_, err := conn.readWireMessage(context.Background(), nil)
 				assert.Equal(t, want, err, "expected error %v, got %v", want, err)
+				assert.Equal(t, disconnected, conn.connected, "expected connection state %v, got %v", disconnected,
+					conn.connected)
 			})
 		})
 		t.Run("close", func(t *testing.T) {


### PR DESCRIPTION
We could do this by adding a `connection.listenForCancellation` function and a channel to signal that the listening should stop, but this is difficult to test. Consider the case where `writeWireMessage` doesn't write to the channel to signal that the `listenForCancellation` function should stop. Everything still works, but we have a goroutine leak because `listenForCancellation` blocks waiting on the channel write, which doesn't happen. To make this easier to test, I added a `CancellationListener` abstraction, which can be mocked in tests to track the number of times `Listen` and `StopListening` are called.