### PR TITLE
GODRIVER-1394 Implement a unified test runner

### DIFF
--- a/data/unified-test-format/valid-pass/poc-change-streams.json
+++ b/data/unified-test-format/valid-pass/poc-change-streams.json
@@ -1,0 +1,410 @@
+{
+  "description": "poc-change-streams",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database2",
+        "client": "client1",
+        "databaseName": "change-stream-tests-2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database1",
+        "collectionName": "test2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection3",
+        "database": "database2",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test2",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests-2",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.8.0",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "client0",
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection2",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection3",
+          "arguments": {
+            "document": {
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "z": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test2"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests-2",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "z": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "allChangesForCluster": true,
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test consecutive resume",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "batchSize": 1
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 3
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-change-streams.json
+++ b/data/unified-test-format/valid-pass/poc-change-streams.json
@@ -103,6 +103,9 @@
         {
           "name": "createChangeStream",
           "object": "client0",
+          "arguments": {
+            "pipeline": []
+          },
           "saveResultAsEntity": "changeStream0"
         },
         {
@@ -246,7 +249,8 @@
           "name": "createChangeStream",
           "object": "collection0",
           "arguments": {
-            "batchSize": 1
+            "batchSize": 1,
+            "pipeline": []
           },
           "saveResultAsEntity": "changeStream0"
         },

--- a/data/unified-test-format/valid-pass/poc-change-streams.yml
+++ b/data/unified-test-format/valid-pass/poc-change-streams.yml
@@ -1,0 +1,217 @@
+description: "poc-change-streams"
+
+schemaVersion: "1.0"
+
+createEntities:
+  # Entities for creating changeStreams
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+      # Original tests do not observe getMore commands but only because event
+      # assertions ignore extra events. killCursors is explicitly ignored.
+      ignoreCommandMonitoringEvents: [ getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  # Entities for executing insert operations
+  - client:
+      id: &client1 client1
+      useMultipleMongoses: false
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: &database1Name change-stream-tests
+  - database:
+      id: &database2 database2
+      client: *client1
+      databaseName: &database2Name change-stream-tests-2
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: &collection1Name test
+  - collection:
+      id: &collection2 collection2
+      database: *database1
+      collectionName: &collection2Name test2
+  - collection:
+      id: &collection3 collection3
+      database: *database2
+      collectionName: &collection3Name test
+
+initialData:
+  - collectionName: *collection1Name
+    databaseName: *database1Name
+    documents: []
+  - collectionName: *collection2Name
+    databaseName: *database1Name
+    documents: []
+  - collectionName: *collection3Name
+    databaseName: *database2Name
+    documents: []
+
+tests:
+  - description: "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster."
+    runOnRequirements:
+      - minServerVersion: "3.8.0"
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *client0
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection2
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *collection3
+        arguments:
+          document: { y: 1 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { z: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection2Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database2Name
+            coll: *collection3Name
+          fullDocument:
+            # Original tests did not include _id, but matching now only permits
+            # extra keys for root-level documents.
+            _id: { $$type: objectId }
+            y: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            z: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                cursor: {}
+                pipeline:
+                  - $changeStream:
+                      allChangesForCluster: true
+                      # Some drivers may send a default value for fullDocument
+                      # or omit it entirely (see: SPEC-1350).
+                      fullDocument: { $$unsetOrMatches: default }
+              commandName: aggregate
+              databaseName: admin
+
+  - description: "Test consecutive resume"
+    runOnRequirements:
+      - minServerVersion: "4.1.7"
+        topologies: [ replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ getMore ]
+              closeConnection: true
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          batchSize: 1
+        saveResultAsEntity: *changeStream0
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 2 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 2
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection1Name
+                cursor: { batchSize: 1 }
+                pipeline:
+                  - $changeStream:
+                      fullDocument: { $$unsetOrMatches: default }
+              commandName: aggregate
+              databaseName: *database1Name
+          # The original test only asserted the first command, since expected
+          # events were only an ordered subset. This file does ignore getMore
+          # commands but we must expect the subsequent aggregate commands, since
+          # each failed getMore will resume. While doing so we can also assert
+          # that those commands include a resume token.
+          - &resumingAggregate
+            commandStartedEvent:
+              command:
+                aggregate: *collection1Name
+                cursor: { batchSize: 1 }
+                pipeline:
+                  - $changeStream:
+                      fullDocument: { $$unsetOrMatches: default }
+                      resumeAfter: { $$exists: true }
+              commandName: aggregate
+              databaseName: *database0Name
+          - *resumingAggregate

--- a/data/unified-test-format/valid-pass/poc-change-streams.yml
+++ b/data/unified-test-format/valid-pass/poc-change-streams.yml
@@ -63,6 +63,8 @@ tests:
     operations:
       - name: createChangeStream
         object: *client0
+        arguments:
+          pipeline: []
         saveResultAsEntity: &changeStream0 changeStream0
       - name: insertOne
         object: *collection2
@@ -143,6 +145,7 @@ tests:
         object: *collection0
         arguments:
           batchSize: 1
+          pipeline: []
         saveResultAsEntity: *changeStream0
       - name: insertOne
         object: *collection1

--- a/data/unified-test-format/valid-pass/poc-command-monitoring.json
+++ b/data/unified-test-format/valid-pass/poc-command-monitoring.json
@@ -1,0 +1,222 @@
+{
+  "description": "poc-command-monitoring",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "command-monitoring-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "command-monitoring-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "A successful find event with a getmore and the server kills the cursor",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.1",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "sort": {
+              "_id": 1
+            },
+            "batchSize": 3,
+            "limit": 4
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": {
+                      "$gte": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": 1
+                  },
+                  "batchSize": 3,
+                  "limit": 4
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    },
+                    "ns": "command-monitoring-tests.test",
+                    "firstBatch": [
+                      {
+                        "_id": 1,
+                        "x": 11
+                      },
+                      {
+                        "_id": 2,
+                        "x": 22
+                      },
+                      {
+                        "_id": 3,
+                        "x": 33
+                      }
+                    ]
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "test",
+                  "batchSize": 1
+                },
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": 0,
+                    "ns": "command-monitoring-tests.test",
+                    "nextBatch": [
+                      {
+                        "_id": 4,
+                        "x": 44
+                      }
+                    ]
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A failed find event",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "$or": true
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-command-monitoring.yml
+++ b/data/unified-test-format/valid-pass/poc-command-monitoring.yml
@@ -1,0 +1,101 @@
+description: "poc-command-monitoring"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name command-monitoring-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+
+tests:
+  - description: "A successful find event with a getmore and the server kills the cursor"
+    runOnRequirements:
+      - minServerVersion: "3.1"
+        topologies: [ single, replicaset ]
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id: { $gte: 1 }}
+          sort: { _id: 1 }
+          batchSize: 3
+          limit: 4
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gte : 1 } }
+                sort: { _id: 1 }
+                batchSize: 3
+                limit: 4
+              commandName: find
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                cursor:
+                  id: { $$type: [ int, long ] }
+                  ns: &namespace command-monitoring-tests.test
+                  firstBatch:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 1
+              commandName: getMore
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                cursor:
+                  id: 0
+                  ns: *namespace
+                  nextBatch:
+                    - { _id: 4, x: 44 }
+              commandName: getMore
+
+  - description: "A failed find event"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { $or: true }
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { $or: true }
+              commandName: find
+              databaseName: *database0Name
+          - commandFailedEvent:
+              commandName: find

--- a/data/unified-test-format/valid-pass/poc-crud.json
+++ b/data/unified-test-format/valid-pass/poc-crud.json
@@ -1,0 +1,446 @@
+{
+  "description": "poc-crud",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client0",
+        "databaseName": "admin"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database0",
+        "collectionName": "coll2",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "majority"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    },
+    {
+      "collectionName": "coll2",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "aggregate_out",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 3,
+                    "x": 33
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 4,
+                    "x": 44
+                  }
+                }
+              },
+              {
+                "deleteMany": {
+                  "filter": {
+                    "x": {
+                      "$nin": [
+                        24,
+                        34
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "_id": 4,
+                    "x": 44
+                  },
+                  "upsert": true
+                }
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "deletedCount": 2,
+            "insertedCount": 2,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 3,
+                "3": 4
+              }
+            },
+            "matchedCount": 3,
+            "modifiedCount": 3,
+            "upsertedCount": 1,
+            "upsertedIds": {
+              "5": 4
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection1",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 3,
+                "x": 33
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "deletedCount": 0,
+              "insertedCount": 2,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {}
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "readConcern majority with out stage",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.0",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection2",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "aggregate_out"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll2",
+                  "pipeline": [
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$out": "aggregate_out"
+                    }
+                  ],
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "aggregate_out",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $listLocalSessions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database1",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "dummy": "dummy field"
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "dummy": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "dummy": "dummy field"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-crud.yml
+++ b/data/unified-test-format/valid-pass/poc-crud.yml
@@ -1,0 +1,183 @@
+description: "poc-crud"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - database:
+      id: &database1 database1
+      client: *client0
+      databaseName: &database1Name admin
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+  - collection:
+      id: &collection2 collection2
+      database: *database0
+      collectionName: &collection2Name coll2
+      collectionOptions:
+        readConcern: { level: majority }
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+  - collectionName: *collection1Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+  - collectionName: *collection2Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+  - collectionName: &out aggregate_out
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "BulkWrite with mixed ordered operations"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: { _id: 3, x: 33 }
+            - updateOne:
+                filter: { _id: 2 }
+                update: { $inc: { x: 1 } }
+            - updateMany:
+                filter: { _id: { $gt: 1 } }
+                update: { $inc: { x: 1 } }
+            - insertOne:
+                document: { _id: 4, x: 44 }
+            - deleteMany:
+                filter: { x: { $nin: [ 24, 34 ] } }
+            - replaceOne:
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 44 }
+                upsert: true
+          ordered: true
+        expectResult:
+          deletedCount: 2
+          insertedCount: 2
+          insertedIds: { $$unsetOrMatches: { 0: 3, 3: 4 } }
+          matchedCount: 3
+          modifiedCount: 3
+          upsertedCount: 1
+          upsertedIds: { 5: 4 }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - {_id: 2, x: 24 }
+          - {_id: 3, x: 34 }
+          - {_id: 4, x: 44 }
+
+  - description: "InsertMany continue-on-error behavior with unordered (duplicate key in requests)"
+    operations:
+      - name: insertMany
+        object: *collection1
+        arguments:
+          documents:
+            - { _id: 2, x: 22 }
+            - { _id: 2, x: 22 }
+            - { _id: 3, x: 33 }
+          ordered: false
+        expectError:
+          expectResult:
+            deletedCount: 0
+            insertedCount: 2
+            # Since the map of insertedIds is generated before execution it
+            # could indicate inserts that did not actually succeed. We omit
+            # this field rather than expect drivers to provide an accurate
+            # map filtered by write errors.
+            matchedCount: 0
+            modifiedCount: 0
+            upsertedCount: 0
+            upsertedIds: { }
+    outcome:
+      - collectionName: *collection1Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+
+  - description: "ReplaceOne prohibits atomic modifiers"
+    operations:
+      - name: replaceOne
+        object: *collection1
+        arguments:
+          filter: { _id: 1 }
+          replacement: { $set: { x: 22 }}
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome:
+      - collectionName: *collection1Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+
+  - description: "readConcern majority with out stage"
+    runOnRequirements:
+      - minServerVersion: "4.1.0"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: aggregate
+        object: *collection2
+        arguments:
+          pipeline: &pipeline
+            - $sort: { x : 1 }
+            - $match: { _id: { $gt: 1 } }
+            - $out: *out
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection2Name
+                pipeline: *pipeline
+                readConcern: { level: majority }
+              # The following two assertions were not in the original test
+              commandName: aggregate
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *out
+        databaseName: *database0Name
+        documents:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+
+  - description: "Aggregate with $listLocalSessions"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: aggregate
+        object: *database1
+        arguments:
+          pipeline:
+            - $listLocalSessions: { }
+            - $limit: 1
+            - $addFields: { dummy: "dummy field"}
+            - $project: { _id: 0, dummy: 1}
+        expectResult:
+          - { dummy: "dummy field" }

--- a/data/unified-test-format/valid-pass/poc-gridfs.json
+++ b/data/unified-test-format/valid-pass/poc-gridfs.json
@@ -1,0 +1,299 @@
+{
+  "description": "poc-gridfs",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "length": 10,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "md5": "57d83cd477bfb1ccd975ab33d827a92b",
+          "filename": "length-10",
+          "contentType": "application/octet-stream",
+          "aliases": [],
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "ESIzRA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000006"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 1,
+          "data": {
+            "$binary": {
+              "base64": "VWZ3iA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000007"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 2,
+          "data": {
+            "$binary": {
+              "base64": "mao=",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Delete when length is 10",
+      "operations": [
+        {
+          "name": "delete",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Download when there are three chunks",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectResult": {
+            "$$matchesHexBytes": "112233445566778899aa"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when files entry does not exist",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000000"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when an intermediate chunk is missing",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "files_id": {
+                "$oid": "000000000000000000000005"
+              },
+              "n": 1
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        },
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Upload when length is 5",
+      "operations": [
+        {
+          "name": "upload",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename",
+            "source": {
+              "$$hexBytes": "1122334455"
+            },
+            "chunkSizeBytes": 4
+          },
+          "expectResult": {
+            "$$type": "objectId"
+          },
+          "saveResultAsEntity": "oid0"
+        },
+        {
+          "name": "find",
+          "object": "bucket0_files_collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "uploadDate": -1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "length": 5,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$$type": "date"
+              },
+              "md5": "283d4fea5dded59cf837d3047328f5af",
+              "filename": "filename"
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": {
+                  "$oid": "000000000000000000000007"
+                }
+              }
+            },
+            "sort": {
+              "n": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "ESIzRA==",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 1,
+              "data": {
+                "$binary": {
+                  "base64": "VQ==",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-gridfs.json
+++ b/data/unified-test-format/valid-pass/poc-gridfs.json
@@ -240,7 +240,9 @@
               "uploadDate": {
                 "$$type": "date"
               },
-              "md5": "283d4fea5dded59cf837d3047328f5af",
+              "md5": {
+                "$$unsetOrMatches": "283d4fea5dded59cf837d3047328f5af"
+              },
               "filename": "filename"
             }
           ]

--- a/data/unified-test-format/valid-pass/poc-gridfs.yml
+++ b/data/unified-test-format/valid-pass/poc-gridfs.yml
@@ -1,0 +1,154 @@
+description: "poc-gridfs"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - _id: { $oid: "000000000000000000000005" }
+        length: 10
+        chunkSize: 4
+        uploadDate: { $date: "1970-01-01T00:00:00.000Z" }
+        md5: "57d83cd477bfb1ccd975ab33d827a92b"
+        filename: "length-10"
+        contentType: "application/octet-stream"
+        aliases: []
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - _id: { $oid: "000000000000000000000005" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 0
+        data: { $binary: { base64: "ESIzRA==", subType: "00" } } # hex: 11223344
+      - _id: { $oid: "000000000000000000000006" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 1
+        data: { $binary: { base64: "VWZ3iA==", subType: "00" } } # hex: 55667788
+      - _id: { $oid: "000000000000000000000007" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 2
+        data: { $binary: { base64: "mao=", subType: "00" } } # hex: 99aa
+
+tests:
+  # Changed from original test ("length is 8") to operate on same initialData
+  - description: "Delete when length is 10"
+    operations:
+      - name: delete
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+    # Original test uses "assert.data" syntax to modify outcome collection for
+    # comparison. This can be accomplished using "outcome" directly.
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents: []
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents: []
+
+  - description: "Download when there are three chunks"
+    operations:
+      # Original test uses "download" operation. We use an explicit operation
+      # that returns a stream and then assert the contents of that stream.
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+        expectResult: { $$matchesHexBytes: "112233445566778899aa" }
+
+  - description: "Download when files entry does not exist"
+    operations:
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000000" }
+        # Original test expects "FileNotFound" error, which isn't specified
+        expectError: { isError: true }
+
+  - description: "Download when an intermediate chunk is missing"
+    operations:
+      # Original test uses "arrange" syntax to modify initialData. This can be
+      # accomplished as a delete operation on the chunks collection.
+      - name: deleteOne
+        object: *bucket0_chunks_collection
+        arguments:
+          filter:
+            files_id: { $oid: "000000000000000000000005" }
+            n: 1
+        expectResult:
+          deletedCount: 1
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+        # Original test expects "ChunkIsMissing" error, which isn't specified
+        expectError: { isError: true }
+
+  - description: "Upload when length is 5"
+    operations:
+      # Original test uses "upload" operation. We use an explicit operation
+      # that takes a stream, which has been created from the expected hex bytes.
+      - name: upload
+        object: *bucket0
+        arguments:
+          filename: filename
+          source: { $$hexBytes: "1122334455" }
+          chunkSizeBytes: 4
+        # Original test references the result directly in "assert.data". Here,
+        # we need to save the result as an entity, which we can later reference.
+        expectResult: { $$type: objectId }
+        saveResultAsEntity: &oid0 oid0
+      # "outcome" does not allow operators, but we can perform the assertions
+      # with separate find operations.
+      - name: find
+        object: *bucket0_files_collection
+        arguments:
+          filter: {}
+          sort: { uploadDate: -1 }
+          limit: 1
+        expectResult:
+          - _id: { $$matchesEntity: *oid0 }
+            length: 5
+            chunkSize: 4
+            uploadDate: { $$type: date }
+            md5: "283d4fea5dded59cf837d3047328f5af"
+            filename: filename
+      - name: find
+        object: *bucket0_chunks_collection
+        arguments:
+          # We cannot use the saved ObjectId when querying, but filtering by a
+          # non-zero timestamp will exclude initialData and sort can return the
+          # expected chunks in order.
+          filter: { _id: { $gt: { $oid: "000000000000000000000007" } } }
+          sort: { n: 1 }
+        expectResult:
+          - _id: { $$type: objectId }
+            files_id: { $$matchesEntity: *oid0 }
+            n: 0
+            data: { $binary: { base64: "ESIzRA==", subType: "00" } } # hex 11223344
+          - _id: { $$type: objectId }
+            files_id: { $$matchesEntity: *oid0 }
+            n: 1
+            data: { $binary: { base64: "VQ==", subType: "00" } } # hex 55

--- a/data/unified-test-format/valid-pass/poc-gridfs.yml
+++ b/data/unified-test-format/valid-pass/poc-gridfs.yml
@@ -133,7 +133,8 @@ tests:
             length: 5
             chunkSize: 4
             uploadDate: { $$type: date }
-            md5: "283d4fea5dded59cf837d3047328f5af"
+            # The md5 field is deprecated so some drivers do not calculate it when uploading files.
+            md5: { $$unsetOrMatches: "283d4fea5dded59cf837d3047328f5af" }
             filename: filename
       - name: find
         object: *bucket0_chunks_collection

--- a/data/unified-test-format/valid-pass/poc-retryable-reads.json
+++ b/data/unified-test-format/valid-pass/poc-retryable-reads.json
@@ -1,0 +1,433 @@
+{
+  "description": "poc-retryable-reads",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryReads": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-reads-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate succeeds after InterruptedAtShutdown",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 2
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection1",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ListDatabases succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "listDatabases"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "listDatabases",
+          "object": "client0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-retryable-reads.yml
+++ b/data/unified-test-format/valid-pass/poc-retryable-reads.yml
@@ -1,0 +1,193 @@
+description: "poc-retryable-reads"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ single, replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions: { retryReads: false }
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-reads-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - {_id: 1, x: 11}
+      - {_id: 2, x: 22}
+      - {_id: 3, x: 33}
+
+tests:
+  - description: "Aggregate succeeds after InterruptedAtShutdown"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ aggregate ]
+              errorCode: 11600 # InterruptedAtShutdown
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: &pipeline
+            - $match: { _id: { $gt: 1 } }
+            - $sort: { x: 1 }
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collectionName
+                pipeline: *pipeline
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                aggregate: *collectionName
+                pipeline: *pipeline
+              databaseName: *databaseName
+
+  - description: "Find succeeds on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      # Find options and expected result changed to use common initialData
+      - name: find
+        object: collection0
+        arguments:
+          filter: {}
+          sort: { _id: 1 }
+          limit: 2
+        expectResult:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findAttempt
+            commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                sort: { _id: 1 }
+                limit: 2
+              databaseName: *databaseName
+          - *findAttempt
+
+  - description: "Find fails on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      - name: find
+        object: collection1 # client uses retryReads=false
+        arguments:
+          filter: {}
+          # Other arguments in the original test are not relevant
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client1
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+              databaseName: *databaseName
+
+  - description: "Find fails on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      - name: find
+        object: collection0
+        arguments:
+          filter: {}
+          # Other arguments in the original test are not relevant
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findAttempt
+            commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+              databaseName: *databaseName
+          - *findAttempt
+
+  - description: "ListDatabases succeeds on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ listDatabases ]
+              closeConnection: true
+      - name: listDatabases
+        object: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command: { listDatabases: 1 }
+          - commandStartedEvent:
+              command: { listDatabases: 1 }

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -1,0 +1,481 @@
+{
+  "description": "poc-retryable-writes",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-writes-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndUpdate is committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is not committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is never committed",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany succeeds after PrimarySteppedDown",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189,
+                "errorLabels": [
+                  "RetryableWriteError"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3,
+                "x": 33
+              },
+              {
+                "_id": 4,
+                "x": 44
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "insertedCount": 2,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 3,
+                "1": 4
+              }
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after connection failure when retryWrites option is false",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client1",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after multiple retryable writeConcernErrors",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -297,7 +297,9 @@
             "ordered": true
           },
           "expectResult": {
-            "insertedCount": 2,
+            "insertedCount": {
+              "$$unsetOrMatches": 2
+            },
             "insertedIds": {
               "$$unsetOrMatches": {
                 "0": 3,

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.yml
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.yml
@@ -1,0 +1,212 @@
+description: "poc-retryable-writes"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6"
+    topologies: [ replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions: { retryWrites: false }
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-writes-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+
+tests:
+  - description: "FindOneAndUpdate is committed on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectResult: { _id: 1, x: 11 }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+
+  - description: "FindOneAndUpdate is not committed on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 1 }
+            data: { failBeforeCommitExceptionCode: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectResult: { _id: 1, x: 11 }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+
+  - description: "FindOneAndUpdate is never committed"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 2 }
+            data: { failBeforeCommitExceptionCode: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectError: { isError: true }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "InsertMany succeeds after PrimarySteppedDown"
+    runOnRequirements: &failCommand_requirements
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.7"
+        # Original test uses "sharded", but retryable writes requires a sharded
+        # cluster backed by replica sets
+        topologies: [ sharded-replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: 189 # PrimarySteppedDown
+              errorLabels: [  RetryableWriteError ]
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            # Documents are modified from original test for "initialData"
+            - { _id: 3, x: 33 }
+            - { _id: 4, x: 44 }
+          ordered: true
+        expectResult:
+          # insertMany returns a BulkWriteResult, but there is no reason to
+          # assert other fields
+          insertedCount: 2
+          insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+
+  - description: "InsertOne fails after connection failure when retryWrites option is false"
+    runOnRequirements: *failCommand_requirements
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client1
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: [ insert ]
+                closeConnection: true
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          # If retryWrites is false, the driver should not add the
+          # RetryableWriteError label to the error.
+          errorLabelsOmit: [ RetryableWriteError ]
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "InsertOne fails after multiple retryable writeConcernErrors"
+    runOnRequirements: *failCommand_requirements
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ insert ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ RetryableWriteError ]
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }  # The write was still applied

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.yml
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.yml
@@ -141,9 +141,7 @@ tests:
             - { _id: 4, x: 44 }
           ordered: true
         expectResult:
-          # insertMany returns a BulkWriteResult, but there is no reason to
-          # assert other fields
-          insertedCount: 2
+          insertedCount: { $$unsetOrMatches: 2 }
           insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } }
     outcome:
       - collectionName: *collectionName

--- a/data/unified-test-format/valid-pass/poc-sessions.json
+++ b/data/unified-test-format/valid-pass/poc-sessions.json
@@ -1,0 +1,466 @@
+{
+  "description": "poc-sessions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "session-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "session-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server supports explicit sessions",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server supports implicit sessions",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Dirty explicit session is discarded",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.8",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 2
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-sessions.yml
+++ b/data/unified-test-format/valid-pass/poc-sessions.yml
@@ -1,0 +1,214 @@
+description: "poc-sessions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name session-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Server supports explicit sessions"
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - &find_with_implicit_session
+        name: find
+        object: *collection0
+        arguments:
+          filter: { _id: -1 }
+        expectResult: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 2 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$sessionLsid: *session0 }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Server supports implicit sessions"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - { _id: 2 }
+                ordered: true
+                # Original test did not include any assertion, but we can use
+                # $$type to expect an arbitrary lsid document
+                lsid: { $$type: object }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Dirty explicit session is discarded"
+    # Original test specified retryWrites=true, but that is now the default.
+    # Retryable writes will require a sharded-replicaset, though.
+    runOnRequirements:
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.8"
+        topologies: [ sharded-replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 3 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 3 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          # ajv's YAML parser is unable to handle anchors on array elements, so
+          # we define an anchor on the commandStartedEvent object instead
+          - commandStartedEvent: &insert_attempt
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 2 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent: *insert_attempt
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 3 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 2
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }

--- a/data/unified-test-format/valid-pass/poc-transactions-convenient-api.json
+++ b/data/unified-test-format/valid-pass/poc-transactions-convenient-api.json
@@ -1,0 +1,505 @@
+{
+  "description": "poc-transactions-convenient-api",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        },
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session1",
+        "client": "client1"
+      }
+    },
+    {
+      "session": {
+        "id": "session2",
+        "client": "client0",
+        "sessionOptions": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "withTransaction and no transaction options set",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from client",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session1",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection1",
+                "arguments": {
+                  "session": "session1",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from defaultTransactionOptions",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session2",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session2",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction explicit transaction options",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ],
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-transactions-convenient-api.yml
+++ b/data/unified-test-format/valid-pass/poc-transactions-convenient-api.yml
@@ -1,0 +1,235 @@
+description: "poc-transactions-convenient-api"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions:
+        readConcernLevel: local
+        w: 1
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName transaction-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+  - session:
+      id: &session0 session0
+      client: *client0
+  - session:
+      id: &session1 session1
+      client: *client1
+  - session:
+      id: &session2 session2
+      client: *client0
+      sessionOptions:
+        defaultTransactionOptions:
+          readConcern: { level: majority }
+          writeConcern: { w: 1 }
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents: []
+
+tests:
+  - description: "withTransaction and no transaction options set"
+    operations:
+      - name: withTransaction
+        object: *session0
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session0
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                # omitted fields
+                readConcern: { $$exists: false }
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                autocommit: false
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: &outcome
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1 }
+
+  - description: "withTransaction inherits transaction options from client"
+    operations:
+      - name: withTransaction
+        object: *session1
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection1
+              arguments:
+                session: *session1
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client1
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session1 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: local }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session1 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome
+
+  - description: "withTransaction inherits transaction options from defaultTransactionOptions"
+    operations:
+      - name: withTransaction
+        object: *session2
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session2
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session2 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: majority }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session2 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome
+
+  - description: "withTransaction explicit transaction options"
+    operations:
+      - name: withTransaction
+        object: *session0
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session0
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+          readConcern: { level: majority }
+          writeConcern: { w: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: majority }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome

--- a/data/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
+++ b/data/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
@@ -1,0 +1,409 @@
+{
+  "description": "poc-transactions-mongos-pin-auto",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ],
+            "errorCodeName": "Interrupted"
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "unpin after transient error within a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "abortTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.yml
+++ b/data/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.yml
@@ -1,0 +1,169 @@
+description: "poc-transactions-mongos-pin-auto"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name transaction-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+
+tests:
+  - description: "remain pinned after non-transient Interrupted error on insertOne"
+    operations:
+      - &startTransaction
+        name: startTransaction
+        object: *session0
+      - &firstInsert
+        name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 3 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 3 } } }
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: 11601 # Interrupted
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectError:
+          errorLabelsOmit: [ TransientTransactionError, UnknownTransactionCommitResult ]
+          errorCodeName: Interrupted
+      - name: assertSessionPinned
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: commitTransaction
+        object: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &firstInsertEvent
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 3 } ]
+                ordered: true
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent: &secondInsertEvent
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 4 } ]
+                ordered: true
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+                # Original test expected any value, but we can assert an object
+                recoveryToken: { $$type: object }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }
+
+  - description: "unpin after transient error within a transaction"
+    operations:
+      - *startTransaction
+      - *firstInsert
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectError:
+          errorLabelsContain: [ TransientTransactionError ]
+          errorLabelsOmit: [ UnknownTransactionCommitResult ]
+      - name: assertSessionUnpinned
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: abortTransaction
+        object: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *firstInsertEvent
+          - commandStartedEvent: *secondInsertEvent
+          - commandStartedEvent:
+              command:
+                abortTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+                # Original test expected any value, but we can assert an object
+                recoveryToken: { $$type: object }
+              commandName: abortTransaction
+              databaseName: admin
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }

