### PR TITLE
GODRIVER-1805 Add tests for unmarshalling BSON with undefined fields

### DIFF
--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -286,19 +286,16 @@ func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
 		DefinedField string `bson:"DefinedField"`
 	}
 
-	unmarshalExpectedResponse := func(t *testing.T, BSON []byte) *expectedResponse {
+	createExpectedResponse := func(t *testing.T, doc D) *expectedResponse {
 		t.Helper()
-		responseDoc := expectedResponse{}
-		err := Unmarshal(BSON, &responseDoc)
-		assert.Nil(t, err, "Error unmarshalling BSON: %v", err)
-		return &responseDoc
-	}
 
-	marshalBSON := func(t *testing.T, doc D) []byte {
-		t.Helper()
 		marshalledBSON, err := Marshal(doc)
-		assert.Nil(t, err, "Error marshalling BSON: %v", err)
-		return marshalledBSON
+		assert.Nil(t, err, "error marshalling BSON: %v", err)
+
+		responseDoc := expectedResponse{}
+		err = Unmarshal(marshalledBSON, &responseDoc)
+		assert.Nil(t, err, "error unmarshalling BSON: %v", err)
+		return &responseDoc
 	}
 
 	testCases := []struct {
@@ -427,8 +424,7 @@ func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			marshalledBSON := marshalBSON(t, tc.testBSON)
-			responseDoc := unmarshalExpectedResponse(t, marshalledBSON)
+			responseDoc := createExpectedResponse(t, tc.testBSON)
 			assert.Equal(t, "value", responseDoc.DefinedField, "expected DefinedField to be 'value', got %q", responseDoc.DefinedField)
 		})
 	}

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -168,7 +168,7 @@ func TestCachingDecodersNotSharedAcrossRegistries(t *testing.T) {
 }
 
 func TestUnmarshalExtJSONWithUndefinedField(t *testing.T) {
-	// When unmarshalling, fields that are undefined in the destination struct are skipped.
+	// When unmarshalling extJSON, fields that are undefined in the destination struct are skipped.
 	// This process must not skip other, defined fields and must not raise errors.
 	type expectedResponse struct {
 		DefinedField string
@@ -274,6 +274,161 @@ func TestUnmarshalExtJSONWithUndefinedField(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			responseDoc := unmarshalExpectedResponse(t, tc.testJSON)
+			assert.Equal(t, "value", responseDoc.DefinedField, "expected DefinedField to be 'value', got %q", responseDoc.DefinedField)
+		})
+	}
+}
+
+func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
+	// When unmarshalling BSON, fields that are undefined in the destination struct are skipped.
+	// This process must not skip other, defined fields and must not raise errors.
+	type expectedResponse struct {
+		DefinedField string `bson:"DefinedField"`
+	}
+
+	unmarshalExpectedResponse := func(t *testing.T, BSON []byte) *expectedResponse {
+		t.Helper()
+		responseDoc := expectedResponse{}
+		err := Unmarshal(BSON, &responseDoc)
+		assert.Nil(t, err, "Error unmarshalling BSON: %v", err)
+		return &responseDoc
+	}
+
+	marshalBSON := func(t *testing.T, doc D) []byte {
+		t.Helper()
+		marshalledBSON, err := Marshal(doc)
+		assert.Nil(t, err, "Error marshalling BSON: %v", err)
+		return marshalledBSON
+	}
+
+	testCases := []struct {
+		name     string
+		testBSON D
+	}{
+		{
+			"no array",
+			D{
+				{"UndefinedField", D{
+					{"key", 1},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"outer array",
+			D{
+				{"UndefinedField", A{D{
+					{"key", 1},
+				}}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"embedded array",
+			D{
+				{"UndefinedField", D{
+					{"key", A{1}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"outer array and embedded array",
+			D{
+				{"UndefinedField", A{D{
+					{"key", A{1}},
+				}}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"embedded document",
+			D{
+				{"UndefinedField", D{
+					{"key", D{
+						{"one", "two"},
+					}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"doubly embedded document",
+			D{
+				{"UndefinedField", D{
+					{"key", D{
+						{"one", D{
+							{"two", "three"},
+						}},
+					}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"embedded document and embedded array",
+			D{
+				{"UndefinedField", D{
+					{"key", D{
+						{"one", D{
+							{"two", A{3}},
+						}},
+					}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"embedded document and embedded array in outer array",
+			D{
+				{"UndefinedField", A{D{
+					{"key", D{
+						{"one", A{3}},
+					}},
+				}}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"code with scope",
+			D{
+				{"UndefinedField", D{
+					{"logic", D{
+						{"$code", "foo"},
+						{"$scope", D{
+							{"bar", 1},
+						}},
+					}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"embedded array of code with scope",
+			D{
+				{"UndefinedField", D{
+					{"logic", A{D{
+						{"$code", "foo"},
+						{"$scope", D{
+							{"bar", 1},
+						}},
+					}}},
+				}},
+				{"DefinedField", "value"},
+			},
+		},
+		{
+			"empty embedded document",
+			D{
+				{"UndefinedField", D{}},
+				{"DefinedField", "value"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalledBSON := marshalBSON(t, tc.testBSON)
+			responseDoc := unmarshalExpectedResponse(t, marshalledBSON)
 			assert.Equal(t, "value", responseDoc.DefinedField, "expected DefinedField to be 'value', got %q", responseDoc.DefinedField)
 		})
 	}


### PR DESCRIPTION
[GODRIVER-1805](https://jira.mongodb.org/browse/GODRIVER-1805)

Adds tests for unmarshalling BSON with undefined fields. Faulty behavior was recently discovered when unmarshalling extended JSON with undefined fields; this behavior was fixed in [1235](https://jira.mongodb.org/browse/GODRIVER-1235), and test coverage was added. The same faulty behavior does not exist for BSON, but these tests should cover any theoretical `value_reader#Skip()` errors.