### PR TITLE
GODRIVER-1653 Use non-timeout context for AbortTransaction

### DIFF
--- a/internal/background_context.go
+++ b/internal/background_context.go
@@ -1,0 +1,34 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import "context"
+
+// backgroundContext is an implementation of the context.Context interface that wraps a child Context. Value requests
+// are forwarded to the child Context but the Done and Err functions are overridden to ensure the new context does not
+// time out or get cancelled.
+type backgroundContext struct {
+	context.Context
+	childValuesCtx context.Context
+}
+
+// NewBackgroundContext creates a new Context whose behavior matches that of context.Background(), but Value calls are
+// forwarded to the provided ctx parameter. If ctx is nil, context.Background() is returned.
+func NewBackgroundContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+
+	return &backgroundContext{
+		Context:        context.Background(),
+		childValuesCtx: ctx,
+	}
+}
+
+func (b *backgroundContext) Value(key interface{}) interface{} {
+	return b.childValuesCtx.Value(key)
+}

--- a/internal/background_context_test.go
+++ b/internal/background_context_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+)
+
+func TestBackgroundContext(t *testing.T) {
+	t.Run("NewBackgroundContext accepts a nil child", func(t *testing.T) {
+		ctx := NewBackgroundContext(nil)
+		assert.Equal(t, context.Background(), ctx, "expected context.Background() for a nil child")
+	})
+	t.Run("Value requests are forwarded", func(t *testing.T) {
+		// Tests the Value function.
+
+		type ctxKey struct{}
+		expectedVal := "value"
+		childCtx := context.WithValue(context.Background(), ctxKey{}, expectedVal)
+
+		ctx := NewBackgroundContext(childCtx)
+		gotVal, ok := ctx.Value(ctxKey{}).(string)
+		assert.True(t, ok, "expected context to contain a string value for ctxKey")
+		assert.Equal(t, expectedVal, gotVal, "expected value for ctxKey to be %q, got %q", expectedVal, gotVal)
+	})
+	t.Run("background context does not have a deadline", func(t *testing.T) {
+		// Tests the Deadline function.
+
+		childCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		ctx := NewBackgroundContext(childCtx)
+		deadline, ok := ctx.Deadline()
+		assert.False(t, ok, "expected context to have no deadline, but got %v", deadline)
+	})
+	t.Run("background context cannot be cancelled", func(t *testing.T) {
+		// Tests the Done and Err functions.
+
+		childCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ctx := NewBackgroundContext(childCtx)
+		select {
+		case <-ctx.Done():
+			t.Fatalf("expected context to not expire, but Done channel had a value; ctx error: %v", ctx.Err())
+		default:
+		}
+		assert.Nil(t, ctx.Err(), "expected context error to be nil, got %v", ctx.Err())
+	})
+}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -99,8 +99,10 @@ func SessionFromContext(ctx context.Context) Session {
 // callback, sessCtx must be used as the Context parameter for any operations that should be part of the transaction. If
 // the ctx parameter already has a Session attached to it, it will be replaced by this session. The fn callback may be
 // run multiple times during WithTransaction due to retry attempts, so it must be idempotent. Non-retryable operation
-// errors or any operation errors that occur after the timeout expires will be returned without retrying. For a usage
-// example, see the Client.StartSession method documentation.
+// errors or any operation errors that occur after the timeout expires will be returned without retrying. If the
+// callback fails, the driver will call AbortTransaction. Because this method must succeed to ensure that server-side
+// resources are properly cleaned up, context deadlines and cancellations will not be respected during this call. For a
+// usage example, see the Client.StartSession method documentation.
 //
 // ClusterTime, OperationTime, Client, and ID return the session's current operation time, the session's current cluster
 // time, the Client associated with the session, and the ID document associated with the session, respectively. The ID
@@ -182,7 +184,9 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 		res, err := fn(NewSessionContext(ctx, s))
 		if err != nil {
 			if s.clientSession.TransactionRunning() {
-				_ = s.AbortTransaction(ctx)
+				// Wrap the user-provided Context in a new one that behaves like context.Background() for deadlines and
+				// cancellations, but forwards Value requests to the original one.
+				_ = s.AbortTransaction(internal.NewBackgroundContext(ctx))
 			}
 
 			select {
@@ -252,10 +256,6 @@ func (s *sessionImpl) StartTransaction(opts ...*options.TransactionOptions) erro
 
 // AbortTransaction implements the Session interface.
 func (s *sessionImpl) AbortTransaction(ctx context.Context) error {
-	// Wrap the user-provided Context in a new one that behaves like context.Background() for deadlines and
-	// cancellations, but forwards Value requests to the original one.
-	ctx = internal.NewBackgroundContext(ctx)
-
 	err := s.clientSession.CheckAbortTransaction()
 	if err != nil {
 		return err

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -88,11 +88,7 @@ func SessionFromContext(ctx context.Context) Session {
 // active transaction for this session or the transaction has been aborted.
 //
 // AbortTransaction aborts the active transaction for this session. This method will return an error if there is no
-// active transaction for this session or the transaction has been committed or aborted. Because this method has to run
-// successfully to ensure that the server-side resources for a transaction are cleaned up, it will overwrite the context
-// passed to it with a context that has no deadline and cannot be cancelled. The new context will wrap the original
-// context and will propagate context.Value() requests to the original one. This allows for context values to be used
-// with the command monitoring API.
+// active transaction for this session or the transaction has been committed or aborted.
 //
 // WithTransaction starts a transaction on this session and runs the fn callback. Errors with the
 // TransientTransactionError and UnknownTransactionCommitResult labels are retried for up to 120 seconds. Inside the

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -9,6 +9,7 @@ package mongo
 import (
 	"context"
 	"errors"
+	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -28,8 +29,11 @@ import (
 )
 
 var (
-	connsCheckedOut  int
-	errorInterrupted int32 = 11601
+	connsCheckedOut        int
+	errorInterrupted       int32 = 11601
+	withTxnStartedEvents   []*event.CommandStartedEvent
+	withTxnSucceededEvents []*event.CommandSucceededEvent
+	withTxnFailedEvents    []*event.CommandFailedEvent
 )
 
 func TestConvenientTransactions(t *testing.T) {
@@ -177,9 +181,82 @@ func TestConvenientTransactions(t *testing.T) {
 				"expected error with label %v, got %v", driver.TransientTransactionError, cmdErr)
 		})
 	})
+	t.Run("abortTransaction does not time out", func(t *testing.T) {
+		// Create a special CommandMonitor that only records information about abortTransaction events and also
+		// records the Context used in the CommandStartedEvent listener.
+		var abortStarted []*event.CommandStartedEvent
+		var abortSucceeded []*event.CommandSucceededEvent
+		var abortFailed []*event.CommandFailedEvent
+		var abortCtx context.Context
+		monitor := &event.CommandMonitor{
+			Started: func(ctx context.Context, evt *event.CommandStartedEvent) {
+				if evt.CommandName == "abortTransaction" {
+					abortStarted = append(abortStarted, evt)
+					if abortCtx == nil {
+						abortCtx = ctx
+					}
+				}
+			},
+			Succeeded: func(_ context.Context, evt *event.CommandSucceededEvent) {
+				if evt.CommandName == "abortTransaction" {
+					abortSucceeded = append(abortSucceeded, evt)
+				}
+			},
+			Failed: func(_ context.Context, evt *event.CommandFailedEvent) {
+				if evt.CommandName == "abortTransaction" {
+					log.Printf("FAILED: %v\n", evt.Failure)
+					abortFailed = append(abortFailed, evt)
+				}
+			},
+		}
+
+		client := setupConvenientTransactions(t, options.Client().SetMonitor(monitor))
+		coll := client.Database("foo").Collection("bar")
+		sess, err := client.StartSession()
+		assert.Nil(t, err, "StartSession error: %v", err)
+		defer func() {
+			sess.EndSession(bgCtx)
+			_ = coll.Drop(bgCtx)
+			_ = client.Disconnect(bgCtx)
+		}()
+
+		// Create a cancellable Context with a value for ctxKey.
+		type ctxKey struct{}
+		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKey{}, "foobar"))
+		defer cancel()
+
+		// The WithTransaction callback does an Insert to ensure that the txn has been started server-side. After the
+		// insert succeeds, it cancels the Context created above and returns a non-retryable error, which forces
+		// WithTransaction to abort the txn.
+		callbackErr := errors.New("error")
+		callback := func(sc SessionContext) (interface{}, error) {
+			_, err = coll.InsertOne(sc, bson.D{{"x", 1}})
+			if err != nil {
+				return nil, err
+			}
+
+			cancel()
+			return nil, callbackErr
+		}
+
+		_, err = sess.WithTransaction(ctx, callback)
+		assert.Equal(t, callbackErr, err, "expected WithTransaction error %v, got %v", callbackErr, err)
+
+		// Assert that abortTransaction was sent once and succeede.
+		assert.Equal(t, 1, len(abortStarted), "expected 1 abortTransaction started event, got %d", len(abortStarted))
+		assert.Equal(t, 1, len(abortSucceeded), "expected 1 abortTransaction succeeded event, got %d",
+			len(abortSucceeded))
+		assert.Equal(t, 0, len(abortFailed), "expected 0 abortTransaction failed event, got %d", len(abortFailed))
+
+		// Assert that the Context propagated to the CommandStartedEvent listener for abortTransaction contained a value
+		// for ctxKey.
+		ctxValue, ok := abortCtx.Value(ctxKey{}).(string)
+		assert.True(t, ok, "expected context for abortTransaction to contain ctxKey")
+		assert.Equal(t, "foobar", ctxValue, "expected value for ctxKey to be 'world', got %s", ctxValue)
+	})
 }
 
-func setupConvenientTransactions(t *testing.T) *Client {
+func setupConvenientTransactions(t *testing.T, extraClientOpts ...*options.ClientOptions) *Client {
 	cs := testutil.ConnString(t)
 	poolMonitor := &event.PoolMonitor{
 		Event: func(evt *event.PoolEvent) {
@@ -191,9 +268,11 @@ func setupConvenientTransactions(t *testing.T) *Client {
 			}
 		},
 	}
+
 	clientOpts := options.Client().ApplyURI(cs.Original).SetReadPreference(readpref.Primary()).
 		SetWriteConcern(writeconcern.New(writeconcern.WMajority())).SetPoolMonitor(poolMonitor)
-	client, err := Connect(bgCtx, clientOpts)
+	fullClientOpts := []*options.ClientOptions{clientOpts}
+	client, err := Connect(bgCtx, append(fullClientOpts, extraClientOpts...)...)
 	assert.Nil(t, err, "Connect error: %v", err)
 
 	version, err := getServerVersion(client.Database("admin"))

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -9,7 +9,6 @@ package mongo
 import (
 	"context"
 	"errors"
-	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -204,7 +203,6 @@ func TestConvenientTransactions(t *testing.T) {
 			},
 			Failed: func(_ context.Context, evt *event.CommandFailedEvent) {
 				if evt.CommandName == "abortTransaction" {
-					log.Printf("FAILED: %v\n", evt.Failure)
 					abortFailed = append(abortFailed, evt)
 				}
 			},

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -210,8 +210,15 @@ func TestConvenientTransactions(t *testing.T) {
 			},
 		}
 
+		// Set up a new Client using the command monitor defined above get a handle to a collection. The collection
+		// needs to be explicitly created on the server because implicit collection creation is not allowed in
+		// transactions for server versions <= 4.2.
 		client := setupConvenientTransactions(t, options.Client().SetMonitor(monitor))
-		coll := client.Database("foo").Collection("bar")
+		db := client.Database("foo")
+		coll := db.Collection("bar")
+		err := db.RunCommand(bgCtx, bson.D{{"create", coll.Name()}}).Err()
+		assert.Nil(t, err, "error creating collection on server: %v\n", err)
+
 		sess, err := client.StartSession()
 		assert.Nil(t, err, "StartSession error: %v", err)
 		defer func() {


### PR DESCRIPTION
Main open question is whether this should apply to all `AbortTransaction` calls or only those done implicitly through `WithTransaction`. For the initial PR, I have it apply to all calls, but I'm open to changing it if anyone disagrees.

EDIT: After thinking about this more, I changed it to only use the special context for implicit `AbortTransaction` calls done via `WithTransaction`.