### PR TITLE
GODRIVER-613 Remove error return from bsoncore builders

### DIFF
--- a/x/bsonx/bsoncore/bson_arraybuilder.go
+++ b/x/bsonx/bsoncore/bson_arraybuilder.go
@@ -36,17 +36,13 @@ func (a *ArrayBuilder) startArray() *ArrayBuilder {
 
 // Build updates the length of the array and index to the beginning of the documents length
 // bytes, then returns the array (bson bytes)
-func (a *ArrayBuilder) Build() (Array, error) {
+func (a *ArrayBuilder) Build() Array {
 	lastIndex := len(a.indexes) - 1
 	lastKey := len(a.keys) - 1
-	var err error
-	a.arr, err = AppendArrayEnd(a.arr, a.indexes[lastIndex])
-	if err != nil {
-		return nil, err
-	}
+	a.arr, _ = AppendArrayEnd(a.arr, a.indexes[lastIndex])
 	a.indexes = a.indexes[:lastIndex]
 	a.keys = a.keys[:lastKey]
-	return a.arr, nil
+	return a.arr
 }
 
 // incrementKey() increments the value keys and returns the key to be used to a.appendArray* functions
@@ -194,6 +190,6 @@ func (a *ArrayBuilder) StartArray() *ArrayBuilder {
 
 // FinishArray builds the most recent array created
 func (a *ArrayBuilder) FinishArray() *ArrayBuilder {
-	a.arr, _ = a.Build()
+	a.arr = a.Build()
 	return a
 }

--- a/x/bsonx/bsoncore/bson_arraybuilder_test.go
+++ b/x/bsonx/bsoncore/bson_arraybuilder_test.go
@@ -177,7 +177,7 @@ func TestArrayBuilder(t *testing.T) {
 				params = append(params, reflect.ValueOf(param))
 			}
 			results := fn.Call(params)
-			got, _ := results[0].Interface().(*ArrayBuilder).Build()
+			got := results[0].Interface().(*ArrayBuilder).Build()
 			want := tc.expected
 			if !bytes.Equal(got, want) {
 				t.Errorf("Did not receive expected bytes. got %v; want %v", got, want)
@@ -187,8 +187,8 @@ func TestArrayBuilder(t *testing.T) {
 	t.Run("TestBuildTwoElementsArray", func(t *testing.T) {
 		intArr := BuildDocumentFromElements(nil, AppendInt32Element(nil, "0", int32(1)))
 		expected := BuildDocumentFromElements(nil, AppendArrayElement(AppendInt32Element(nil, "0", int32(3)), "1", intArr))
-		elem, _ := NewArrayBuilder().AppendInt32(int32(1)).Build()
-		result, _ := NewArrayBuilder().AppendInt32(int32(3)).AppendArray(elem).Build()
+		elem := NewArrayBuilder().AppendInt32(int32(1)).Build()
+		result := NewArrayBuilder().AppendInt32(int32(3)).AppendArray(elem).Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Arrays do not match. got %v; want %v", result, expected)
 		}
@@ -197,7 +197,7 @@ func TestArrayBuilder(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendInt32Element(nil, "0", int32(256)))
 		var expected Document
 		expected = BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docElement))
-		result, _ := NewArrayBuilder().StartArray().AppendInt32(int32(256)).FinishArray().Build()
+		result := NewArrayBuilder().StartArray().AppendInt32(int32(256)).FinishArray().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
 		}
@@ -207,7 +207,7 @@ func TestArrayBuilder(t *testing.T) {
 		docInline := BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docElement))
 		var expected Document
 		expected = BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docInline))
-		result, _ := NewArrayBuilder().StartArray().StartArray().AppendDouble(3.14).FinishArray().FinishArray().Build()
+		result := NewArrayBuilder().StartArray().StartArray().AppendDouble(3.14).FinishArray().FinishArray().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
 		}