--- a/data/unified-test-format/valid-pass/poc-transactions.json
+++ b/data/unified-test-format/valid-pass/poc-transactions.json
@@ -1,0 +1,322 @@
+{
+  "description": "poc-transactions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "explicitly create collection using create command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "create",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create index on a non-existing collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "name": "x_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "test",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "createIndexes",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/poc-transactions.yml
+++ b/data/unified-test-format/valid-pass/poc-transactions.yml
@@ -1,0 +1,170 @@
+description: "poc-transactions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name transaction-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Client side error in command starting transaction"
+    operations:
+      - name: startTransaction
+        object: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: { .: . } }
+        # Original test only asserted a generic error
+        expectError: { isClientError: true }
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: *session0
+          state: starting
+
+  - description: "explicitly create collection using create command"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *collection0Name
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: commitTransaction
+        object: *session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: create
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+
+  - description: "create index on a non-existing collection"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createIndex
+        object: *collection0
+        arguments:
+          session: *session0
+          name: &indexName "x_1"
+          keys: { x: 1 }
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+      - name: commitTransaction
+        object: *session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0Name
+                indexes:
+                  - name: *indexName
+                    key: { x: 1 }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: createIndexes
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin

--- a/internal/testutil/helpers/helpers.go
+++ b/internal/testutil/helpers/helpers.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -185,6 +186,27 @@ func VerifyConnStringOptions(t *testing.T, cs connstring.ConnString, options map
 			require.Contains(t, opt, fmt.Sprint(value))
 		}
 	}
+}
+
+// RawSliceToInterfaceSlice converts a []bson.Raw to []interface{}.
+func RawSliceToInterfaceSlice(elems []bson.Raw) []interface{} {
+	out := make([]interface{}, 0, len(elems))
+	for _, elem := range elems {
+		out = append(out, elem)
+	}
+	return out
+}
+
+// RawToInterfaceSlice converts a bson.Raw that is internally an array to []interface{}.
+func RawToInterfaceSlice(doc bson.Raw) []interface{} {
+	values, _ := doc.Values()
+
+	out := make([]interface{}, 0, len(values))
+	for _, val := range values {
+		out = append(out, val.Document())
+	}
+
+	return out
 }
 
 // Convert each interface{} value in the map to a string.

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -387,7 +387,8 @@ func (b *Bucket) openDownloadStream(filter interface{}, opts ...*options.FindOpt
 		return newDownloadStream(nil, foundFile.ChunkSize, &foundFile), nil
 	}
 
