### PR TITLE
GODRIVER-1740 Remove auth-related fields from description.Server

### DIFF
--- a/internal/string_util.go
+++ b/internal/string_util.go
@@ -1,0 +1,42 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// StringSliceFromRawElement decodes the provided BSON element into a []string. This internally calls
+// StringSliceFromRawValue on the element's value. The error conditions outlined in that function's documentation
+// apply for this function as well.
+func StringSliceFromRawElement(element bson.RawElement, name string) ([]string, error) {
+	return StringSliceFromRawValue(element.Value(), name)
+}
+
+// StringSliceFromRawValue decodes the provided BSON value into a []string. This function returns an error if the
+// value is not an array or any of the elements in the array are not strings.
+func StringSliceFromRawValue(val bson.RawValue, name string) ([]string, error) {
+	arr, ok := val.ArrayOK()
+	if !ok {
+		return nil, fmt.Errorf("expected '%s' to be an array but it's a BSON %s", name, val.Type)
+	}
+	vals, err := arr.Values()
+	if err != nil {
+		return nil, err
+	}
+	var strs []string
+	for _, val := range vals {
+		str, ok := val.StringValueOK()
+		if !ok {
+			return nil, fmt.Errorf("expected '%s' to be an array of strings, but found a BSON %s", name, val.Type)
+		}
+		strs = append(strs, str)
+	}
+	return strs, nil
+}

