### PR TITLE
README.md: add -u flag on installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ your project. This can be done either by importing packages from `go.mongodb.org
 step install the dependency or by explicitly running
 
 ```bash
-go get go.mongodb.org/mongo-driver/mongo
+go get -u go.mongodb.org/mongo-driver/mongo
 ```
 
 When using a version of Go that does not support modules, the driver can be installed using `dep` by running


### PR DESCRIPTION
I'm avid user of this library, even after hundreds of use with this library, i still going back to this repository and read the README.md for sample code, until i realize that i haven't update this library on my modules cache, so would it be better if we add -u flag ?