### PR TITLE
GODRIVER-1394 Remove receiver from mongotest functions

### DIFF
--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -109,7 +109,7 @@ func runChangeStreamTest(mt *mtest.T, test changeStreamTest, testFile changeStre
 
 	// Pin to a single mongos because some tests set fail points and in a sharded cluster, the failpoint and command
 	// that fail must be sent to the same mongos.
-	if mt.TopologyKind() == mtest.Sharded {
+	if mtest.ClusterTopologyKind() == mtest.Sharded {
 		mtOpts = mtOpts.ClientType(mtest.Pinned)
 	}
 

--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -192,7 +192,7 @@ func runChangeStreamOperations(mt *mtest.T, test changeStreamTest) error {
 			}, false)
 		}
 		// Use the global client to run the operations so they don't show up in the expectations
-		mt.DB = mt.GlobalClient().Database(op.Database)
+		mt.DB = mtest.GlobalClient().Database(op.Database)
 		mt.Coll = mt.DB.Collection(op.Collection)
 
 		var err error

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -51,7 +51,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 	assert.NotEqual(mt, keyID, "", "%s env var not set", awsAccessKeyID)
 	assert.NotEqual(mt, secretAccessKey, "", "%s env var not set", awsSecretAccessKey)
-	defaultKvClientOptions := options.Client().ApplyURI(mt.ConnString())
+	defaultKvClientOptions := options.Client().ApplyURI(mtest.ClusterURI())
 
 	mt.RunOpts("data key and double encryption", noClientOpts, func(mt *mtest.T) {
 		// set up options structs
@@ -100,7 +100,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 						startedEvents = append(startedEvents, evt)
 					},
 				}
-				kvClientOpts := options.Client().ApplyURI(mt.ConnString()).SetMonitor(monitor)
+				kvClientOpts := options.Client().ApplyURI(mtest.ClusterURI()).SetMonitor(monitor)
 				cpt := setup(mt, aeo, kvClientOpts, ceo)
 				defer cpt.teardown(mt)
 
