### PR TITLE
GODRIVER-1794 remove SetBucketSize from TestIndexView/create_one/all_options

### DIFF
--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/google/go-cmp/cmp"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
@@ -98,13 +96,12 @@ func TestIndexView(t *testing.T) {
 				})
 
 			// Only check SetBucketSize if version is less than or equal to 4.4
-			if mtest.CompareServerVersions(mtest.ServerVersion(), "4.4") <= 0 {
-				fmt.Println("yo")
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "4.9") <= 0 {
 				opts.SetBucketSize(1)
 			}
 			// Omits collation option because it's incompatible with version option
 			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{
-				Keys: bson.D{{"foo", "text"}},
+				Keys:    bson.D{{"foo", "text"}},
 				Options: opts,
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
@@ -73,30 +75,37 @@ func TestIndexView(t *testing.T) {
 			})
 		})
 		mt.Run("all options", func(mt *mtest.T) {
+			opts := options.Index().
+				SetBackground(false).
+				SetExpireAfterSeconds(10).
+				SetName("a").
+				SetSparse(false).
+				SetUnique(false).
+				SetVersion(1).
+				SetDefaultLanguage("english").
+				SetLanguageOverride("english").
+				SetTextVersion(1).
+				SetWeights(bson.D{}).
+				SetSphereVersion(1).
+				SetBits(2).
+				SetMax(10).
+				SetMin(1).
+				SetPartialFilterExpression(bson.D{}).
+				SetStorageEngine(bson.D{
+					{"wiredTiger", bson.D{
+						{"configString", "block_compressor=zlib"},
+					}},
+				})
+
+			// Only check SetBucketSize if version is less than or equal to 4.4
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "4.4") <= 0 {
+				fmt.Println("yo")
+				opts.SetBucketSize(1)
+			}
 			// Omits collation option because it's incompatible with version option
 			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{
 				Keys: bson.D{{"foo", "text"}},
-				Options: options.Index().
-					SetBackground(false).
-					SetExpireAfterSeconds(10).
-					SetName("a").
-					SetSparse(false).
-					SetUnique(false).
-					SetVersion(1).
-					SetDefaultLanguage("english").
-					SetLanguageOverride("english").
-					SetTextVersion(1).
-					SetWeights(bson.D{}).
-					SetSphereVersion(1).
-					SetBits(2).
-					SetMax(10).
-					SetMin(1).
-					SetPartialFilterExpression(bson.D{}).
-					SetStorageEngine(bson.D{
-						{"wiredTiger", bson.D{
-							{"configString", "block_compressor=zlib"},
-						}},
-					}),
+				Options: opts,
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 		})

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -91,7 +91,6 @@ func TestIndexView(t *testing.T) {
 					SetBits(2).
 					SetMax(10).
 					SetMin(1).
-					SetBucketSize(1).
 					SetPartialFilterExpression(bson.D{}).
 					SetStorageEngine(bson.D{
 						{"wiredTiger", bson.D{

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -95,8 +95,8 @@ func TestIndexView(t *testing.T) {
 					}},
 				})
 
-			// Only check SetBucketSize if version is less than or equal to 4.4
-			if mtest.CompareServerVersions(mtest.ServerVersion(), "4.9") <= 0 {
+			// Only check SetBucketSize if version is less than 4.9
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "4.9") < 0 {
 				opts.SetBucketSize(1)
 			}
 			// Omits collation option because it's incompatible with version option


### PR DESCRIPTION
This is just removing it so that tests pass while we wait for the drivers ticket. I can alter the code instead if this seems too hack-y.