### PR TITLE
Add event package to Makefile and fix gofmt errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BSON_PKGS = $(shell etc/list_pkgs.sh ./bson)
 BSON_TEST_PKGS = $(shell etc/list_test_pkgs.sh ./bson)
+EVENT_PKGS = $(shell etc/list_pkgs.sh ./event)
+EVENT_TEST_PKGS = $(shell etc/list_test_pkgs.sh ./event)
 MONGO_PKGS = $(shell etc/list_pkgs.sh ./mongo)
 MONGO_TEST_PKGS = $(shell etc/list_test_pkgs.sh ./mongo)
 UNSTABLE_PKGS = $(shell etc/list_pkgs.sh ./x)
@@ -8,8 +10,8 @@ TAG_PKG = $(shell etc/list_pkgs.sh ./tag)
 TAG_TEST_PKG = $(shell etc/list_test_pkgs.sh ./tag)
 EXAMPLES_PKGS = $(shell etc/list_pkgs.sh ./examples)
 EXAMPLES_TEST_PKGS = $(shell etc/list_test_pkgs.sh ./examples)
-PKGS = $(BSON_PKGS) $(MONGO_PKGS) $(UNSTABLE_PKGS) $(TAG_PKG) $(EXAMPLES_PKGS)
-TEST_PKGS = $(BSON_TEST_PKGS) $(MONGO_TEST_PKGS) $(UNSTABLE_TEST_PKGS) $(TAG_PKG) $(EXAMPLES_TEST_PKGS)
+PKGS = $(BSON_PKGS) $(EVENT_PKGS) $(MONGO_PKGS) $(UNSTABLE_PKGS) $(TAG_PKG) $(EXAMPLES_PKGS)
+TEST_PKGS = $(BSON_TEST_PKGS) $(EVENT_TEST_PKGS) $(MONGO_TEST_PKGS) $(UNSTABLE_TEST_PKGS) $(TAG_PKG) $(EXAMPLES_TEST_PKGS)
 ATLAS_URIS = "$(ATLAS_FREE)" "$(ATLAS_REPLSET)" "$(ATLAS_SHARD)" "$(ATLAS_TLS11)" "$(ATLAS_TLS12)" "$(ATLAS_FREE_SRV)" "$(ATLAS_REPLSET_SRV)" "$(ATLAS_SHARD_SRV)" "$(ATLAS_TLS11_SRV)" "$(ATLAS_TLS12_SRV)"
 
 TEST_TIMEOUT = 600

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -134,7 +134,7 @@ type TopologyClosedEvent struct {
 // ServerHeartbeatStartedEvent is an event generated when the heartbeat is started.
 type ServerHeartbeatStartedEvent struct {
 	ConnectionID string // The address this heartbeat was sent to with a unique identifier
-	Awaited      bool // If this heartbeat was awaitable
+	Awaited      bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatSucceededEvent is an event generated when the heartbeat succeeds.
@@ -142,7 +142,7 @@ type ServerHeartbeatSucceededEvent struct {
 	DurationNanos int64
 	Reply         description.Server
 	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool // If this heartbeat was awaitable
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatFailedEvent is an event generated when the heartbeat fails.
@@ -150,7 +150,7 @@ type ServerHeartbeatFailedEvent struct {
 	DurationNanos int64
 	Failure       error
 	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool // If this heartbeat was awaitable
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerMonitor represents a monitor that is triggered for different server events. The client
@@ -158,9 +158,9 @@ type ServerHeartbeatFailedEvent struct {
 // the changes in the client's representation of the deployment. The topology represents the
 // overall deployment, and heartbeats are sent to individual servers to check their current status.
 type ServerMonitor struct {
-	ServerDescriptionChanged   func(*ServerDescriptionChangedEvent)
-	ServerOpening              func(*ServerOpeningEvent)
-	ServerClosed               func(*ServerClosedEvent)
+	ServerDescriptionChanged func(*ServerDescriptionChangedEvent)
+	ServerOpening            func(*ServerOpeningEvent)
+	ServerClosed             func(*ServerClosedEvent)
 	// TopologyDescriptionChanged is called when the topology is locked, so the callback should
 	// not attempt any operation that requires server selection on the same client.
 	TopologyDescriptionChanged func(*TopologyDescriptionChangedEvent)


### PR DESCRIPTION
I noticed the `event` package is missing from our Makefile. There were some `gofmt` issues in the SDAM monitoring event descriptions, so this PR fixes those and modifies the Makefile so these things are caught in CI.