-	if foundFile.ChunkSize == 0 {
+	// For a file with non-zero length, chunkSize must exist so we know what size to expect when downloading chunks.
+	if _, err := cursor.Current.LookupErr("chunkSize"); err != nil {
 		return nil, ErrMissingChunkSize
 	}
 

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -381,14 +381,16 @@ func (b *Bucket) openDownloadStream(filter interface{}, opts ...*options.FindOpt
 	}
 
 	if foundFile.Length == 0 {
-		return newDownloadStream(nil, b.chunkSize, &foundFile), nil
+		return newDownloadStream(nil, foundFile.ChunkSize, &foundFile), nil
 	}
 
 	chunksCursor, err := b.findChunks(ctx, foundFile.ID)
 	if err != nil {
 		return nil, err
 	}
-	return newDownloadStream(chunksCursor, b.chunkSize, &foundFile), nil
+	// The chunk size can be overridden for individual files, so the expected chunk size should be the "chunkSize"
+	// field from the files collection document, not the bucket's chunk size.
+	return newDownloadStream(chunksCursor, foundFile.ChunkSize, &foundFile), nil
 }
 
 func deadlineContext(deadline time.Time) (context.Context, context.CancelFunc) {

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -7,7 +7,11 @@
 package mtest
 
 import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
@@ -31,6 +35,11 @@ func ClusterURI() string {
 	return testContext.connString.Original
 }
 
+// ClusterConnString returns the parsed ConnString for the cluster.
+func ClusterConnString() connstring.ConnString {
+	return testContext.connString
+}
+
 // GlobalClient returns a Client connected to the cluster configured with read concern majority, write concern majority,
 // and read preference primary.
 func GlobalClient() *mongo.Client {
@@ -46,4 +55,23 @@ func GlobalTopology() *topology.Topology {
 // version.
 func ServerVersion() string {
 	return testContext.serverVersion
+}
+
+// SetFailPoint configures the provided fail point on the cluster under test using the provided Client.
+func SetFailPoint(fp FailPoint, client *mongo.Client) error {
+	admin := client.Database("admin")
+	if err := admin.RunCommand(Background, fp).Err(); err != nil {
+		return fmt.Errorf("error creating fail point: %v", err)
+	}
+	return nil
+}
+
+// SetRawFailPoint configures the fail point represented by the fp parameter on the cluster under test using the
+// provided Client
+func SetRawFailPoint(fp bson.Raw, client *mongo.Client) error {
+	admin := client.Database("admin")
+	if err := admin.RunCommand(Background, fp).Err(); err != nil {
+		return fmt.Errorf("error creating fail point: %v", err)
+	}
+	return nil
 }

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -131,8 +131,8 @@ func newT(wrapped *testing.T, opts ...*Options) *T {
 		}
 	}
 
-	if t.shouldSkip() {
-		t.Skip("no matching environmental constraint found")
+	if err := t.verifyConstraints(); err != nil {
+		t.Skipf("skipping due to environmental constraints: %v", err)
 	}
 
 	if t.collName == "" {
@@ -473,9 +473,8 @@ func (t *T) SetFailPoint(fp FailPoint) {
 		}
 	}
 
-	admin := t.Client.Database("admin")
-	if err := admin.RunCommand(Background, fp).Err(); err != nil {
-		t.Fatalf("error creating fail point on server: %v", err)
+	if err := SetFailPoint(fp, t.Client); err != nil {
+		t.Fatal(err)
 	}
 	t.failPointNames = append(t.failPointNames, fp.ConfigureFailPoint)
 }
@@ -485,9 +484,8 @@ func (t *T) SetFailPoint(fp FailPoint) {
 // the failpoint will appear in command monitoring channels. The fail point will be automatically disabled after this
 // test has run.
 func (t *T) SetFailPointFromDocument(fp bson.Raw) {
-	admin := t.Client.Database("admin")
-	if err := admin.RunCommand(Background, fp).Err(); err != nil {
-		t.Fatalf("error creating fail point on server: %v", err)
+	if err := SetRawFailPoint(fp, t.Client); err != nil {
+		t.Fatal(err)
 	}
 
 	name := fp.Index(0).Value().StringValue()
@@ -639,71 +637,86 @@ func (t *T) createTestCollection() {
 	}, createOnServer)
 }
 
-// matchesServerVersion checks if the current server version is in the range [min, max]. Server versions will only be
-// compared if they are non-empty.
-func matchesServerVersion(min, max string) bool {
+// verifyVersionConstraints returns an error if the cluster's server version is not in the range [min, max]. Server
+// versions will only be checked if they are non-empty.
+func verifyVersionConstraints(min, max string) error {
 	if min != "" && CompareServerVersions(testContext.serverVersion, min) < 0 {
-		return false
+		return fmt.Errorf("server version %q is lower than min required version %q", testContext.serverVersion, min)
 	}
-	return max == "" || CompareServerVersions(testContext.serverVersion, max) <= 0
+	if max != "" && CompareServerVersions(testContext.serverVersion, max) > 0 {
+		return fmt.Errorf("server version %q is higher than max version %q", testContext.serverVersion, max)
+	}
+	return nil
 }
 
-// matchesTopology checks if the current topology is present in topologies.
-// if topologies is empty, true is returned without any additional checks.
-func matchesTopology(topologies []TopologyKind) bool {
+// verifyTopologyConstraints returns an error if the cluster's topology kind does not match one of the provided
+// kinds. If the topologies slice is empty, nil is returned without any additional checks.
+func verifyTopologyConstraints(topologies []TopologyKind) error {
 	if len(topologies) == 0 {
-		return true
+		return nil
 	}
 
 	for _, topo := range topologies {
-		if topo == testContext.topoKind {
-			return true
+		// For ShardedReplicaSet, we won't get an exact match because testContext.topoKind will be Sharded so we do an
+		// additional comparison with the testContext.shardedReplicaSet field.
+		if topo == testContext.topoKind || (topo == ShardedReplicaSet && testContext.shardedReplicaSet) {
+			return nil
 		}
 	}
-	return false
+	return fmt.Errorf("topology kind %q does not match any of the required kinds %q", testContext.topoKind, topologies)
 }
 
-// matchesRunOnBlock returns true if the current environmental constraints match the given RunOnBlock.
-func matchesRunOnBlock(rob RunOnBlock) bool {
-	if !matchesServerVersion(rob.MinServerVersion, rob.MaxServerVersion) {
-		return false
+// verifyRunOnBlockConstraint returns an error if the current environment does nto match the provided RunOnBlock.
+func verifyRunOnBlockConstraint(rob RunOnBlock) error {
+	if err := verifyVersionConstraints(rob.MinServerVersion, rob.MaxServerVersion); err != nil {
+		return err
 	}
-	return matchesTopology(rob.Topology)
+
+	return verifyTopologyConstraints(rob.Topology)
 }
 
-func (t *T) shouldSkip() bool {
+// verifyConstraints returns an error if the current environment does not match the constraints specified for the test.
+func (t *T) verifyConstraints() error {
 	// Check constraints not specified as runOn blocks
-	if !matchesServerVersion(t.minServerVersion, t.maxServerVersion) {
-		return true
+	if err := verifyVersionConstraints(t.minServerVersion, t.maxServerVersion); err != nil {
+		return err
 	}
-	if !matchesTopology(t.validTopologies) {
-		return true
+	if err := verifyTopologyConstraints(t.validTopologies); err != nil {
+		return err
 	}
 	if t.auth != nil && *t.auth != testContext.authEnabled {
-		return true
+		return fmt.Errorf("test requires auth value: %v, cluster auth value: %v", *t.auth, testContext.authEnabled)
 	}
 	if t.ssl != nil && *t.ssl != testContext.sslEnabled {
-		return true
+		return fmt.Errorf("test requires ssl value: %v, cluster ssl value: %v", *t.ssl, testContext.sslEnabled)
 	}
 	if t.enterprise != nil && *t.enterprise != testContext.enterpriseServer {
-		return true
+		return fmt.Errorf("test requires enterprise value: %v, cluster enterprise value: %v", *t.enterprise,
+			testContext.enterpriseServer)
 	}
 	if t.dataLake != nil && *t.dataLake != testContext.dataLake {
-		return true
+		return fmt.Errorf("test requires cluster to be data lake: %v, cluster is data lake: %v", *t.dataLake,
+			testContext.dataLake)
 	}
 
-	// Check runOn blocks
-	// The test can be executed if there are no blocks or at least block matches the current test setup.
+	// Check runOn blocks. The test can be executed if there are no blocks or at least block matches the current test
+	// setup.
 	if len(t.runOn) == 0 {
-		return false
+		return nil
 	}
+
+	// Stop once we find a RunOnBlock that matches the current environment. Record all errors as we go because if we
+	// don't find any matching blocks, we want to report the comparison errors for each block.
+	var runOnErrors []error
 	for _, runOn := range t.runOn {
-		if matchesRunOnBlock(runOn) {
-			return false
+		err := verifyRunOnBlockConstraint(runOn)
+		if err == nil {
+			return nil
 		}
+
+		runOnErrors = append(runOnErrors, err)
 	}
-	// no matching block found
-	return true
+	return fmt.Errorf("no matching RunOnBlock; comparison errors: %v", runOnErrors)
 }
 
 func (t *T) interfaceToInt32(i interface{}) (int32, error) {

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -666,7 +666,7 @@ func verifyTopologyConstraints(topologies []TopologyKind) error {
 	return fmt.Errorf("topology kind %q does not match any of the required kinds %q", testContext.topoKind, topologies)
 }
 
-// verifyRunOnBlockConstraint returns an error if the current environment does nto match the provided RunOnBlock.
+// verifyRunOnBlockConstraint returns an error if the current environment does not match the provided RunOnBlock.
 func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 	if err := verifyVersionConstraints(rob.MinServerVersion, rob.MaxServerVersion); err != nil {
 		return err

--- a/mongo/integration/unified/admin_helpers_test.go
+++ b/mongo/integration/unified/admin_helpers_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	errorInterrupted int32 = 11601
+)
+
+// TerminateOpenTransactions executes a killAllSessions command to ensure open transactions don't cause future
+// operations to hang.
+func TerminateOpenTransactions(ctx context.Context) error {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "4.0") < 0 {
+		return nil
+	}
+
+	commandFn := func(ctx context.Context, client *mongo.Client) error {
+		cmd := bson.D{
+			{"killAllSessions", bson.A{}},
+		}
+
+		err := client.Database("admin").RunCommand(ctx, cmd).Err()
+		if ce, ok := err.(mongo.CommandError); ok && ce.Code == errorInterrupted {
+			// Workaround for SERVER-38335 on server versions below 4.2.
+			err = nil
+		}
+		return err
+	}
+
+	// For sharded clusters, this has to run against all mongos nodes. Otherwise, it can just against on the primary.
+	if mtest.ClusterTopologyKind() != mtest.Sharded {
+		return commandFn(ctx, mtest.GlobalClient())
+	}
+	return runAgainstAllMongoses(ctx, commandFn)
+}
+
+// PerformDistinctWorkaround executes a non-transactional "distinct" command against each mongos in a sharded cluster.
+func PerformDistinctWorkaround(ctx context.Context) error {
+	commandFn := func(ctx context.Context, client *mongo.Client) error {
+		for _, coll := range Entities(ctx).Collections() {
+			newColl := client.Database(coll.Database().Name()).Collection(coll.Name())
+			_, err := newColl.Distinct(ctx, "x", bson.D{})
+			if err != nil {
+				ns := fmt.Sprintf("%s.%s", coll.Database().Name(), coll.Name())
+				return fmt.Errorf("error running distinct for collection %q: %v", ns, err)
+			}
+		}
+
+		return nil
+	}
+
+	return runAgainstAllMongoses(ctx, commandFn)
+}
+
+func RunCommandOnHost(ctx context.Context, host string, commandFn func(context.Context, *mongo.Client) error) error {
+	clientOpts := options.Client().
+		ApplyURI(mtest.ClusterURI()).
+		SetHosts([]string{host})
+
+	client, err := mongo.Connect(ctx, clientOpts)
+	if err != nil {
+		return fmt.Errorf("error creating client to host %q: %v", host, err)
+	}
+	defer client.Disconnect(ctx)
+
+	return commandFn(ctx, client)
+}
+
+func runAgainstAllMongoses(ctx context.Context, commandFn func(context.Context, *mongo.Client) error) error {
+	for _, host := range mtest.ClusterConnString().Hosts {
+		if err := RunCommandOnHost(ctx, host, commandFn); err != nil {
+			return fmt.Errorf("error executing callback against host %q: %v", host, err)
+		}
+	}
+	return nil
+}

--- a/mongo/integration/unified/admin_helpers_test.go
+++ b/mongo/integration/unified/admin_helpers_test.go
@@ -20,10 +20,10 @@ const (
 	errorInterrupted int32 = 11601
 )
 
-// TerminateOpenTransactions executes a killAllSessions command to ensure open transactions don't cause future
-// operations to hang.
-func TerminateOpenTransactions(ctx context.Context) error {
-	if mtest.CompareServerVersions(mtest.ServerVersion(), "4.0") < 0 {
+// TerminateOpenSessions executes a killAllSessions command to ensure that sesssions left open on the server by a test
+// do not cause future tests to hang.
+func TerminateOpenSessions(ctx context.Context) error {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "3.6") < 0 {
 		return nil
 	}
 

--- a/mongo/integration/unified/bsonutil_test.go
+++ b/mongo/integration/unified/bsonutil_test.go
@@ -1,0 +1,79 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"sort"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+var (
+	emptyCoreDocument = bsoncore.NewDocumentBuilder().Build()
+	emptyDocument     = bson.Raw(emptyCoreDocument)
+	emptyRawValue     = bson.RawValue{}
+)
+
+func DocumentToRawValue(doc bson.Raw) bson.RawValue {
+	return bson.RawValue{
+		Type:  bsontype.EmbeddedDocument,
+		Value: doc,
+	}
+}
+
+func RemoveFieldsFromDocument(doc bson.Raw, keys ...string) bson.Raw {
+	newDoc := bsoncore.NewDocumentBuilder()
+	elems, _ := doc.Elements()
+
+	keysMap := make(map[string]struct{})
+	for _, key := range keys {
+		keysMap[key] = struct{}{}
+	}
+
+	for _, elem := range elems {
+		if _, ok := keysMap[elem.Key()]; ok {
+			continue
+		}
+
+		val := elem.Value()
+		newDoc.AppendValue(elem.Key(), bsoncore.Value{Type: val.Type, Data: val.Value})
+	}
+	return bson.Raw(newDoc.Build())
+}
+
+func SortDocument(doc bson.Raw) bson.Raw {
+	elems, _ := doc.Elements()
+	keys := make([]string, 0, len(elems))
+	valuesMap := make(map[string]bson.RawValue)
+
+	for _, elem := range elems {
+		keys = append(keys, elem.Key())
+		valuesMap[elem.Key()] = elem.Value()
+	}
+
+	sort.Strings(keys)
+	sorted := bsoncore.NewDocumentBuilder()
+	for _, key := range keys {
+		val := valuesMap[key]
+		sorted.AppendValue(key, bsoncore.Value{Type: val.Type, Data: val.Value})
+	}
+	return bson.Raw(sorted.Build())
+}
+
+func LookupString(doc bson.Raw, key string) string {
+	return doc.Lookup(key).StringValue()
+}
+
+func MapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/mongo/integration/unified/bucket_operation_execution_test.go
+++ b/mongo/integration/unified/bucket_operation_execution_test.go
@@ -1,0 +1,138 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+func executeBucketDelete(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	bucket, err := Entities(ctx).Bucket(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var id *bson.RawValue
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "id":
+			id = &val
+		default:
+			return nil, fmt.Errorf("unrecongized delete option %q", key)
+		}
+	}
+	if id == nil {
+		return nil, newMissingArgumentError("id")
+	}
+
+	return NewErrorResult(bucket.Delete(*id)), nil
+}
+
+func executeBucketDownload(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	bucket, err := Entities(ctx).Bucket(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var id *bson.RawValue
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "id":
+			id = &val
+		default:
+			return nil, fmt.Errorf("unrecongized delete option %q", key)
+		}
+	}
+	if id == nil {
+		return nil, newMissingArgumentError("id")
+	}
+
+	stream, err := bucket.OpenDownloadStream(*id)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+
+	var buffer bytes.Buffer
+	if _, err := io.Copy(&buffer, stream); err != nil {
+		return NewErrorResult(err), nil
+	}
+
+	return NewValueResult(bsontype.Binary, bsoncore.AppendBinary(nil, 0, buffer.Bytes()), nil), nil
+}
+
+func executeBucketUpload(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	bucket, err := Entities(ctx).Bucket(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filename string
+	var fileBytes []byte
+	opts := options.GridFSUpload()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "chunkSizeBytes":
+			opts.SetChunkSizeBytes(val.Int32())
+		case "filename":
+			filename = val.StringValue()
+		case "metadata":
+			opts.SetMetadata(val.Document())
+		case "source":
+			fileBytes, err = hex.DecodeString(val.Document().Lookup("$$hexBytes").StringValue())
+			if err != nil {
+				return nil, fmt.Errorf("error converting source string to bytes: %v", err)
+			}
+		default:
+			return nil, fmt.Errorf("unrecognized upload option %q", key)
+		}
+	}
+	if filename == "" {
+		return nil, newMissingArgumentError("filename")
+	}
+	if fileBytes == nil {
+		return nil, newMissingArgumentError("source")
+	}
+
+	fileID, err := bucket.UploadFromStream(filename, bytes.NewReader(fileBytes), opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+
+	if operation.ResultEntityID != nil {
+		fileIDValue := bson.RawValue{
+			Type:  bsontype.ObjectID,
+			Value: fileID[:],
+		}
+		if err := Entities(ctx).AddBSONEntity(*operation.ResultEntityID, fileIDValue); err != nil {
+			return nil, fmt.Errorf("error storing result as BSON entity: %v", err)
+		}
+	}
+
+	return NewValueResult(bsontype.ObjectID, fileID[:], nil), nil
+}

--- a/mongo/integration/unified/bucket_options_test.go
+++ b/mongo/integration/unified/bucket_options_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// BucketOptions is a wrapper for *options.BucketOptions. This type implements the bson.Unmarshaler interface to
+// convert BSON documents to a BucketOptions instance.
+type BucketOptions struct {
+	*options.BucketOptions
+}
+
+var _ bson.Unmarshaler = (*BucketOptions)(nil)
+
+func (bo BucketOptions) UnmarshalBSON(data []byte) error {
+	var temp struct {
+		Name      *string                `bson:"name"`
+		ChunkSize *int32                 `bson:"chunkSizeBytes"`
+		RC        *readConcern           `bson:"readConcern"`
+		RP        *readPreference        `bson:"readPreference"`
+		WC        *writeConcern          `bson:"writeConcern"`
+		Extra     map[string]interface{} `bson:",inline"`
+	}
+	if err := bson.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("error unmarshalling to temporary BucketOptions object: %v", err)
+	}
+	if len(temp.Extra) > 0 {
+		return fmt.Errorf("unrecognized fields for BucketOptions: %v", MapKeys(temp.Extra))
+	}
+
+	bo.BucketOptions = options.GridFSBucket()
+	if temp.Name != nil {
+		bo.SetName(*temp.Name)
+	}
+	if temp.ChunkSize != nil {
+		bo.SetChunkSizeBytes(*temp.ChunkSize)
+	}
+	if temp.RC != nil {
+		bo.SetReadConcern(temp.RC.toReadConcernOption())
+	}
+	if temp.RP != nil {
+		rp, err := temp.RP.toReadPrefOption()
+		if err != nil {
+			return fmt.Errorf("error parsing read preference document: %v", err)
+		}
+		bo.SetReadPreference(rp)
+	}
+	if temp.WC != nil {
+		wc, err := temp.WC.toWriteConcernOption()
+		if err != nil {
+			return fmt.Errorf("error parsing write concern document: %v", err)
+		}
+		bo.SetWriteConcern(wc)
+	}
+	return nil
+}

--- a/mongo/integration/unified/bucket_options_test.go
+++ b/mongo/integration/unified/bucket_options_test.go
@@ -13,15 +13,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// BucketOptions is a wrapper for *options.BucketOptions. This type implements the bson.Unmarshaler interface to
+// GridFSBucketOptions is a wrapper for *options.BucketOptions. This type implements the bson.Unmarshaler interface to
 // convert BSON documents to a BucketOptions instance.
-type BucketOptions struct {
+type GridFSBucketOptions struct {
 	*options.BucketOptions
 }
 
-var _ bson.Unmarshaler = (*BucketOptions)(nil)
+var _ bson.Unmarshaler = (*GridFSBucketOptions)(nil)
 
-func (bo BucketOptions) UnmarshalBSON(data []byte) error {
+func (bo GridFSBucketOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
 		Name      *string                `bson:"name"`
 		ChunkSize *int32                 `bson:"chunkSizeBytes"`
@@ -31,10 +31,10 @@ func (bo BucketOptions) UnmarshalBSON(data []byte) error {
 		Extra     map[string]interface{} `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
-		return fmt.Errorf("error unmarshalling to temporary BucketOptions object: %v", err)
+		return fmt.Errorf("error unmarshalling to temporary GridFSBucketOptions object: %v", err)
 	}
 	if len(temp.Extra) > 0 {
-		return fmt.Errorf("unrecognized fields for BucketOptions: %v", MapKeys(temp.Extra))
+		return fmt.Errorf("unrecognized fields for GridFSBucketOptions: %v", MapKeys(temp.Extra))
 	}
 
 	bo.BucketOptions = options.GridFSBucket()

--- a/mongo/integration/unified/bulkwrite_helpers_test.go
+++ b/mongo/integration/unified/bulkwrite_helpers_test.go
@@ -1,0 +1,194 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// This file provides helper functions to convert BSON documents to WriteModel instances.
+
+// createBulkWriteModels converts a bson.Raw that is internally an array to a slice of WriteModel. Each value in the
+// array must be a document in the form { requestType: { optionKey1: optionValue1, ... } }. For example, the document
+// { insertOne: { document: { x: 1 } } } would be translated to an InsertOneModel to insert the document { x: 1 }.
+func createBulkWriteModels(rawModels bson.Raw) ([]mongo.WriteModel, error) {
+	vals, _ := rawModels.Values()
+	models := make([]mongo.WriteModel, 0, len(vals))
+
+	for idx, val := range vals {
+		model, err := createBulkWriteModel(val.Document())
+		if err != nil {
+			return nil, fmt.Errorf("error creating model at index %d: %v", idx, err)
+		}
+		models = append(models, model)
+	}
+	return models, nil
+}
+
+// createBulkWriteModel converts the provided BSON document to a WriteModel.
+func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
+	firstElem := rawModel.Index(0)
+	requestType := firstElem.Key()
+	args := firstElem.Value().Document()
+
+	switch requestType {
+	case "insertOne":
+		return mongo.NewInsertOneModel().SetDocument(args.Lookup("document").Document()), nil
+	case "updateOne":
+		uom := mongo.NewUpdateOneModel().SetFilter(args.Lookup("filter").Document())
+		update, err := createUpdateValue(args.Lookup("update"))
+		if err != nil {
+			return nil, fmt.Errorf("error creating update: %v", err)
+		}
+		uom.SetUpdate(update)
+
+		if val, err := args.LookupErr("arrayFilters"); err == nil {
+			uom.SetArrayFilters(options.ArrayFilters{
+				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+			})
+		}
+		if val, err := args.LookupErr("collation"); err == nil {
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			uom.SetCollation(collation)
+		}
+		if val, err := args.LookupErr("hint"); err == nil {
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			uom.SetHint(hint)
+		}
+		if val, err := args.LookupErr("upsert"); err == nil {
+			uom.SetUpsert(val.Boolean())
+		}
+
+		return uom, nil
+	case "updateMany":
+		umm := mongo.NewUpdateManyModel().SetFilter(args.Lookup("filter").Document())
+		update, err := createUpdateValue(args.Lookup("update"))
+		if err != nil {
+			return nil, fmt.Errorf("error creating update: %v", err)
+		}
+		umm.SetUpdate(update)
+
+		if val, err := args.LookupErr("arrayFilters"); err == nil {
+			umm.SetArrayFilters(options.ArrayFilters{
+				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+			})
+		}
+		if val, err := args.LookupErr("collation"); err == nil {
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			umm.SetCollation(collation)
+		}
+		if val, err := args.LookupErr("hint"); err == nil {
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			umm.SetHint(hint)
+		}
+		if val, err := args.LookupErr("upsert"); err == nil {
+			umm.SetUpsert(val.Boolean())
+		}
+
+		return umm, nil
+	case "deleteOne":
+		dom := mongo.NewDeleteOneModel().SetFilter(args.Lookup("filter").Document())
+
+		if val, err := args.LookupErr("collation"); err == nil {
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			dom.SetCollation(collation)
+		}
+		if val, err := args.LookupErr("hint"); err == nil {
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			dom.SetHint(hint)
+		}
+
+		return dom, nil
+	case "deleteMany":
+		dmm := mongo.NewDeleteManyModel().SetFilter(args.Lookup("filter").Document())
+
+		if val, err := args.LookupErr("collation"); err == nil {
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			dmm.SetCollation(collation)
+		}
+		if val, err := args.LookupErr("hint"); err == nil {
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			dmm.SetHint(hint)
+		}
+
+		return dmm, nil
+	case "replaceOne":
+		rom := mongo.NewReplaceOneModel().
+			SetFilter(args.Lookup("filter").Document()).
+			SetReplacement(args.Lookup("replacement").Document())
+
+		if val, err := args.LookupErr("collation"); err == nil {
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			rom.SetCollation(collation)
+		}
+		if val, err := args.LookupErr("hint"); err == nil {
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			rom.SetHint(hint)
+		}
+		if val, err := args.LookupErr("upsert"); err == nil {
+			rom.SetUpsert(val.Boolean())
+		}
+
+		return rom, nil
+	default:
+		return nil, fmt.Errorf("unrecongized request type: %v", requestType)
+	}
+}
+
+// createUpdateValue converts the provided RawValue to a value that can be passed to UpdateOne/UpdateMany functions.
+// This helper handles both document and pipeline-style updates.
+func createUpdateValue(updateVal bson.RawValue) (interface{}, error) {
+	switch updateVal.Type {
+	case bson.TypeEmbeddedDocument:
+		return updateVal.Document(), nil
+	case bson.TypeArray:
+		var updateDocs []bson.Raw
+		docs, _ := updateVal.Array().Values()
+		for _, doc := range docs {
+			updateDocs = append(updateDocs, doc.Document())
+		}
+
+		return updateDocs, nil
+	default:
+		return nil, fmt.Errorf("unrecognized update type: %s", updateVal.Type)
+	}
+}

--- a/mongo/integration/unified/bulkwrite_helpers_test.go
+++ b/mongo/integration/unified/bulkwrite_helpers_test.go
@@ -104,7 +104,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 		if filter == nil {
 			return nil, newMissingArgumentError("filter")
 		}
-		if filter == nil {
+		if update == nil {
 			return nil, newMissingArgumentError("update")
 		}
 
@@ -153,7 +153,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 		if filter == nil {
 			return nil, newMissingArgumentError("filter")
 		}
-		if filter == nil {
+		if update == nil {
 			return nil, newMissingArgumentError("update")
 		}
 

--- a/mongo/integration/unified/change_stream_operation_execution_test.go
+++ b/mongo/integration/unified/change_stream_operation_execution_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import "context"
+
+func executeIterateUntilDocumentOrError(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	stream, err := Entities(ctx).ChangeStream(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		if stream.TryNext(ctx) {
+			return NewDocumentResult(stream.Current, nil), nil
+		}
+		if stream.Err() != nil {
+			return NewErrorResult(stream.Err()), nil
+		}
+	}
+}

--- a/mongo/integration/unified/client_entity_test.go
+++ b/mongo/integration/unified/client_entity_test.go
@@ -151,6 +151,8 @@ func (c *ClientEntity) getRecordEvents() bool {
 }
 
 func setClientOptionsFromURIOptions(clientOpts *options.ClientOptions, uriOpts bson.M) error {
+	// A write concern can be constructed across multiple URI options (e.g. "w", "j", and "wTimeoutMS") so we declare an
+	// empty writeConcern instance here that can be populated in the loop below.
 	var wc writeConcern
 	var wcSet bool
 

--- a/mongo/integration/unified/client_entity_test.go
+++ b/mongo/integration/unified/client_entity_test.go
@@ -1,0 +1,183 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+)
+
+// ClientEntity is a wrapper for a mongo.Client object that also holds additional information required during test
+// execution.
+type ClientEntity struct {
+	*mongo.Client
+
+	recordEvents    atomic.Value
+	started         []*event.CommandStartedEvent
+	succeeded       []*event.CommandSucceededEvent
+	failed          []*event.CommandFailedEvent
+	ignoredCommands map[string]struct{}
+}
+
+func NewClientEntity(ctx context.Context, entityOptions *EntityOptions) (*ClientEntity, error) {
+	entity := &ClientEntity{
+		// The "configureFailPoint" command should always be ignored.
+		ignoredCommands: map[string]struct{}{
+			"configureFailPoint": {},
+		},
+	}
+	entity.setRecordEvents(true)
+
+	// Construct a ClientOptions instance by first applying the cluster URI and then the URIOptions map to ensure that
+	// the options specified in the test file take precedence.
+	clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
+	if entityOptions.URIOptions != nil {
+		if err := setClientOptionsFromURIOptions(clientOpts, entityOptions.URIOptions); err != nil {
+			return nil, fmt.Errorf("error parsing URI options: %v", err)
+		}
+	}
+	// UseMultipleMongoses only requires options to be set if we're connected to a sharded cluster and it's set to
+	// false. If it's unset or true, we make no changes because the cluster URI already includes all mongos nodes.
+	if mtest.ClusterTopologyKind() == mtest.Sharded && !entityOptions.UseMultipleMongoses {
+		clientOpts.SetHosts(mtest.ClusterConnString().Hosts[:1])
+	}
+	if entityOptions.ObserveEvents != nil {
+		// Configure a command monitor that listens for the specified event types. We don't take the IgnoredCommands
+		// option into account here because it can be overridden at the test level after the entity has already been
+		// created, so we store the events for now but account for it when iterating over them later.
+		monitor := &event.CommandMonitor{}
+
+		for _, eventType := range entityOptions.ObserveEvents {
+			switch eventType {
+			case "commandStartedEvent":
+				monitor.Started = entity.processStartedEvent
+			case "commandSucceededEvent":
+				monitor.Succeeded = entity.processSucceededEvent
+			case "commandFailedEvent":
+				monitor.Failed = entity.processFailedEvent
+			default:
+				return nil, fmt.Errorf("unrecognized event type %s", eventType)
+			}
+		}
+		clientOpts.SetMonitor(monitor)
+	}
+	for _, cmd := range entityOptions.IgnoredCommands {
+		entity.ignoredCommands[cmd] = struct{}{}
+	}
+
+	client, err := mongo.Connect(ctx, clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error creating mongo.Client: %v", err)
+	}
+
+	entity.Client = client
+	return entity, nil
+}
+
+func (c *ClientEntity) StopListeningForEvents() {
+	c.setRecordEvents(false)
+}
+
+func (c *ClientEntity) StartedEvents() []*event.CommandStartedEvent {
+	var events []*event.CommandStartedEvent
+	for _, evt := range c.started {
+		if _, ok := c.ignoredCommands[evt.CommandName]; !ok {
+			events = append(events, evt)
+		}
+	}
+
+	return events
+}
+
+func (c *ClientEntity) SucceededEvents() []*event.CommandSucceededEvent {
+	var events []*event.CommandSucceededEvent
+	for _, evt := range c.succeeded {
+		if _, ok := c.ignoredCommands[evt.CommandName]; !ok {
+			events = append(events, evt)
+		}
+	}
+
+	return events
+}
+
+func (c *ClientEntity) FailedEvents() []*event.CommandFailedEvent {
+	var events []*event.CommandFailedEvent
+	for _, evt := range c.failed {
+		if _, ok := c.ignoredCommands[evt.CommandName]; !ok {
+			events = append(events, evt)
+		}
+	}
+
+	return events
+}
+
+func (c *ClientEntity) processStartedEvent(_ context.Context, evt *event.CommandStartedEvent) {
+	if c.getRecordEvents() {
+		c.started = append(c.started, evt)
+	}
+}
+
+func (c *ClientEntity) processSucceededEvent(_ context.Context, evt *event.CommandSucceededEvent) {
+	if c.getRecordEvents() {
+		c.succeeded = append(c.succeeded, evt)
+	}
+}
+
+func (c *ClientEntity) processFailedEvent(_ context.Context, evt *event.CommandFailedEvent) {
+	if c.getRecordEvents() {
+		c.failed = append(c.failed, evt)
+	}
+}
+
+func (c *ClientEntity) setRecordEvents(record bool) {
+	c.recordEvents.Store(record)
+}
+
+func (c *ClientEntity) getRecordEvents() bool {
+	return c.recordEvents.Load().(bool)
+}
+
+func setClientOptionsFromURIOptions(clientOpts *options.ClientOptions, uriOpts bson.M) error {
+	var wc writeConcern
+	var wcSet bool
+
+	for key, value := range uriOpts {
+		switch key {
+		case "heartbeatFrequencyMS":
+			clientOpts.SetHeartbeatInterval(time.Duration(value.(int32)) * time.Millisecond)
+		case "readConcernLevel":
+			clientOpts.SetReadConcern(readconcern.New(readconcern.Level(value.(string))))
+		case "retryReads":
+			clientOpts.SetRetryReads(value.(bool))
+		case "retryWrites":
+			clientOpts.SetRetryWrites(value.(bool))
+		case "w":
+			wc.W = value
+			wcSet = true
+		default:
+			return fmt.Errorf("unrecognized URI option %s", key)
+		}
+	}
+
+	if wcSet {
+		converted, err := wc.toWriteConcernOption()
+		if err != nil {
+			return fmt.Errorf("error creating write concern: %v", err)
+		}
+		clientOpts.SetWriteConcern(converted)
+	}
+	return nil
+}

--- a/mongo/integration/unified/client_operation_execution_test.go
+++ b/mongo/integration/unified/client_operation_execution_test.go
@@ -20,7 +20,7 @@ import (
 
 // This file contains helpers to execute client operations.
 
-func executeCreateChangeStream(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeCreateChangeStream(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	var watcher interface {
 		Watch(context.Context, interface{}, ...*options.ChangeStreamOptions) (*mongo.ChangeStream, error)
 	}
@@ -82,7 +82,7 @@ func executeCreateChangeStream(ctx context.Context, operation *Operation, sess m
 		return nil, newMissingArgumentError("pipeline")
 	}
 
-	stream, err := watcher.Watch(getOperationContext(ctx, sess), pipeline, opts)
+	stream, err := watcher.Watch(ctx, pipeline, opts)
 	if err != nil {
 		return NewErrorResult(err), nil
 	}
@@ -96,7 +96,7 @@ func executeCreateChangeStream(ctx context.Context, operation *Operation, sess m
 	return NewEmptyResult(), nil
 }
 
-func executeListDatabases(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeListDatabases(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	client, err := Entities(ctx).Client(operation.Object)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func executeListDatabases(ctx context.Context, operation *Operation, sess mongo.
 		}
 	}
 
-	res, err := client.ListDatabases(getOperationContext(ctx, sess), filter, opts)
+	res, err := client.ListDatabases(ctx, filter, opts)
 	if err != nil {
 		return NewErrorResult(err), nil
 	}

--- a/mongo/integration/unified/client_operation_execution_test.go
+++ b/mongo/integration/unified/client_operation_execution_test.go
@@ -1,0 +1,149 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// This file contains helpers to execute client operations.
+
+func executeCreateChangeStream(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	var watcher interface {
+		Watch(context.Context, interface{}, ...*options.ChangeStreamOptions) (*mongo.ChangeStream, error)
+	}
+	var err error
+
+	watcher, err = Entities(ctx).Client(operation.Object)
+	if err != nil {
+		watcher, err = Entities(ctx).Database(operation.Object)
+	}
+	if err != nil {
+		watcher, err = Entities(ctx).Collection(operation.Object)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("no client, database, or collection entity found with ID %q", operation.Object)
+	}
+
+	// TODO: pipeline is a required argument for watch() so we should error if it's not present in the Arguments doc,
+	// but multiple instances of the createChangeStream operation don't specify it in the JSON files.
+	pipeline := []interface{}{}
+	opts := options.ChangeStream()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "batchSize":
+			opts.SetBatchSize(val.Int32())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(*collation)
+		case "fullDocument":
+			switch fd := val.StringValue(); fd {
+			case "default":
+				opts.SetFullDocument(options.Default)
+			case "updateLookup":
+				opts.SetFullDocument(options.UpdateLookup)
+			default:
+				return nil, fmt.Errorf("unrecognized fullDocument value %q", fd)
+			}
+		case "maxAwaitTimeMS":
+			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "pipeline":
+			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+		case "resumeAfter":
+			opts.SetResumeAfter(val.Document())
+		case "startAfter":
+			opts.SetStartAfter(val.Document())
+		case "startAtOperationTime":
+			t, i := val.Timestamp()
+			opts.SetStartAtOperationTime(&primitive.Timestamp{T: t, I: i})
+		default:
+			return nil, fmt.Errorf("unrecongized createChangeStream option %q", key)
+		}
+	}
+	if pipeline == nil {
+		return nil, newMissingArgumentError("pipeline")
+	}
+
+	stream, err := watcher.Watch(getOperationContext(ctx, sess), pipeline, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+
+	if operation.ResultEntityID == nil {
+		return nil, fmt.Errorf("no entity name provided to store executeChangeStream result")
+	}
+	if err := Entities(ctx).AddChangeStreamEntity(*operation.ResultEntityID, stream); err != nil {
+		return nil, fmt.Errorf("error storing result as changeStream entity: %v", err)
+	}
+	return NewEmptyResult(), nil
+}
+
+func executeListDatabases(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	client, err := Entities(ctx).Client(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	// We set a default filter rather than erroring if the Arguments doc doesn't have a "filter" field because the
+	// spec says drivers should support this field, not must.
+	filter := emptyDocument
+	opts := options.ListDatabases()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "authorizedDatabases":
+			opts.SetAuthorizedDatabases(val.Boolean())
+		case "filter":
+			filter = val.Document()
+		case "nameOnly":
+			opts.SetNameOnly(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized listDatabases option %q", key)
+		}
+	}
+
+	res, err := client.ListDatabases(getOperationContext(ctx, sess), filter, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+
+	specsArray := bsoncore.NewArrayBuilder()
+	for _, spec := range res.Databases {
+		rawSpec := bsoncore.NewDocumentBuilder().
+			AppendString("name", spec.Name).
+			AppendInt64("sizeOnDisk", spec.SizeOnDisk).
+			AppendBoolean("empty", spec.Empty).
+			Build()
+
+		specsArray.AppendDocument(rawSpec)
+	}
+	raw := bsoncore.NewDocumentBuilder().
+		AppendArray("databases", specsArray.Build()).
+		AppendInt64("totalSize", res.TotalSize).
+		Build()
+	return NewDocumentResult(raw, nil), nil
+}

--- a/mongo/integration/unified/client_operation_execution_test.go
+++ b/mongo/integration/unified/client_operation_execution_test.go
@@ -37,9 +37,7 @@ func executeCreateChangeStream(ctx context.Context, operation *Operation, sess m
 		return nil, fmt.Errorf("no client, database, or collection entity found with ID %q", operation.Object)
 	}
 
-	// TODO: pipeline is a required argument for watch() so we should error if it's not present in the Arguments doc,
-	// but multiple instances of the createChangeStream operation don't specify it in the JSON files.
-	pipeline := []interface{}{}
+	var pipeline []interface{}
 	opts := options.ChangeStream()
 
 	elems, _ := operation.Arguments.Elements()

--- a/mongo/integration/unified/client_operation_execution_test.go
+++ b/mongo/integration/unified/client_operation_execution_test.go
@@ -75,7 +75,7 @@ func executeCreateChangeStream(ctx context.Context, operation *Operation, sess m
 			t, i := val.Timestamp()
 			opts.SetStartAtOperationTime(&primitive.Timestamp{T: t, I: i})
 		default:
-			return nil, fmt.Errorf("unrecongized createChangeStream option %q", key)
+			return nil, fmt.Errorf("unrecognized createChangeStream option %q", key)
 		}
 	}
 	if pipeline == nil {

--- a/mongo/integration/unified/collection_data_test.go
+++ b/mongo/integration/unified/collection_data_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+type CollectionData struct {
+	DatabaseName   string     `bson:"databaseName"`
+	CollectionName string     `bson:"collectionName"`
+	Documents      []bson.Raw `bson:"documents"`
+}
+
+// CreateCollection configures the collection represented by the receiver using the internal client. This function
+// first drops the collection and then creates it and inserts the seed data if needed.
+func (c *CollectionData) CreateCollection(ctx context.Context) error {
+	db := mtest.GlobalClient().Database(c.DatabaseName)
+	coll := db.Collection(c.CollectionName, options.Collection().SetWriteConcern(mtest.MajorityWc))
+	if err := coll.Drop(ctx); err != nil {
+		return fmt.Errorf("error dropping collection: %v", err)
+	}
+
+	// If no data is given, create the collection with write concern "majority".
+	if len(c.Documents) == 0 {
+		// The write concern has to be manually specified in the command document because RunCommand does not honor
+		// the database's write concern.
+		create := bson.D{
+			{"create", coll.Name()},
+			{"writeConcern", bson.D{
+				{"w", "majority"},
+			}},
+		}
+		if err := db.RunCommand(ctx, create).Err(); err != nil {
+			return fmt.Errorf("error creating collection: %v", err)
+		}
+		return nil
+	}
+
+	docs := testhelpers.RawSliceToInterfaceSlice(c.Documents)
+	if _, err := coll.InsertMany(ctx, docs); err != nil {
+		return fmt.Errorf("error inserting data: %v", err)
+	}
+	return nil
+}
+
+// VerifyContents asserts that the collection on the server represented by this CollectionData instance contains the
+// expected documents.
+func (c *CollectionData) VerifyContents(ctx context.Context) error {
+	collOpts := options.Collection().
+		SetReadPreference(readpref.Primary()).
+		SetReadConcern(readconcern.Local())
+	coll := mtest.GlobalClient().Database(c.DatabaseName).Collection(c.CollectionName, collOpts)
+
+	cursor, err := coll.Find(ctx, bson.D{}, options.Find().SetSort(bson.M{"_id": 1}))
+	if err != nil {
+		return fmt.Errorf("Find error: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var docs []bson.Raw
+	if err := cursor.All(ctx, &docs); err != nil {
+		return fmt.Errorf("cursor iteration error: %v", err)
+	}
+
+	// Verify the slice lengths are equal. This also covers the case of asserting that the collection is empty if
+	// c.Documents is an empty slice.
+	if len(c.Documents) != len(docs) {
+		return fmt.Errorf("expected %d documents but found %d: %v", len(c.Documents), len(docs), docs)
+	}
+
+	// We can't use VerifyValuesMatch here because the rules for evaluating matches (e.g. flexible numeric comparisons
+	// and special $$ operators) do not apply when verifying collection outcomes. We have to permit variations in key
+	// order, though, so we sort documents before doing a byte-wise comparison.
+	for idx, expected := range c.Documents {
+		expected = SortDocument(expected)
+		actual := SortDocument(docs[idx])
+
+		if !bytes.Equal(expected, actual) {
+			return fmt.Errorf("document comparison error at index %d: expected %s, got %s", idx, expected, actual)
+		}
+	}
+	return nil
+}
+
+func (c *CollectionData) Namespace() string {
+	return fmt.Sprintf("%s.%s", c.DatabaseName, c.CollectionName)
+}

--- a/mongo/integration/unified/collection_operation_execution_test.go
+++ b/mongo/integration/unified/collection_operation_execution_test.go
@@ -1,0 +1,789 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// This file contains helpers to execute collection operations.
+
+func executeAggregate(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	var aggregator interface {
+		Aggregate(context.Context, interface{}, ...*options.AggregateOptions) (*mongo.Cursor, error)
+	}
+	var err error
+
+	aggregator, err = Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		aggregator, err = Entities(ctx).Database(operation.Object)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("no database or collection entity found with ID %q", operation.Object)
+	}
+
+	var pipeline []interface{}
+	opts := options.Aggregate()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "allowDiskUse":
+			opts.SetAllowDiskUse(val.Boolean())
+		case "batchSize":
+			opts.SetBatchSize(val.Int32())
+		case "bypassDocumentValidation":
+			opts.SetBypassDocumentValidation(val.Boolean())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "comment":
+			opts.SetComment(val.StringValue())
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "maxAwaitTimeMS":
+			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "pipeline":
+			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+		}
+	}
+	if pipeline == nil {
+		return nil, newMissingArgumentError("pipeline")
+	}
+
+	cursor, err := aggregator.Aggregate(getOperationContext(ctx, sess), pipeline, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	defer cursor.Close(ctx)
+
+	var docs []bson.Raw
+	if err := cursor.All(ctx, &docs); err != nil {
+		return NewErrorResult(err), nil
+	}
+	return NewCursorResult(docs), nil
+}
+
+func executeBulkWrite(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var models []mongo.WriteModel
+	opts := options.BulkWrite()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "ordered":
+			opts.SetOrdered(val.Boolean())
+		case "requests":
+			models, err = createBulkWriteModels(val.Array())
+			if err != nil {
+				return nil, fmt.Errorf("error creating write models: %v", err)
+			}
+		default:
+			return nil, fmt.Errorf("unrecognized bulkWrite option %q", key)
+		}
+	}
+	if models == nil {
+		return nil, newMissingArgumentError("requests")
+	}
+
+	res, err := coll.BulkWrite(getOperationContext(ctx, sess), models, opts)
+	raw := emptyCoreDocument
+	if res != nil {
+		rawUpsertedIDs := emptyDocument
+		if res.UpsertedIDs != nil {
+			rawUpsertedIDs, err = bson.Marshal(res.UpsertedIDs)
+			if err != nil {
+				return nil, fmt.Errorf("error marshalling UpsertedIDs map to BSON: %v", err)
+			}
+		}
+
+		raw = bsoncore.NewDocumentBuilder().
+			AppendInt64("insertedCount", res.InsertedCount).
+			AppendInt64("deletedCount", res.DeletedCount).
+			AppendInt64("matchedCount", res.MatchedCount).
+			AppendInt64("modifiedCount", res.ModifiedCount).
+			AppendInt64("upsertedCount", res.UpsertedCount).
+			AppendDocument("upsertedIds", rawUpsertedIDs).
+			Build()
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeCountDocuments(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter bson.Raw
+	opts := options.Count()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "filter":
+			filter = bson.Raw(val.Document())
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		case "limit":
+			opts.SetLimit(int64(val.Int64()))
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "skip":
+			opts.SetSkip(int64(val.Int32()))
+		default:
+			return nil, fmt.Errorf("unrecognized countDocuments option %q", key)
+		}
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	count, err := coll.CountDocuments(getOperationContext(ctx, sess), filter, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	return NewValueResult(bsontype.Int64, bsoncore.AppendInt64(nil, count), nil), nil
+}
+
+func executeCreateIndex(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys bson.Raw
+	indexOpts := options.Index()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "2dsphereIndexVersion":
+			indexOpts.SetSphereVersion(val.Int32())
+		case "background":
+			indexOpts.SetBackground(val.Boolean())
+		case "bits":
+			indexOpts.SetBits(val.Int32())
+		case "bucketSize":
+			indexOpts.SetBucketSize(val.Int32())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			indexOpts.SetCollation(collation)
+		case "defaultLanguage":
+			indexOpts.SetDefaultLanguage(val.StringValue())
+		case "expireAfterSeconds":
+			indexOpts.SetExpireAfterSeconds(val.Int32())
+		case "hidden":
+			indexOpts.SetHidden(val.Boolean())
+		case "keys":
+			keys = val.Document()
+		case "languageOverride":
+			indexOpts.SetLanguageOverride(val.StringValue())
+		case "max":
+			indexOpts.SetMax(val.Double())
+		case "min":
+			indexOpts.SetMin(val.Double())
+		case "name":
+			indexOpts.SetName(val.StringValue())
+		case "partialFilterExpression":
+			indexOpts.SetPartialFilterExpression(val.Document())
+		case "sparse":
+			indexOpts.SetSparse(val.Boolean())
+		case "storageEngine":
+			indexOpts.SetStorageEngine(val.Document())
+		case "unique":
+			indexOpts.SetUnique(val.Boolean())
+		case "version":
+			indexOpts.SetVersion(val.Int32())
+		case "textIndexVersion":
+			indexOpts.SetTextVersion(val.Int32())
+		case "weights":
+			indexOpts.SetWeights(val.Document())
+		case "wildcardProjection":
+			indexOpts.SetWildcardProjection(val.Document())
+		default:
+			return nil, fmt.Errorf("unrecognized createIndex option %q", key)
+		}
+	}
+	if keys == nil {
+		return nil, newMissingArgumentError("keys")
+	}
+
+	model := mongo.IndexModel{
+		Keys:    keys,
+		Options: indexOpts,
+	}
+	name, err := coll.Indexes().CreateOne(getOperationContext(ctx, sess), model)
+	return NewValueResult(bsontype.String, bsoncore.AppendString(nil, name), nil), nil
+}
+
+func executeDeleteOne(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter bson.Raw
+	opts := options.Delete()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "filter":
+			filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		default:
+			return nil, fmt.Errorf("unrecognized deleteOne option %q", key)
+		}
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	res, err := coll.DeleteOne(getOperationContext(ctx, sess), filter, opts)
+	raw := emptyCoreDocument
+	if res != nil {
+		raw = bsoncore.NewDocumentBuilder().
+			AppendInt64("deletedCount", res.DeletedCount).
+			Build()
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeDeleteMany(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter bson.Raw
+	opts := options.Delete()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "filter":
+			filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		default:
+			return nil, fmt.Errorf("unrecognized deleteMany option %q", key)
+		}
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	res, err := coll.DeleteMany(getOperationContext(ctx, sess), filter, opts)
+	raw := emptyCoreDocument
+	if res != nil {
+		raw = bsoncore.NewDocumentBuilder().
+			AppendInt64("deletedCount", res.DeletedCount).
+			Build()
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeDistinct(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var fieldName string
+	var filter bson.Raw
+	opts := options.Distinct()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "fieldName":
+			fieldName = val.StringValue()
+		case "filter":
+			filter = val.Document()
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		default:
+			return nil, fmt.Errorf("unrecognized estimatedDocumentCount option %q", key)
+		}
+	}
+	if fieldName == "" {
+		return nil, newMissingArgumentError("fieldName")
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	res, err := coll.Distinct(getOperationContext(ctx, sess), fieldName, filter, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	_, rawRes, err := bson.MarshalValue(res)
+	if err != nil {
+		return nil, fmt.Errorf("error converting Distinct result to raw BSON: %v", err)
+	}
+	return NewValueResult(bsontype.Array, rawRes, nil), nil
+}
+
+func executeEstimatedDocumentCount(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := options.EstimatedDocumentCount()
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		default:
+			return nil, fmt.Errorf("unrecognized estimatedDocumentCount option %q", key)
+		}
+	}
+
+	count, err := coll.EstimatedDocumentCount(getOperationContext(ctx, sess), opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	return NewValueResult(bsontype.Int64, bsoncore.AppendInt64(nil, count), nil), nil
+}
+
+func executeFind(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter bson.Raw
+	opts := options.Find()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "allowDiskUse":
+			opts.SetAllowDiskUse(val.Boolean())
+		case "allowPartialResults":
+			opts.SetAllowPartialResults(val.Boolean())
+		case "batchSize":
+			opts.SetBatchSize(val.Int32())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "comment":
+			opts.SetComment(val.StringValue())
+		case "filter":
+			filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		case "limit":
+			opts.SetLimit(int64(val.Int32()))
+		case "max":
+			opts.SetMax(val.Document())
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "min":
+			opts.SetMin(val.Document())
+		case "noCursorTimeout":
+			opts.SetNoCursorTimeout(val.Boolean())
+		case "oplogReplay":
+			opts.SetOplogReplay(val.Boolean())
+		case "projection":
+			opts.SetProjection(val.Document())
+		case "returnKey":
+			opts.SetReturnKey(val.Boolean())
+		case "showRecordId":
+			opts.SetShowRecordID(val.Boolean())
+		case "skip":
+			opts.SetSkip(int64(val.Int32()))
+		case "snapshot":
+			opts.SetSnapshot(val.Boolean())
+		case "sort":
+			opts.SetSort(val.Document())
+		default:
+			return nil, fmt.Errorf("unrecognized find option %q", key)
+		}
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	cursor, err := coll.Find(getOperationContext(ctx, sess), filter, opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	defer cursor.Close(ctx)
+
+	var docs []bson.Raw
+	if err := cursor.All(ctx, &docs); err != nil {
+		return NewErrorResult(err), nil
+	}
+	return NewCursorResult(docs), nil
+}
+
+func executeFindOneAndUpdate(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter bson.Raw
+	var update interface{}
+	opts := options.FindOneAndUpdate()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "arrayFilters":
+			opts.SetArrayFilters(options.ArrayFilters{
+				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+			})
+		case "bypassDocumentValidation":
+			opts.SetBypassDocumentValidation(val.Boolean())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "filter":
+			filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		case "maxTimeMS":
+			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
+		case "projection":
+			opts.SetProjection(val.Document())
+		case "returnDocument":
+			switch rd := val.StringValue(); rd {
+			case "After":
+				opts.SetReturnDocument(options.After)
+			case "Before":
+				opts.SetReturnDocument(options.Before)
+			default:
+				return nil, fmt.Errorf("unrecognized returnDocument value %q", rd)
+			}
+		case "sort":
+			opts.SetSort(val.Document())
+		case "update":
+			update, err = createUpdateValue(val)
+			if err != nil {
+				return nil, fmt.Errorf("error processing update value: %q", err)
+			}
+		case "upsert":
+			opts.SetUpsert(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized find option %q", key)
+		}
+	}
+	if filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+	if update == nil {
+		return nil, newMissingArgumentError("update")
+	}
+
+	res, err := coll.FindOneAndUpdate(getOperationContext(ctx, sess), filter, update, opts).DecodeBytes()
+	return NewDocumentResult(res, err), nil
+}
+
+func executeInsertMany(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var documents []interface{}
+	opts := options.InsertMany()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "documents":
+			documents = testhelpers.RawToInterfaceSlice(val.Array())
+		case "ordered":
+			opts.SetOrdered(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized insertMany option %q", key)
+		}
+	}
+	if documents == nil {
+		return nil, newMissingArgumentError("documents")
+	}
+
+	res, err := coll.InsertMany(getOperationContext(ctx, sess), documents, opts)
+	raw := emptyCoreDocument
+	if res != nil {
+		// We return InsertedIDs as []interface{} but the CRUD spec documents it as a map[int64]interface{}, so
+		// comparisons will fail if we include it in the result document. This is marked as an optional field and is
+		// always surrounded in an $$unsetOrMatches assertion, so we leave it out of the document.
+		raw = bsoncore.NewDocumentBuilder().
+			AppendInt32("insertedCount", int32(len(res.InsertedIDs))).
+			AppendInt32("deletedCount", 0).
+			AppendInt32("matchedCount", 0).
+			AppendInt32("modifiedCount", 0).
+			AppendInt32("upsertedCount", 0).
+			AppendDocument("upsertedIds", bsoncore.NewDocumentBuilder().Build()).
+			Build()
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeInsertOne(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var document bson.Raw
+	opts := options.InsertOne()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "document":
+			document = val.Document()
+		case "bypassDocumentValidation":
+			opts.SetBypassDocumentValidation(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized insertMany option %q", key)
+		}
+	}
+	if document == nil {
+		return nil, newMissingArgumentError("documents")
+	}
+
+	res, err := coll.InsertOne(getOperationContext(ctx, sess), document, opts)
+	raw := emptyCoreDocument
+	if res != nil {
+		t, data, err := bson.MarshalValue(res.InsertedID)
+		if err != nil {
+			return nil, fmt.Errorf("error convertined InsertedID field to BSON: %v", err)
+		}
+		raw = bsoncore.NewDocumentBuilder().
+			AppendValue("insertedId", bsoncore.Value{Type: t, Data: data}).
+			Build()
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeReplaceOne(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := emptyDocument
+	replacement := emptyDocument
+	opts := options.Replace()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "bypassDocumentValidation":
+			opts.SetBypassDocumentValidation(val.Boolean())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			opts.SetCollation(collation)
+		case "filter":
+			filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			opts.SetHint(hint)
+		case "replacement":
+			replacement = val.Document()
+		case "upsert":
+			opts.SetUpsert(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized deleteOne option %q", key)
+		}
+	}
+
+	res, err := coll.ReplaceOne(getOperationContext(ctx, sess), filter, replacement, opts)
+	raw, buildErr := buildUpdateResultDocument(res)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeUpdateOne(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	updateArgs, err := createUpdateArguments(operation.Arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := coll.UpdateOne(getOperationContext(ctx, sess), updateArgs.filter, updateArgs.update, updateArgs.opts)
+	raw, buildErr := buildUpdateResultDocument(res)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func executeUpdateMany(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	coll, err := Entities(ctx).Collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	updateArgs, err := createUpdateArguments(operation.Arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := coll.UpdateMany(getOperationContext(ctx, sess), updateArgs.filter, updateArgs.update, updateArgs.opts)
+	raw, buildErr := buildUpdateResultDocument(res)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return NewDocumentResult(raw, err), nil
+}
+
+func buildUpdateResultDocument(res *mongo.UpdateResult) (bsoncore.Document, error) {
+	if res == nil {
+		return emptyCoreDocument, nil
+	}
+
+	builder := bsoncore.NewDocumentBuilder().
+		AppendInt64("matchedCount", res.MatchedCount).
+		AppendInt64("modifiedCount", res.ModifiedCount).
+		AppendInt64("upsertedCount", res.UpsertedCount)
+
+	if res.UpsertedID != nil {
+		t, data, err := bson.MarshalValue(res.UpsertedID)
+		if err != nil {
+			return nil, fmt.Errorf("error converting UpsertedID to BSON: %v", err)
+		}
+		builder.AppendValue("upsertedId", bsoncore.Value{Type: t, Data: data})
+	}
+	return builder.Build(), nil
+}

--- a/mongo/integration/unified/collection_operation_execution_test.go
+++ b/mongo/integration/unified/collection_operation_execution_test.go
@@ -70,6 +70,8 @@ func executeAggregate(ctx context.Context, operation *Operation, sess mongo.Sess
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
 			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+		default:
+			return nil, fmt.Errorf("unrecognized aggregate option %q", key)
 		}
 	}
 	if pipeline == nil {
@@ -392,7 +394,7 @@ func executeDistinct(ctx context.Context, operation *Operation, sess mongo.Sessi
 		case "maxTimeMS":
 			opts.SetMaxTime(time.Duration(val.Int32()) * time.Millisecond)
 		default:
-			return nil, fmt.Errorf("unrecognized estimatedDocumentCount option %q", key)
+			return nil, fmt.Errorf("unrecognized distinct option %q", key)
 		}
 	}
 	if fieldName == "" {
@@ -581,7 +583,7 @@ func executeFindOneAndUpdate(ctx context.Context, operation *Operation, sess mon
 		case "upsert":
 			opts.SetUpsert(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized find option %q", key)
+			return nil, fmt.Errorf("unrecognized findOneAndUpdate option %q", key)
 		}
 	}
 	if filter == nil {
@@ -660,7 +662,7 @@ func executeInsertOne(ctx context.Context, operation *Operation, sess mongo.Sess
 		case "bypassDocumentValidation":
 			opts.SetBypassDocumentValidation(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized insertMany option %q", key)
+			return nil, fmt.Errorf("unrecognized insertOne option %q", key)
 		}
 	}
 	if document == nil {
@@ -718,7 +720,7 @@ func executeReplaceOne(ctx context.Context, operation *Operation, sess mongo.Ses
 		case "upsert":
 			opts.SetUpsert(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized deleteOne option %q", key)
+			return nil, fmt.Errorf("unrecognized replaceOne option %q", key)
 		}
 	}
 

--- a/mongo/integration/unified/command_monitoring_test.go
+++ b/mongo/integration/unified/command_monitoring_test.go
@@ -1,0 +1,175 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+)
+
+type CommandMonitoringEvent struct {
+	CommandStartedEvent *struct {
+		Command      bson.Raw `bson:"command"`
+		CommandName  *string  `bson:"commandName"`
+		DatabaseName *string  `bson:"databaseName"`
+	} `bson:"commandStartedEvent"`
+
+	CommandSucceededEvent *struct {
+		CommandName *string  `bson:"commandName"`
+		Reply       bson.Raw `bson:"reply"`
+	} `bson:"commandSucceededEvent"`
+
+	CommandFailedEvent *struct {
+		CommandName *string `bson:"commandName"`
+	} `bson:"commandFailedEvent"`
+}
+
+type ExpectedEvents struct {
+	ClientID string                   `bson:"client"`
+	Events   []CommandMonitoringEvent `bson:"events"`
+}
+
+func VerifyEvents(ctx context.Context, expectedEvents *ExpectedEvents) error {
+	client, err := Entities(ctx).Client(expectedEvents.ClientID)
+	if err != nil {
+		return err
+	}
+
+	if expectedEvents.Events == nil {
+		return nil
+	}
+
+	started := client.StartedEvents()
+	succeeded := client.SucceededEvents()
+	failed := client.FailedEvents()
+
+	// If the Events array is nil, verify that no events were sent.
+	if len(expectedEvents.Events) == 0 {
+		if len(started) != 0 {
+			return fmt.Errorf("expected no events but got started events %v", stringifyStartedEvents(started))
+		}
+		if len(succeeded) != 0 {
+			return fmt.Errorf("expected no events but got succeeded events %v", stringifySucceededEvents(succeeded))
+		}
+		if len(failed) != 0 {
+			return fmt.Errorf("expected no events but got failed events %v", stringifyFailedEvents(failed))
+		}
+		return nil
+	}
+
+	for idx, evt := range expectedEvents.Events {
+		switch {
+		case evt.CommandStartedEvent != nil:
+			if len(started) == 0 {
+				return newEventVerificationError(idx, "no CommandStartedEvent published")
+			}
+
+			actual := started[0]
+			started = started[1:]
+
+			expected := evt.CommandStartedEvent
+			if expected.CommandName != nil && *expected.CommandName != actual.CommandName {
+				return newEventVerificationError(idx, "expected command name %q, got %q", *expected.CommandName,
+					actual.CommandName)
+			}
+			if expected.DatabaseName != nil && *expected.DatabaseName != actual.DatabaseName {
+				return newEventVerificationError(idx, "expected database name %q, got %q", *expected.DatabaseName,
+					actual.DatabaseName)
+			}
+			if expected.Command != nil {
+				expectedDoc := DocumentToRawValue(expected.Command)
+				actualDoc := DocumentToRawValue(actual.Command)
+				if err := VerifyValuesMatch(ctx, expectedDoc, actualDoc, true); err != nil {
+					return newEventVerificationError(idx, "error comparing command documents: %v", err)
+				}
+			}
+		case evt.CommandSucceededEvent != nil:
+			if len(succeeded) == 0 {
+				return newEventVerificationError(idx, "no CommandSucceededEvent published")
+			}
+
+			actual := succeeded[0]
+			succeeded = succeeded[1:]
+
+			expected := evt.CommandSucceededEvent
+			if expected.CommandName != nil && *expected.CommandName != actual.CommandName {
+				return newEventVerificationError(idx, "expected command name %q, got %q", *expected.CommandName,
+					actual.CommandName)
+			}
+			if expected.Reply != nil {
+				expectedDoc := DocumentToRawValue(expected.Reply)
+				actualDoc := DocumentToRawValue(actual.Reply)
+				if err := VerifyValuesMatch(ctx, expectedDoc, actualDoc, true); err != nil {
+					return newEventVerificationError(idx, "error comparing reply documents: %v", err)
+				}
+			}
+		case evt.CommandFailedEvent != nil:
+			if len(failed) == 0 {
+				return newEventVerificationError(idx, "no CommandFailedEvent published")
+			}
+
+			actual := failed[0]
+			failed = failed[1:]
+
+			expected := evt.CommandFailedEvent
+			if expected.CommandName != nil && *expected.CommandName != actual.CommandName {
+				return newEventVerificationError(idx, "expected command name %q, got %q", *expected.CommandName,
+					actual.CommandName)
+			}
+		default:
+			return newEventVerificationError(idx, "no expected event set on CommandMonitoringEvent instance")
+		}
+	}
+
+	// Verify that there are no remaining events.
+	if len(started) > 0 {
+		return fmt.Errorf("extra started events published: %v", stringifyStartedEvents(started))
+	}
+	if len(succeeded) > 0 {
+		return fmt.Errorf("extra succeeded events published: %v", stringifySucceededEvents(succeeded))
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("extra failed events published: %v", stringifyFailedEvents(failed))
+	}
+
+	return nil
+}
+
+func newEventVerificationError(idx int, msg string, args ...interface{}) error {
+	fullMsg := fmt.Sprintf(msg, args...)
+	return fmt.Errorf("event comparison failed at index %d: %s", idx, fullMsg)
+}
+
+func stringifyStartedEvents(events []*event.CommandStartedEvent) []string {
+	converted := make([]string, 0, len(events))
+	for _, evt := range events {
+		converted = append(converted, fmt.Sprintf("%s", evt.Command))
+	}
+
+	return converted
+}
+
+func stringifySucceededEvents(events []*event.CommandSucceededEvent) []string {
+	converted := make([]string, 0, len(events))
+	for _, evt := range events {
+		converted = append(converted, fmt.Sprintf("command name: %s, reply: %s", evt.CommandName, evt.Reply))
+	}
+
+	return converted
+}
+
+func stringifyFailedEvents(events []*event.CommandFailedEvent) []string {
+	converted := make([]string, 0, len(events))
+	for _, evt := range events {
+		converted = append(converted, fmt.Sprintf("command name: %s, failure: %s", evt.CommandName, evt.Failure))
+	}
+
+	return converted
+}

--- a/mongo/integration/unified/common_options_test.go
+++ b/mongo/integration/unified/common_options_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+)
+
+// This file defines helper types to convert BSON documents to ReadConcern, WriteConcern, and ReadPref objects.
+
+type readConcern struct {
+	Level string `bson:"level"`
+}
+
+func (rc *readConcern) toReadConcernOption() *readconcern.ReadConcern {
+	return readconcern.New(readconcern.Level(rc.Level))
+}
+
+type writeConcern struct {
+	Journal    *bool       `bson:"journal"`
+	W          interface{} `bson:"w"`
+	WTimeoutMS *int32      `bson:"wtimeoutMS"`
+}
+
+func (wc *writeConcern) toWriteConcernOption() (*writeconcern.WriteConcern, error) {
+	var wcOptions []writeconcern.Option
+	if wc.Journal != nil {
+		wcOptions = append(wcOptions, writeconcern.J(*wc.Journal))
+	}
+	if wc.W != nil {
+		switch converted := wc.W.(type) {
+		case string:
+			if converted != "majority" {
+				return nil, fmt.Errorf("invalid write concern 'w' string value %q", converted)
+			}
+			wcOptions = append(wcOptions, writeconcern.WMajority())
+		case int32:
+			wcOptions = append(wcOptions, writeconcern.W(int(converted)))
+		default:
+			return nil, fmt.Errorf("invalid type for write concern 'w' field %T", wc.W)
+		}
+	}
+	if wc.WTimeoutMS != nil {
+		wTimeout := time.Duration(*wc.WTimeoutMS) * time.Millisecond
+		wcOptions = append(wcOptions, writeconcern.WTimeout(wTimeout))
+	}
+
+	return writeconcern.New(wcOptions...), nil
+}
+
+type readPreference struct {
+	Mode                string   `bson:"mode"`
+	TagSets             []bson.D `bson:"tagSets"`
+	MaxStalenessSeconds *int64   `bson:"maxStalenessSeconds"`
+	Hedge               bson.M   `bson:"hedge"`
+}
+
+func (rp *readPreference) toReadPrefOption() (*readpref.ReadPref, error) {
+	mode, err := readpref.ModeFromString(rp.Mode)
+	if err != nil {
+		return nil, fmt.Errorf("invalid read preference mode %q", rp.Mode)
+	}
+
+	var rpOptions []readpref.Option
+	if rp.TagSets != nil {
+		return nil, fmt.Errorf("tagSets not supported")
+	}
+	if rp.MaxStalenessSeconds != nil {
+		maxStaleness := time.Duration(*rp.MaxStalenessSeconds) * time.Second
+		rpOptions = append(rpOptions, readpref.WithMaxStaleness(maxStaleness))
+	}
+	if rp.Hedge != nil {
+		if len(rp.Hedge) > 1 {
+			return nil, fmt.Errorf("invalid read preference hedge document: length cannot be greater than 1")
+		}
+		if enabled, ok := rp.Hedge["enabled"]; ok {
+			rpOptions = append(rpOptions, readpref.WithHedgeEnabled(enabled.(bool)))
+		}
+	}
+
+	return readpref.New(mode, rpOptions...)
+}

--- a/mongo/integration/unified/context_test.go
+++ b/mongo/integration/unified/context_test.go
@@ -45,7 +45,7 @@ func AddFailPoint(ctx context.Context, failPoint string, client *mongo.Client) e
 }
 
 func AddTargetedFailPoint(ctx context.Context, failPoint string, host string) error {
-	failPoints := ctx.Value(failPointsKey).(map[string]string)
+	failPoints := ctx.Value(targetedFailPointsKey).(map[string]string)
 	if _, ok := failPoints[failPoint]; ok {
 		return fmt.Errorf("fail point %q already exists in tracked targeted fail points map", failPoint)
 	}

--- a/mongo/integration/unified/context_test.go
+++ b/mongo/integration/unified/context_test.go
@@ -1,0 +1,67 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ctxKey is used to define keys for values stored in context.Context objects.
+type ctxKey string
+
+const (
+	// entitiesKey is used to store an EntityMap instance in a Context.
+	entitiesKey ctxKey = "test-entities"
+	// failPointsKey is used to store a map from a fail point name to the Client instance used to configure it.
+	failPointsKey ctxKey = "test-failpoints"
+	// targetedFailPointsKey is used to store a map from a fail point name to the host on which the fail point is set.
+	targetedFailPointsKey ctxKey = "test-targeted-failpoints"
+)
+
+// NewTestContext creates a new Context derived from ctx with values initialized to store the state required for test
+// execution.
+func NewTestContext(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, entitiesKey, NewEntityMap())
+	ctx = context.WithValue(ctx, failPointsKey, make(map[string]*mongo.Client))
+	ctx = context.WithValue(ctx, targetedFailPointsKey, make(map[string]string))
+	return ctx
+}
+
+func AddFailPoint(ctx context.Context, failPoint string, client *mongo.Client) error {
+	failPoints := ctx.Value(failPointsKey).(map[string]*mongo.Client)
+	if _, ok := failPoints[failPoint]; ok {
+		return fmt.Errorf("fail point %q already exists in tracked fail points map", failPoint)
+	}
+
+	failPoints[failPoint] = client
+	return nil
+}
+
+func AddTargetedFailPoint(ctx context.Context, failPoint string, host string) error {
+	failPoints := ctx.Value(failPointsKey).(map[string]string)
+	if _, ok := failPoints[failPoint]; ok {
+		return fmt.Errorf("fail point %q already exists in tracked targeted fail points map", failPoint)
+	}
+
+	failPoints[failPoint] = host
+	return nil
+}
+
+func FailPoints(ctx context.Context) map[string]*mongo.Client {
+	return ctx.Value(failPointsKey).(map[string]*mongo.Client)
+}
+
+func TargetedFailPoints(ctx context.Context) map[string]string {
+	return ctx.Value(targetedFailPointsKey).(map[string]string)
+}
+
+func Entities(ctx context.Context) *EntityMap {
+	return ctx.Value(entitiesKey).(*EntityMap)
+}

--- a/mongo/integration/unified/crud_helpers_test.go
+++ b/mongo/integration/unified/crud_helpers_test.go
@@ -1,0 +1,159 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// newMissingArgumentError creates an error to convey that an argument that is required to run an operation is missing
+// from the operation's arguments document.
+func newMissingArgumentError(arg string) error {
+	return fmt.Errorf("operation arguments document is missing required field %q", arg)
+}
+
+type updateArguments struct {
+	filter bson.Raw
+	update interface{}
+	opts   *options.UpdateOptions
+}
+
+func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
+	ua := &updateArguments{
+		opts: options.Update(),
+	}
+	var err error
+
+	elems, _ := args.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "arrayFilters":
+			ua.opts.SetArrayFilters(options.ArrayFilters{
+				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+			})
+		case "bypassDocumentValidation":
+			ua.opts.SetBypassDocumentValidation(val.Boolean())
+		case "collation":
+			collation, err := createCollation(val.Document())
+			if err != nil {
+				return nil, fmt.Errorf("error creating collation: %v", err)
+			}
+			ua.opts.SetCollation(collation)
+		case "filter":
+			ua.filter = val.Document()
+		case "hint":
+			hint, err := createHint(val)
+			if err != nil {
+				return nil, fmt.Errorf("error creating hint: %v", err)
+			}
+			ua.opts.SetHint(hint)
+		case "update":
+			ua.update, err = createUpdateValue(val)
+			if err != nil {
+				return nil, fmt.Errorf("error processing update value: %v", err)
+			}
+		case "upsert":
+			ua.opts.SetUpsert(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized deleteOne option %q", key)
+		}
+	}
+	if ua.filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+	if ua.update == nil {
+		return nil, newMissingArgumentError("update")
+	}
+
+	return ua, nil
+}
+
+type listCollectionsArguments struct {
+	filter bson.Raw
+	opts   *options.ListCollectionsOptions
+}
+
+func createListCollectionsArguments(args bson.Raw) (*listCollectionsArguments, error) {
+	lca := &listCollectionsArguments{
+		opts: options.ListCollections(),
+	}
+
+	elems, _ := args.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "batchSize":
+			lca.opts.SetBatchSize(val.Int32())
+		case "filter":
+			lca.filter = val.Document()
+		case "nameOnly":
+			lca.opts.SetNameOnly(val.Boolean())
+		default:
+			return nil, fmt.Errorf("unrecognized listCollections option %q", key)
+		}
+	}
+	if lca.filter == nil {
+		return nil, newMissingArgumentError("filter")
+	}
+
+	return lca, nil
+}
+
+func createCollation(args bson.Raw) (*options.Collation, error) {
+	var collation options.Collation
+	elems, _ := args.Elements()
+
+	for _, elem := range elems {
+		switch elem.Key() {
+		case "locale":
+			collation.Locale = elem.Value().StringValue()
+		case "caseLevel":
+			collation.CaseLevel = elem.Value().Boolean()
+		case "caseFirst":
+			collation.CaseFirst = elem.Value().StringValue()
+		case "strength":
+			collation.Strength = int(elem.Value().Int32())
+		case "numericOrdering":
+			collation.NumericOrdering = elem.Value().Boolean()
+		case "alternate":
+			collation.Alternate = elem.Value().StringValue()
+		case "maxVariable":
+			collation.MaxVariable = elem.Value().StringValue()
+		case "normalization":
+			collation.Normalization = elem.Value().Boolean()
+		case "backwards":
+			collation.Backwards = elem.Value().Boolean()
+		default:
+			return nil, fmt.Errorf("unrecognized collation option %q", elem.Key())
+		}
+	}
+	return &collation, nil
+}
+
+func createHint(val bson.RawValue) (interface{}, error) {
+	var hint interface{}
+
+	switch val.Type {
+	case bsontype.String:
+		hint = val.StringValue()
+	case bsontype.EmbeddedDocument:
+		hint = val.Document()
+	default:
+		return nil, fmt.Errorf("unrecognized hint value type %s", val.Type)
+	}
+	return hint, nil
+}

--- a/mongo/integration/unified/crud_helpers_test.go
+++ b/mongo/integration/unified/crud_helpers_test.go
@@ -67,7 +67,7 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 		case "upsert":
 			ua.opts.SetUpsert(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized deleteOne option %q", key)
+			return nil, fmt.Errorf("unrecognized update option %q", key)
 		}
 	}
 	if ua.filter == nil {

--- a/mongo/integration/unified/database_operation_execution_test.go
+++ b/mongo/integration/unified/database_operation_execution_test.go
@@ -12,13 +12,12 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // This file contains helpers to execute database operations.
 
-func executeCreateCollection(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeCreateCollection(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	db, err := Entities(ctx).Database(operation.Object)
 	if err != nil {
 		return nil, err
@@ -41,11 +40,11 @@ func executeCreateCollection(ctx context.Context, operation *Operation, sess mon
 		return nil, newMissingArgumentError("collName")
 	}
 
-	err = db.CreateCollection(getOperationContext(ctx, sess), collName)
+	err = db.CreateCollection(ctx, collName)
 	return NewErrorResult(err), nil
 }
 
-func executeDropCollection(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeDropCollection(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	db, err := Entities(ctx).Database(operation.Object)
 	if err != nil {
 		return nil, err
@@ -68,11 +67,11 @@ func executeDropCollection(ctx context.Context, operation *Operation, sess mongo
 		return nil, newMissingArgumentError("collection")
 	}
 
-	err = db.Collection(collName).Drop(getOperationContext(ctx, sess))
+	err = db.Collection(collName).Drop(ctx)
 	return NewErrorResult(err), nil
 }
 
-func executeListCollections(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeListCollections(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	db, err := Entities(ctx).Database(operation.Object)
 	if err != nil {
 		return nil, err
@@ -83,7 +82,7 @@ func executeListCollections(ctx context.Context, operation *Operation, sess mong
 		return nil, err
 	}
 
-	cursor, err := db.ListCollections(getOperationContext(ctx, sess), listCollArgs.filter, listCollArgs.opts)
+	cursor, err := db.ListCollections(ctx, listCollArgs.filter, listCollArgs.opts)
 	if err != nil {
 		return NewErrorResult(err), nil
 	}
@@ -96,7 +95,7 @@ func executeListCollections(ctx context.Context, operation *Operation, sess mong
 	return NewCursorResult(docs), nil
 }
 
-func executeListCollectionNames(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeListCollectionNames(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	db, err := Entities(ctx).Database(operation.Object)
 	if err != nil {
 		return nil, err
@@ -107,7 +106,7 @@ func executeListCollectionNames(ctx context.Context, operation *Operation, sess 
 		return nil, err
 	}
 
-	names, err := db.ListCollectionNames(getOperationContext(ctx, sess), listCollArgs.filter, listCollArgs.opts)
+	names, err := db.ListCollectionNames(ctx, listCollArgs.filter, listCollArgs.opts)
 	if err != nil {
 		return NewErrorResult(err), nil
 	}
@@ -118,7 +117,7 @@ func executeListCollectionNames(ctx context.Context, operation *Operation, sess 
 	return NewValueResult(bsontype.Array, data, nil), nil
 }
 
-func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+func executeRunCommand(ctx context.Context, operation *Operation) (*OperationResult, error) {
 	db, err := Entities(ctx).Database(operation.Object)
 	if err != nil {
 		return nil, err
@@ -163,6 +162,6 @@ func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Ses
 		return nil, newMissingArgumentError("command")
 	}
 
-	res, err := db.RunCommand(getOperationContext(ctx, sess), command, opts).DecodeBytes()
+	res, err := db.RunCommand(ctx, command, opts).DecodeBytes()
 	return NewDocumentResult(res, err), nil
 }

--- a/mongo/integration/unified/database_operation_execution_test.go
+++ b/mongo/integration/unified/database_operation_execution_test.go
@@ -124,8 +124,6 @@ func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Ses
 		return nil, err
 	}
 
-	// TODO: file GODRIVER ticket for write concern
-
 	var command bson.Raw
 	opts := options.RunCmd()
 

--- a/mongo/integration/unified/database_operation_execution_test.go
+++ b/mongo/integration/unified/database_operation_execution_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// This file contains helpers to execute database operations.
+
+func executeCreateCollection(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	db, err := Entities(ctx).Database(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var collName string
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collection":
+			collName = val.StringValue()
+		default:
+			return nil, fmt.Errorf("unrecognized createCollection option %q", key)
+		}
+	}
+	if collName == "" {
+		return nil, newMissingArgumentError("collName")
+	}
+
+	err = db.CreateCollection(getOperationContext(ctx, sess), collName)
+	return NewErrorResult(err), nil
+}
+
+func executeDropCollection(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	db, err := Entities(ctx).Database(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var collName string
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "collection":
+			collName = val.StringValue()
+		default:
+			return nil, fmt.Errorf("unrecognized dropCollection option %q", key)
+		}
+	}
+	if collName == "" {
+		return nil, newMissingArgumentError("collection")
+	}
+
+	err = db.Collection(collName).Drop(getOperationContext(ctx, sess))
+	return NewErrorResult(err), nil
+}
+
+func executeListCollections(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	db, err := Entities(ctx).Database(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	listCollArgs, err := createListCollectionsArguments(operation.Arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	cursor, err := db.ListCollections(getOperationContext(ctx, sess), listCollArgs.filter, listCollArgs.opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	defer cursor.Close(ctx)
+
+	var docs []bson.Raw
+	if err := cursor.All(ctx, &cursor); err != nil {
+		return NewErrorResult(err), nil
+	}
+	return NewCursorResult(docs), nil
+}
+
+func executeListCollectionNames(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	db, err := Entities(ctx).Database(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	listCollArgs, err := createListCollectionsArguments(operation.Arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := db.ListCollectionNames(getOperationContext(ctx, sess), listCollArgs.filter, listCollArgs.opts)
+	if err != nil {
+		return NewErrorResult(err), nil
+	}
+	_, data, err := bson.MarshalValue(names)
+	if err != nil {
+		return nil, fmt.Errorf("error converting collection names slice to BSON: %v", err)
+	}
+	return NewValueResult(bsontype.Array, data, nil), nil
+}
+
+func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Session) (*OperationResult, error) {
+	db, err := Entities(ctx).Database(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: file GODRIVER ticket for write concern
+
+	var command bson.Raw
+	opts := options.RunCmd()
+
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "command":
+			command = val.Document()
+		case "commandName":
+			// This is only necessary for languages that cannot preserve key order in the command document, so we can
+			// ignore it.
+		case "readConcern":
+			return nil, fmt.Errorf("readConcern in runCommand not supported")
+		case "readPreference":
+			var temp readPreference
+			if err := bson.Unmarshal(val.Document(), &temp); err != nil {
+				return nil, fmt.Errorf("error unmarshalling readPreference option: %v", err)
+			}
+
+			rp, err := temp.toReadPrefOption()
+			if err != nil {
+				return nil, fmt.Errorf("error creating readpref.ReadPref object: %v", err)
+			}
+			opts.SetReadPreference(rp)
+		case "writeConcern":
+			return nil, fmt.Errorf("writeConcern in runCommand not supported")
+		default:
+			return nil, fmt.Errorf("unrecognized runCommand option %q", key)
+		}
+	}
+	if command == nil {
+		return nil, newMissingArgumentError("command")
+	}
+
+	res, err := db.RunCommand(getOperationContext(ctx, sess), command, opts).DecodeBytes()
+	return NewDocumentResult(res, err), nil
+}

--- a/mongo/integration/unified/database_operation_execution_test.go
+++ b/mongo/integration/unified/database_operation_execution_test.go
@@ -141,6 +141,7 @@ func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Ses
 			// This is only necessary for languages that cannot preserve key order in the command document, so we can
 			// ignore it.
 		case "readConcern":
+			// GODRIVER-1774: We currently don't support overriding read concern for RunCommand.
 			return nil, fmt.Errorf("readConcern in runCommand not supported")
 		case "readPreference":
 			var temp readPreference
@@ -154,6 +155,7 @@ func executeRunCommand(ctx context.Context, operation *Operation, sess mongo.Ses
 			}
 			opts.SetReadPreference(rp)
 		case "writeConcern":
+			// GODRIVER-1774: We currently don't support overriding write concern for RunCommand.
 			return nil, fmt.Errorf("writeConcern in runCommand not supported")
 		default:
 			return nil, fmt.Errorf("unrecognized runCommand option %q", key)

--- a/mongo/integration/unified/db_collection_options_test.go
+++ b/mongo/integration/unified/db_collection_options_test.go
@@ -31,7 +31,7 @@ func (d *DBOrCollectionOptions) UnmarshalBSON(data []byte) error {
 		return fmt.Errorf("error unmarshalling to temporary DBOrCollectionOptions object: %v", err)
 	}
 	if len(temp.Extra) > 0 {
-		return fmt.Errorf("unregonized fields for DBOrCollectionOptions: %v", MapKeys(temp.Extra))
+		return fmt.Errorf("unrecognized fields for DBOrCollectionOptions: %v", MapKeys(temp.Extra))
 	}
 
 	d.DBOptions = options.Database()

--- a/mongo/integration/unified/db_collection_options_test.go
+++ b/mongo/integration/unified/db_collection_options_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type DBOrCollectionOptions struct {
+	DBOptions         *options.DatabaseOptions
+	CollectionOptions *options.CollectionOptions
+}
+
+// UnmarshalBSON specifies custom BSON unmarshalling behavior to convert db/collection options from BSON/JSON documents
+// to their corresponding Go objects.
+func (d *DBOrCollectionOptions) UnmarshalBSON(data []byte) error {
+	var temp struct {
+		RC    *readConcern           `bson:"readConcern"`
+		RP    *readPreference        `bson:"readPreference"`
+		WC    *writeConcern          `bson:"writeConcern"`
+		Extra map[string]interface{} `bson:",inline"`
+	}
+	if err := bson.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("error unmarshalling to temporary DBOrCollectionOptions object: %v", err)
+	}
+	if len(temp.Extra) > 0 {
+		return fmt.Errorf("unregonized fields for DBOrCollectionOptions: %v", MapKeys(temp.Extra))
+	}
+
+	d.DBOptions = options.Database()
+	d.CollectionOptions = options.Collection()
+	if temp.RC != nil {
+		rc := temp.RC.toReadConcernOption()
+		d.DBOptions.SetReadConcern(rc)
+		d.CollectionOptions.SetReadConcern(rc)
+	}
+	if temp.RP != nil {
+		rp, err := temp.RP.toReadPrefOption()
+		if err != nil {
+			return fmt.Errorf("error parsing read preference document: %v", err)
+		}
+
+		d.DBOptions.SetReadPreference(rp)
+		d.CollectionOptions.SetReadPreference(rp)
+	}
+	if temp.WC != nil {
+		wc, err := temp.WC.toWriteConcernOption()
+		if err != nil {
+			return fmt.Errorf("error parsing write concern document: %v", err)
+		}
+
+		d.DBOptions.SetWriteConcern(wc)
+		d.CollectionOptions.SetWriteConcern(wc)
+	}
+
+	return nil
+}

--- a/mongo/integration/unified/entity_test.go
+++ b/mongo/integration/unified/entity_test.go
@@ -141,7 +141,7 @@ func (em *EntityMap) BSONValue(id string) (bson.RawValue, error) {
 func (em *EntityMap) ChangeStream(id string) (*mongo.ChangeStream, error) {
 	client, ok := em.changeStreams[id]
 	if !ok {
-		return nil, newEntityNotFoundError("client", id)
+		return nil, newEntityNotFoundError("change stream", id)
 	}
 	return client, nil
 }

--- a/mongo/integration/unified/entity_test.go
+++ b/mongo/integration/unified/entity_test.go
@@ -1,0 +1,294 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/gridfs"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// EntityOptions represents all options that can be used to configure an entity. Because there are multiple entity
+// types, only a subset of the options that this type contains apply to any given entity.
+type EntityOptions struct {
+	// Options that apply to all entity types.
+	ID string `bson:"id"`
+
+	// Options for client entities.
+	URIOptions          bson.M   `bson:"uriOptions"`
+	UseMultipleMongoses bool     `bson:"useMultipleMongoses"`
+	ObserveEvents       []string `bson:"observeEvents"`
+	IgnoredCommands     []string `bson:"ignoreCommandMonitoringEvents"`
+
+	// Options for database entities.
+	DatabaseName    string                 `bson:"databaseName"`
+	DatabaseOptions *DBOrCollectionOptions `bson:"databaseOptions"`
+
+	// Options for collection entities.
+	CollectionName    string                 `bson:"collectionName"`
+	CollectionOptions *DBOrCollectionOptions `bson:"collectionOptions"`
+
+	// Options for session entities.
+	SessionOptions *SessionOptions `bson:"sessionOptions"`
+
+	// Options for bucket entities.
+	BucketOptions *BucketOptions `bson:"bucketOptions"`
+
+	// Options that reference other entities.
+	ClientID   string `bson:"client"`
+	DatabaseID string `bson:"database"`
+}
+
+// EntityMap is used to store entities during tests. This type enforces uniqueness so no two entities can have the same
+// ID, even if they are of different types. It also enforces referential integrity so construction of an entity that
+// references another (e.g. a database entity references a client) will fail if the referenced entity does not exist.
+type EntityMap struct {
+	allEntities   map[string]struct{}
+	changeStreams map[string]*mongo.ChangeStream
+	clients       map[string]*ClientEntity
+	dbs           map[string]*mongo.Database
+	collections   map[string]*mongo.Collection
+	sessions      map[string]mongo.Session
+	buckets       map[string]*gridfs.Bucket
+	bsonValues    map[string]bson.RawValue
+}
+
+func NewEntityMap() *EntityMap {
+	return &EntityMap{
+		allEntities:   make(map[string]struct{}),
+		buckets:       make(map[string]*gridfs.Bucket),
+		bsonValues:    make(map[string]bson.RawValue),
+		changeStreams: make(map[string]*mongo.ChangeStream),
+		clients:       make(map[string]*ClientEntity),
+		collections:   make(map[string]*mongo.Collection),
+		dbs:           make(map[string]*mongo.Database),
+		sessions:      make(map[string]mongo.Session),
+	}
+}
+
+func (em *EntityMap) AddBSONEntity(id string, val bson.RawValue) error {
+	if err := em.verifyEntityDoesNotExist(id); err != nil {
+		return err
+	}
+
+	em.allEntities[id] = struct{}{}
+	em.bsonValues[id] = val
+	return nil
+}
+
+func (em *EntityMap) AddChangeStreamEntity(id string, stream *mongo.ChangeStream) error {
+	if err := em.verifyEntityDoesNotExist(id); err != nil {
+		return err
+	}
+
+	em.allEntities[id] = struct{}{}
+	em.changeStreams[id] = stream
+	return nil
+}
+
+func (em *EntityMap) AddEntity(ctx context.Context, entityType string, entityOptions *EntityOptions) error {
+	if err := em.verifyEntityDoesNotExist(entityOptions.ID); err != nil {
+		return err
+	}
+
+	var err error
+	switch entityType {
+	case "client":
+		err = em.addClientEntity(ctx, entityOptions)
+	case "database":
+		err = em.addDatabaseEntity(entityOptions)
+	case "collection":
+		err = em.addCollectionEntity(entityOptions)
+	case "session":
+		err = em.addSessionEntity(entityOptions)
+	case "bucket":
+		err = em.addBucketEntity(entityOptions)
+	default:
+		return fmt.Errorf("unrecognized entity type %q", entityType)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error constructing entity of type %q: %v", entityType, err)
+	}
+	em.allEntities[entityOptions.ID] = struct{}{}
+	return nil
+}
+
+func (em *EntityMap) Bucket(id string) (*gridfs.Bucket, error) {
+	bucket, ok := em.buckets[id]
+	if !ok {
+		return nil, newEntityNotFoundError("bucket", id)
+	}
+	return bucket, nil
+}
+
+func (em *EntityMap) BSONValue(id string) (bson.RawValue, error) {
+	val, ok := em.bsonValues[id]
+	if !ok {
+		return emptyRawValue, newEntityNotFoundError("BSON", id)
+	}
+	return val, nil
+}
+
+func (em *EntityMap) ChangeStream(id string) (*mongo.ChangeStream, error) {
+	client, ok := em.changeStreams[id]
+	if !ok {
+		return nil, newEntityNotFoundError("client", id)
+	}
+	return client, nil
+}
+
+func (em *EntityMap) Client(id string) (*ClientEntity, error) {
+	client, ok := em.clients[id]
+	if !ok {
+		return nil, newEntityNotFoundError("client", id)
+	}
+	return client, nil
+}
+
+func (em *EntityMap) Clients() map[string]*ClientEntity {
+	return em.clients
+}
+
+func (em *EntityMap) Collections() map[string]*mongo.Collection {
+	return em.collections
+}
+
+func (em *EntityMap) Collection(id string) (*mongo.Collection, error) {
+	coll, ok := em.collections[id]
+	if !ok {
+		return nil, newEntityNotFoundError("collection", id)
+	}
+	return coll, nil
+}
+
+func (em *EntityMap) Database(id string) (*mongo.Database, error) {
+	db, ok := em.dbs[id]
+	if !ok {
+		return nil, newEntityNotFoundError("database", id)
+	}
+	return db, nil
+}
+
+func (em *EntityMap) Session(id string) (mongo.Session, error) {
+	sess, ok := em.sessions[id]
+	if !ok {
+		return nil, newEntityNotFoundError("session", id)
+	}
+	return sess, nil
+}
+
+// Close disposes of the session and client entities associated with this map.
+func (em *EntityMap) Close(ctx context.Context) []error {
+	for _, sess := range em.sessions {
+		sess.EndSession(ctx)
+	}
+
+	var errs []error
+	for id, client := range em.clients {
+		if err := client.Disconnect(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("error closing client with ID %q: %v", id, err))
+		}
+	}
+	return errs
+}
+
+func (em *EntityMap) addClientEntity(ctx context.Context, EntityOptions *EntityOptions) error {
+	var client *ClientEntity
+	client, err := NewClientEntity(ctx, EntityOptions)
+	if err != nil {
+		return fmt.Errorf("error creating client entity: %v", err)
+	}
+
+	em.clients[EntityOptions.ID] = client
+	return nil
+}
+
+func (em *EntityMap) addDatabaseEntity(EntityOptions *EntityOptions) error {
+	client, ok := em.clients[EntityOptions.ClientID]
+	if !ok {
+		return newEntityNotFoundError("client", EntityOptions.ClientID)
+	}
+
+	dbOpts := options.Database()
+	if EntityOptions.DatabaseOptions != nil {
+		dbOpts = EntityOptions.DatabaseOptions.DBOptions
+	}
+
+	em.dbs[EntityOptions.ID] = client.Database(EntityOptions.DatabaseName, dbOpts)
+	return nil
+}
+
+func (em *EntityMap) addCollectionEntity(EntityOptions *EntityOptions) error {
+	db, ok := em.dbs[EntityOptions.DatabaseID]
+	if !ok {
+		return newEntityNotFoundError("database", EntityOptions.DatabaseID)
+	}
+
+	collOpts := options.Collection()
+	if EntityOptions.CollectionOptions != nil {
+		collOpts = EntityOptions.CollectionOptions.CollectionOptions
+	}
+
+	em.collections[EntityOptions.ID] = db.Collection(EntityOptions.CollectionName, collOpts)
+	return nil
+}
+
+func (em *EntityMap) addSessionEntity(EntityOptions *EntityOptions) error {
+	client, ok := em.clients[EntityOptions.ClientID]
+	if !ok {
+		return newEntityNotFoundError("client", EntityOptions.ClientID)
+	}
+
+	sessionOpts := options.Session()
+	if EntityOptions.SessionOptions != nil {
+		sessionOpts = EntityOptions.SessionOptions.SessionOptions
+	}
+
+	sess, err := client.StartSession(sessionOpts)
+	if err != nil {
+		return fmt.Errorf("error starting session: %v", err)
+	}
+
+	em.sessions[EntityOptions.ID] = sess
+	return nil
+}
+
+func (em *EntityMap) addBucketEntity(EntityOptions *EntityOptions) error {
+	db, ok := em.dbs[EntityOptions.DatabaseID]
+	if !ok {
+		return newEntityNotFoundError("database", EntityOptions.DatabaseID)
+	}
+
+	bucketOpts := options.GridFSBucket()
+	if EntityOptions.BucketOptions != nil {
+		bucketOpts = EntityOptions.BucketOptions.BucketOptions
+	}
+
+	bucket, err := gridfs.NewBucket(db, bucketOpts)
+	if err != nil {
+		return fmt.Errorf("error creating GridFS bucket: %v", err)
+	}
+
+	em.buckets[EntityOptions.ID] = bucket
+	return nil
+}
+
+func (em *EntityMap) verifyEntityDoesNotExist(id string) error {
+	if _, ok := em.allEntities[id]; ok {
+		return fmt.Errorf("entity with ID %q already exists", id)
+	}
+	return nil
+}
+
+func newEntityNotFoundError(entityType, entityID string) error {
+	return fmt.Errorf("no %s entity found with ID %q", entityType, entityID)
+}

--- a/mongo/integration/unified/error_test.go
+++ b/mongo/integration/unified/error_test.go
@@ -1,0 +1,160 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ExpectedError represents an error that is expected to occur during a test. This type ignores the "isError" field in
+// test files because it is always true if it is specified, so the runner can simply assert that an error occurred.
+type ExpectedError struct {
+	IsClientError  *bool          `bson:"isClientError"`
+	ErrorSubstring *string        `bson:"errorContains"`
+	Code           *int32         `bson:"errorCode"`
+	CodeName       *string        `bson:"errorCodeName"`
+	IncluedLabels  []string       `bson:"errorLabelsContain"`
+	OmittedLabels  []string       `bson:"errorLabelsOmit"`
+	ExpectedResult *bson.RawValue `bson:"expectResult"`
+}
+
+// VerifyOperationError compares the expected error to the actual operation result. If the expected parameter is nil,
+// this function will only check that result.Err is also nil. Otherwise, it will check that result.Err is non-nil and
+// will perform any other assertions required by the ExpectedError object. An error is returned if any checks fail.
+func VerifyOperationError(ctx context.Context, expected *ExpectedError, result *OperationResult) error {
+	if expected == nil {
+		if result.Err != nil {
+			return fmt.Errorf("expected no error, but got %v", result.Err)
+		}
+		return nil
+	}
+
+	if result.Err == nil {
+		return fmt.Errorf("expected error, got nil")
+	}
+
+	// Check ErrorSubstring for both client and server-side errors.
+	if expected.ErrorSubstring != nil {
+		if !strings.Contains(result.Err.Error(), *expected.ErrorSubstring) {
+			return fmt.Errorf("expected error %v to contain substring %s", result.Err, *expected.ErrorSubstring)
+		}
+	}
+
+	// extractErrorDetails will only succeed for server errors, so it's "ok" return value can be used to determine
+	// if we got a server or client-side error.
+	details, serverError := extractErrorDetails(result.Err)
+	if expected.IsClientError != nil {
+		if isClientError := !serverError; *expected.IsClientError != isClientError {
+			return fmt.Errorf("expected error %v to be a client error: %v, is client error: %v", result.Err,
+				*expected.IsClientError, isClientError)
+		}
+	}
+	if !serverError {
+		// Error if extractErrorDetails failed but the test requires assertions about server error details.
+		if expected.Code != nil || expected.CodeName != nil || expected.IncluedLabels != nil || expected.OmittedLabels != nil {
+			return fmt.Errorf("failed to extract details from error %v of type %T", result.Err, result.Err)
+		}
+	}
+
+	if expected.Code != nil {
+		var found bool
+		for _, code := range details.codes {
+			if code == *expected.Code {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("expected error %v to have code %d", result.Err, *expected.Code)
+		}
+	}
+	if expected.CodeName != nil {
+		var found bool
+		for _, codeName := range details.codeNames {
+			if codeName == *expected.CodeName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("expected error %v to have code name %q", result.Err, *expected.CodeName)
+		}
+	}
+	for _, label := range expected.IncluedLabels {
+		if !stringSliceContains(details.labels, label) {
+			return fmt.Errorf("expected error %v to contain label %q", result.Err, label)
+		}
+	}
+	for _, label := range expected.OmittedLabels {
+		if stringSliceContains(details.labels, label) {
+			return fmt.Errorf("expected error %v to not contain label %q", result.Err, label)
+		}
+	}
+
+	if expected.ExpectedResult != nil {
+		if err := VerifyOperationResult(ctx, *expected.ExpectedResult, result); err != nil {
+			return fmt.Errorf("result comparison error: %v", err)
+		}
+	}
+	return nil
+}
+
+// errorDetails consolidates information from different server error types.
+type errorDetails struct {
+	codes     []int32
+	codeNames []string
+	labels    []string
+}
+
+// extractErrorDetails creates an errorDetails instance based on the provided error. It returns the details and an "ok"
+// value which is true if the provided error is of a known type that can be processed.
+func extractErrorDetails(err error) (errorDetails, bool) {
+	var details errorDetails
+
+	switch converted := err.(type) {
+	case mongo.CommandError:
+		details.codes = []int32{converted.Code}
+		details.codeNames = []string{converted.Name}
+		details.labels = converted.Labels
+	case mongo.WriteException:
+		if converted.WriteConcernError != nil {
+			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
+			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
+		}
+		for _, we := range converted.WriteErrors {
+			details.codes = append(details.codes, int32(we.Code))
+		}
+		details.labels = converted.Labels
+	case mongo.BulkWriteException:
+		if converted.WriteConcernError != nil {
+			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
+			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
+		}
+		for _, we := range converted.WriteErrors {
+			details.codes = append(details.codes, int32(we.Code))
+		}
+		details.labels = converted.Labels
+	default:
+		return errorDetails{}, false
+	}
+
+	return details, true
+}
+
+func stringSliceContains(arr []string, target string) bool {
+	for _, val := range arr {
+		if val == target {
+			return true
+		}
+	}
+	return false
+}

--- a/mongo/integration/unified/error_test.go
+++ b/mongo/integration/unified/error_test.go
@@ -22,7 +22,7 @@ type ExpectedError struct {
 	ErrorSubstring *string        `bson:"errorContains"`
 	Code           *int32         `bson:"errorCode"`
 	CodeName       *string        `bson:"errorCodeName"`
-	IncluedLabels  []string       `bson:"errorLabelsContain"`
+	IncludedLabels []string       `bson:"errorLabelsContain"`
 	OmittedLabels  []string       `bson:"errorLabelsOmit"`
 	ExpectedResult *bson.RawValue `bson:"expectResult"`
 }
@@ -60,7 +60,7 @@ func VerifyOperationError(ctx context.Context, expected *ExpectedError, result *
 	}
 	if !serverError {
 		// Error if extractErrorDetails failed but the test requires assertions about server error details.
-		if expected.Code != nil || expected.CodeName != nil || expected.IncluedLabels != nil || expected.OmittedLabels != nil {
+		if expected.Code != nil || expected.CodeName != nil || expected.IncludedLabels != nil || expected.OmittedLabels != nil {
 			return fmt.Errorf("failed to extract details from error %v of type %T", result.Err, result.Err)
 		}
 	}
@@ -89,7 +89,7 @@ func VerifyOperationError(ctx context.Context, expected *ExpectedError, result *
 			return fmt.Errorf("expected error %v to have code name %q", result.Err, *expected.CodeName)
 		}
 	}
-	for _, label := range expected.IncluedLabels {
+	for _, label := range expected.IncludedLabels {
 		if !stringSliceContains(details.labels, label) {
 			return fmt.Errorf("expected error %v to contain label %q", result.Err, label)
 		}

--- a/mongo/integration/unified/gridfs_bucket_operation_execution_test.go
+++ b/mongo/integration/unified/gridfs_bucket_operation_execution_test.go
@@ -35,7 +35,7 @@ func executeBucketDelete(ctx context.Context, operation *Operation) (*OperationR
 		case "id":
 			id = &val
 		default:
-			return nil, fmt.Errorf("unrecongized delete option %q", key)
+			return nil, fmt.Errorf("unrecognized bucket delete option %q", key)
 		}
 	}
 	if id == nil {
@@ -61,7 +61,7 @@ func executeBucketDownload(ctx context.Context, operation *Operation) (*Operatio
 		case "id":
 			id = &val
 		default:
-			return nil, fmt.Errorf("unrecongized delete option %q", key)
+			return nil, fmt.Errorf("unrecognized bucket download option %q", key)
 		}
 	}
 	if id == nil {
@@ -109,7 +109,7 @@ func executeBucketUpload(ctx context.Context, operation *Operation) (*OperationR
 				return nil, fmt.Errorf("error converting source string to bytes: %v", err)
 			}
 		default:
-			return nil, fmt.Errorf("unrecognized upload option %q", key)
+			return nil, fmt.Errorf("unrecognized bucket upload option %q", key)
 		}
 	}
 	if filename == "" {

--- a/mongo/integration/unified/gridfs_bucket_operation_execution_test.go
+++ b/mongo/integration/unified/gridfs_bucket_operation_execution_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func executeBucketDelete(ctx context.Context, operation *Operation) (*OperationResult, error) {
-	bucket, err := Entities(ctx).Bucket(operation.Object)
+	bucket, err := Entities(ctx).GridFSBucket(operation.Object)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func executeBucketDelete(ctx context.Context, operation *Operation) (*OperationR
 }
 
 func executeBucketDownload(ctx context.Context, operation *Operation) (*OperationResult, error) {
-	bucket, err := Entities(ctx).Bucket(operation.Object)
+	bucket, err := Entities(ctx).GridFSBucket(operation.Object)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func executeBucketDownload(ctx context.Context, operation *Operation) (*Operatio
 }
 
 func executeBucketUpload(ctx context.Context, operation *Operation) (*OperationResult, error) {
-	bucket, err := Entities(ctx).Bucket(operation.Object)
+	bucket, err := Entities(ctx).GridFSBucket(operation.Object)
 	if err != nil {
 		return nil, err
 	}

--- a/mongo/integration/unified/main.go
+++ b/mongo/integration/unified/main.go
@@ -1,0 +1,7 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified

--- a/mongo/integration/unified/main_test.go
+++ b/mongo/integration/unified/main_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestMain(m *testing.M) {
+	if err := mtest.Setup(); err != nil {
+		log.Fatal(err)
+	}
+	defer os.Exit(m.Run())
+	if err := mtest.Teardown(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/mongo/integration/unified/matches_test.go
+++ b/mongo/integration/unified/matches_test.go
@@ -78,7 +78,7 @@ func verifyValuesMatch(ctx context.Context, expected, actual bson.RawValue) erro
 			}
 
 			// Get the value from actualDoc here but don't check the error until later because some of the special
-			// matching operaators can assert that the value isn't present in the document (e.g. $$exists).
+			// matching operators can assert that the value isn't present in the document (e.g. $$exists).
 			actualValue, err := actualDoc.LookupErr(expectedKey)
 			if specialDoc, ok := expectedValue.DocumentOK(); ok && requiresSpecialMatching(specialDoc) {
 				if err := evaluateSpecialComparison(ctx, specialDoc, actualValue, expectedKey); err != nil {

--- a/mongo/integration/unified/matches_test.go
+++ b/mongo/integration/unified/matches_test.go
@@ -1,0 +1,325 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+)
+
+// keyPathCtxKey is used as a key for a Context object. The value conveys the BSON key path that is currently being
+// compared.
+type keyPathCtxKey struct{}
+
+// extraKeysAllowedCtxKey is used as a key for a Context object. The value conveys whether or not the document under
+// test can contain extra keys. For example, if the expected document is {x: 1}, the document {x: 1, y: 1} would match
+// if the value for this key is true.
+type extraKeysAllowedCtxKey struct{}
+
+func makeMatchContext(ctx context.Context, keyPath string, extraKeysAllowed bool) context.Context {
+	ctx = context.WithValue(ctx, keyPathCtxKey{}, keyPath)
+	return context.WithValue(ctx, extraKeysAllowedCtxKey{}, extraKeysAllowed)
+}
+
+// VerifyValuesMatch compares the provided BSON values and returns an error if they do not match. If the values are
+// documents and extraKeysAllowed is true, the actual value will be allowed to have additional keys at the top-level.
+// For example, an expected document {x: 1} would match the actual document {x: 1, y: 1}.
+func VerifyValuesMatch(ctx context.Context, expected, actual bson.RawValue, extraKeysAllowed bool) error {
+	return verifyValuesMatch(makeMatchContext(ctx, "", extraKeysAllowed), expected, actual)
+}
+
+func verifyValuesMatch(ctx context.Context, expected, actual bson.RawValue) error {
+	keyPath := ctx.Value(keyPathCtxKey{}).(string)
+	extraKeysAllowed := ctx.Value(extraKeysAllowedCtxKey{}).(bool)
+
+	if expectedDoc, ok := expected.DocumentOK(); ok {
+		// If the root document only has one element and the key is a special matching operator, the actual value might
+		// not actually be a document. In this case, evaluate the special operator with the actual value rather than
+		// doing an element-wise document comparison.
+		if requiresSpecialMatching(expectedDoc) {
+			if err := evaluateSpecialComparison(ctx, expectedDoc, actual, ""); err != nil {
+				return newMatchingError(keyPath, "error doing special matching assertion: %v", err)
+			}
+			return nil
+		}
+
+		actualDoc, ok := actual.DocumentOK()
+		if !ok {
+			return newMatchingError(keyPath, "expected value to be a document but got a %s", actual.Type)
+		}
+
+		expectedElems, _ := expectedDoc.Elements()
+		if !extraKeysAllowed {
+			actualElems, _ := actualDoc.Elements()
+			if len(expectedElems) != len(actualElems) {
+				return newMatchingError(keyPath, "expected document length %d, got %d", len(expectedElems),
+					len(actualElems))
+			}
+		}
+
+		// Perform element-wise comparisons.
+		for _, expectedElem := range expectedElems {
+			expectedKey := expectedElem.Key()
+			expectedValue := expectedElem.Value()
+
+			fullKeyPath := expectedKey
+			if keyPath != "" {
+				fullKeyPath = keyPath + "." + expectedKey
+			}
+
+			// Get the value from actualDoc here but don't check the error until later because some of the special
+			// matching operaators can assert that the value isn't present in the document (e.g. $$exists).
+			actualValue, err := actualDoc.LookupErr(expectedKey)
+			if specialDoc, ok := expectedValue.DocumentOK(); ok && requiresSpecialMatching(specialDoc) {
+				if err := evaluateSpecialComparison(ctx, specialDoc, actualValue, expectedKey); err != nil {
+					return newMatchingError(fullKeyPath, "error doing special matching assertion: %v", err)
+				}
+				continue
+			}
+
+			// This isn't a special comparison. Assert that the value exists in the actual document.
+			if err != nil {
+				return newMatchingError(fullKeyPath, "key not found in actual document")
+			}
+
+			// Nested documents cannot have extra keys, so we unconditionally pass false for extraKeysAllowed.
+			comparisonCtx := makeMatchContext(ctx, fullKeyPath, false)
+			if err := verifyValuesMatch(comparisonCtx, expectedValue, actualValue); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+	if expectedArr, ok := expected.ArrayOK(); ok {
+		actualArr, ok := actual.ArrayOK()
+		if !ok {
+			return newMatchingError(keyPath, "expected value to be an array but got a %s", actual.Type)
+		}
+
+		expectedValues, _ := expectedArr.Values()
+		actualValues, _ := actualArr.Values()
+
+		// Arrays must always have the same number of elements.
+		if len(expectedValues) != len(actualValues) {
+			return newMatchingError(keyPath, "expected array length %d, got %d", len(expectedValues),
+				len(actualValues))
+		}
+
+		for idx, expectedValue := range expectedValues {
+			// Use the index as the key to augment the key path.
+			fullKeyPath := fmt.Sprintf("%d", idx)
+			if keyPath != "" {
+				fullKeyPath = keyPath + "." + fullKeyPath
+			}
+
+			comparisonCtx := makeMatchContext(ctx, fullKeyPath, extraKeysAllowed)
+			err := verifyValuesMatch(comparisonCtx, expectedValue, actualValues[idx])
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	// Numeric values must be considered equal even if their types are different (e.g. if expected is an int32 and
+	// actual is an int64).
+	if expected.IsNumber() {
+		if !actual.IsNumber() {
+			return newMatchingError(keyPath, "expected value to be a number but got a %s", actual.Type)
+		}
+
+		expectedInt64 := expected.AsInt64()
+		actualInt64 := actual.AsInt64()
+		if expectedInt64 != actualInt64 {
+			return newMatchingError(keyPath, "expected numeric value %d, got %d", expectedInt64, actualInt64)
+		}
+		return nil
+	}
+
+	// If expected is not a recursive or numeric type, we can directly call Equal to do the comparison.
+	if !expected.Equal(actual) {
+		return newMatchingError(keyPath, "expected value %s, got %s", expected, actual)
+	}
+	return nil
+}
+
+func evaluateSpecialComparison(ctx context.Context, assertionDoc bson.Raw, actual bson.RawValue, fieldName string) error {
+	assertionElem := assertionDoc.Index(0)
+	assertion := assertionElem.Key()
+	assertionVal := assertionElem.Value()
+
+	switch assertion {
+	case "$$exists":
+		shouldExist := assertionVal.Boolean()
+		exists := actual.Validate() == nil
+		if shouldExist != exists {
+			return fmt.Errorf("expected value to exist: %v; value actually exists: %v", shouldExist, exists)
+		}
+	case "$$type":
+		possibleTypes, err := getTypesArray(assertionVal)
+		if err != nil {
+			return fmt.Errorf("error getting possible types for a $$type assertion: %v", err)
+		}
+
+		for _, possibleType := range possibleTypes {
+			if actual.Type == possibleType {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected type to be one of %v but was %s", possibleTypes, actual.Type)
+	case "$$matchesEntity":
+		expected, err := Entities(ctx).BSONValue(assertionVal.StringValue())
+		if err != nil {
+			return err
+		}
+
+		// $$matchesEntity doesn't modify the nesting level of the key path so we can propagate ctx without changes.
+		return verifyValuesMatch(ctx, expected, actual)
+	case "$$matchesHexBytes":
+		expectedBytes, err := hex.DecodeString(assertionVal.StringValue())
+		if err != nil {
+			return fmt.Errorf("error converting $$matcesHexBytes value to bytes: %v", err)
+		}
+
+		_, actualBytes, ok := actual.BinaryOK()
+		if !ok {
+			return fmt.Errorf("expected binary value for a $$matchesHexBytes assertion, but got a %s", actual.Type)
+		}
+		if !bytes.Equal(expectedBytes, actualBytes) {
+			return fmt.Errorf("expected bytes %v, got %v", expectedBytes, actualBytes)
+		}
+	case "$$unsetOrMatches":
+		if actual.Validate() != nil {
+			return nil
+		}
+
+		// $$unsetOrMatches doesn't modify the nesting level or the key path so we can propagate the context to the
+		// comparison function without changing anything.
+		return verifyValuesMatch(ctx, assertionVal, actual)
+	case "$$sessionLsid":
+		sess, err := Entities(ctx).Session(assertionVal.StringValue())
+		if err != nil {
+			return err
+		}
+
+		expectedID := sess.ID()
+		actualID, ok := actual.DocumentOK()
+		if !ok {
+			return fmt.Errorf("expected document value for a $$sessionLsid assertion, but got a %s", actual.Type)
+		}
+		if !bytes.Equal(expectedID, actualID) {
+			return fmt.Errorf("expected lsid %v, got %v", expectedID, actualID)
+		}
+	default:
+		return fmt.Errorf("unrecognized special matching assertion %q", assertion)
+	}
+
+	return nil
+}
+
+func requiresSpecialMatching(doc bson.Raw) bool {
+	elems, _ := doc.Elements()
+	return len(elems) == 1 && strings.HasPrefix(elems[0].Key(), "$$")
+}
+
+func getTypesArray(val bson.RawValue) ([]bsontype.Type, error) {
+	switch val.Type {
+	case bsontype.String:
+		convertedType, err := convertStringToBSONType(val.StringValue())
+		if err != nil {
+			return nil, err
+		}
+
+		return []bsontype.Type{convertedType}, nil
+	case bsontype.Array:
+		var typeStrings []string
+		if err := val.Unmarshal(&typeStrings); err != nil {
+			return nil, fmt.Errorf("error unmarshalling to slice of strings: %v", err)
+		}
+
+		var types []bsontype.Type
+		for _, typeStr := range typeStrings {
+			convertedType, err := convertStringToBSONType(typeStr)
+			if err != nil {
+				return nil, err
+			}
+
+			types = append(types, convertedType)
+		}
+		return types, nil
+	default:
+		return nil, fmt.Errorf("invalid type to convert to bsontype.Type slice: %s", val.Type)
+	}
+}
+
+func convertStringToBSONType(typeStr string) (bsontype.Type, error) {
+	switch typeStr {
+	case "double":
+		return bsontype.Double, nil
+	case "string":
+		return bsontype.String, nil
+	case "object":
+		return bsontype.EmbeddedDocument, nil
+	case "array":
+		return bsontype.Array, nil
+	case "binData":
+		return bsontype.Binary, nil
+	case "undefined":
+		return bsontype.Undefined, nil
+	case "objectId":
+		return bsontype.ObjectID, nil
+	case "boolean":
+		return bsontype.Boolean, nil
+	case "date":
+		return bsontype.DateTime, nil
+	case "null":
+		return bsontype.Null, nil
+	case "regex":
+		return bsontype.Regex, nil
+	case "dbPointer":
+		return bsontype.DBPointer, nil
+	case "javascript":
+		return bsontype.JavaScript, nil
+	case "symbol":
+		return bsontype.Symbol, nil
+	case "javascriptWithScope":
+		return bsontype.CodeWithScope, nil
+	case "int":
+		return bsontype.Int32, nil
+	case "timestamp":
+		return bsontype.Timestamp, nil
+	case "long":
+		return bsontype.Int64, nil
+	case "decimal":
+		return bsontype.Decimal128, nil
+	case "minKey":
+		return bsontype.MinKey, nil
+	case "maxKey":
+		return bsontype.MaxKey, nil
+	default:
+		return bsontype.Type(0), fmt.Errorf("unrecognized BSON type string %q", typeStr)
+	}
+}
+
+// newMatchingError creates an error to convey that BSON value comparison failed at the provided key path. If the
+// key path is empty (e.g. because the values being compared were not documents), the error message will contain the
+// phrase "top-level" instead of the path.
+func newMatchingError(keyPath, msg string, args ...interface{}) error {
+	fullMsg := fmt.Sprintf(msg, args...)
+	if keyPath == "" {
+		return fmt.Errorf("comparison error at top-level: %s", fullMsg)
+	}
+	return fmt.Errorf("comparison error at key %q: %s", keyPath, fullMsg)
+}

--- a/mongo/integration/unified/matches_test.go
+++ b/mongo/integration/unified/matches_test.go
@@ -100,14 +100,14 @@ func verifyValuesMatch(ctx context.Context, expected, actual bson.RawValue) erro
 		}
 		// If required, verify that the actual document does not have extra elements. We do this by iterating over the
 		// actual and checking for each key in the expected rather than comparing element counts because the presence of
-		// special operators can cause incorrect counts For example, the doucment {y: {$$exists: false}} has one
+		// special operators can cause incorrect counts. For example, the document {y: {$$exists: false}} has one
 		// element, but should match the document {}, which has none.
 		if !extraKeysAllowed {
 			actualElems, _ := actualDoc.Elements()
 			for _, actualElem := range actualElems {
 				if _, err := expectedDoc.LookupErr(actualElem.Key()); err != nil {
-					return newMatchingError(keyPath, "actual document %s contains extra key %q", actualDoc,
-						actualElem.Key())
+					return newMatchingError(keyPath, "extra key %q found in actual document %s", actualElem.Key(),
+						actualDoc)
 				}
 			}
 		}
@@ -421,7 +421,7 @@ func TestMatches(t *testing.T) {
 			{"embedded - should exist and does", embeddedExists, `{"x": {"y": 1}}`, true},
 			{"embedded - should exist and does not", embeddedExists, `{"x": {}}`, false},
 			{"embedded - should not exist and does", embeddedNotExists, `{"x": {"y": 1}}`, false},
-			{"embedded - should not exist and does not", embeddedNotExists, `{"x": {}}`, true}, // TODO
+			{"embedded - should not exist and does not", embeddedNotExists, `{"x": {}}`, true},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -497,7 +497,7 @@ func TestMatches(t *testing.T) {
 			{"top-level does not match", topLevel, `{"x": 2}`, false},
 			{"nested unset", nested, `{}`, true},
 			{"nested matches", nested, `{"x": {"y": 1}}`, true},
-			{"nested null exists but is null", nested, `{"x": "null"}`, false}, // null should not be considered unset
+			{"nested field exists but is null", nested, `{"x": null}`, false}, // null should not be considered unset
 			{"nested does not match", nested, `{"x": {"y": 2}}`, false},
 			{"nested does not match due to extra keys", nested, `{"x": {"y": 1, "z": 1}}`, false},
 		}

--- a/mongo/integration/unified/operation_test.go
+++ b/mongo/integration/unified/operation_test.go
@@ -1,0 +1,140 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type Operation struct {
+	Name           string         `bson:"name"`
+	Object         string         `bson:"object"`
+	Arguments      bson.Raw       `bson:"arguments"`
+	ExpectedError  *ExpectedError `bson:"expectError"`
+	ExpectedResult *bson.RawValue `bson:"expectResult"`
+	ResultEntityID *string        `bson:"saveResultAsEntity"`
+}
+
+// Execute runs the operation and verifies the returned result and/or error. If the result needs to be saved as
+// an entity, it also updates the EntityMap associated with ctx to do so.
+func (op *Operation) Execute(ctx context.Context) error {
+	res, err := op.run(ctx)
+	if err != nil {
+		return fmt.Errorf("execution failed: %v", err)
+	}
+
+	if err := VerifyOperationError(ctx, op.ExpectedError, res); err != nil {
+		return fmt.Errorf("error verification failed: %v", err)
+	}
+
+	if op.ExpectedResult != nil {
+		if err := VerifyOperationResult(ctx, *op.ExpectedResult, res); err != nil {
+			return fmt.Errorf("result verification failed: %v", err)
+		}
+	}
+	return nil
+}
+
+func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
+	if op.Object == "testRunner" {
+		// testRunner operations don't have results or expected errors, so we use NewEmptyResult to fake a result.
+		return NewEmptyResult(), executeTestRunnerOperation(ctx, op)
+	}
+
+	// Special handling for the "session" field because it applies to all operations.
+	var sess mongo.Session
+	var err error
+	if id, ok := op.Arguments.Lookup("session").StringValueOK(); ok {
+		sess, err = Entities(ctx).Session(id)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set op.Arguments to a new document that has the "session" field removed so individual operations do
+		// not have to account for it.
+		op.Arguments = RemoveFieldsFromDocument(op.Arguments, "session")
+	}
+
+	switch op.Name {
+	case "aggregate":
+		return executeAggregate(ctx, op, sess)
+	case "bulkWrite":
+		return executeBulkWrite(ctx, op, sess)
+	case "commitTransaction":
+		return executeCommitTransaction(ctx, op)
+	case "countDocuments":
+		return executeCountDocuments(ctx, op, sess)
+	case "createChangeStream":
+		return executeCreateChangeStream(ctx, op, sess)
+	case "createCollection":
+		return executeCreateCollection(ctx, op, sess)
+	case "createIndex":
+		return executeCreateIndex(ctx, op, sess)
+	case "delete":
+		return executeBucketDelete(ctx, op)
+	case "download":
+		return executeBucketDownload(ctx, op)
+	case "deleteOne":
+		return executeDeleteOne(ctx, op, sess)
+	case "deleteMany":
+		return executeDeleteMany(ctx, op, sess)
+	case "distinct":
+		return executeDistinct(ctx, op, sess)
+	case "dropCollection":
+		return executeDropCollection(ctx, op, sess)
+	case "endSession":
+		// The EndSession() method doesn't return a result, so we return a non-nil empty result.
+		return NewEmptyResult(), executeEndSession(ctx, op)
+	case "estimatedDocumentCount":
+		return executeEstimatedDocumentCount(ctx, op, sess)
+	case "find":
+		return executeFind(ctx, op, sess)
+	case "findOneAndUpdate":
+		return executeFindOneAndUpdate(ctx, op, sess)
+	case "insertMany":
+		return executeInsertMany(ctx, op, sess)
+	case "insertOne":
+		return executeInsertOne(ctx, op, sess)
+	case "iterateUntilDocumentOrError":
+		return executeIterateUntilDocumentOrError(ctx, op)
+	case "listCollections":
+		return executeListCollections(ctx, op, sess)
+	case "listCollectionNames":
+		return executeListCollectionNames(ctx, op, sess)
+	case "listDatabases":
+		return executeListDatabases(ctx, op, sess)
+	case "replaceOne":
+		return executeReplaceOne(ctx, op, sess)
+	case "runCommand":
+		return executeRunCommand(ctx, op, sess)
+	case "startTransaction":
+		return executeStartTransaction(ctx, op)
+	case "updateOne":
+		return executeUpdateOne(ctx, op, sess)
+	case "updateMany":
+		return executeUpdateMany(ctx, op, sess)
+	case "upload":
+		return executeBucketUpload(ctx, op)
+	case "withTransaction":
+		// executeWithTransaction internally verifies results/errors for each operation, so it doesn't return a result.
+		return NewEmptyResult(), executeWithTransaction(ctx, op)
+	default:
+		return nil, fmt.Errorf("unrecognized entity operation %q", op.Name)
+	}
+}
+
+// getOperationContext gets the Context object that should be used to execute an op.
+func getOperationContext(ctx context.Context, sess mongo.Session) context.Context {
+	if sess == nil {
+		return ctx
+	}
+	return mongo.NewSessionContext(ctx, sess)
+}

--- a/mongo/integration/unified/operation_test.go
+++ b/mongo/integration/unified/operation_test.go
@@ -63,37 +63,53 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 	}
 
 	switch op.Name {
+	// Session operations
 	case "abortTransaction":
 		return executeAbortTransaction(ctx, op)
+	case "commitTransaction":
+		return executeCommitTransaction(ctx, op)
+	case "endSession":
+		// The EndSession() method doesn't return a result, so we return a non-nil empty result.
+		return NewEmptyResult(), executeEndSession(ctx, op)
+	case "startTransaction":
+		return executeStartTransaction(ctx, op)
+	case "withTransaction":
+		// executeWithTransaction internally verifies results/errors for each operation, so it doesn't return a result.
+		return NewEmptyResult(), executeWithTransaction(ctx, op)
+
+	// Client operations
+	case "createChangeStream":
+		return executeCreateChangeStream(ctx, op)
+	case "listDatabases":
+		return executeListDatabases(ctx, op)
+
+	// Database operations
+	case "createCollection":
+		return executeCreateCollection(ctx, op)
+	case "dropCollection":
+		return executeDropCollection(ctx, op)
+	case "listCollections":
+		return executeListCollections(ctx, op)
+	case "listCollectionNames":
+		return executeListCollectionNames(ctx, op)
+	case "runCommand":
+		return executeRunCommand(ctx, op)
+
+	// Collection operations
 	case "aggregate":
 		return executeAggregate(ctx, op)
 	case "bulkWrite":
 		return executeBulkWrite(ctx, op)
-	case "commitTransaction":
-		return executeCommitTransaction(ctx, op)
 	case "countDocuments":
 		return executeCountDocuments(ctx, op)
-	case "createChangeStream":
-		return executeCreateChangeStream(ctx, op)
-	case "createCollection":
-		return executeCreateCollection(ctx, op)
 	case "createIndex":
 		return executeCreateIndex(ctx, op)
-	case "delete":
-		return executeBucketDelete(ctx, op)
-	case "download":
-		return executeBucketDownload(ctx, op)
 	case "deleteOne":
 		return executeDeleteOne(ctx, op)
 	case "deleteMany":
 		return executeDeleteMany(ctx, op)
 	case "distinct":
 		return executeDistinct(ctx, op)
-	case "dropCollection":
-		return executeDropCollection(ctx, op)
-	case "endSession":
-		// The EndSession() method doesn't return a result, so we return a non-nil empty result.
-		return NewEmptyResult(), executeEndSession(ctx, op)
 	case "estimatedDocumentCount":
 		return executeEstimatedDocumentCount(ctx, op)
 	case "find":
@@ -104,29 +120,24 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 		return executeInsertMany(ctx, op)
 	case "insertOne":
 		return executeInsertOne(ctx, op)
-	case "iterateUntilDocumentOrError":
-		return executeIterateUntilDocumentOrError(ctx, op)
-	case "listCollections":
-		return executeListCollections(ctx, op)
-	case "listCollectionNames":
-		return executeListCollectionNames(ctx, op)
-	case "listDatabases":
-		return executeListDatabases(ctx, op)
 	case "replaceOne":
 		return executeReplaceOne(ctx, op)
-	case "runCommand":
-		return executeRunCommand(ctx, op)
-	case "startTransaction":
-		return executeStartTransaction(ctx, op)
 	case "updateOne":
 		return executeUpdateOne(ctx, op)
 	case "updateMany":
 		return executeUpdateMany(ctx, op)
+
+	// GridFS operations
+	case "delete":
+		return executeBucketDelete(ctx, op)
+	case "download":
+		return executeBucketDownload(ctx, op)
 	case "upload":
 		return executeBucketUpload(ctx, op)
-	case "withTransaction":
-		// executeWithTransaction internally verifies results/errors for each operation, so it doesn't return a result.
-		return NewEmptyResult(), executeWithTransaction(ctx, op)
+
+	// Change Stream operations
+	case "iterateUntilDocumentOrError":
+		return executeIterateUntilDocumentOrError(ctx, op)
 	default:
 		return nil, fmt.Errorf("unrecognized entity operation %q", op.Name)
 	}

--- a/mongo/integration/unified/operation_test.go
+++ b/mongo/integration/unified/operation_test.go
@@ -50,13 +50,12 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 	}
 
 	// Special handling for the "session" field because it applies to all operations.
-	var sess mongo.Session
-	var err error
 	if id, ok := op.Arguments.Lookup("session").StringValueOK(); ok {
-		sess, err = Entities(ctx).Session(id)
+		sess, err := Entities(ctx).Session(id)
 		if err != nil {
 			return nil, err
 		}
+		ctx = mongo.NewSessionContext(ctx, sess)
 
 		// Set op.Arguments to a new document that has the "session" field removed so individual operations do
 		// not have to account for it.
@@ -67,62 +66,62 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 	case "abortTransaction":
 		return executeAbortTransaction(ctx, op)
 	case "aggregate":
-		return executeAggregate(ctx, op, sess)
+		return executeAggregate(ctx, op)
 	case "bulkWrite":
-		return executeBulkWrite(ctx, op, sess)
+		return executeBulkWrite(ctx, op)
 	case "commitTransaction":
 		return executeCommitTransaction(ctx, op)
 	case "countDocuments":
-		return executeCountDocuments(ctx, op, sess)
+		return executeCountDocuments(ctx, op)
 	case "createChangeStream":
-		return executeCreateChangeStream(ctx, op, sess)
+		return executeCreateChangeStream(ctx, op)
 	case "createCollection":
-		return executeCreateCollection(ctx, op, sess)
+		return executeCreateCollection(ctx, op)
 	case "createIndex":
-		return executeCreateIndex(ctx, op, sess)
+		return executeCreateIndex(ctx, op)
 	case "delete":
 		return executeBucketDelete(ctx, op)
 	case "download":
 		return executeBucketDownload(ctx, op)
 	case "deleteOne":
-		return executeDeleteOne(ctx, op, sess)
+		return executeDeleteOne(ctx, op)
 	case "deleteMany":
-		return executeDeleteMany(ctx, op, sess)
+		return executeDeleteMany(ctx, op)
 	case "distinct":
-		return executeDistinct(ctx, op, sess)
+		return executeDistinct(ctx, op)
 	case "dropCollection":
-		return executeDropCollection(ctx, op, sess)
+		return executeDropCollection(ctx, op)
 	case "endSession":
 		// The EndSession() method doesn't return a result, so we return a non-nil empty result.
 		return NewEmptyResult(), executeEndSession(ctx, op)
 	case "estimatedDocumentCount":
-		return executeEstimatedDocumentCount(ctx, op, sess)
+		return executeEstimatedDocumentCount(ctx, op)
 	case "find":
-		return executeFind(ctx, op, sess)
+		return executeFind(ctx, op)
 	case "findOneAndUpdate":
-		return executeFindOneAndUpdate(ctx, op, sess)
+		return executeFindOneAndUpdate(ctx, op)
 	case "insertMany":
-		return executeInsertMany(ctx, op, sess)
+		return executeInsertMany(ctx, op)
 	case "insertOne":
-		return executeInsertOne(ctx, op, sess)
+		return executeInsertOne(ctx, op)
 	case "iterateUntilDocumentOrError":
 		return executeIterateUntilDocumentOrError(ctx, op)
 	case "listCollections":
-		return executeListCollections(ctx, op, sess)
+		return executeListCollections(ctx, op)
 	case "listCollectionNames":
-		return executeListCollectionNames(ctx, op, sess)
+		return executeListCollectionNames(ctx, op)
 	case "listDatabases":
-		return executeListDatabases(ctx, op, sess)
+		return executeListDatabases(ctx, op)
 	case "replaceOne":
-		return executeReplaceOne(ctx, op, sess)
+		return executeReplaceOne(ctx, op)
 	case "runCommand":
-		return executeRunCommand(ctx, op, sess)
+		return executeRunCommand(ctx, op)
 	case "startTransaction":
 		return executeStartTransaction(ctx, op)
 	case "updateOne":
-		return executeUpdateOne(ctx, op, sess)
+		return executeUpdateOne(ctx, op)
 	case "updateMany":
-		return executeUpdateMany(ctx, op, sess)
+		return executeUpdateMany(ctx, op)
 	case "upload":
 		return executeBucketUpload(ctx, op)
 	case "withTransaction":
@@ -131,12 +130,4 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 	default:
 		return nil, fmt.Errorf("unrecognized entity operation %q", op.Name)
 	}
-}
-
-// getOperationContext gets the Context object that should be used to execute an op.
-func getOperationContext(ctx context.Context, sess mongo.Session) context.Context {
-	if sess == nil {
-		return ctx
-	}
-	return mongo.NewSessionContext(ctx, sess)
 }

--- a/mongo/integration/unified/operation_test.go
+++ b/mongo/integration/unified/operation_test.go
@@ -64,6 +64,8 @@ func (op *Operation) run(ctx context.Context) (*OperationResult, error) {
 	}
 
 	switch op.Name {
+	case "abortTransaction":
+		return executeAbortTransaction(ctx, op)
 	case "aggregate":
 		return executeAggregate(ctx, op, sess)
 	case "bulkWrite":

--- a/mongo/integration/unified/result_test.go
+++ b/mongo/integration/unified/result_test.go
@@ -50,7 +50,7 @@ func NewValueResult(valueType bsontype.Type, data []byte, err error) *OperationR
 
 // NewCursorResult creates an OperationResult that contains documents retrieved by fully iterating a cursor.
 func NewCursorResult(arr []bson.Raw) *OperationResult {
-	// If the operation returned no documents, the array might be nil. It isn't possible to distingiush between this
+	// If the operation returned no documents, the array might be nil. It isn't possible to distinguish between this
 	// case and the case where there is no cursor result, so we overwrite the result with an non-nil empty slice.
 	result := arr
 	if result == nil {

--- a/mongo/integration/unified/result_test.go
+++ b/mongo/integration/unified/result_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+)
+
+// OperationResult holds the result and/or error returned by an op.
+type OperationResult struct {
+	// For operations that return a single result, this field holds a BSON representation.
+	Result bson.RawValue
+
+	// CursorResult holds the documents retrieved by iterating a Cursor.
+	CursorResult []bson.Raw
+
+	// Err holds the error returned by an operation. This is mutually exclusive with CursorResult but not with Result
+	// because some operations (e.g. bulkWrite) can return both a result and an error.
+	Err error
+}
+
+// NewEmptyResult returns an OperationResult with no fields set. This should be used if the operation does not check
+// results or errors.
+func NewEmptyResult() *OperationResult {
+	return &OperationResult{}
+}
+
+// NewDocumentResult is a helper to create a value result where the value is a BSON document.
+func NewDocumentResult(result []byte, err error) *OperationResult {
+	return NewValueResult(bsontype.EmbeddedDocument, result, err)
+}
+
+// NewValueResult creates an OperationResult where the result is a BSON value of an arbitrary type. Because some
+// operations can return both a result and an error (e.g. bulkWrite), the err parameter should be the error returned
+// by the op, if any.
+func NewValueResult(valueType bsontype.Type, data []byte, err error) *OperationResult {
+	return &OperationResult{
+		Result: bson.RawValue{Type: valueType, Value: data},
+		Err:    err,
+	}
+}
+
+// NewCursorResult creates an OperationResult that contains documents retrieved by fully iterating a cursor.
+func NewCursorResult(arr []bson.Raw) *OperationResult {
+	// If the operation returned no documents, the array might be nil. It isn't possible to distingiush between this
+	// case and the case where there is no cursor result, so we overwrite the result with an non-nil empty slice.
+	result := arr
+	if result == nil {
+		result = make([]bson.Raw, 0)
+	}
+
+	return &OperationResult{
+		CursorResult: result,
+	}
+}
+
+// NewErrorResult creates an OperationResult that only holds an error. This should only be used when executing an
+// operation that can return a result or an error, but not both.
+func NewErrorResult(err error) *OperationResult {
+	return &OperationResult{
+		Err: err,
+	}
+}
+
+func VerifyOperationResult(ctx context.Context, expected bson.RawValue, actual *OperationResult) error {
+	actualVal := actual.Result
+	if actual.CursorResult != nil {
+		_, data, err := bson.MarshalValue(actual.CursorResult)
+		if err != nil {
+			return fmt.Errorf("error converting cursorResult array to BSON: %v", err)
+		}
+
+		actualVal = bson.RawValue{
+			Type:  bsontype.Array,
+			Value: data,
+		}
+	}
+
+	// For document results and arrays of root documents (i.e. cursor results), the actual value can have additional
+	// top-level keys. Single-value array results (e.g. from distinct) must match exactly, so we set extraKeysAllowed to
+	// false only for that case.
+	extraKeysAllowed := actual.Result.Type != bsontype.Array
+	return VerifyValuesMatch(ctx, expected, actualVal, extraKeysAllowed)
+}

--- a/mongo/integration/unified/schema_version_test.go
+++ b/mongo/integration/unified/schema_version_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+var (
+	supportedSchemaVersions = map[int]string{
+		1: "1.0",
+	}
+)
+
+// CheckSchemaVersion determines if the provided schema version is supported and returns an error if it is not.
+func CheckSchemaVersion(version string) error {
+	// First get the major version number from the schema. The schema version string should be in the format
+	// "major.minor.patch", "major.minor", or "major".
+
+	parts := strings.Split(version, ".")
+	if len(parts) == 0 {
+		return fmt.Errorf("error splitting schema version %q into parts", version)
+	}
+
+	majorVersion, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("error converting major version component %q to an integer: %v", parts[0], err)
+	}
+
+	// Find the latest supported version for the major version and use that to determine if the provided version is
+	// supported.
+	supportedVersion, ok := supportedSchemaVersions[majorVersion]
+	if !ok {
+		return fmt.Errorf("major version %d not supported", majorVersion)
+	}
+	if mtest.CompareServerVersions(supportedVersion, version) < 0 {
+		return fmt.Errorf(
+			"latest version supported for major version %d is %q, which is incompatible with specified version %q",
+			majorVersion, supportedVersion, version,
+		)
+	}
+	return nil
+}

--- a/mongo/integration/unified/session_operation_execution_test.go
+++ b/mongo/integration/unified/session_operation_execution_test.go
@@ -24,7 +24,7 @@ func executeAbortTransaction(ctx context.Context, operation *Operation) (*Operat
 	// AbortTransaction takes no options, so the arguments doc must be nil or empty.
 	elems, _ := operation.Arguments.Elements()
 	if len(elems) > 0 {
-		return nil, fmt.Errorf("unrecognized commitTransaction options %v", operation.Arguments)
+		return nil, fmt.Errorf("unrecognized abortTransaction options %v", operation.Arguments)
 	}
 
 	return NewErrorResult(sess.AbortTransaction(ctx)), nil

--- a/mongo/integration/unified/session_operation_execution_test.go
+++ b/mongo/integration/unified/session_operation_execution_test.go
@@ -15,6 +15,21 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+func executeAbortTransaction(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	sess, err := Entities(ctx).Session(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	// AbortTransaction takes no options, so the arguments doc must be nil or empty.
+	elems, _ := operation.Arguments.Elements()
+	if len(elems) > 0 {
+		return nil, fmt.Errorf("unrecognized commitTransaction options %v", operation.Arguments)
+	}
+
+	return NewErrorResult(sess.AbortTransaction(ctx)), nil
+}
+
 func executeEndSession(ctx context.Context, operation *Operation) error {
 	sess, err := Entities(ctx).Session(operation.Object)
 	if err != nil {

--- a/mongo/integration/unified/session_operation_execution_test.go
+++ b/mongo/integration/unified/session_operation_execution_test.go
@@ -1,0 +1,100 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func executeEndSession(ctx context.Context, operation *Operation) error {
+	sess, err := Entities(ctx).Session(operation.Object)
+	if err != nil {
+		return err
+	}
+
+	// EnsSession takes no options, so the arguments doc must be nil or empty.
+	elems, _ := operation.Arguments.Elements()
+	if len(elems) > 0 {
+		return fmt.Errorf("unrecognized endSession options %v", operation.Arguments)
+	}
+
+	sess.EndSession(ctx)
+	return nil
+}
+
+func executeCommitTransaction(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	sess, err := Entities(ctx).Session(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	// CommitTransaction takes no options, so the arguments doc must be nil or empty.
+	elems, _ := operation.Arguments.Elements()
+	if len(elems) > 0 {
+		return nil, fmt.Errorf("unrecognized commitTransaction options %v", operation.Arguments)
+	}
+
+	return NewErrorResult(sess.CommitTransaction(ctx)), nil
+}
+
+func executeStartTransaction(ctx context.Context, operation *Operation) (*OperationResult, error) {
+	sess, err := Entities(ctx).Session(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := options.Transaction()
+	if operation.Arguments != nil {
+		var temp TransactionOptions
+		if err := bson.Unmarshal(operation.Arguments, &temp); err != nil {
+			return nil, fmt.Errorf("error unmarshalling arguments to TransactionOptions: %v", err)
+		}
+
+		opts = temp.TransactionOptions
+	}
+
+	return NewErrorResult(sess.StartTransaction(opts)), nil
+}
+
+func executeWithTransaction(ctx context.Context, operation *Operation) error {
+	sess, err := Entities(ctx).Session(operation.Object)
+	if err != nil {
+		return err
+	}
+
+	// Process the "callback" argument. This is an array of Operation objects, each of which should be executed inside
+	// the transaction.
+	callback, err := operation.Arguments.LookupErr("callback")
+	if err != nil {
+		return newMissingArgumentError("callback")
+	}
+	var operations []*Operation
+	if err := callback.Unmarshal(&operations); err != nil {
+		return fmt.Errorf("error transforming callback option to slice of operations: %v", err)
+	}
+
+	// Remove the "callback" field and process the other options.
+	var temp TransactionOptions
+	if err := bson.Unmarshal(RemoveFieldsFromDocument(operation.Arguments, "callback"), &temp); err != nil {
+		return fmt.Errorf("error unmarshalling arguments to TransactionOptions: %v", err)
+	}
+
+	_, err = sess.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (interface{}, error) {
+		for idx, op := range operations {
+			if err := op.Execute(ctx); err != nil {
+				return nil, fmt.Errorf("error executing operation %q at index %d: %v", op.Name, idx, err)
+			}
+		}
+		return nil, nil
+	}, temp.TransactionOptions)
+	return err
+}

--- a/mongo/integration/unified/session_options_test.go
+++ b/mongo/integration/unified/session_options_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TransactionOptions is a wrapper for *options.TransactionOptions. This type implements the bson.Unmarshaler interface
+// to convert BSON documents to a TransactionOptions instance.
+type TransactionOptions struct {
+	*options.TransactionOptions
+}
+
+var _ bson.Unmarshaler = (*TransactionOptions)(nil)
+
+func (to *TransactionOptions) UnmarshalBSON(data []byte) error {
+	var temp struct {
+		RC              *readConcern           `bson:"readConcern"`
+		RP              *readPreference        `bson:"readPreference"`
+		WC              *writeConcern          `bson:"writeConcern"`
+		MaxCommitTimeMS *int64                 `bson:"maxCommitTimeMS"`
+		Extra           map[string]interface{} `bson:",inline"`
+	}
+	if err := bson.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("error unmarshalling to temporary TransactionOptions object: %v", err)
+	}
+	if len(temp.Extra) > 0 {
+		return fmt.Errorf("unrecognized fields for TransactionOptions: %v", MapKeys(temp.Extra))
+	}
+
+	to.TransactionOptions = options.Transaction()
+	if temp.MaxCommitTimeMS != nil {
+		mctms := time.Duration(*temp.MaxCommitTimeMS) * time.Millisecond
+		to.SetMaxCommitTime(&mctms)
+	}
+	if rc := temp.RC; rc != nil {
+		to.SetReadConcern(rc.toReadConcernOption())
+	}
+	if rp := temp.RP; rp != nil {
+		converted, err := rp.toReadPrefOption()
+		if err != nil {
+			return fmt.Errorf("error parsing read preference document: %v", err)
+		}
+		to.SetReadPreference(converted)
+	}
+	if wc := temp.WC; wc != nil {
+		converted, err := wc.toWriteConcernOption()
+		if err != nil {
+			return fmt.Errorf("error parsing write concern document: %v", err)
+		}
+		to.SetWriteConcern(converted)
+	}
+	return nil
+}
+
+// SessionOptions is a wrapper for *options.SessionOptions. This type implements the bson.Unmarshaler interface to
+// convert BSON documents to a SessionOptions instance.
+type SessionOptions struct {
+	*options.SessionOptions
+}
+
+var _ bson.Unmarshaler = (*SessionOptions)(nil)
+
+func (so *SessionOptions) UnmarshalBSON(data []byte) error {
+	var temp struct {
+		Causal          *bool                  `bson:"causalConsistency"`
+		MaxCommitTimeMS *int64                 `bson:"maxCommitTimeMS"`
+		TxnOptions      *TransactionOptions    `bson:"defaultTransactionOptions"`
+		Extra           map[string]interface{} `bson:",inline"`
+	}
+	if err := bson.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("error unmarshalling to temporary SessionOptions object: %v", err)
+	}
+	if len(temp.Extra) > 0 {
+		return fmt.Errorf("unrecognized fields for SessionOptions: %v", MapKeys(temp.Extra))
+	}
+
+	so.SessionOptions = options.Session()
+	if temp.Causal != nil {
+		so.SetCausalConsistency(*temp.Causal)
+	}
+	if temp.MaxCommitTimeMS != nil {
+		mctms := time.Duration(*temp.MaxCommitTimeMS) * time.Millisecond
+		so.SetDefaultMaxCommitTime(&mctms)
+	}
+	if rc := temp.TxnOptions.ReadConcern; rc != nil {
+		so.SetDefaultReadConcern(rc)
+	}
+	if rp := temp.TxnOptions.ReadPreference; rp != nil {
+		so.SetDefaultReadPreference(rp)
+	}
+	if wc := temp.TxnOptions.WriteConcern; wc != nil {
+		so.SetDefaultWriteConcern(wc)
+	}
+	return nil
+}

--- a/mongo/integration/unified/testrunner_operation_test.go
+++ b/mongo/integration/unified/testrunner_operation_test.go
@@ -138,15 +138,17 @@ func verifyLastTwoLsidsEqual(ctx context.Context, clientID string, expectedEqual
 		return err
 	}
 
-	if len(client.started) < 2 {
+	allEvents := client.StartedEvents()
+	if len(allEvents) < 2 {
 		return fmt.Errorf("client has recorded fewer than two command started events")
 	}
+	lastTwoEvents := allEvents[len(allEvents)-2:]
 
-	firstID, err := client.started[0].Command.LookupErr("lsid")
+	firstID, err := lastTwoEvents[0].Command.LookupErr("lsid")
 	if err != nil {
 		return fmt.Errorf("first command has no 'lsid' field: %v", client.started[0].Command)
 	}
-	secondID, err := client.started[1].Command.LookupErr("lsid")
+	secondID, err := lastTwoEvents[1].Command.LookupErr("lsid")
 	if err != nil {
 		return fmt.Errorf("first command has no 'lsid' field: %v", client.started[1].Command)
 	}

--- a/mongo/integration/unified/testrunner_operation_test.go
+++ b/mongo/integration/unified/testrunner_operation_test.go
@@ -1,0 +1,212 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
+)
+
+func executeTestRunnerOperation(ctx context.Context, operation *Operation) error {
+	args := operation.Arguments
+
+	switch operation.Name {
+	case "failPoint":
+		clientID := LookupString(args, "client")
+		client, err := Entities(ctx).Client(clientID)
+		if err != nil {
+			return err
+		}
+
+		fpDoc := args.Lookup("failPoint").Document()
+		if err := mtest.SetRawFailPoint(fpDoc, client.Client); err != nil {
+			return err
+		}
+		return AddFailPoint(ctx, fpDoc.Index(0).Value().StringValue(), client.Client)
+	case "targetedFailPoint":
+		sessID := LookupString(args, "session")
+		sess, err := Entities(ctx).Session(sessID)
+		if err != nil {
+			return err
+		}
+
+		clientSession := extractClientSession(sess)
+		if clientSession.PinnedServer == nil {
+			return fmt.Errorf("session is not pinned to a server")
+		}
+
+		targetHost := clientSession.PinnedServer.Addr.String()
+		fpDoc := args.Lookup("failPoint").Document()
+		commandFn := func(ctx context.Context, client *mongo.Client) error {
+			return mtest.SetRawFailPoint(fpDoc, client)
+		}
+
+		if err := RunCommandOnHost(ctx, targetHost, commandFn); err != nil {
+			return err
+		}
+		return AddTargetedFailPoint(ctx, fpDoc.Index(0).Value().StringValue(), targetHost)
+	case "assertSessionTransactionState":
+		sessID := LookupString(args, "session")
+		sess, err := Entities(ctx).Session(sessID)
+		if err != nil {
+			return err
+		}
+
+		var expectedState session.TransactionState
+		switch stateStr := LookupString(args, "state"); stateStr {
+		case "none":
+			expectedState = session.None
+		case "starting":
+			expectedState = session.Starting
+		case "in_progress":
+			expectedState = session.InProgress
+		case "committed":
+			expectedState = session.Committed
+		case "aborted":
+			expectedState = session.Aborted
+		default:
+			return fmt.Errorf("unrecognized session state type %q", stateStr)
+		}
+
+		if actualState := extractClientSession(sess).TransactionState; actualState != expectedState {
+			return fmt.Errorf("expected session state %q does not match actual state %q", expectedState, actualState)
+		}
+		return nil
+	case "assertSessionPinned":
+		return verifySessionPinnedState(ctx, LookupString(args, "session"), true)
+	case "assertSessionUnpinned":
+		return verifySessionPinnedState(ctx, LookupString(args, "session"), false)
+	case "assertSameLsidOnLastTwoCommands":
+		return verifyLastTwoLsidsEqual(ctx, LookupString(args, "client"), true)
+	case "assertDifferentLsidOnLastTwoCommands":
+		return verifyLastTwoLsidsEqual(ctx, LookupString(args, "client"), false)
+	case "assertSessionDirty":
+		return verifySessionDirtyState(ctx, LookupString(args, "session"), true)
+	case "assertSessionNotDirty":
+		return verifySessionDirtyState(ctx, LookupString(args, "session"), false)
+	case "assertCollectionExists":
+		db := LookupString(args, "databaseName")
+		coll := LookupString(args, "collectionName")
+		return verifyCollectionExists(ctx, db, coll, true)
+	case "assertCollectionNotExists":
+		db := LookupString(args, "databaseName")
+		coll := LookupString(args, "collectionName")
+		return verifyCollectionExists(ctx, db, coll, false)
+	case "assertIndexExists":
+		db := LookupString(args, "databaseName")
+		coll := LookupString(args, "collectionName")
+		index := LookupString(args, "indexName")
+		return verifyIndexExists(ctx, db, coll, index, true)
+	case "assertIndexNotExists":
+		db := LookupString(args, "databaseName")
+		coll := LookupString(args, "collectionName")
+		index := LookupString(args, "indexName")
+		return verifyIndexExists(ctx, db, coll, index, false)
+	default:
+		return fmt.Errorf("unrecognized testRunner operation %q", operation.Name)
+	}
+}
+
+func extractClientSession(sess mongo.Session) *session.Client {
+	return sess.(mongo.XSession).ClientSession()
+}
+
+func verifySessionPinnedState(ctx context.Context, sessionID string, expectedPinned bool) error {
+	sess, err := Entities(ctx).Session(sessionID)
+	if err != nil {
+		return err
+	}
+
+	if isPinned := extractClientSession(sess).PinnedServer != nil; expectedPinned != isPinned {
+		return fmt.Errorf("session pinned state mismatch; expected to be pinned: %v, is pinned: %v", expectedPinned, isPinned)
+	}
+	return nil
+}
+
+func verifyLastTwoLsidsEqual(ctx context.Context, clientID string, expectedEqual bool) error {
+	client, err := Entities(ctx).Client(clientID)
+	if err != nil {
+		return err
+	}
+
+	if len(client.started) < 2 {
+		return fmt.Errorf("client has recorded fewer than two command started events")
+	}
+
+	firstID, err := client.started[0].Command.LookupErr("lsid")
+	if err != nil {
+		return fmt.Errorf("first command has no 'lsid' field: %v", client.started[0].Command)
+	}
+	secondID, err := client.started[1].Command.LookupErr("lsid")
+	if err != nil {
+		return fmt.Errorf("first command has no 'lsid' field: %v", client.started[1].Command)
+	}
+
+	areEqual := firstID.Equal(secondID)
+	if expectedEqual && !areEqual {
+		return fmt.Errorf("expected last two lsids to be equal, but got %s and %s", firstID, secondID)
+	}
+	if !expectedEqual && areEqual {
+		return fmt.Errorf("expected last two lsids to be different but both were %s", firstID)
+	}
+	return nil
+}
+
+func verifySessionDirtyState(ctx context.Context, sessionID string, expectedDirty bool) error {
+	sess, err := Entities(ctx).Session(sessionID)
+	if err != nil {
+		return err
+	}
+
+	if isDirty := extractClientSession(sess).Dirty; expectedDirty != isDirty {
+		return fmt.Errorf("session dirty state mismatch; expected to be dirty: %v, is dirty: %v", expectedDirty, isDirty)
+	}
+	return nil
+}
+
+func verifyCollectionExists(ctx context.Context, dbName, collName string, expectedExists bool) error {
+	db := mtest.GlobalClient().Database(dbName)
+	collections, err := db.ListCollectionNames(ctx, bson.M{"name": collName})
+	if err != nil {
+		return fmt.Errorf("error running ListCollectionNames: %v", err)
+	}
+
+	if exists := len(collections) == 1; expectedExists != exists {
+		ns := fmt.Sprintf("%s.%s", dbName, collName)
+		return fmt.Errorf("collection existence mismatch; expected namespace %q to exist: %v, exists: %v", ns,
+			expectedExists, exists)
+	}
+	return nil
+}
+
+func verifyIndexExists(ctx context.Context, dbName, collName, indexName string, expectedExists bool) error {
+	iv := mtest.GlobalClient().Database(dbName).Collection(collName).Indexes()
+	cursor, err := iv.List(ctx)
+	if err != nil {
+		return fmt.Errorf("error running IndexView.List: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var exists bool
+	for cursor.Next(ctx) {
+		if LookupString(cursor.Current, "name") == indexName {
+			exists = true
+			break
+		}
+	}
+	if expectedExists != exists {
+		ns := fmt.Sprintf("%s.%s", dbName, collName)
+		return fmt.Errorf("index existence mismatch: expected index %q to exist in namespace %q: %v, exists: %v",
+			indexName, ns, expectedExists, exists)
+	}
+	return nil
+}

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -56,7 +56,7 @@ type TestFile struct {
 
 func TestUnifiedSpec(t *testing.T) {
 	// Ensure the cluster is in a clean state before test execution begins.
-	if err := TerminateOpenTransactions(mtest.Background); err != nil {
+	if err := TerminateOpenSessions(mtest.Background); err != nil {
 		t.Fatalf("error terminating open transactions: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func runTestCase(mt *mtest.T, testFile TestFile, testCase *TestCase) {
 		// Failed tests should terminate any transactions left open on the server. If the helper also fails, we
 		// only log the error because the actual test failure has already occurred and should be preserved.
 		if mt.Failed() {
-			if err := TerminateOpenTransactions(mtest.Background); err != nil {
+			if err := TerminateOpenSessions(mtest.Background); err != nil {
 				mt.Logf("error terminating open transactions after failed test: %v", err)
 			}
 		}

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -1,0 +1,244 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package unified
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+var (
+	directories = []string{
+		"unified-test-format/valid-pass",
+	}
+
+	skippedTestDescriptions = map[string]struct{}{
+		"A successful find event with a getmore and the server kills the cursor": {},
+		"Client side error in command starting transaction":                      {},
+	}
+)
+
+const (
+	dataDirectory               = "../../../data"
+	lowHeartbeatFrequency int32 = 50
+)
+
+type TestCase struct {
+	Description       string             `bson:"description"`
+	RunOnRequirements []mtest.RunOnBlock `bson:"runOnRequirements"`
+	SkipReason        *string            `bson:"skipReason"`
+	Operations        []*Operation       `bson:"operations"`
+	ExpectedEvents    []*ExpectedEvents  `bson:"expectEvents"`
+	Outcome           []*CollectionData  `bson:"outcome"`
+}
+
+type TestFile struct {
+	Description       string                      `bson:"description"`
+	SchemaVersion     string                      `bson:"schemaVersion"`
+	RunOnRequirements []mtest.RunOnBlock          `bson:"runOnRequirements"`
+	CreateEntities    []map[string]*EntityOptions `bson:"createEntities"`
+	InitialData       []*CollectionData           `bson:"initialData"`
+	TestCases         []*TestCase                 `bson:"tests"`
+}
+
+func TestUnifiedSpec(t *testing.T) {
+	// Ensure the cluster is in a clean state before test execution begins.
+	if err := TerminateOpenTransactions(mtest.Background); err != nil {
+		t.Fatalf("error terminating open transactions: %v", err)
+	}
+
+	for _, testDir := range directories {
+		t.Run(testDir, func(t *testing.T) {
+			for _, filename := range testhelpers.FindJSONFilesInDir(t, path.Join(dataDirectory, testDir)) {
+				t.Run(filename, func(t *testing.T) {
+					runTestFile(t, path.Join(dataDirectory, testDir, filename))
+				})
+			}
+		})
+	}
+}
+
+func runTestFile(t *testing.T, filepath string) {
+	content, err := ioutil.ReadFile(filepath)
+	assert.Nil(t, err, "ReadFile error for file %q: %v", filepath, err)
+
+	var testFile TestFile
+	err = bson.UnmarshalExtJSON(content, false, &testFile)
+	assert.Nil(t, err, "UnmarshalExtJSON error for file %q: %v", filepath, err)
+
+	// Validate that we support the schema declared by the test file before attempting to use its contents.
+	err = CheckSchemaVersion(testFile.SchemaVersion)
+	assert.Nil(t, err, "schema version %q not supported: %v", testFile.SchemaVersion, err)
+
+	// Create mtest wrapper, which will skip the test if needed.
+	mtOpts := mtest.NewOptions().
+		RunOn(testFile.RunOnRequirements...).
+		CreateClient(false)
+	mt := mtest.New(t, mtOpts)
+	defer mt.Close()
+
+	for _, testCase := range testFile.TestCases {
+		mtOpts := mtest.NewOptions().
+			RunOn(testCase.RunOnRequirements...).
+			CreateClient(false)
+		mt.RunOpts(testCase.Description, mtOpts, func(mt *mtest.T) {
+			runTestCase(mt, testFile, testCase)
+		})
+	}
+}
+
+func runTestCase(mt *mtest.T, testFile TestFile, testCase *TestCase) {
+	if testCase.SkipReason != nil {
+		mt.Skipf("skipping for reason: %q", *testCase.SkipReason)
+	}
+	if _, ok := skippedTestDescriptions[testCase.Description]; ok {
+		mt.Skip("skipping due to known failure")
+	}
+
+	testCtx := NewTestContext(mtest.Background)
+
+	defer func() {
+		// Failed tests should terminate any transactions left open on the server. If the helper also fails, we
+		// only log the error because the actual test failure has already occurred and should be preserved.
+		if mt.Failed() {
+			if err := TerminateOpenTransactions(mtest.Background); err != nil {
+				mt.Logf("error terminating open transactions after failed test: %v", err)
+			}
+		}
+
+		for _, err := range DisableUntargetedFailPoints(testCtx) {
+			mt.Log(err)
+		}
+		for _, err := range DisableTargetedFailPoints(testCtx) {
+			mt.Log(err)
+		}
+		for _, err := range Entities(testCtx).Close(testCtx) {
+			mt.Log(err)
+		}
+	}()
+
+	// Set up collections based on the file-level initialData field.
+	for _, collData := range testFile.InitialData {
+		if err := collData.CreateCollection(testCtx); err != nil {
+			mt.Fatalf("error setting up collection %q: %v", collData.Namespace(), err)
+		}
+	}
+
+	// Set up entities based on the file-level createEntities field. For client entities, if the test will configure
+	// a fail point, set a low heartbeatFrequencyMS value into the URI options map if one is not already present.
+	// This speeds up recovery time for the client if the fail point forces the server to return a state change
+	// error.
+	shouldSetHeartbeatFrequency := LowerHeartbeatFrequencyRequired(testCase)
+	for idx, entity := range testFile.CreateEntities {
+		for entityType, entityOptions := range entity {
+			if shouldSetHeartbeatFrequency && entityType == "client" {
+				if entityOptions.URIOptions == nil {
+					entityOptions.URIOptions = make(bson.M)
+				}
+				if _, ok := entityOptions.URIOptions["heartbeatFrequencyMS"]; !ok {
+					entityOptions.URIOptions["heartbeatFrequencyMS"] = lowHeartbeatFrequency
+				}
+			}
+
+			if err := Entities(testCtx).AddEntity(testCtx, entityType, entityOptions); err != nil {
+				mt.Fatalf("error creating entity at index %d: %v", idx, err)
+			}
+		}
+	}
+
+	// Work around SERVER-39704.
+	if DistinctWorkaroundRequired(testCase) {
+		if err := PerformDistinctWorkaround(testCtx); err != nil {
+			mt.Fatalf("error performing \"distinct\" workaround: %v", err)
+		}
+	}
+
+	for idx, operation := range testCase.Operations {
+		err := operation.Execute(testCtx)
+		assert.Nil(mt, err, "error running operation %q at index %d: %v", operation.Name, idx, err)
+	}
+
+	for _, client := range Entities(testCtx).Clients() {
+		client.StopListeningForEvents()
+	}
+
+	for idx, expectedEvents := range testCase.ExpectedEvents {
+		err := VerifyEvents(testCtx, expectedEvents)
+		assert.Nil(mt, err, "events verification failed at index %d: %v", idx, err)
+	}
+
+	for idx, collData := range testCase.Outcome {
+		err := collData.VerifyContents(testCtx)
+		assert.Nil(mt, err, "error verifying outcome for collection %q at index %d: %v",
+			collData.Namespace(), idx, err)
+	}
+}
+
+func DistinctWorkaroundRequired(testCase *TestCase) bool {
+	if mtest.ClusterTopologyKind() != mtest.Sharded {
+		return false
+	}
+
+	for _, op := range testCase.Operations {
+		if op.Name == "distinct" {
+			return true
+		}
+	}
+	return false
+}
+
+func LowerHeartbeatFrequencyRequired(testCase *TestCase) bool {
+	for _, op := range testCase.Operations {
+		if op.Name == "failPoint" {
+			return true
+		}
+	}
+	return false
+}
+
+func DisableUntargetedFailPoints(ctx context.Context) []error {
+	var errs []error
+	for fpName, client := range FailPoints(ctx) {
+		if err := disableFailPointWithClient(ctx, fpName, client); err != nil {
+			errs = append(errs, fmt.Errorf("error disabling fail point %q: %v", fpName, err))
+		}
+	}
+	return errs
+}
+
+func DisableTargetedFailPoints(ctx context.Context) []error {
+	var errs []error
+	for fpName, host := range TargetedFailPoints(ctx) {
+		commandFn := func(ctx context.Context, client *mongo.Client) error {
+			return disableFailPointWithClient(ctx, fpName, client)
+		}
+		if err := RunCommandOnHost(ctx, host, commandFn); err != nil {
+			errs = append(errs, fmt.Errorf("error disabling targeted fail point %q on host %q: %v", fpName, host, err))
+		}
+	}
+	return errs
+}
+
+func disableFailPointWithClient(ctx context.Context, fpName string, client *mongo.Client) error {
+	cmd := bson.D{
+		{"configureFailPoint", fpName},
+		{"mode", "off"},
+	}
+	if err := client.Database("admin").RunCommand(ctx, cmd).Err(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -26,8 +26,14 @@ var (
 	}
 
 	skippedTestDescriptions = map[string]struct{}{
+		// GODRIVER-1773: This test runs a "find" with limit=4 and batchSize=3. It expects batchSize values of three for
+		// the "find" and one for the "getMore", but we send three for both.
 		"A successful find event with a getmore and the server kills the cursor": {},
-		"Client side error in command starting transaction":                      {},
+
+		// This test expects the driver to raise a client-side error when inserting a document with a key that contains
+		// a "." or "$". We don't do this validation and the server is moving towards supporting this, so we don't have
+		// any plans to add it. This test will need to be changed once the server support lands anyway.
+		"Client side error in command starting transaction": {},
 	}
 )
 

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -150,10 +150,10 @@ func runTestCase(mt *mtest.T, testFile TestFile, testCase *TestCase) {
 		for _, err := range Entities(testCtx).Close(testCtx) {
 			mt.Log(err)
 		}
-		// Tests that failed or started a transaction should terminate any sessions left open on the server. This is
-		// reqiured even if the test attempted to commit/abort the transaction because an abortTransaction command can
-		// fail if it's sent to a mongos that isn't aware of the transaction.
-		if mt.Failed() || testCase.StartsTransaction() {
+		// Tests that started a transaction should terminate any sessions left open on the server. This is required even
+		// if the test attempted to commit/abort the transaction because an abortTransaction command can fail if it's
+		// sent to a mongos that isn't aware of the transaction.
+		if testCase.StartsTransaction() {
 			if err := TerminateOpenSessions(mtest.Background); err != nil {
 				mt.Logf("error terminating open transactions after failed test: %v", err)
 			}

--- a/x/bsonx/bsoncore/bson_arraybuilder.go
+++ b/x/bsonx/bsoncore/bson_arraybuilder.go
@@ -180,6 +180,12 @@ func (a *ArrayBuilder) AppendMinKey() *ArrayBuilder {
 	return a
 }
 
+// AppendValue appends a BSON value to the array.
+func (a *ArrayBuilder) AppendValue(val Value) *ArrayBuilder {
+	a.arr = AppendValueElement(a.arr, a.incrementKey(), val)
+	return a
+}
+
 // StartArray starts building an inline Array. After this document is completed,
 // the user must call a.FinishArray
 func (a *ArrayBuilder) StartArray() *ArrayBuilder {

--- a/x/bsonx/bsoncore/bson_documentbuilder.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder.go
@@ -168,6 +168,12 @@ func (db *DocumentBuilder) AppendMinKey(key string) *DocumentBuilder {
 	return db
 }
 
+// AppendValue will append a BSON element with the provided key and value to the document.
+func (db *DocumentBuilder) AppendValue(key string, val Value) *DocumentBuilder {
+	db.doc = AppendValueElement(db.doc, key, val)
+	return db
+}
+
 // StartDocument starts building an inline document element with the provided key
 // After this document is completed, the user must call finishDocument
 func (db *DocumentBuilder) StartDocument(key string) *DocumentBuilder {


### PR DESCRIPTION
Summary of changes by package:

- `data` - These are YAML/JSON tests. Ignore for reviews.
- `internal/testutil` - Some general-purpose helpers. All minor changes.
- `mongo/gridfs` - Ignore for reviews. These are changes from GODRIVER-1770 because they're required to make tests pass. Once the PR for that ticket is merged, I'll rebase and these should go away. Also applies to `mongo/integration/gridfs_test.go`.
- `mongo/integration/mtest` - This is our existing testing framework. I added some global helper functions, made changes to support the "sharded-replicaset" constraint, and added context to our messages when we skip tests. Previously, these would just say "no matching environmental constraint found" but will now say something like "server version 4.0 is less than min required version 4.2".
- `mongo/integration/unified` - These are the main files to review and constitute the actual unified test runner.
- `x/bsonx/bsoncore` - The `DocumentBuilder` and `ArrayBuilder` types gain functions to append arbitrary BSON values. We already had a standalone `AppendValueElement` function, so this is a small change.

Important design decisions for the implementation:

- Entities and fail points for the test are stored in the test's `context.Context` instance. This makes our function signatures less verbose because we can pass around a context rather than lots of extra parameters. It's not a totally proper use of contexts because contexts should be immutable and we're storing mutable maps as values, but this is test-only code and makes our tests easier to work with IMO.
- The `runTestCase` function gets an `mtest.T` instance, but does not pass it to its helpers. Instead, the helpers return errors to convey failure. This makes the runner more verbose due to error checks, but also means that we can add context to errors and avoid cryptic failures deep in the execution stack, so I think it's worth it.
- Arguments for operations are kept as `bson.Raw` rather than `bson.D`/`bson.M`. This makes the code a little more verbose when converting from the arguments document to a Go object, but is better because Raw is a closed type system whereas D/M are not.
- Types and some of their methods are exported. The unified runner is all in one package, so everything can be package-private, but exporting allows us to define API boundaries. For example, `Operation.Execute` is exported to indicate that it can be called from something outside of `Operation`, but `Operation.run` is not because it should only be used internally within `Operation`.

TODO:
- [x] File GODRIVER tickets for tests that we intentionally skip (i.e. those listed in the `skippedTestDescriptions` map).
- [x] File GODRIVER ticket to allow specifying `ReadConcern` and `WriteConcern` options for `RunCommand`. The test runner currently errors if these options are encountered.
- [x] Support the `tagSets` option for read preferences in the test runner. This currently errors because I couldn't figure out what the structure is based on the spec. Currently discussing this on Slack, so I'll update the PR once it's working.