### PR TITLE
GODRIVER-1751 Ensure codecs that cache are not shared across registries

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -93,7 +93,7 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterDefaultDecoder(reflect.Map, defaultMapCodec).
 		RegisterDefaultDecoder(reflect.Slice, defaultSliceCodec).
 		RegisterDefaultDecoder(reflect.String, defaultStringCodec).
-		RegisterDefaultDecoder(reflect.Struct, defaultStructCodec).
+		RegisterDefaultDecoder(reflect.Struct, newDefaultStructCodec()).
 		RegisterDefaultDecoder(reflect.Ptr, NewPointerCodec()).
 		RegisterTypeMapEntry(bsontype.Double, tFloat64).
 		RegisterTypeMapEntry(bsontype.String, tString).

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -36,6 +36,16 @@ func (d decodeBinaryError) Error() string {
 	return fmt.Sprintf("only binary values with subtype 0x00 or 0x02 can be decoded into %s, but got subtype %v", d.typeName, d.subtype)
 }
 
+func newDefaultStructCodec() *StructCodec {
+	codec, err := NewStructCodec(DefaultStructTagParser)
+	if err != nil {
+		// This function is called from the codec registration path, so errors can't be propagated. If there's an error
+		// constructing the StructCodec, we panic to avoid losing it.
+		panic(fmt.Errorf("error creating default StructCodec: %v", err))
+	}
+	return codec
+}
+
 // DefaultValueDecoders is a namespace type for the default ValueDecoders used
 // when creating a registry.
 type DefaultValueDecoders struct{}

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -55,6 +55,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 	var pbool = func(b bool) *bool { return &b }
 	var pi32 = func(i32 int32) *int32 { return &i32 }
 	var pi64 = func(i64 int64) *int64 { return &i64 }
