### PR TITLE
GODRIVER-1725 Resync change stream spec tests

### DIFF
--- a/data/change-streams/README.rst
+++ b/data/change-streams/README.rst
@@ -33,7 +33,7 @@ Each YAML file has the following keys:
   - ``description``: The name of the test.
   - ``minServerVersion``: The minimum server version to run this test against. If not present, assume there is no minimum server version.
   - ``maxServerVersion``: Reserved for later use
-  - ``failPoint``(optional): The configureFailPoint command document to run to configure a fail point on the primary server.
+  - ``failPoint``: Optional configureFailPoint command document to run to configure a fail point on the primary server.
   - ``target``: The entity on which to run the change stream. Valid values are:
   
     - ``collection``: Watch changes on collection ``database_name.collection_name``
@@ -171,7 +171,7 @@ The following tests have not yet been automated, but MUST still be tested. All t
 #. ``ChangeStream`` must continuously track the last seen ``resumeToken``
 #. ``ChangeStream`` will throw an exception if the server response is missing the resume token (if wire version is < 8, this is a driver-side error; for 8+, this is a server-side error)
 #. After receiving a ``resumeToken``, ``ChangeStream`` will automatically resume one time on a resumable error with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
-#. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command. Note that retryable reads may retry ``aggregate`` commands. Drivers should be careful to distinguish retries from resume attempts. Alternatively, drivers may specify `retryReads=false` or avoid using a [retryable error](../../retryable-reads/retryable-reads.rst#retryable-error) for this test.
+#. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command. Note that retryable reads may retry ``aggregate`` commands. Drivers should be careful to distinguish retries from resume attempts. Alternatively, drivers may specify ``retryReads=false`` or avoid using a `retryable error <../../retryable-reads/retryable-reads.rst#retryable-error>`_ for this test.
 #. **Removed**
 #. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.

--- a/data/change-streams/change-streams-errors.json
+++ b/data/change-streams/change-streams-errors.json
@@ -14,7 +14,7 @@
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "error": {
           "code": 40573

--- a/data/change-streams/change-streams-errors.yml
+++ b/data/change-streams/change-streams-errors.yml
@@ -12,7 +12,7 @@ tests:
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations: []
-    expectations: []
+    expectations: ~
     result:
       error:
         code: 40573

--- a/data/change-streams/change-streams.json
+++ b/data/change-streams/change-streams.json
@@ -82,7 +82,7 @@
           }
         }
       ],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "success": [
           {

--- a/data/change-streams/change-streams.yml
+++ b/data/change-streams/change-streams.yml
@@ -58,7 +58,7 @@ tests:
         arguments:
           document:
             x: 1
-    expectations: []
+    expectations: ~
     result:
       success:
         -

--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -41,7 +41,7 @@ type changeStreamTest struct {
 	Pipeline         []bson.Raw              `bson:"changeStreamPipeline"`
 	Options          bson.Raw                `bson:"changeStreamOptions"`
 	Operations       []changeStreamOperation `bson:"operations"`
-	Expectations     []*expectation          `bson:"expectations"`
+	Expectations     *[]*expectation         `bson:"expectations"`
 	Result           changeStreamResult      `bson:"result"`
 
 	// set of namespaces created in a test

--- a/mongo/integration/cmd_monitoring_helpers_test.go
+++ b/mongo/integration/cmd_monitoring_helpers_test.go
@@ -216,7 +216,7 @@ func checkExpectations(mt *mtest.T, expectations *[]*expectation, id0, id1 bson.
 		return !ok
 	})
 
-	// If the epxectations field in the test JSON is non-null but is empty, we want to assert that no events were
+	// If the expectations field in the test JSON is non-null but is empty, we want to assert that no events were
 	// emitted.
 	if len(*expectations) == 0 {
 		numEvents := len(mt.GetAllStartedEvents())

--- a/mongo/integration/command_monitoring_test.go
+++ b/mongo/integration/command_monitoring_test.go
@@ -35,7 +35,7 @@ type monitoringTest struct {
 	MaxServerVersion  string               `bson:"ignore_if_server_version_greater_than"`
 	IgnoredTopologies []mtest.TopologyKind `bson:"ignore_if_topology_type"`
 	Operation         monitoringOperation  `bson:"operation"`
-	Expectations      []*expectation       `bson:"expectations"`
+	Expectations      *[]*expectation      `bson:"expectations"`
 }
 
 type monitoringOperation struct {

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -87,15 +87,15 @@ func decodeTestData(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val refle
 }
 
 type testCase struct {
-	Description         string         `bson:"description"`
-	SkipReason          string         `bson:"skipReason"`
-	FailPoint           *bson.Raw      `bson:"failPoint"`
-	ClientOptions       bson.Raw       `bson:"clientOptions"`
-	SessionOptions      bson.Raw       `bson:"sessionOptions"`
-	Operations          []*operation   `bson:"operations"`
-	Expectations        []*expectation `bson:"expectations"`
-	UseMultipleMongoses bool           `bson:"useMultipleMongoses"`
-	Outcome             *outcome       `bson:"outcome"`
+	Description         string          `bson:"description"`
+	SkipReason          string          `bson:"skipReason"`
+	FailPoint           *bson.Raw       `bson:"failPoint"`
+	ClientOptions       bson.Raw        `bson:"clientOptions"`
+	SessionOptions      bson.Raw        `bson:"sessionOptions"`
+	Operations          []*operation    `bson:"operations"`
+	Expectations        *[]*expectation `bson:"expectations"`
+	UseMultipleMongoses bool            `bson:"useMultipleMongoses"`
+	Outcome             *outcome        `bson:"outcome"`
 
 	// set in code if the test is a GridFS test
 	chunkSize int32


### PR DESCRIPTION
This commit also modifies our checking of command monitoring events in tests:

- Skip monitoring assertions if the expectations field in the test JSON is null
- Assert that no events were published if the expectations field is a non-null empty array