### PR TITLE
GODRIVER-1394 Require multiple hosts to exist if useMultipleMongoses=true

### DIFF
--- a/mongo/integration/unified/client_entity_test.go
+++ b/mongo/integration/unified/client_entity_test.go
@@ -51,9 +51,9 @@ func NewClientEntity(ctx context.Context, entityOptions *EntityOptions) (*Client
 	}
 	// UseMultipleMongoses is only relevant if we're connected to a sharded cluster. Options changes and validation are
 	// only required if the option is explicitly set. If it's unset, we make no changes because the cluster URI already
-	// includes all nodes and we don't enfoce any limits on the number of nodes.
+	// includes all nodes and we don't enforce any limits on the number of nodes.
 	if mtest.ClusterTopologyKind() == mtest.Sharded && entityOptions.UseMultipleMongoses != nil {
-		if err := evalulateUseMultipleMongoses(clientOpts, *entityOptions.UseMultipleMongoses); err != nil {
+		if err := evaluateUseMultipleMongoses(clientOpts, *entityOptions.UseMultipleMongoses); err != nil {
 			return nil, err
 		}
 	}
@@ -187,7 +187,7 @@ func setClientOptionsFromURIOptions(clientOpts *options.ClientOptions, uriOpts b
 	return nil
 }
 
-func evalulateUseMultipleMongoses(clientOpts *options.ClientOptions, useMultipleMongoses bool) error {
+func evaluateUseMultipleMongoses(clientOpts *options.ClientOptions, useMultipleMongoses bool) error {
 	hosts := mtest.ClusterConnString().Hosts
 
 	if !useMultipleMongoses {

--- a/mongo/integration/unified/entity_test.go
+++ b/mongo/integration/unified/entity_test.go
@@ -24,7 +24,7 @@ type EntityOptions struct {
 
 	// Options for client entities.
 	URIOptions          bson.M   `bson:"uriOptions"`
-	UseMultipleMongoses bool     `bson:"useMultipleMongoses"`
+	UseMultipleMongoses *bool    `bson:"useMultipleMongoses"`
 	ObserveEvents       []string `bson:"observeEvents"`
 	IgnoredCommands     []string `bson:"ignoreCommandMonitoringEvents"`
 


### PR DESCRIPTION
Our handling for the `useMultipleMongoses` option is incorrect because we're not verifying that there are multiple mongos servers if the option is explicitly set to true. See the `useMultipleMongoses` bullet in the `client` entity definition [here](https://github.com/mongodb/specifications/blob/61b8189193b8647b58ba18321aaf4a77933aa7b9/source/unified-test-format/unified-test-format.rst#entity) for a description of the correct behavior.