### PR TITLE
Fix checks for error names and labels in spec tests

### DIFF
--- a/data/retryable-writes/insertOne-serverErrors.json
+++ b/data/retryable-writes/insertOne-serverErrors.json
@@ -966,7 +966,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },

--- a/data/retryable-writes/insertOne-serverErrors.yml
+++ b/data/retryable-writes/insertOne-serverErrors.yml
@@ -442,6 +442,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:


### PR DESCRIPTION
I resynced the retryable writes tests as part of this PR because the
changes for the spec tests and the test runner are related.

The test runner change is to correctly check error names and labels. Our
existing code only honors these expectations if the error is a
`mongo.CommandError` (i.e. an `ok: 0` error from the server). However,
these expectations can exist for `ok: 1` cases if there was a write
concern error. The test runner now extracts common details from
different error types and then makes the necessary assertions.

GODRIVER-1739
GODRIVER-1741