### PR TITLE
GODRIVER-150 Raise error for read message length too large 

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -375,10 +375,10 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 	}
 
 	// In the case of an isMaster response where MaxMessageSize has not yet been set, use a hard-coded
-	// 48000 bytes instead.
+	// 48000000 bytes instead.
 	maxMessageSize := c.desc.MaxMessageSize
 	if maxMessageSize == 0 {
-		maxMessageSize = 48000
+		maxMessageSize = 48000000
 	}
 	if uint32(len(dst)) > maxMessageSize {
 		c.close()

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -374,6 +374,17 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 		}
 	}
 
+	// In the case of an isMaster response where MaxMessageSize has not yet been set, use a hard-coded
+	// 48000 bytes instead.
+	maxMessageSize := c.desc.MaxMessageSize
+	if maxMessageSize == 0 {
+		maxMessageSize = 48000
+	}
+	if uint32(len(dst)) > maxMessageSize {
+		c.close()
+		return nil, ConnectionError{ConnectionID: c.id, Wrapped: nil, message: "length of read message too large"}
+	}
+
 	c.bumpIdleDeadline()
 	return dst, nil
 }

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -30,8 +30,10 @@ import (
 
 var globalConnectionID uint64 = 1
 
-var defaultMaxMessageSize uint32 = 48000000
-var errResponseTooLarge error = errors.New("length of read message too large")
+var (
+	defaultMaxMessageSize uint32 = 48000000
+	errResponseTooLarge   error  = errors.New("length of read message too large")
+)
 
 func nextConnectionID() uint64 { return atomic.AddUint64(&globalConnectionID, 1) }
 

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -493,7 +493,7 @@ func TestConnection(t *testing.T) {
 					}{
 						{
 							"message too large errors with small max message size",
-							[]byte{0x0A, 0x00, 0x00, 0x00, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A},
+							[]byte{0x0A, 0x00, 0x00, 0x00}, // defines a message size of 10 in hex with the first four bytes.
 							description.Server{MaxMessageSize: 9},
 						},
 						{

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -485,6 +485,41 @@ func TestConnection(t *testing.T) {
 					}
 					listener.assertMethodsCalled(t, 1, 1)
 				})
+				t.Run("message too large errors", func(t *testing.T) {
+					testCases := []struct {
+						name   string
+						buffer []byte
+						desc   description.Server
+					}{
+						{
+							"message too large errors with small max message size",
+							[]byte{0x0A, 0x00, 0x00, 0x00, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A},
+							description.Server{MaxMessageSize: 9},
+						},
+						{
+							"message too large errors with default max message size",
+							append([]byte{0x04, 0x6C, 0xDC, 0x02}, make([]byte, 4800000)...),
+							description.Server{},
+						},
+					}
+					for _, tc := range testCases {
+						t.Run(tc.name, func(t *testing.T) {
+							err := errors.New("length of read message too large")
+							tnc := &testNetConn{buf: make([]byte, len(tc.buffer))}
+							copy(tnc.buf, tc.buffer)
+							conn := &connection{id: "foobar", nc: tnc, connected: connected, desc: tc.desc}
+							listener := newTestCancellationListener(false)
+							conn.cancellationListener = listener
+
+							want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: err.Error()}
+							_, got := conn.readWireMessage(context.Background(), nil)
+							if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
+								t.Errorf("errors do not match. got %v; want %v", got, want)
+							}
+							listener.assertMethodsCalled(t, 1, 1)
+						})
+					}
+				})
 				t.Run("success", func(t *testing.T) {
 					want := []byte{0x0A, 0x00, 0x00, 0x00, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A}
 					tnc := &testNetConn{buf: make([]byte, len(want))}
@@ -957,41 +992,4 @@ func (t *testCancellationListener) assertMethodsCalled(testingT *testing.T, numL
 	assert.Equal(testingT, numListen, t.numListen, "expected Listen to be called %d times, got %d", numListen, t.numListen)
 	assert.Equal(testingT, numStopListening, t.numStopListening, "expected StopListening to be called %d times, got %d",
 		numListen, t.numListen)
-}
-
-var testCases = []struct {
-	name   string
-	buffer []byte
-	desc   description.Server
-}{
-	{
-		"message too large errors with small max message size",
-		[]byte{0x0A, 0x00, 0x00, 0x00, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A},
-		description.Server{MaxMessageSize: 9},
-	},
-	{
-		"message too large errors with default max message size",
-		append([]byte{0x04, 0x6C, 0xDC, 0x02}, make([]byte, 4800000)...),
-		description.Server{},
-	},
-}
-
-func TestReadWireMessageTooLarge(t *testing.T) {
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := errors.New("length of read message too large")
-			tnc := &testNetConn{buf: make([]byte, len(tc.buffer))}
-			copy(tnc.buf, tc.buffer)
-			conn := &connection{id: "foobar", nc: tnc, connected: connected, desc: tc.desc}
-			listener := newTestCancellationListener(false)
-			conn.cancellationListener = listener
-
-			want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: err.Error()}
-			_, got := conn.readWireMessage(context.Background(), nil)
-			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
-				t.Errorf("errors do not match. got %v; want %v", got, want)
-			}
-			listener.assertMethodsCalled(t, 1, 1)
-		})
-	}
 }

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -498,7 +498,7 @@ func TestConnection(t *testing.T) {
 						},
 						{
 							"message too large errors with default max message size",
-							append([]byte{0x04, 0x6C, 0xDC, 0x02}, make([]byte, 4800000)...),
+							[]byte{0x01, 0x6C, 0xDC, 0x02}, // defines a message size of 48000001 in hex with the first four bytes.
 							description.Server{},
 						},
 					}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -486,7 +486,7 @@ func TestConnection(t *testing.T) {
 					listener.assertMethodsCalled(t, 1, 1)
 				})
 				t.Run("message too large errors", func(t *testing.T) {
-					errMsg := "length of read message too large"
+					err := errors.New("length of read message too large")
 					buffer := []byte{0x0A, 0x00, 0x00, 0x00, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A}
 					tnc := &testNetConn{buf: make([]byte, len(buffer))}
 					copy(tnc.buf, buffer)
@@ -495,7 +495,7 @@ func TestConnection(t *testing.T) {
 					listener := newTestCancellationListener(false)
 					conn.cancellationListener = listener
 
-					want := ConnectionError{ConnectionID: "foobar", Wrapped: nil, message: errMsg}
+					want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: err.Error()}
 					_, got := conn.readWireMessage(context.Background(), nil)
 					if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 						t.Errorf("errors do not match. got %v; want %v", got, want)


### PR DESCRIPTION
Checks the length of the read message in `connection#readWireMessage()` to make sure it does not exceed the `MaxMessageSize` defined in the server description.

Adds a unit test to make sure error is raised.