### PR TITLE
Use Go 1.15 in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -134,9 +134,14 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          # any go tools that we need
+
+          # Install any go tools that we need. Do this in a temp directory because running "go get" inside the driver
+          # repo will update the driver's go.mod/go.sum files. This puts the contents of go.mod/go.sum out of sync with
+          # the vendor directory and tests fail to compile due to inconsistent vendoring.
+          cd $(mktemp -d)
           go get -u golang.org/x/lint/golint
           go get -u github.com/kisielk/errcheck
+          cd -
 
           # initialize submodules
           git submodule init
@@ -1562,61 +1567,61 @@ axes:
   - id: os-ssl-legacy
     display_name: OS
     values:
-      - id: "ubuntu1404-go-1-13"
+      - id: "ubuntu1404-go-1-15"
         display_name: "Ubuntu 14.04"
         run_on: ubuntu1404-test
         variables:
-          GO_DIST: "/opt/golang/go1.13"
+          GO_DIST: "/opt/golang/go1.15"
 
   # OSes that require >= 3.2 for SSL
   - id: os-ssl-32
     display_name: OS
     values:
-      - id: "windows-64-go-1-13"
+      - id: "windows-64-go-1-15"
         display_name: "Windows 64-bit"
         run_on:
           - windows-64-vs2017-test
         variables:
           GCC_PATH: "/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin"
-          GO_DIST: "C:\\golang\\go1.13"
+          GO_DIST: "C:\\golang\\go1.15"
           PYTHON3_BINARY: "C:/python/Python38/python.exe"
           VENV_BIN_DIR: "Scripts"
-      - id: "ubuntu1604-64-go-1-13"
+      - id: "ubuntu1604-64-go-1-15"
         display_name: "Ubuntu 16.04"
         run_on: ubuntu1604-build
         variables:
-          GO_DIST: "/opt/golang/go1.13"
+          GO_DIST: "/opt/golang/go1.15"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
-      - id: "osx-go-1-13"
+      - id: "osx-go-1-15"
         display_name: "MacOS 10.14"
         run_on: macos-1014
         variables:
-          GO_DIST: "/opt/golang/go1.13"
+          GO_DIST: "/opt/golang/go1.15"
           PYTHON3_BINARY: python3
 
   - id: os-aws-auth
     display_name: OS
     values:
-      - id: "windows-64-vsMulti-small-go-1-13"
+      - id: "windows-64-vsMulti-small-go-1-15"
         display_name: "Windows 64-bit"
         run_on:
           - windows-64-vsMulti-small
         variables:
           GCC_PATH: "/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin"
-          GO_DIST: "C:\\golang\\go1.13"
+          GO_DIST: "C:\\golang\\go1.15"
           SKIP_ECS_AUTH_TEST: true
           PYTHON3: "C:/python/Python38/python.exe"
-      - id: "ubuntu1804-64-go-1-13"
+      - id: "ubuntu1804-64-go-1-15"
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
         variables:
-          GO_DIST: "/opt/golang/go1.13"
+          GO_DIST: "/opt/golang/go1.15"
           PYTHON3: python3
-      - id: "osx-go-1-13"
+      - id: "osx-go-1-15"
         display_name: "MacOS 10.14"
         run_on: macos-1014
         variables:
-          GO_DIST: "/opt/golang/go1.13"
+          GO_DIST: "/opt/golang/go1.15"
           SKIP_ECS_AUTH_TEST: true
           SKIP_EC2_AUTH_TEST: true
           PYTHON3: python3
@@ -1627,7 +1632,7 @@ buildvariants:
     run_on:
       - ubuntu1604-build
     expansions:
-      GO_DIST: "/opt/golang/go1.13"
+      GO_DIST: "/opt/golang/go1.15"
     tasks:
       - name: ".static-analysis"
 
@@ -1636,7 +1641,7 @@ buildvariants:
     run_on:
       - ubuntu1604-build
     expansions:
-      GO_DIST: "/opt/golang/go1.13"
+      GO_DIST: "/opt/golang/go1.15"
     tasks:
       - name: ".performance"
 
@@ -1645,7 +1650,7 @@ buildvariants:
     run_on:
       - ubuntu1604-test
     expansions:
-      GO_DIST: "/opt/golang/go1.13"
+      GO_DIST: "/opt/golang/go1.15"
     tasks:
       - name: ".compile-check"
 
@@ -1654,7 +1659,7 @@ buildvariants:
     run_on:
       - ubuntu1604-build
     expansions:
-      GO_DIST: "/opt/golang/go1.13"
+      GO_DIST: "/opt/golang/go1.15"
     tasks:
       - name: "atlas-test"
 
@@ -1663,7 +1668,7 @@ buildvariants:
     run_on:
       - ubuntu1604-build
     expansions:
-      GO_DIST: "/opt/golang/go1.13"
+      GO_DIST: "/opt/golang/go1.15"
     tasks:
       - name: "test-atlas-data-lake"
 
@@ -1717,14 +1722,14 @@ buildvariants:
       - name: "aws-auth-test"
 
   - matrix_name: "ocsp-test"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["ubuntu1604-64-go-1-13"] }
+    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["ubuntu1604-64-go-1-15"] }
     display_name: "OCSP ${version} ${os-ssl-32}"
     batchtime: 20160 # 14 days
     tasks:
       - name: ".ocsp"
 
   - matrix_name: "ocsp-test-windows"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["windows-64-go-1-13"] }
+    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["windows-64-go-1-15"] }
     display_name: "OCSP ${version} ${os-ssl-32}"
     batchtime: 20160 # 14 days
     tasks:
