### PR TITLE
GODRIVER-1793 Avoid panic if opts is nil when call InsertOne 

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -329,7 +329,7 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 	imOpts := make([]*options.InsertManyOptions, len(opts))
 	for i, opt := range opts {
 		imo := options.InsertMany()
-		if opt.BypassDocumentValidation != nil && *opt.BypassDocumentValidation {
+		if opt != nil && opt.BypassDocumentValidation != nil && *opt.BypassDocumentValidation {
 			imo = imo.SetBypassDocumentValidation(*opt.BypassDocumentValidation)
 		}
 		imOpts[i] = imo


### PR DESCRIPTION
In current version, `coll.InsertOne(ctx,doc,nil)` will trigger panic, because `opts` will be [nil] inside `InsertOne()`, then panic happens when call `opt.BypassDocumentValidation != nil`:
```
func (coll *Collection) InsertOne(ctx context.Context, document interface{},
	opts ...*options.InsertOneOptions) (*InsertOneResult, error) {

	imOpts := make([]*options.InsertManyOptions, len(opts))
	for i, opt := range opts {
		imo := options.InsertMany()
		if opt.BypassDocumentValidation != nil && *opt.BypassDocumentValidation {
			imo = imo.SetBypassDocumentValidation(*opt.BypassDocumentValidation)
		}
		imOpts[i] = imo
	}
...
```