### PR TITLE
GODRIVER-526 Unskip keys in command monitoring assertions

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -279,7 +279,7 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 		Session(sess).WriteConcern(wc).CommandMonitor(coll.client.monitor).
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
-		Deployment(coll.client.deployment).Crypt(coll.client.crypt)
+		Deployment(coll.client.deployment).Crypt(coll.client.crypt).Ordered(true)
 	imo := options.MergeInsertManyOptions(opts...)
 	if imo.BypassDocumentValidation != nil && *imo.BypassDocumentValidation {
 		op = op.BypassDocumentValidation(*imo.BypassDocumentValidation)
@@ -454,7 +454,7 @@ func (coll *Collection) delete(ctx context.Context, filter interface{}, deleteOn
 		Session(sess).WriteConcern(wc).CommandMonitor(coll.client.monitor).
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
-		Deployment(coll.client.deployment).Crypt(coll.client.crypt)
+		Deployment(coll.client.deployment).Crypt(coll.client.crypt).Ordered(true)
 	if do.Hint != nil {
 		op = op.Hint(true)
 	}
@@ -551,7 +551,7 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.crypt).Hint(uo.Hint != nil).
-		ArrayFilters(uo.ArrayFilters != nil)
+		ArrayFilters(uo.ArrayFilters != nil).Ordered(true)
 
 	if uo.BypassDocumentValidation != nil && *uo.BypassDocumentValidation {
 		op = op.BypassDocumentValidation(*uo.BypassDocumentValidation)

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -325,6 +325,10 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 	if lco.NameOnly != nil {
 		op = op.NameOnly(*lco.NameOnly)
 	}
+	if lco.BatchSize != nil {
+		op = op.BatchSize(*lco.BatchSize)
+	}
+
 	retry := driver.RetryNone
 	if db.client.retryReads {
 		retry = driver.RetryOncePerCommand

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -109,45 +109,66 @@ func TestDatabase(t *testing.T) {
 	})
 
 	mt.RunOpts("list collections", noClientOpts, func(mt *mtest.T) {
-		testCases := []struct {
-			name             string
-			expectedTopology mtest.TopologyKind
-			cappedOnly       bool
-		}{
-			{"standalone no filter", mtest.Single, false},
-			{"standalone filter", mtest.Single, true},
-			{"replica set no filter", mtest.ReplicaSet, false},
-			{"replica set filter", mtest.ReplicaSet, true},
-			{"sharded no filter", mtest.Sharded, false},
-			{"sharded filter", mtest.Sharded, true},
-		}
-		for _, tc := range testCases {
-			tcOpts := mtest.NewOptions().Topologies(tc.expectedTopology)
-			mt.RunOpts(tc.name, tcOpts, func(mt *mtest.T) {
-				mt.CreateCollection(mtest.Collection{Name: listCollUncapped}, true)
-				mt.CreateCollection(mtest.Collection{
-					Name:       listCollCapped,
-					CreateOpts: bson.D{{"capped", true}, {"size", 64 * 1024}},
-				}, true)
+		mt.RunOpts("verify results", noClientOpts, func(mt *mtest.T) {
+			testCases := []struct {
+				name             string
+				expectedTopology mtest.TopologyKind
+				cappedOnly       bool
+			}{
+				{"standalone no filter", mtest.Single, false},
+				{"standalone filter", mtest.Single, true},
+				{"replica set no filter", mtest.ReplicaSet, false},
+				{"replica set filter", mtest.ReplicaSet, true},
+				{"sharded no filter", mtest.Sharded, false},
+				{"sharded filter", mtest.Sharded, true},
+			}
+			for _, tc := range testCases {
+				tcOpts := mtest.NewOptions().Topologies(tc.expectedTopology)
+				mt.RunOpts(tc.name, tcOpts, func(mt *mtest.T) {
+					mt.CreateCollection(mtest.Collection{Name: listCollUncapped}, true)
+					mt.CreateCollection(mtest.Collection{
+						Name:       listCollCapped,
+						CreateOpts: bson.D{{"capped", true}, {"size", 64 * 1024}},
+					}, true)
 
-				filter := bson.D{}
-				if tc.cappedOnly {
-					filter = bson.D{{"options.capped", true}}
-				}
-
-				var err error
-				for i := 0; i < 1; i++ {
-					cursor, err := mt.DB.ListCollections(mtest.Background, filter)
-					assert.Nil(mt, err, "ListCollections error (iteration %v): %v", i, err)
-
-					err = verifyListCollections(cursor, tc.cappedOnly)
-					if err == nil {
-						return
+					filter := bson.D{}
+					if tc.cappedOnly {
+						filter = bson.D{{"options.capped", true}}
 					}
-				}
-				mt.Fatalf("error verifying list collections result: %v", err)
-			})
-		}
+
+					var err error
+					for i := 0; i < 1; i++ {
+						cursor, err := mt.DB.ListCollections(mtest.Background, filter)
+						assert.Nil(mt, err, "ListCollections error (iteration %v): %v", i, err)
+
+						err = verifyListCollections(cursor, tc.cappedOnly)
+						if err == nil {
+							return
+						}
+					}
+					mt.Fatalf("error verifying list collections result: %v", err)
+				})
+			}
+		})
+		mt.RunOpts("batch size", mtest.NewOptions().MinServerVersion("3.0"), func(mt *mtest.T) {
+			// Create two new collections so there will be three total.
+			for i := 0; i < 2; i++ {
+				mt.CreateCollection(mtest.Collection{
+					Name: fmt.Sprintf("list-collections-batchSize-%d", i),
+				}, true)
+			}
+
+			mt.ClearEvents()
+			lcOpts := options.ListCollections().SetBatchSize(2)
+			_, err := mt.DB.ListCollectionNames(mtest.Background, bson.D{}, lcOpts)
+			assert.Nil(mt, err, "ListCollectionNames error: %v", err)
+
+			evt := mt.GetStartedEvent()
+			assert.Equal(mt, "listCollections", evt.CommandName, "expected 'listCollections' command to be sent, got %q",
+				evt.CommandName)
+			_, err = evt.Command.LookupErr("cursor", "batchSize")
+			assert.Nil(mt, err, "expected command %s to contain key 'batchSize'", evt.Command)
+		})
 	})
 
 	mt.RunOpts("run command cursor", noClientOpts, func(mt *mtest.T) {

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -10,6 +10,9 @@ package options
 type ListCollectionsOptions struct {
 	// If true, each collection document will only contain a field for the collection name. The default value is false.
 	NameOnly *bool
+
+	// The maximum number of documents to be included in each batch returned by the server.
+	BatchSize *int32
 }
 
 // ListCollections creates a new ListCollectionsOptions instance.
@@ -23,6 +26,12 @@ func (lc *ListCollectionsOptions) SetNameOnly(b bool) *ListCollectionsOptions {
 	return lc
 }
 
+// SetBatchSize sets the value for the BatchSize field.
+func (lc *ListCollectionsOptions) SetBatchSize(size int32) *ListCollectionsOptions {
+	lc.BatchSize = &size
+	return lc
+}
+
 // MergeListCollectionsOptions combines the given ListCollectionsOptions instances into a single *ListCollectionsOptions
 // in a last-one-wins fashion.
 func MergeListCollectionsOptions(opts ...*ListCollectionsOptions) *ListCollectionsOptions {
@@ -33,6 +42,9 @@ func MergeListCollectionsOptions(opts ...*ListCollectionsOptions) *ListCollectio
 		}
 		if opt.NameOnly != nil {
 			lc.NameOnly = opt.NameOnly
+		}
+		if opt.BatchSize != nil {
+			lc.BatchSize = opt.BatchSize
 		}
 	}
 

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -34,6 +34,7 @@ type ListCollections struct {
 	selector       description.ServerSelector
 	retry          *driver.RetryMode
 	result         driver.CursorResponse
+	batchSize      *int32
 }
 
 // NewListCollections constructs and returns a new ListCollections.
@@ -95,6 +96,12 @@ func (lc *ListCollections) command(dst []byte, desc description.SelectedServer) 
 	if lc.nameOnly != nil {
 		dst = bsoncore.AppendBooleanElement(dst, "nameOnly", *lc.nameOnly)
 	}
+	cursorDoc := bsoncore.NewDocumentBuilder()
+	if lc.batchSize != nil {
+		cursorDoc.AppendInt32("batchSize", *lc.batchSize)
+	}
+	dst = bsoncore.AppendDocumentElement(dst, "cursor", cursorDoc.Build())
+
 	return dst, nil
 }
 
@@ -206,5 +213,15 @@ func (lc *ListCollections) Retry(retry driver.RetryMode) *ListCollections {
 	}
 
 	lc.retry = &retry
+	return lc
+}
+
+// BatchSize specifies the number of documents to return in every batch.
+func (lc *ListCollections) BatchSize(batchSize int32) *ListCollections {
+	if lc == nil {
+		lc = new(ListCollections)
+	}
+
+	lc.batchSize = &batchSize
 	return lc
 }


### PR DESCRIPTION
Summary of changes:

1. `Collection.Insert*`, `Collection.Delete*`, and `Collection.Update*` helpers changed to `ordered: true` unconditionally.
2. `ListCollections` changed to accept a `BatchSize` option. The command generation now appends a `cursor` subdocument, similar to that for `aggregate`. There is a new test in `mongo/integration/database_test.go` for this option.
3. The expectation comparison code in our test runners changed to use `LookupErr` instead of `Lookup`. It now uses `assert.Nil`/`assert.NotNil` on that error to assert that a field is present/absent in a command.