### PR TITLE
GODRIVER-1757 Specify exact path for LoadLibrary call

### DIFF
--- a/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
+++ b/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
@@ -10,10 +10,12 @@ int sspi_init(
 )
 {
 	// Load the secur32.dll library using its exact path. Passing the exact DLL path rather than allowing LoadLibrary to
-	// search in different locations removes the possibility of DLL preloading attacks.
+	// search in different locations removes the possibility of DLL preloading attacks. We use GetSystemDirectoryA and
+	// LoadLibraryA rather than the GetSystemDirectory/LoadLibrary aliases to ensure the ANSI versions are used so we
+	// don't have to account for variations in char sizes if UNICODE is enabled.
 
 	// Passing a 0 size will return the required buffer length to hold the path, including the null terminator.
-	int requiredLen = GetSystemDirectory(NULL, 0);
+	int requiredLen = GetSystemDirectoryA(NULL, 0);
 	if (!requiredLen) {
 		return GetLastError();
 	}
@@ -21,7 +23,7 @@ int sspi_init(
 	// Allocate a buffer to hold the system directory + "\secur32.dll" (length 12, not including null terminator).
 	int actualLen = requiredLen + 12;
 	char *directoryBuffer = (char *) calloc(1, actualLen);
-	int directoryLen = GetSystemDirectory(directoryBuffer, actualLen);
+	int directoryLen = GetSystemDirectoryA(directoryBuffer, actualLen);
 	if (!directoryLen) {
 		free(directoryBuffer);
 		return GetLastError();
@@ -31,7 +33,7 @@ int sspi_init(
 	char *dllName = "\\secur32.dll";
 	strcpy_s(&(directoryBuffer[directoryLen]), actualLen - directoryLen, dllName);
 
-	sspi_secur32_dll = LoadLibrary(directoryBuffer);
+	sspi_secur32_dll = LoadLibraryA(directoryBuffer);
 	free(directoryBuffer);
 	if (!sspi_secur32_dll) {
 		return GetLastError();

--- a/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
+++ b/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
@@ -23,6 +23,7 @@ int sspi_init(
 	char *directoryBuffer = (char *) calloc(1, actualLen);
 	int directoryLen = GetSystemDirectory(directoryBuffer, actualLen);
 	if (!directoryLen) {
+		free(directoryBuffer);
 		return GetLastError();
 	}
 
@@ -31,6 +32,7 @@ int sspi_init(
 	strcpy_s(&(directoryBuffer[directoryLen]), actualLen - directoryLen, dllName);
 
 	sspi_secur32_dll = LoadLibrary(directoryBuffer);
+	free(directoryBuffer);
 	if (!sspi_secur32_dll) {
 		return GetLastError();
 	}


### PR DESCRIPTION
We currently call `LoadLibrary("secur32.dll")` in our SSPI code. This allows for DLL preloading attacks because an attacker can place a DLL with that name in the application directory and it would be favored over the system version.

The changes in this PR use `GetSystemDirectory` to find out where `secur32.dll` is located so we can construct the full path and ensure that `LoadLibrary` only looks for it there. The motivation for the solution is in the `LoadLibrary` documentation's [Parameters section](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya#parameters):

> If the string specifies a full path, the function searches only that path for the module.

> If the string specifies a relative path or a module name without a path, the function uses a standard search strategy to find the module; for more information, see the Remarks.

Another option I considered was to use `LoadLibraryEx` with the `LOAD_LIBRARY_SEARCH_SYSTEM32` flag, but this function doesn't work for Windows XP and requires patched Windows update for versions lower than Windows 10, so this seemed like a more robust solution.