### PR TITLE
GODRIVER-1726 Fix SDAM error handling for write concern errors

### DIFF
--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -11,6 +11,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,16 +24,18 @@ import (
 
 func TestSDAMErrorHandling(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	clientOpts := options.Client().
-		ApplyURI(mt.ConnString()).
-		SetRetryWrites(false).
-		SetPoolMonitor(poolMonitor).
-		SetWriteConcern(mtest.MajorityWc)
+	baseClientOpts := func() *options.ClientOptions {
+		return options.Client().
+			ApplyURI(mt.ConnString()).
+			SetRetryWrites(false).
+			SetPoolMonitor(poolMonitor).
+			SetWriteConcern(mtest.MajorityWc)
+	}
 	baseMtOpts := func() *mtest.Options {
 		mtOpts := mtest.NewOptions().
 			Topologies(mtest.ReplicaSet). // Don't run on sharded clusters to avoid complexity of sharded failpoints.
 			MinServerVersion("4.0").      // 4.0+ is required to use failpoints on replica sets.
-			ClientOptions(clientOpts)
+			ClientOptions(baseClientOpts())
 
 		if mt.TopologyKind() == mtest.Sharded {
 			// Pin to a single mongos because the tests use failpoints.
@@ -201,5 +204,91 @@ func TestSDAMErrorHandling(t *testing.T) {
 				assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
 			})
 		})
+		mt.RunOpts("server errors", noClientOpts, func(mt *mtest.T) {
+			// Integration tests for the SDAM error handling code path for errors in server response documents. These
+			// errors can be part of the top-level document in ok:0 responses or in a nested writeConcernError document.
+
+			// On 4.4, some state change errors include a topologyVersion field. Because we're triggering these errors
+			// via failCommand, the topologyVersion does not actually change as it would in an actual state change.
+			// This causes the SDAM error handling code path to think we've already handled this state change and
+			// ignore the error because it's stale. To avoid this altogether, we cap the test to <= 4.2.
+			serverErrorsMtOpts := baseMtOpts().
+				MinServerVersion("4.0"). // failCommand support
+				MaxServerVersion("4.2").
+				ClientOptions(baseClientOpts().SetRetryWrites(false))
+
+			testCases := []struct {
+				name            string
+				errorCode       int32
+				isShutdownError bool
+			}{
+				// NodeIsRecovering error that is also a ShutdownError so pool will always be cleared.
+				{"node is recovering, shutdown", 11600, true},
+				// NodeIsRecovering error that is not a ShutdownError so pool is only cleared for pre-4.2.
+				{"node is recovering, not shutdown", 11602, false},
+				// NotMaster error. None of the NotMaster errors are in the ShutdownError category, so the pool is
+				// only cleared for pre-4.2.
+				{"not master", 10107, false},
+			}
+			for _, tc := range testCases {
+				mt.RunOpts(fmt.Sprintf("command error - %s", tc.name), serverErrorsMtOpts, func(mt *mtest.T) {
+					clearPoolChan()
+
+					// Cause the next insert to fail with an ok:0 response.
+					fp := mtest.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode: mtest.FailPointMode{
+							Times: 1,
+						},
+						Data: mtest.FailPointData{
+							FailCommands: []string{"insert"},
+							ErrorCode:    tc.errorCode,
+						},
+					}
+					mt.SetFailPoint(fp)
+
+					runServerErrorsTest(mt, tc.isShutdownError)
+				})
+				mt.RunOpts(fmt.Sprintf("write concern error - %s", tc.name), serverErrorsMtOpts, func(mt *mtest.T) {
+					clearPoolChan()
+
+					// Cause the next insert to fail with a write concern error.
+					fp := mtest.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode: mtest.FailPointMode{
+							Times: 1,
+						},
+						Data: mtest.FailPointData{
+							FailCommands: []string{"insert"},
+							WriteConcernError: &mtest.WriteConcernErrorData{
+								Code: tc.errorCode,
+							},
+						},
+					}
+					mt.SetFailPoint(fp)
+
+					runServerErrorsTest(mt, tc.isShutdownError)
+				})
+			}
+		})
 	})
+}
+
+func runServerErrorsTest(mt *mtest.T, isShutdownError bool) {
+	mt.Helper()
+
+	_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+	assert.NotNil(mt, err, "expected InsertOne error, got nil")
+
+	// The pool should always be cleared for shutdown errors, regardless of server version.
+	if isShutdownError {
+		assert.True(mt, isPoolCleared(), "expected pool to be cleared, but was not")
+		return
+	}
+
+	// For non-shutdown errors, the pool is only cleared if the error is from a pre-4.2 server.
+	wantCleared := mtest.CompareServerVersions(mt.ServerVersion(), "4.2") < 0
+	gotCleared := isPoolCleared()
+	assert.Equal(mt, wantCleared, gotCleared, "expected pool to be cleared: %v; pool was cleared: %v",
+		wantCleared, gotCleared)
 }

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -332,6 +332,9 @@ func (s *Server) RequestImmediateCheck() {
 	}
 }
 
+// getWriteConcernErrorForProcessing extracts a driver.WriteConcernError from the provided error. This function returns
+// (error, true) if the error is a WriteConcernError and the falls under the requirements for SDAM error
+// handling and (nil, false) otherwise.
 func getWriteConcernErrorForProcessing(err error) (*driver.WriteConcernError, bool) {
 	writeCmdErr, ok := err.(driver.WriteCommandError)
 	if !ok {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -378,7 +378,6 @@ func (s *Server) ProcessError(err error, conn driver.Connection) {
 		}
 		return
 	}
-	// if wcerr, ok := err.(driver.WriteConcernError); ok && (wcerr.NodeIsRecovering() || wcerr.NotMaster()) {
 	if wcerr, ok := getWriteConcernErrorForProcessing(err); ok {
 		// ignore stale error
 		if description.CompareTopologyVersion(desc.TopologyVersion, wcerr.TopologyVersion) >= 0 {

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -205,13 +205,15 @@ func TestServer(t *testing.T) {
 		s.connectionstate = connected
 		s.pool.connected = connected
 
-		wce := driver.WriteConcernError{
-			Name:            "",
-			Code:            10107,
-			Message:         "not master",
-			Details:         []byte{},
-			Labels:          []string{},
-			TopologyVersion: nil,
+		wce := driver.WriteCommandError{
+			WriteConcernError: &driver.WriteConcernError{
+				Name:            "",
+				Code:            10107,
+				Message:         "not master",
+				Details:         []byte{},
+				Labels:          []string{},
+				TopologyVersion: nil,
+			},
 		}
 		s.ProcessError(wce, initConnection{})
 


### PR DESCRIPTION
I took this ticket as an opportunity to add some integration tests for SDAM error handling. They now ensure that we correctly process NodeIsRecovering and NotMaster errors correctly when they're in an ok:0 or writeConcernError document. Unfortunately, each test takes ~0.5 seconds to run because of minHeartbeatFrequency, but I still think they're worth having. Also, we don't have SDAM monitoring, so we can't actually assert that the server was marked Unknown, but by testing on both 4.0 and 4.2, we can assert that the server's connection pool was cleared, which is at least enough to ensure that we're correctly entering the SDAM error handling code path.