--- a/x/bsonx/bsoncore/bson_documentbuilder.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder.go
@@ -32,15 +32,11 @@ func NewDocumentBuilder() *DocumentBuilder {
 
 // Build updates the length of the document and index to the beginning of the documents length
 // bytes, then returns the document (bson bytes)
-func (db *DocumentBuilder) Build() (Document, error) {
+func (db *DocumentBuilder) Build() Document {
 	last := len(db.indexes) - 1
-	var err error
-	db.doc, err = AppendDocumentEnd(db.doc, db.indexes[last])
-	if err != nil {
-		return nil, err
-	}
+	db.doc, _ = AppendDocumentEnd(db.doc, db.indexes[last])
 	db.indexes = db.indexes[:last]
-	return db.doc, nil
+	return db.doc
 }
 
 // AppendInt32 will append an int32 element using key and i32 to DocumentBuilder.doc
@@ -182,6 +178,6 @@ func (db *DocumentBuilder) StartDocument(key string) *DocumentBuilder {
 
 // FinishDocument builds the most recent document created
 func (db *DocumentBuilder) FinishDocument() *DocumentBuilder {
-	db.doc, _ = db.Build()
+	db.doc = db.Build()
 	return db
 }

--- a/x/bsonx/bsoncore/bson_documentbuilder_test.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder_test.go
@@ -179,7 +179,7 @@ func TestDocumentBuilder(t *testing.T) {
 			}
 			results := fn.Call(params)
 			got := results[0].Interface().(*DocumentBuilder)
-			doc, _ := got.Build()
+			doc := got.Build()
 			want := tc.expected
 			if !bytes.Equal(doc, want) {
 				t.Errorf("Did not receive expected bytes. got %v; want %v", got, want)
@@ -189,8 +189,8 @@ func TestDocumentBuilder(t *testing.T) {
 	t.Run("TestBuildTwoElements", func(t *testing.T) {
 		intArr := BuildDocumentFromElements(nil, AppendInt32Element(nil, "0", int32(1)))
 		expected := BuildDocumentFromElements(nil, AppendArrayElement(AppendInt32Element(nil, "x", int32(3)), "y", intArr))
-		elem, _ := NewArrayBuilder().AppendInt32(int32(1)).Build()
-		result, _ := NewDocumentBuilder().AppendInt32("x", int32(3)).AppendArray("y", elem).Build()
+		elem := NewArrayBuilder().AppendInt32(int32(1)).Build()
+		result := NewDocumentBuilder().AppendInt32("x", int32(3)).AppendArray("y", elem).Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
 		}
@@ -199,7 +199,7 @@ func TestDocumentBuilder(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendInt32Element(nil, "x", int32(256)))
 		var expected Document
 		expected = BuildDocumentFromElements(nil, AppendDocumentElement(nil, "y", docElement))
-		result, _ := NewDocumentBuilder().StartDocument("y").AppendInt32("x", int32(256)).FinishDocument().Build()
+		result := NewDocumentBuilder().StartDocument("y").AppendInt32("x", int32(256)).FinishDocument().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
 		}
@@ -209,7 +209,7 @@ func TestDocumentBuilder(t *testing.T) {
 		docInline := BuildDocumentFromElements(nil, AppendDocumentElement(nil, "y", docElement))
 		var expected Document
 		expected = BuildDocumentFromElements(nil, AppendDocumentElement(nil, "z", docInline))
-		result, _ := NewDocumentBuilder().StartDocument("z").StartDocument("y").AppendDouble("x", 3.14).FinishDocument().FinishDocument().Build()
+		result := NewDocumentBuilder().StartDocument("z").StartDocument("y").AppendDouble("x", 3.14).FinishDocument().FinishDocument().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
 		}


### PR DESCRIPTION
The DocumentBuilder and ArrayBuilder Build() functions return both a Document/Array and an error, so they can't be used inline when declaring a struct. They don't need to return errors, though, because we're building the BSON, so we know it is not malformed.