### PR TITLE
GODRIVER-1831 Avoid accidental extra getMore when using limit on Find

### DIFF
--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -909,6 +909,9 @@ func TestCollection(t *testing.T) {
 				{
 					201, 201, 0,
 				},
+				{
+					100, 200, 120,
+				},
 			}
 
 			for _, tc := range testCases {
@@ -920,7 +923,11 @@ func TestCollection(t *testing.T) {
 				var docs []interface{}
 				err = cursor.All(mtest.Background, &docs)
 				assert.Nil(mt, err, "All error: %v", err)
-				assert.Equal(mt, int(tc.limit), len(docs), "expected number of docs to be %v, got %v", tc.limit, len(docs))
+				if (201 - tc.skip) < tc.limit {
+					assert.Equal(mt, int(201-tc.skip), len(docs), "expected number of docs to be %v, got %v", tc.limit, len(docs))
+				} else {
+					assert.Equal(mt, int(tc.limit), len(docs), "expected number of docs to be %v, got %v", tc.limit, len(docs))
+				}
 			}
 		})
 		mt.Run("unset batch size does not surpass limit", func(mt *mtest.T) {

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -883,6 +883,20 @@ func TestCollection(t *testing.T) {
 			_, ok := err.(mongo.CommandError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.CommandError{}, err)
 		})
+		mt.Run("unset batch size does not surpass limit", func(mt *mtest.T) {
+			initCollection(mt, mt.Coll)
+			for _, limit := range []int64{2, 3, 4} {
+				opts := options.Find().SetSkip(0).SetLimit(limit)
+				cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, opts)
+				assert.Nil(mt, err, "Find error with limit: %v", err)
+
+				var docs []interface{}
+				err = cursor.All(mtest.Background, &docs)
+				assert.Nil(mt, err, "All error with limit: %v", err)
+
+				assert.Equal(mt, int(limit), len(docs), "expected number of docs to be %v, got %v", limit, len(docs))
+			}
+		})
 	})
 	mt.RunOpts("find one", noClientOpts, func(mt *mtest.T) {
 		mt.Run("limit", func(mt *mtest.T) {

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -241,7 +241,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 
 	// Required for legacy operations which don't support limit.
 	numToReturn := bc.batchSize
-	if bc.limit != 0 && bc.numReturned+bc.batchSize > bc.limit {
+	if bc.limit != 0 && bc.numReturned+bc.batchSize >= bc.limit {
 		numToReturn = bc.limit - bc.numReturned
 		if numToReturn <= 0 {
 			err := bc.Close(ctx)


### PR DESCRIPTION
[GODRIVER-1831](https://jira.mongodb.org/browse/GODRIVER-1831)

Includes change [from this PR](https://github.com/mongodb/mongo-go-driver/pull/561) to legacy `batch_cursor#getMore()` to fix a bug found by an external user on MDB versioned 2.6.12: when `numReturned == limit` and `batchSize` is not set on a `batchCursor` an extra `getMore` is run when the cursor should have just been closed

Adds a test to make sure that when `batchSize` is not set on a `batchCursor`, a set limit will not be surpassed accidentally.