### PR TITLE
GODRIVER-1729 Fix test error for 1.15

### DIFF
--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -1322,7 +1322,11 @@ func TestDefaultValueDecoders(t *testing.T) {
 					nil,
 					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.String, Return: string("not-valid-%%%%://")},
 					bsonrwtest.ReadString,
-					errors.New("parse not-valid-%%%%://: first path segment in URL cannot contain colon"),
+					&url.Error{
+						Op:  "parse",
+						URL: "not-valid-%%%%://",
+						Err: errors.New("first path segment in URL cannot contain colon"),
+					},
 				},
 				{
 					"can set false",


### PR DESCRIPTION
This change is needed because the stringification of the `url.Error` type changed between 1.13 and 1.15. To make the test more robust to these sorts of changes, we directly construct a `url.Error` and compare to that rather than using knowledge about the stringified value. This change is only needed on the release/1.4 branch because it was already done on the master branch as part of GODRIVER-1680.