@@ -188,7 +188,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				kvClientOpts := defaultKvClientOptions
 
 				if tc.externalVault {
-					externalKvOpts := options.Client().ApplyURI(mt.ConnString()).SetAuth(options.Credential{
+					externalKvOpts := options.Client().ApplyURI(mtest.ClusterURI()).SetAuth(options.Credential{
 						Username: "fake-user",
 						Password: "fake-password",
 					})
@@ -842,7 +842,7 @@ func setup(mt *mtest.T, aeo *options.AutoEncryptionOptions, kvClientOpts *option
 				cpt.cseStarted = append(cpt.cseStarted, evt)
 			},
 		}
-		opts := options.Client().ApplyURI(mt.ConnString()).SetWriteConcern(mtest.MajorityWc).
+		opts := options.Client().ApplyURI(mtest.ClusterURI()).SetWriteConcern(mtest.MajorityWc).
 			SetReadPreference(mtest.PrimaryRp).SetAutoEncryptionOptions(aeo).SetMonitor(cseMonitor)
 		cpt.cseClient, err = mongo.Connect(mtest.Background, opts)
 		assert.Nil(mt, err, "Connect error for encrypted client: %v", err)

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -100,7 +100,7 @@ func TestClient(t *testing.T) {
 		).Err()
 		assert.Nil(mt, err, "createUser error: %v", err)
 
-		baseConnString := mt.ConnString()
+		baseConnString := mtest.ClusterURI()
 		// remove username/password from base conn string
 		revisedConnString := "mongodb://"
 		split := strings.Split(baseConnString, "@")
@@ -269,7 +269,7 @@ func TestClient(t *testing.T) {
 	})
 	mt.RunOpts("watch", noClientOpts, func(mt *mtest.T) {
 		mt.Run("disconnected", func(mt *mtest.T) {
-			c, err := mongo.NewClient(options.Client().ApplyURI(mt.ConnString()))
+			c, err := mongo.NewClient(options.Client().ApplyURI(mtest.ClusterURI()))
 			assert.Nil(mt, err, "NewClient error: %v", err)
 			_, err = c.Watch(mtest.Background, mongo.Pipeline{})
 			assert.Equal(mt, mongo.ErrClientDisconnected, err, "expected error %v, got %v", mongo.ErrClientDisconnected, err)

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -404,7 +404,7 @@ func TestClient(t *testing.T) {
 	})
 
 	// Test that direct connections work as expected.
-	firstServerAddr := mt.GlobalTopology().Description().Servers[0].Addr
+	firstServerAddr := mtest.GlobalTopology().Description().Servers[0].Addr
 	directConnectionOpts := options.Client().
 		ApplyURI(fmt.Sprintf("mongodb://%s", firstServerAddr)).
 		SetReadPreference(readpref.Primary()).

--- a/mongo/integration/command_monitoring_test.go
+++ b/mongo/integration/command_monitoring_test.go
@@ -76,7 +76,7 @@ func runMonitoringTest(mt *mtest.T, test monitoringTest, testFile monitoringTest
 		// ignored topologies have to be handled separately because mtest only accepts topologies to run on, not
 		// topologies to ignore
 		for _, top := range test.IgnoredTopologies {
-			if top == mt.TopologyKind() {
+			if top == mtest.ClusterTopologyKind() {
 				mt.Skipf("skipping topology %v", top)
 			}
 		}

--- a/mongo/integration/command_monitoring_test.go
+++ b/mongo/integration/command_monitoring_test.go
@@ -81,7 +81,7 @@ func runMonitoringTest(mt *mtest.T, test monitoringTest, testFile monitoringTest
 			}
 		}
 
-		setupColl := mt.GlobalClient().Database(mt.DB.Name()).Collection(mt.Coll.Name())
+		setupColl := mtest.GlobalClient().Database(mt.DB.Name()).Collection(mt.Coll.Name())
 		insertDocuments(mt, setupColl, testFile.Data)
 		mt.ClearEvents()
 		runMonitoringOperation(mt, test.Operation)

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -115,9 +115,9 @@ func killSessions(mt *mtest.T) {
 // replica sets, the command is run against the primary. sharded clusters, the command is run against each mongos.
 func runCommandOnAllServers(mt *mtest.T, commandFn func(client *mongo.Client) error) error {
 	opts := options.Client().
-		ApplyURI(mt.ConnString())
+		ApplyURI(mtest.ClusterURI())
 
-	if mt.TopologyKind() != mtest.Sharded {
+	if mtest.ClusterTopologyKind() != mtest.Sharded {
 		client, err := mongo.Connect(mtest.Background, opts)
 		if err != nil {
 			return fmt.Errorf("error creating replica set client: %v", err)
@@ -1405,7 +1405,7 @@ func executeCreateCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) err
 
 func executeAdminCommand(mt *mtest.T, op *operation) {
 	// Per the streamable isMaster test format description, a separate client must be used to execute this operation.
-	clientOpts := options.Client().ApplyURI(mt.ConnString())
+	clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
 	client, err := mongo.Connect(mtest.Background, clientOpts)
 	assert.Nil(mt, err, "Connect error: %v", err)
 	defer func() {

--- a/mongo/integration/data_lake_test.go
+++ b/mongo/integration/data_lake_test.go
@@ -96,14 +96,14 @@ func TestAtlasDataLake(t *testing.T) {
 }
 
 func getBaseClientOptions(mt *mtest.T) *options.ClientOptions {
-	opts := options.Client().ApplyURI(mt.ConnString())
+	opts := options.Client().ApplyURI(mtest.ClusterURI())
 	return options.Client().SetHosts(opts.Hosts)
 }
 
 func getBaseCredential(mt *mtest.T) options.Credential {
 	mt.Helper()
 
-	cred := options.Client().ApplyURI(mt.ConnString()).Auth
-	assert.NotNil(mt, cred, "expected options for URI %q to have a non-nil Auth field", mt.ConnString())
+	cred := options.Client().ApplyURI(mtest.ClusterURI()).Auth
+	assert.NotNil(mt, cred, "expected options for URI %q to have a non-nil Auth field", mtest.ClusterURI())
 	return *cred
 }

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -260,11 +260,11 @@ func TestDatabase(t *testing.T) {
 				ReadOnly: false,
 				Options:  bson.Raw(optionsDoc),
 			}
-			if mtest.CompareServerVersions(mt.ServerVersion(), "3.6") >= 0 {
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.6") >= 0 {
 				uuidSubtype, uuidData := cursor.Current.Lookup("info", "uuid").Binary()
 				expectedSpec.UUID = &primitive.Binary{Subtype: uuidSubtype, Data: uuidData}
 			}
-			if mtest.CompareServerVersions(mt.ServerVersion(), "3.4") >= 0 {
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.4") >= 0 {
 				keysDoc := bsoncore.NewDocumentBuilder().
 					AppendInt32("_id", 1).
 					Build()

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -51,7 +51,7 @@ func TestErrors(t *testing.T) {
 				},
 			})
 
-			client, err := mongo.Connect(mtest.Background, options.Client().ApplyURI(mt.ConnString()))
+			client, err := mongo.Connect(mtest.Background, options.Client().ApplyURI(mtest.ClusterURI()))
 			assert.Nil(mt, err, "Connect error: %v", err)
 			defer client.Disconnect(mtest.Background)
 

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -331,7 +331,7 @@ func TestIndexView(t *testing.T) {
 				KeysDocument: bson.Raw(keysDoc),
 				Version:      2,
 			}
-			if mtest.CompareServerVersions(mt.ServerVersion(), "3.4") < 0 {
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.4") < 0 {
 				expectedSpec.Version = 1
 			}
 

--- a/mongo/integration/mongos_pinning_test.go
+++ b/mongo/integration/mongos_pinning_test.go
@@ -25,7 +25,7 @@ func TestMongosPinning(t *testing.T) {
 	mt := mtest.New(t, mtOpts)
 	defer mt.Close()
 
-	if len(options.Client().ApplyURI(mt.ConnString()).Hosts) < 2 {
+	if len(options.Client().ApplyURI(mtest.ClusterURI()).Hosts) < 2 {
 		mt.Skip("skipping because at least 2 mongoses are required")
 	}
 

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package mtest
 
 import (

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -33,17 +33,17 @@ func ClusterURI() string {
 
 // GlobalClient returns a client configured with read concern majority, write concern majority, and read preference
 // primary. The returned client is not tied to the receiver and is valid outside the lifetime of the receiver.
-func (*T) GlobalClient() *mongo.Client {
+func GlobalClient() *mongo.Client {
 	return testContext.client
 }
 
 // GlobalTopology returns the Topology backing the global Client.
-func (*T) GlobalTopology() *topology.Topology {
+func GlobalTopology() *topology.Topology {
 	return testContext.topo
 }
 
 // ServerVersion returns the server version of the cluster. This assumes that all nodes in the cluster have the same
 // version.
-func (*T) ServerVersion() string {
+func ServerVersion() string {
 	return testContext.serverVersion
 }

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -11,12 +11,12 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
-// AuthEnabled returns whether or not this test is running in an environment with auth.
+// AuthEnabled returns whether or not the cluster requires auth.
 func AuthEnabled() bool {
 	return testContext.authEnabled
 }
 
-// SSLEnabled returns whether or not this test is running in an environment with SSL.
+// SSLEnabled returns whether or not the cluster requires SSL.
 func SSLEnabled() bool {
 	return testContext.sslEnabled
 }
@@ -26,18 +26,18 @@ func ClusterTopologyKind() TopologyKind {
 	return testContext.topoKind
 }
 
-// ClusterURI returns the connection string used to create the client for this test.
+// ClusterURI returns the connection string for the cluster.
 func ClusterURI() string {
 	return testContext.connString.Original
 }
 
-// GlobalClient returns a client configured with read concern majority, write concern majority, and read preference
-// primary. The returned client is not tied to the receiver and is valid outside the lifetime of the receiver.
+// GlobalClient returns a Client connected to the cluster configured with read concern majority, write concern majority,
+// and read preference primary.
 func GlobalClient() *mongo.Client {
 	return testContext.client
 }
 
-// GlobalTopology returns the Topology backing the global Client.
+// GlobalTopology returns a Topology that's connected to the cluster.
 func GlobalTopology() *topology.Topology {
 	return testContext.topo
 }

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -1,0 +1,43 @@
+package mtest
+
+import (
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+)
+
+// AuthEnabled returns whether or not this test is running in an environment with auth.
+func AuthEnabled() bool {
+	return testContext.authEnabled
+}
+
+// SSLEnabled returns whether or not this test is running in an environment with SSL.
+func SSLEnabled() bool {
+	return testContext.sslEnabled
+}
+
+// ClusterTopologyKind returns the topology kind of the cluster under test.
+func ClusterTopologyKind() TopologyKind {
+	return testContext.topoKind
+}
+
+// ClusterURI returns the connection string used to create the client for this test.
+func ClusterURI() string {
+	return testContext.connString.Original
+}
+
+// GlobalClient returns a client configured with read concern majority, write concern majority, and read preference
+// primary. The returned client is not tied to the receiver and is valid outside the lifetime of the receiver.
+func (*T) GlobalClient() *mongo.Client {
+	return testContext.client
+}
+
+// GlobalTopology returns the Topology backing the global Client.
+func (*T) GlobalTopology() *topology.Topology {
+	return testContext.topo
+}
+
+// ServerVersion returns the server version of the cluster. This assumes that all nodes in the cluster have the same
+// version.
+func (*T) ServerVersion() string {
+	return testContext.serverVersion
+}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -21,7 +21,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
 var (
@@ -517,26 +516,6 @@ func (t *T) ClearFailPoints() {
 	t.failPointNames = t.failPointNames[:0]
 }
 
-// AuthEnabled returns whether or not this test is running in an environment with auth.
-func (t *T) AuthEnabled() bool {
-	return testContext.authEnabled
-}
-
-// SSLEnabled returns whether or not this test is running in an environment with SSL.
-func (t *T) SSLEnabled() bool {
-	return testContext.sslEnabled
-}
-
-// TopologyKind returns the topology kind of the environment
-func (t *T) TopologyKind() TopologyKind {
-	return testContext.topoKind
-}
-
-// ConnString returns the connection string used to create the client for this test.
-func (t *T) ConnString() string {
-	return testContext.connString.Original
-}
-
 // CloneDatabase modifies the default database for this test to match the given options.
 func (t *T) CloneDatabase(opts *options.DatabaseOptions) {
 	t.DB = t.Client.Database(t.dbName, opts)
@@ -547,23 +526,6 @@ func (t *T) CloneCollection(opts *options.CollectionOptions) {
 	var err error
 	t.Coll, err = t.Coll.Clone(opts)
 	assert.Nil(t, err, "error cloning collection: %v", err)
-}
-
-// GlobalClient returns a client configured with read concern majority, write concern majority, and read preference
-// primary. The returned client is not tied to the receiver and is valid outside the lifetime of the receiver.
-func (*T) GlobalClient() *mongo.Client {
-	return testContext.client
-}
-
-// GlobalTopology returns the Topology backing the global Client.
-func (*T) GlobalTopology() *topology.Topology {
-	return testContext.topo
-}
-
-// ServerVersion returns the server version of the cluster. This assumes that all nodes in the cluster have the same
-// version.
-func (*T) ServerVersion() string {
-	return testContext.serverVersion
 }
 
 func sanitizeCollectionName(db string, coll string) string {

--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -51,7 +51,7 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 	defer mt.Close()
 
 	clientOpts := options.Client().
-		ApplyURI(mt.ConnString()).
+		ApplyURI(mtest.ClusterURI()).
 		SetRetryWrites(false).
 		SetPoolMonitor(poolMonitor)
 

--- a/mongo/integration/retryable_writes_spec_test.go
+++ b/mongo/integration/retryable_writes_spec_test.go
@@ -63,7 +63,7 @@ func runRetryableWritesTest(mt *mtest.T, test retryableWritesTest, testFile retr
 	testClientOpts := createClientOptions(mt, test.ClientOptions)
 	testClientOpts.SetHeartbeatInterval(defaultHeartbeatInterval)
 	opts := mtest.NewOptions().ClientOptions(testClientOpts)
-	if mt.TopologyKind() == mtest.Sharded && !test.UseMultipleMongoses {
+	if mtest.ClusterTopologyKind() == mtest.Sharded && !test.UseMultipleMongoses {
 		// pin to a single mongos
 		opts = opts.ClientType(mtest.Pinned)
 	}

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -26,7 +26,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
 	baseClientOpts := func() *options.ClientOptions {
 		return options.Client().
-			ApplyURI(mt.ConnString()).
+			ApplyURI(mtest.ClusterURI()).
 			SetRetryWrites(false).
 			SetPoolMonitor(poolMonitor).
 			SetWriteConcern(mtest.MajorityWc)
@@ -37,7 +37,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 			MinServerVersion("4.0").      // 4.0+ is required to use failpoints on replica sets.
 			ClientOptions(baseClientOpts())
 
-		if mt.TopologyKind() == mtest.Sharded {
+		if mtest.ClusterTopologyKind() == mtest.Sharded {
 			// Pin to a single mongos because the tests use failpoints.
 			mtOpts.ClientType(mtest.Pinned)
 		}

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -293,7 +293,7 @@ func runServerErrorsTest(mt *mtest.T, isShutdownError bool) {
 	}
 
 	// For non-shutdown errors, the pool is only cleared if the error is from a pre-4.2 server.
-	wantCleared := mtest.CompareServerVersions(mt.ServerVersion(), "4.2") < 0
+	wantCleared := mtest.CompareServerVersions(mtest.ServerVersion(), "4.2") < 0
 	gotCleared := isPoolCleared()
 	assert.Equal(mt, wantCleared, gotCleared, "expected pool to be cleared: %v; pool was cleared: %v",
 		wantCleared, gotCleared)

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -38,7 +38,7 @@ func TestSDAMProse(t *testing.T) {
 		//
 		// Tests on < 4.4 should process at least numberOfNodes * X/frequency messages.
 
-		numNodes := len(options.Client().ApplyURI(mt.ConnString()).Hosts)
+		numNodes := len(options.Client().ApplyURI(mtest.ClusterURI()).Hosts)
 		timeDuration := 250 * time.Millisecond
 		numExpectedResponses := numNodes * int(timeDuration/lowHeartbeatFrequency)
 		if mtest.CompareServerVersions(mt.ServerVersion(), "4.4") >= 0 {

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -41,7 +41,7 @@ func TestSDAMProse(t *testing.T) {
 		numNodes := len(options.Client().ApplyURI(mtest.ClusterURI()).Hosts)
 		timeDuration := 250 * time.Millisecond
 		numExpectedResponses := numNodes * int(timeDuration/lowHeartbeatFrequency)
-		if mtest.CompareServerVersions(mt.ServerVersion(), "4.4") >= 0 {
+		if mtest.CompareServerVersions(mtest.ServerVersion(), "4.4") >= 0 {
 			numExpectedResponses = numNodes * (2*int(timeDuration/lowHeartbeatFrequency) + 1)
 		}
 

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -70,7 +70,7 @@ func TestSessions(t *testing.T) {
 	mtOpts := mtest.NewOptions().MinServerVersion("3.6").Topologies(mtest.ReplicaSet, mtest.Sharded).
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	hosts := options.Client().ApplyURI(mt.ConnString()).Hosts
+	hosts := options.Client().ApplyURI(mtest.ClusterURI()).Hosts
 
 	// Pin to a single mongos so heartbeats/handshakes to other mongoses won't cause errors.
 	clusterTimeOpts := mtest.NewOptions().

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -211,7 +211,7 @@ func runSpecTestFile(t *testing.T, specDir, fileName string) {
 
 func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 	opts := mtest.NewOptions().DatabaseName(testFile.DatabaseName).CollectionName(testFile.CollectionName)
-	if mt.TopologyKind() == mtest.Sharded && !test.UseMultipleMongoses {
+	if mtest.ClusterTopologyKind() == mtest.Sharded && !test.UseMultipleMongoses {
 		// pin to a single mongos
 		opts = opts.ClientType(mtest.Pinned)
 	}
@@ -237,7 +237,7 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		}
 
 		// work around for SERVER-39704: run a non-transactional distinct against each shard in a sharded cluster
-		if mt.TopologyKind() == mtest.Sharded && test.Description == "distinct" {
+		if mtest.ClusterTopologyKind() == mtest.Sharded && test.Description == "distinct" {
 			err := runCommandOnAllServers(mt, func(mongosClient *mongo.Client) error {
 				coll := mongosClient.Database(mt.DB.Name()).Collection(mt.Coll.Name())
 				_, err := coll.Distinct(mtest.Background, "x", bson.D{})
@@ -421,7 +421,7 @@ func executeTestRunnerOperation(mt *mtest.T, testCase *testCase, op *operation, 
 		}
 
 		targetHost := clientSession.PinnedServer.Addr.String()
-		opts := options.Client().ApplyURI(mt.ConnString()).SetHosts([]string{targetHost})
+		opts := options.Client().ApplyURI(mtest.ClusterURI()).SetHosts([]string{targetHost})
 		client, err := mongo.Connect(mtest.Background, opts)
 		if err != nil {
 			return fmt.Errorf("Connect error for targeted client: %v", err)

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -521,7 +521,7 @@ func verifyIndexState(mt *mtest.T, op *operation, shouldExist bool) error {
 
 func indexExists(mt *mtest.T, dbName, collName, indexName string) (bool, error) {
 	// Use global client because listIndexes cannot be executed inside a transaction.
-	iv := mt.GlobalClient().Database(dbName).Collection(collName).Indexes()
+	iv := mtest.GlobalClient().Database(dbName).Collection(collName).Indexes()
 	cursor, err := iv.List(mtest.Background)
 	if err != nil {
 		return false, fmt.Errorf("IndexView.List error: %v", err)
@@ -557,7 +557,7 @@ func collectionExists(mt *mtest.T, dbName, collName string) (bool, error) {
 	}
 
 	// Use global client because listCollections cannot be executed inside a transaction.
-	collections, err := mt.GlobalClient().Database(dbName).ListCollectionNames(mtest.Background, filter)
+	collections, err := mtest.GlobalClient().Database(dbName).ListCollectionNames(mtest.Background, filter)
 	if err != nil {
 		return false, fmt.Errorf("ListCollectionNames error: %v", err)
 	}
@@ -907,7 +907,7 @@ func verifyTestOutcome(mt *mtest.T, outcomeColl *outcomeCollection) {
 	if outcomeColl.Name != "" {
 		collName = outcomeColl.Name
 	}
-	coll := mt.GlobalClient().Database(mt.DB.Name()).Collection(collName, checkOutcomeOpts)
+	coll := mtest.GlobalClient().Database(mt.DB.Name()).Collection(collName, checkOutcomeOpts)
 
 	findOpts := options.Find().
 		SetSort(bson.M{"_id": 1})


### PR DESCRIPTION
This is some clean up that's required for us to implement the unified test runner. The main change I made was moving some functions that had a `mtest.T` as their receiver to be standalone functions because they were just proxies to query global testing state. All of these functions moved from `mongotest.go` to `global_state.go`. The rest of the changes are in the callers. 