+	defaultStructCodec := newDefaultStructCodec()
 
 	type subtest struct {
 		name   string

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -27,6 +27,10 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
+var (
+	defaultTestStructCodec = newDefaultStructCodec()
+)
+
 func TestDefaultValueDecoders(t *testing.T) {
 	var dvd DefaultValueDecoders
 	var wrong = func(string, string) string { return "wrong" }
@@ -55,7 +59,6 @@ func TestDefaultValueDecoders(t *testing.T) {
 	var pbool = func(b bool) *bool { return &b }
 	var pi32 = func(i32 int32) *int32 { return &i32 }
 	var pi64 = func(i64 int64) *int64 { return &i64 }
-	defaultStructCodec := newDefaultStructCodec()
 
 	type subtest struct {
 		name   string
@@ -2198,7 +2201,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 		},
 		{
 			"StructCodec.DecodeValue",
-			defaultStructCodec,
+			defaultTestStructCodec,
 			[]subtest{
 				{
 					"Not struct",
@@ -3498,7 +3501,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 				emptyInterfaceStruct{},
 				bsonrw.NewBSONDocumentReader(docBytes),
 				emptyInterfaceErrorRegistry,
-				defaultStructCodec,
+				defaultTestStructCodec,
 				emptyInterfaceStructErr,
 			},
 			{
@@ -3509,7 +3512,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 				stringStruct{},
 				bsonrw.NewBSONDocumentReader(docBytes),
 				NewRegistryBuilder().Build(),
-				defaultStructCodec,
+				defaultTestStructCodec,
 				stringStructErr,
 			},
 			{
@@ -3517,7 +3520,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 				outer{},
 				bsonrw.NewBSONDocumentReader(outerDoc),
 				nestedRegistry,
-				defaultStructCodec,
+				defaultTestStructCodec,
 				nestedErr,
 			},
 		}
@@ -3547,7 +3550,7 @@ func TestDefaultValueDecoders(t *testing.T) {
 			dc := DecodeContext{Registry: buildDefaultRegistry()}
 			vr := bsonrw.NewBSONDocumentReader(outerBytes)
 			val := reflect.New(reflect.TypeOf(outer{})).Elem()
-			err := defaultStructCodec.DecodeValue(dc, vr, val)
+			err := defaultTestStructCodec.DecodeValue(dc, vr, val)
 
 			decodeErr, ok := err.(*DecodeError)
 			assert.True(t, ok, "expected DecodeError, got %v of type %T", err, err)

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -104,7 +104,7 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		RegisterDefaultEncoder(reflect.Map, defaultMapCodec).
 		RegisterDefaultEncoder(reflect.Slice, defaultSliceCodec).
 		RegisterDefaultEncoder(reflect.String, defaultStringCodec).
-		RegisterDefaultEncoder(reflect.Struct, defaultStructCodec).
+		RegisterDefaultEncoder(reflect.Struct, newDefaultStructCodec()).
 		RegisterDefaultEncoder(reflect.Ptr, NewPointerCodec()).
 		RegisterHookEncoder(tValueMarshaler, ValueEncoderFunc(dve.ValueMarshalerEncodeValue)).
 		RegisterHookEncoder(tMarshaler, ValueEncoderFunc(dve.MarshalerEncodeValue)).

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -66,6 +66,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 	vmStruct := struct{ V testValueMarshalPtr }{testValueMarshalPtr{t: bsontype.String, buf: []byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00}}}
 	mStruct := struct{ V testMarshalPtr }{testMarshalPtr{buf: bsoncore.BuildDocument(nil, bsoncore.AppendDoubleElement(nil, "pi", 3.14159))}}
 	pStruct := struct{ V testProxyPtr }{testProxyPtr{ret: int64(1234567890)}}
+	defaultStructCodec := newDefaultStructCodec()
 
 	type subtest struct {
 		name   string

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -66,7 +66,6 @@ func TestDefaultValueEncoders(t *testing.T) {
 	vmStruct := struct{ V testValueMarshalPtr }{testValueMarshalPtr{t: bsontype.String, buf: []byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00}}}
 	mStruct := struct{ V testMarshalPtr }{testMarshalPtr{buf: bsoncore.BuildDocument(nil, bsoncore.AppendDoubleElement(nil, "pi", 3.14159))}}
 	pStruct := struct{ V testProxyPtr }{testProxyPtr{ret: int64(1234567890)}}
-	defaultStructCodec := newDefaultStructCodec()
 
 	type subtest struct {
 		name   string
@@ -1085,7 +1084,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		},
 		{
 			"StructEncodeValue",
-			defaultStructCodec,
+			defaultTestStructCodec,
 			[]subtest{
 				{
 					"interface value",

--- a/bson/bsoncodec/pointer_codec.go
+++ b/bson/bsoncodec/pointer_codec.go
@@ -14,11 +14,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
-var defaultPointerCodec = &PointerCodec{
-	ecache: make(map[reflect.Type]ValueEncoder),
-	dcache: make(map[reflect.Type]ValueDecoder),
-}
-
 var _ ValueEncoder = &PointerCodec{}
 var _ ValueDecoder = &PointerCodec{}
 

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -19,11 +19,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
-var defaultStructCodec = &StructCodec{
-	cache:  make(map[reflect.Type]*structDescription),
-	parser: DefaultStructTagParser,
-}
-
 // DecodeError represents an error that occurs when unmarshalling BSON bytes into a native Go type.
 type DecodeError struct {
 	keys    []string
@@ -103,6 +98,11 @@ func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) 
 	}
 
 	return codec, nil
+}
+
+func newDefaultStructCodec() *StructCodec {
+	codec, _ := NewStructCodec(DefaultStructTagParser)
+	return codec
 }
 
 // EncodeValue handles encoding generic struct types.

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -100,11 +100,6 @@ func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) 
 	return codec, nil
 }
 
-func newDefaultStructCodec() *StructCodec {
-	codec, _ := NewStructCodec(DefaultStructTagParser)
-	return codec
-}
-
 // EncodeValue handles encoding generic struct types.
 func (sc *StructCodec) EncodeValue(r EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Struct {


### PR DESCRIPTION
It was complicated to put these tests in the `bsoncodec` package because it required a lot of manual setup, so I put them in the `bson` package as a type of "integration" test for `bsoncodec` instead. This lets us push down all of the setup work to helpers that already exist in `bson`.