### PR TITLE
GODRIVER-1788 correctly replace errors in IndexView CreateMany

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -272,7 +272,7 @@ func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ..
 
 	err = op.Execute(ctx)
 	if err != nil {
-		return nil, err
+		return nil, replaceErrors(err)
 	}
 
 	return names, nil

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -220,7 +220,8 @@ func TestIndexView(t *testing.T) {
 				})
 			}
 		})
-		mt.Run("replace error", func(mt *mtest.T) {
+		// Needs to run on these versions for failpoints
+		mt.RunOpts("replace error", mtest.NewOptions().Topologies(mtest.ReplicaSet).MinServerVersion("4.0"), func(mt *mtest.T) {
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
 				Mode:               "alwaysOn",
@@ -341,7 +342,8 @@ func TestIndexView(t *testing.T) {
 				})
 			}
 		})
-		mt.Run("replace error", func(mt *mtest.T) {
+		// Needs to run on these versions for failpoints
+		mt.RunOpts("replace error", mtest.NewOptions().Topologies(mtest.ReplicaSet).MinServerVersion("4.0"), func(mt *mtest.T) {
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
 				Mode:               "alwaysOn",


### PR DESCRIPTION
After reading through, I'm pretty sure that this is the only spot that isn't replacing errors correctly. Also fixed the CreateMany commitQuorum tests while i was there.