@@ -1732,7 +1737,7 @@ buildvariants:
       - name: ".ocsp-rsa !.ocsp-staple"
 
   - matrix_name: "ocsp-test-macos"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["osx-go-1-13"] }
+    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["osx-go-1-15"] }
     display_name: "OCSP ${version} ${os-ssl-32}"
     batchtime: 20160 # 14 days
     tasks:

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -30,7 +30,9 @@ func noerr(t *testing.T, err error) {
 	}
 }
 
-func requireErrEqual(t *testing.T, err1 error, err2 error) { require.True(t, compareErrors(err1, err2)) }
+func requireErrEqual(t *testing.T, err1 error, err2 error) {
+	require.True(t, compareErrors(err1, err2))
+}
 
 func TestTimeRoundTrip(t *testing.T) {
 	val := struct {

--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -104,7 +104,9 @@ func (rv RawValue) UnmarshalWithContext(dc *bsoncodec.DecodeContext, val interfa
 }
 
 func convertFromCoreValue(v bsoncore.Value) RawValue { return RawValue{Type: v.Type, Value: v.Data} }
-func convertToCoreValue(v RawValue) bsoncore.Value   { return bsoncore.Value{Type: v.Type, Data: v.Value} }
+func convertToCoreValue(v RawValue) bsoncore.Value {
+	return bsoncore.Value{Type: v.Type, Data: v.Value}
+}
 
 // Validate ensures the value is a valid BSON value.
 func (rv RawValue) Validate() error { return convertToCoreValue(rv).Validate() }
@@ -176,7 +178,9 @@ func (rv RawValue) ObjectID() primitive.ObjectID { return convertToCoreValue(rv)
 
 // ObjectIDOK is the same as ObjectID, except it returns a boolean instead of
 // panicking.
-func (rv RawValue) ObjectIDOK() (primitive.ObjectID, bool) { return convertToCoreValue(rv).ObjectIDOK() }
+func (rv RawValue) ObjectIDOK() (primitive.ObjectID, bool) {
+	return convertToCoreValue(rv).ObjectIDOK()
+}
 
 // Boolean returns the boolean value the Value represents. It panics if the
 // value is a BSON type other than boolean.
@@ -214,7 +218,9 @@ func (rv RawValue) RegexOK() (pattern, options string, ok bool) {
 
 // DBPointer returns the BSON dbpointer value the Value represents. It panics if the value is a BSON
 // type other than DBPointer.
-func (rv RawValue) DBPointer() (string, primitive.ObjectID) { return convertToCoreValue(rv).DBPointer() }
+func (rv RawValue) DBPointer() (string, primitive.ObjectID) {
+	return convertToCoreValue(rv).DBPointer()
+}
 
 // DBPointerOK is the same as DBPoitner, except that it returns a boolean
 // instead of panicking.

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -116,7 +116,7 @@ func TestMongoHelpers(t *testing.T) {
 			got, id, err := transformAndEnsureID(bson.DefaultRegistry, doc)
 			assert.Nil(t, err, "transformAndEnsureID error: %v", err)
 			_, ok := id.(string)
-			assert.True(t, ok, "expected returned id type %T, got %T", string(0), id)
+			assert.True(t, ok, "expected returned id type string, got %T", id)
 			assert.Equal(t, got, want, "expected document %v, got %v", got, want)
 		})
 	})

--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -39,11 +39,14 @@ import (
 // EmptyDocumentLength is the length of a document that has been started/ended but has no elements.
 const EmptyDocumentLength = 5
 
+// nullTerminator is a string version of the 0 byte that is appended at the end of cstrings.
+const nullTerminator = string(byte(0))
+
 // AppendType will append t to dst and return the extended buffer.
 func AppendType(dst []byte, t bsontype.Type) []byte { return append(dst, byte(t)) }
 
 // AppendKey will append key to dst and return the extended buffer.
-func AppendKey(dst []byte, key string) []byte { return append(dst, key+string(0x00)...) }
+func AppendKey(dst []byte, key string) []byte { return append(dst, key+nullTerminator...) }
 
 // AppendHeader will append Type t and key to dst and return the extended
 // buffer.
@@ -427,7 +430,7 @@ func AppendNullElement(dst []byte, key string) []byte { return AppendHeader(dst,
 
 // AppendRegex will append pattern and options to dst and return the extended buffer.
 func AppendRegex(dst []byte, pattern, options string) []byte {
-	return append(dst, pattern+string(0x00)+options+string(0x00)...)
+	return append(dst, pattern+nullTerminator+options+nullTerminator...)
 }
 
 // AppendRegexElement will append a BSON regex element using key, pattern, and

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -490,7 +490,9 @@ func ReadCompressedOriginalOpCode(src []byte) (opcode OpCode, rem []byte, ok boo
 
 // ReadCompressedUncompressedSize reads the uncompressed size of a
 // compressed wiremessage to dst.
-func ReadCompressedUncompressedSize(src []byte) (size int32, rem []byte, ok bool) { return readi32(src) }
+func ReadCompressedUncompressedSize(src []byte) (size int32, rem []byte, ok bool) {
+	return readi32(src)
+}
 
 // ReadCompressedCompressorID reads the ID of the compressor to dst.
 func ReadCompressedCompressorID(src []byte) (id CompressorID, rem []byte, ok bool) {


### PR DESCRIPTION
I filed two separate tickets to use Go 1.15 in Evergreen and to fix vet/fmt errors for 1.15, but they're dependent on each other so I have them in one pull request. Once this is approved, we can figure out if we want to backport both or rebase/merge instead of squashing and just backport the vet/fmt fixes.