--- a/internal/string_util.go
+++ b/internal/string_util.go
@@ -15,26 +15,29 @@ import (
 // StringSliceFromRawElement decodes the provided BSON element into a []string. This internally calls
 // StringSliceFromRawValue on the element's value. The error conditions outlined in that function's documentation
 // apply for this function as well.
-func StringSliceFromRawElement(element bson.RawElement, name string) ([]string, error) {
-	return StringSliceFromRawValue(element.Value(), name)
+func StringSliceFromRawElement(element bson.RawElement) ([]string, error) {
+	return StringSliceFromRawValue(element.Key(), element.Value())
 }
 
-// StringSliceFromRawValue decodes the provided BSON value into a []string. This function returns an error if the
-// value is not an array or any of the elements in the array are not strings.
-func StringSliceFromRawValue(val bson.RawValue, name string) ([]string, error) {
+// StringSliceFromRawValue decodes the provided BSON value into a []string. This function returns an error if the value
+// is not an array or any of the elements in the array are not strings. The name parameter is used to add context to
+// error messages.
+func StringSliceFromRawValue(name string, val bson.RawValue) ([]string, error) {
 	arr, ok := val.ArrayOK()
 	if !ok {
 		return nil, fmt.Errorf("expected '%s' to be an array but it's a BSON %s", name, val.Type)
 	}
-	vals, err := arr.Values()
+
+	arrayValues, err := arr.Values()
 	if err != nil {
 		return nil, err
 	}
+
 	var strs []string
-	for _, val := range vals {
-		str, ok := val.StringValueOK()
+	for _, arrayVal := range arrayValues {
+		str, ok := arrayVal.StringValueOK()
 		if !ok {
-			return nil, fmt.Errorf("expected '%s' to be an array of strings, but found a BSON %s", name, val.Type)
+			return nil, fmt.Errorf("expected '%s' to be an array of strings, but found a BSON %s", name, arrayVal.Type)
 		}
 		strs = append(strs, str)
 	}

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -75,7 +75,7 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 		switch element.Key() {
 		case "arbiters":
 			var err error
-			desc.Arbiters, err = internal.StringSliceFromRawElement(element, "arbiters")
+			desc.Arbiters, err = internal.StringSliceFromRawElement(element)
 			if err != nil {
 				desc.LastError = err
 				return desc
@@ -88,7 +88,7 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 			}
 		case "compression":
 			var err error
-			desc.Compression, err = internal.StringSliceFromRawElement(element, "compression")
+			desc.Compression, err = internal.StringSliceFromRawElement(element)
 			if err != nil {
 				desc.LastError = err
 				return desc
@@ -107,7 +107,7 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 			}
 		case "hosts":
 			var err error
-			desc.Hosts, err = internal.StringSliceFromRawElement(element, "hosts")
+			desc.Hosts, err = internal.StringSliceFromRawElement(element)
 			if err != nil {
 				desc.LastError = err
 				return desc
@@ -204,7 +204,7 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 			}
 		case "passives":
 			var err error
-			desc.Passives, err = internal.StringSliceFromRawElement(element, "passives")
+			desc.Passives, err = internal.StringSliceFromRawElement(element)
 			if err != nil {
 				desc.LastError = err
 				return desc

--- a/mongo/description/server_test.go
+++ b/mongo/description/server_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/mongo/address"
@@ -49,16 +48,10 @@ func TestServer(t *testing.T) {
 			{"sessionTimeoutMinutes", Server{SessionTimeoutMinutes: 1}, false},
 			{"setName", Server{SetName: "foo"}, false},
 			{"setVersion", Server{SetVersion: 1}, false},
-			{
-				"speculativeAuthenticate",
-				Server{SpeculativeAuthenticate: bson.Raw{'\x08', '\x00', '\x00', '\x00', '\x0A', 'x', '\x00', '\x00'}},
-				true,
-			},
 			{"tags", Server{Tags: tag.Set{tag.Tag{"foo", "bar"}}}, false},
 			{"topologyVersion", Server{TopologyVersion: &TopologyVersion{primitive.NewObjectID(), 0}}, false},
 			{"kind", Server{Kind: Standalone}, false},
 			{"wireVersion", Server{WireVersion: &VersionRange{1, 2}}, false},
-			{"saslSupportedMechs", Server{SaslSupportedMechs: []string{"foo"}}, true},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -65,13 +65,17 @@ type authHandshaker struct {
 	wrapped driver.Handshaker
 	options *HandshakeOptions
 
-	conversation SpeculativeConversation
+	handshakeInfo driver.HandshakeInformation
+	conversation  SpeculativeConversation
 }
 
-// GetDescription performs an isMaster to retrieve the initial description for conn.
-func (ah *authHandshaker) GetDescription(ctx context.Context, addr address.Address, conn driver.Connection) (description.Server, error) {
+var _ driver.Handshaker = (*authHandshaker)(nil)
+
+// GetHandshakeInformation performs the initial MongoDB handshake to retrieve the required information for the provided
+// connection.
+func (ah *authHandshaker) GetHandshakeInformation(ctx context.Context, addr address.Address, conn driver.Connection) (driver.HandshakeInformation, error) {
 	if ah.wrapped != nil {
-		return ah.wrapped.GetDescription(ctx, addr, conn)
+		return ah.wrapped.GetHandshakeInformation(ctx, addr, conn)
 	}
 
 	op := operation.NewIsMaster().
@@ -85,23 +89,24 @@ func (ah *authHandshaker) GetDescription(ctx context.Context, addr address.Addre
 			var err error
 			ah.conversation, err = speculativeAuth.CreateSpeculativeConversation()
 			if err != nil {
-				return description.Server{}, newAuthError("failed to create conversation", err)
+				return driver.HandshakeInformation{}, newAuthError("failed to create conversation", err)
 			}
 
 			firstMsg, err := ah.conversation.FirstMessage()
 			if err != nil {
-				return description.Server{}, newAuthError("failed to create speculative authentication message", err)
+				return driver.HandshakeInformation{}, newAuthError("failed to create speculative authentication message", err)
 			}
 
 			op = op.SpeculativeAuthenticate(firstMsg)
 		}
 	}
 
-	desc, err := op.GetDescription(ctx, addr, conn)
+	var err error
+	ah.handshakeInfo, err = op.GetHandshakeInformation(ctx, addr, conn)
 	if err != nil {
-		return description.Server{}, newAuthError("handshake failure", err)
+		return driver.HandshakeInformation{}, newAuthError("handshake failure", err)
 	}
-	return desc, nil
+	return ah.handshakeInfo, nil
 }
 
 // FinishHandshake performs authentication for conn if necessary.
@@ -117,9 +122,10 @@ func (ah *authHandshaker) FinishHandshake(ctx context.Context, conn driver.Conne
 	desc := conn.Description()
 	if performAuth(desc) && ah.options.Authenticator != nil {
 		cfg := &Config{
-			Description:  desc,
-			Connection:   conn,
-			ClusterClock: ah.options.ClusterClock,
+			Description:   desc,
+			Connection:    conn,
+			ClusterClock:  ah.options.ClusterClock,
+			HandshakeInfo: ah.handshakeInfo,
 		}
 
 		if err := ah.authenticate(ctx, cfg); err != nil {
@@ -136,7 +142,7 @@ func (ah *authHandshaker) FinishHandshake(ctx context.Context, conn driver.Conne
 func (ah *authHandshaker) authenticate(ctx context.Context, cfg *Config) error {
 	// If the initial isMaster reply included a response to the speculative authentication attempt, we only need to
 	// conduct the remainder of the conversation.
-	if speculativeResponse := cfg.Description.SpeculativeAuthenticate; speculativeResponse != nil {
+	if speculativeResponse := ah.handshakeInfo.SpeculativeAuthenticate; speculativeResponse != nil {
 		// Defensively ensure that the server did not include a response if speculative auth was not attempted.
 		if ah.conversation == nil {
 			return errors.New("speculative auth was not attempted but the server included a response")
@@ -159,9 +165,10 @@ func Handshaker(h driver.Handshaker, options *HandshakeOptions) driver.Handshake
 
 // Config holds the information necessary to perform an authentication attempt.
 type Config struct {
-	Description  description.Server
-	Connection   driver.Connection
-	ClusterClock *session.ClusterClock
+	Description   description.Server
+	Connection    driver.Connection
+	ClusterClock  *session.ClusterClock
+	HandshakeInfo driver.HandshakeInformation
 }
 
 // Authenticator handles authenticating a connection.

--- a/x/mongo/driver/auth/default.go
+++ b/x/mongo/driver/auth/default.go
@@ -52,7 +52,7 @@ func (a *DefaultAuthenticator) Auth(ctx context.Context, cfg *Config) error {
 	var actual Authenticator
 	var err error
 
-	switch chooseAuthMechanism(cfg.Description) {
+	switch chooseAuthMechanism(cfg) {
 	case SCRAMSHA256:
 		actual, err = newScramSHA256Authenticator(a.Cred)
 	case SCRAMSHA1:
@@ -71,9 +71,9 @@ func (a *DefaultAuthenticator) Auth(ctx context.Context, cfg *Config) error {
 // If a server provides a list of supported mechanisms, we choose
 // SCRAM-SHA-256 if it exists or else MUST use SCRAM-SHA-1.
 // Otherwise, we decide based on what is supported.
-func chooseAuthMechanism(desc description.Server) string {
-	if desc.SaslSupportedMechs != nil {
-		for _, v := range desc.SaslSupportedMechs {
+func chooseAuthMechanism(cfg *Config) string {
+	if saslSupportedMechs := cfg.HandshakeInfo.SaslSupportedMechs; saslSupportedMechs != nil {
+		for _, v := range saslSupportedMechs {
 			if v == SCRAMSHA256 {
 				return v
 			}
@@ -81,7 +81,7 @@ func chooseAuthMechanism(desc description.Server) string {
 		return SCRAMSHA1
 	}
 
-	if err := description.ScramSHA1Supported(desc.WireVersion); err == nil {
+	if err := description.ScramSHA1Supported(cfg.HandshakeInfo.Description.WireVersion); err == nil {
 		return SCRAMSHA1
 	}
 

--- a/x/mongo/driver/auth/speculative_scram_test.go
+++ b/x/mongo/driver/auth/speculative_scram_test.go
@@ -80,10 +80,10 @@ func TestSpeculativeSCRAM(t *testing.T) {
 				}
 
 				// Do both parts of the handshake.
-				desc, err := handshaker.GetDescription(context.Background(), address.Address("localhost:27017"), conn)
-				assert.Nil(t, err, "GetDescription error: %v", err)
-				assert.NotNil(t, desc.SpeculativeAuthenticate, "desc.SpeculativeAuthenticate not set")
-				conn.Desc = desc // Set conn.Desc so the new description will be used for the authentication.
+				info, err := handshaker.GetHandshakeInformation(context.Background(), address.Address("localhost:27017"), conn)
+				assert.Nil(t, err, "GetHandshakeInformation error: %v", err)
+				assert.NotNil(t, info.SpeculativeAuthenticate, "desc.SpeculativeAuthenticate not set")
+				conn.Desc = info.Description // Set conn.Desc so the new description will be used for the authentication.
 
 				err = handshaker.FinishHandshake(context.Background(), conn)
 				assert.Nil(t, err, "FinishHandshake error: %v", err)
@@ -160,11 +160,11 @@ func TestSpeculativeSCRAM(t *testing.T) {
 					ReadResp: responses,
 				}
 
-				desc, err := handshaker.GetDescription(context.Background(), address.Address("localhost:27017"), conn)
-				assert.Nil(t, err, "GetDescription error: %v", err)
-				assert.Nil(t, desc.SpeculativeAuthenticate, "expected desc.SpeculativeAuthenticate to be unset, got %s",
-					bson.Raw(desc.SpeculativeAuthenticate))
-				conn.Desc = desc
+				info, err := handshaker.GetHandshakeInformation(context.Background(), address.Address("localhost:27017"), conn)
+				assert.Nil(t, err, "GetHandshakeInformation error: %v", err)
+				assert.Nil(t, info.SpeculativeAuthenticate, "expected desc.SpeculativeAuthenticate to be unset, got %s",
+					bson.Raw(info.SpeculativeAuthenticate))
+				conn.Desc = info.Description
 
 				err = handshaker.FinishHandshake(context.Background(), conn)
 				assert.Nil(t, err, "FinishHandshake error: %v", err)

--- a/x/mongo/driver/auth/speculative_x509_test.go
+++ b/x/mongo/driver/auth/speculative_x509_test.go
@@ -46,10 +46,10 @@ func TestSpeculativeX509(t *testing.T) {
 			ReadResp: responses,
 		}
 
-		desc, err := handshaker.GetDescription(context.Background(), address.Address("localhost:27017"), conn)
+		info, err := handshaker.GetHandshakeInformation(context.Background(), address.Address("localhost:27017"), conn)
 		assert.Nil(t, err, "GetDescription error: %v", err)
-		assert.NotNil(t, desc.SpeculativeAuthenticate, "desc.SpeculativeAuthenticate not set")
-		conn.Desc = desc
+		assert.NotNil(t, info.SpeculativeAuthenticate, "desc.SpeculativeAuthenticate not set")
+		conn.Desc = info.Description
 
 		err = handshaker.FinishHandshake(context.Background(), conn)
 		assert.Nil(t, err, "FinishHandshake error: %v", err)
@@ -90,11 +90,11 @@ func TestSpeculativeX509(t *testing.T) {
 			ReadResp: responses,
 		}
 
-		desc, err := handshaker.GetDescription(context.Background(), address.Address("localhost:27017"), conn)
+		info, err := handshaker.GetHandshakeInformation(context.Background(), address.Address("localhost:27017"), conn)
 		assert.Nil(t, err, "GetDescription error: %v", err)
-		assert.Nil(t, desc.SpeculativeAuthenticate, "expected desc.SpeculativeAuthenticate to be unset, got %s",
-			bson.Raw(desc.SpeculativeAuthenticate))
-		conn.Desc = desc
+		assert.Nil(t, info.SpeculativeAuthenticate, "expected desc.SpeculativeAuthenticate to be unset, got %s",
+			bson.Raw(info.SpeculativeAuthenticate))
+		conn.Desc = info.Description
 
 		err = handshaker.FinishHandshake(context.Background(), conn)
 		assert.Nil(t, err, "FinishHandshake error: %v", err)

--- a/x/mongo/driver/operation/ismaster.go
+++ b/x/mongo/driver/operation/ismaster.go
@@ -251,7 +251,7 @@ func (im *IsMaster) GetHandshakeInformation(ctx context.Context, _ address.Addre
 	// Cast to bson.Raw to lookup saslSupportedMechs to avoid converting from bsoncore.Value to bson.RawValue for the
 	// StringSliceFromRawValue call.
 	if saslSupportedMechs, lookupErr := bson.Raw(im.res).LookupErr("saslSupportedMechs"); lookupErr == nil {
-		info.SaslSupportedMechs, err = internal.StringSliceFromRawValue(saslSupportedMechs, "saslSupportedMechs")
+		info.SaslSupportedMechs, err = internal.StringSliceFromRawValue("saslSupportedMechs", saslSupportedMechs)
 	}
 	return info, err
 }

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -161,10 +161,14 @@ func (c *connection) connect(ctx context.Context) {
 		return
 	}
 
+	var handshakeInfo driver.HandshakeInformation
 	handshakeStartTime := time.Now()
 	handshakeConn := initConnection{c}
-	c.desc, err = handshaker.GetDescription(ctx, c.addr, handshakeConn)
+	handshakeInfo, err = handshaker.GetHandshakeInformation(ctx, c.addr, handshakeConn)
 	if err == nil {
+		// We only need to retain the Description field as the connection's description. The authentication-related
+		// fields in handshakeInfo are tracked by the handshaker if necessary.
+		c.desc = handshakeInfo.Description
 		c.isMasterRTT = time.Since(handshakeStartTime)
 		err = handshaker.FinishHandshake(ctx, handshakeConn)
 	}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -29,7 +29,7 @@ type testHandshaker struct {
 	finishHandshake         func(context.Context, driver.Connection) error
 }
 
-// GetDescription implements the Handshaker interface.
+// GetHandshakeInformation implements the Handshaker interface.
 func (th *testHandshaker) GetHandshakeInformation(ctx context.Context, addr address.Address, conn driver.Connection) (driver.HandshakeInformation, error) {
 	if th.getHandshakeInformation != nil {
 		return th.getHandshakeInformation(ctx, addr, conn)

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -25,16 +25,16 @@ import (
 )
 
 type testHandshaker struct {
-	getDescription  func(context.Context, address.Address, driver.Connection) (description.Server, error)
-	finishHandshake func(context.Context, driver.Connection) error
+	getHandshakeInformation func(context.Context, address.Address, driver.Connection) (driver.HandshakeInformation, error)
+	finishHandshake         func(context.Context, driver.Connection) error
 }
 
 // GetDescription implements the Handshaker interface.
-func (th *testHandshaker) GetDescription(ctx context.Context, addr address.Address, conn driver.Connection) (description.Server, error) {
-	if th.getDescription != nil {
-		return th.getDescription(ctx, addr, conn)
+func (th *testHandshaker) GetHandshakeInformation(ctx context.Context, addr address.Address, conn driver.Connection) (driver.HandshakeInformation, error) {
+	if th.getHandshakeInformation != nil {
+		return th.getHandshakeInformation(ctx, addr, conn)
 	}
-	return description.Server{}, nil
+	return driver.HandshakeInformation{}, nil
 }
 
 // FinishHandshake implements the Handshaker interface.
@@ -118,8 +118,8 @@ func TestConnection(t *testing.T) {
 				conn, err := newConnection(address.Address(""),
 					WithHandshaker(func(Handshaker) Handshaker {
 						return &testHandshaker{
-							getDescription: func(context.Context, address.Address, driver.Connection) (description.Server, error) {
-								return description.Server{}, handshakerError
+							getHandshakeInformation: func(context.Context, address.Address, driver.Connection) (driver.HandshakeInformation, error) {
+								return driver.HandshakeInformation{}, handshakerError
 							},
 						}
 					}),


### PR DESCRIPTION
The main change here is to remove the `SpeculativeAuthenticate` and `SaslSupportedMechs` fields from `description.Server`. The idea is that these fields are only required for the connection handshake, so we don't need to track them once that's done. To do this, I changed the `driver.Handshaker` interface from

```
type Handshaker interface {
    GetDescription(context.Context, address.Address, Connection) (description.Server, error)
}
```

to

```
type HandshakeInformation struct {
	Description             description.Server
	SpeculativeAuthenticate bsoncore.Document
	SaslSupportedMechs      []string
}

type Handshaker interface {
    GetHandshakeInformation(context.Context, address.Address, Connection) (HandshakeInformation, error)
}
```

The `IsMaster` operation changed to continue implementing this interface. It now constructs a server description as it did before, but also manually looks up these two fields from the `isMaster` response to populate a `HandshakeInformation`.

The `authHandshaker` type, which is created once per handshake, retains the `HandshakeInformation` instance and also adds it to the `auth.Config` that's passed down to the underlying `Authenticator` so the relevant information can be accessed during authentication.