### PR TITLE
GODRIVER-1832 add CSFLE internal client

### DIFF
--- a/data/client-side-encryption/README.rst
+++ b/data/client-side-encryption/README.rst
@@ -318,7 +318,7 @@ For each KMS provider (``aws``, ``azure``, ``gcp``, and ``local``), referred to 
 
    - Expect the return value to be a BSON binary subtype 6, referred to as ``encrypted``.
    - Use ``client_encrypted`` to insert ``{ _id: "<provider_name>", "value": <encrypted> }`` into ``db.coll``.
-   - Use ``client_encrypted`` to run a find querying with ``_id`` of "<provider_name>" and expect ``value`` to be "hello local".
+   - Use ``client_encrypted`` to run a find querying with ``_id`` of "<provider_name>" and expect ``value`` to be "hello <provider_name>".
 
 #. Call ``client_encryption.encrypt()`` with the value "hello <provider_name>", the algorithm ``AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic``, and the ``key_alt_name`` of ``<provider_name>_altname``.
 

--- a/data/client-side-encryption/aggregate.json
+++ b/data/client-side-encryption/aggregate.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -271,18 +259,6 @@
               "cursor": {}
             },
             "command_name": "aggregate"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
           }
         },
         {

--- a/data/client-side-encryption/aggregate.yml
+++ b/data/client-side-encryption/aggregate.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -83,13 +76,6 @@ tests:
             cursor: {}
           command_name: aggregate
       # Needs to fetch key when decrypting results
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/azureKMS.json
+++ b/data/client-side-encryption/azureKMS.json
@@ -142,18 +142,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/azureKMS.yml
+++ b/data/client-side-encryption/azureKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/data/client-side-encryption/basic.json
+++ b/data/client-side-encryption/basic.json
@@ -147,18 +147,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -279,18 +267,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/data/client-side-encryption/basic.yml
+++ b/data/client-side-encryption/basic.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -81,13 +74,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/data/client-side-encryption/bulk.json
+++ b/data/client-side-encryption/bulk.json
@@ -181,18 +181,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/bulk.yml
+++ b/data/client-side-encryption/bulk.yml
@@ -39,13 +39,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/count.json
+++ b/data/client-side-encryption/count.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/count.yml
+++ b/data/client-side-encryption/count.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/countDocuments.json
+++ b/data/client-side-encryption/countDocuments.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/countDocuments.yml
+++ b/data/client-side-encryption/countDocuments.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/delete.json
+++ b/data/client-side-encryption/delete.json
@@ -154,18 +154,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -272,18 +260,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/data/client-side-encryption/delete.yml
+++ b/data/client-side-encryption/delete.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/data/client-side-encryption/distinct.json
+++ b/data/client-side-encryption/distinct.json
@@ -164,18 +164,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/distinct.yml
+++ b/data/client-side-encryption/distinct.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/explain.json
+++ b/data/client-side-encryption/explain.json
@@ -158,18 +158,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/explain.yml
+++ b/data/client-side-encryption/explain.yml
@@ -33,13 +33,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/find.json
+++ b/data/client-side-encryption/find.json
@@ -163,18 +163,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -298,18 +286,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/data/client-side-encryption/find.yml
+++ b/data/client-side-encryption/find.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -77,13 +70,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/data/client-side-encryption/findOneAndDelete.json
+++ b/data/client-side-encryption/findOneAndDelete.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/findOneAndDelete.yml
+++ b/data/client-side-encryption/findOneAndDelete.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/findOneAndReplace.json
+++ b/data/client-side-encryption/findOneAndReplace.json
@@ -150,18 +150,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/findOneAndReplace.yml
+++ b/data/client-side-encryption/findOneAndReplace.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/findOneAndUpdate.json
+++ b/data/client-side-encryption/findOneAndUpdate.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/findOneAndUpdate.yml
+++ b/data/client-side-encryption/findOneAndUpdate.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/gcpKMS.json
+++ b/data/client-side-encryption/gcpKMS.json
@@ -144,18 +144,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/gcpKMS.yml
+++ b/data/client-side-encryption/gcpKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/data/client-side-encryption/getMore.json
+++ b/data/client-side-encryption/getMore.json
@@ -182,18 +182,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/getMore.yml
+++ b/data/client-side-encryption/getMore.yml
@@ -38,13 +38,6 @@ tests:
             find: *collection_name
             batchSize: 2
           command_name: find
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/insert.json
+++ b/data/client-side-encryption/insert.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -254,18 +242,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/data/client-side-encryption/insert.yml
+++ b/data/client-side-encryption/insert.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -70,13 +63,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/data/client-side-encryption/keyAltName.json
+++ b/data/client-side-encryption/keyAltName.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/keyAltName.yml
+++ b/data/client-side-encryption/keyAltName.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/localKMS.json
+++ b/data/client-side-encryption/localKMS.json
@@ -117,18 +117,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/localKMS.yml
+++ b/data/client-side-encryption/localKMS.yml
@@ -26,13 +26,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/data/client-side-encryption/localSchema.json
+++ b/data/client-side-encryption/localSchema.json
@@ -139,18 +139,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/localSchema.yml
+++ b/data/client-side-encryption/localSchema.yml
@@ -25,13 +25,6 @@ tests:
           filter: { _id: 1 }
         result: [*doc0]
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/maxWireVersion.json
+++ b/data/client-side-encryption/maxWireVersion.json
@@ -50,6 +50,9 @@
         "autoEncryptOpts": {
           "kmsProviders": {
             "aws": {}
+          },
+          "extraOptions": {
+            "mongocryptdBypassSpawn": true
           }
         }
       },

--- a/data/client-side-encryption/maxWireVersion.yml
+++ b/data/client-side-encryption/maxWireVersion.yml
@@ -12,6 +12,8 @@ tests:
       autoEncryptOpts:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
+        extraOptions:
+          mongocryptdBypassSpawn: true # mongocryptd probably won't be on the path
     operations:
       - name: insertOne
         arguments:

--- a/data/client-side-encryption/missingKey.json
+++ b/data/client-side-encryption/missingKey.json
@@ -143,18 +143,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "different"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "different",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/missingKey.yml
+++ b/data/client-side-encryption/missingKey.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "different"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/replaceOne.json
+++ b/data/client-side-encryption/replaceOne.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/replaceOne.yml
+++ b/data/client-side-encryption/replaceOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/types.json
+++ b/data/client-side-encryption/types.json
@@ -106,18 +106,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -257,18 +245,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -405,18 +381,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -659,18 +623,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -807,18 +759,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -1060,18 +1000,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1217,18 +1145,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1369,18 +1285,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {

--- a/data/client-side-encryption/types.yml
+++ b/data/client-side-encryption/types.yml
@@ -27,13 +27,6 @@ tests:
           filter: { _id: 1 }
         result: *doc0
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
           filter: { _id: 1 }
         result: *doc1
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -123,13 +109,6 @@ tests:
           filter: { _id: 1 }
         result: *doc2
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -197,13 +176,6 @@ tests:
           filter: { _id: 1 }
         result: *doc6
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -245,13 +217,6 @@ tests:
           filter: { _id: 1 }
         result: *doc7
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -319,13 +284,6 @@ tests:
           filter: { _id: 1 }
         result: *doc10
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -367,13 +325,6 @@ tests:
           filter: { _id: 1 }
         result: *doc11
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -415,13 +366,6 @@ tests:
           filter: { _id: 1 }
         result: *doc13
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/updateMany.json
+++ b/data/client-side-encryption/updateMany.json
@@ -167,18 +167,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/updateMany.yml
+++ b/data/client-side-encryption/updateMany.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/data/client-side-encryption/updateOne.json
+++ b/data/client-side-encryption/updateOne.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/data/client-side-encryption/updateOne.yml
+++ b/data/client-side-encryption/updateOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -181,7 +181,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt).
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).
 		ServerAPI(bw.collection.client.serverAPI)
 	if bw.bypassDocumentValidation != nil && *bw.bypassDocumentValidation {
 		op = op.BypassDocumentValidation(*bw.bypassDocumentValidation)
@@ -231,7 +231,7 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt).Hint(hasHint).
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ServerAPI(bw.collection.client.serverAPI)
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
@@ -312,7 +312,7 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt).Hint(hasHint).
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ArrayFilters(hasArrayFilters).ServerAPI(bw.collection.client.serverAPI)
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -169,7 +169,7 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 		Session(sess).CommandMonitor(db.client.monitor).
 		ServerSelector(readSelect).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).ReadConcern(db.readConcern).
-		Crypt(db.client.crypt).ReadPreference(ro.ReadPreference).ServerAPI(db.client.serverAPI), sess, nil
+		Crypt(db.client.cryptFLE).ReadPreference(ro.ReadPreference).ServerAPI(db.client.serverAPI), sess, nil
 }
 
 // RunCommand executes the given command against the database. This function does not obey the Database's read
@@ -273,7 +273,7 @@ func (db *Database) Drop(ctx context.Context) error {
 	op := operation.NewDropDatabase().
 		Session(sess).WriteConcern(wc).CommandMonitor(db.client.monitor).
 		ServerSelector(selector).ClusterClock(db.client.clock).
-		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.crypt).
+		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI)
 
 	err = op.Execute(ctx)
@@ -364,7 +364,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 	op := operation.NewListCollections(filterDoc).
 		Session(sess).ReadPreference(db.readPreference).CommandMonitor(db.client.monitor).
 		ServerSelector(selector).ClusterClock(db.client.clock).
-		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.crypt).
+		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI)
 	if lco.NameOnly != nil {
 		op = op.NameOnly(*lco.NameOnly)
@@ -385,7 +385,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		return nil, replaceErrors(err)
 	}
 
-	bc, err := op.Result(driver.CursorOptions{Crypt: db.client.crypt})
+	bc, err := op.Result(driver.CursorOptions{Crypt: db.client.cryptFLE})
 	if err != nil {
 		closeImplicitSession(sess)
 		return nil, replaceErrors(err)
@@ -478,7 +478,7 @@ func (db *Database) Watch(ctx context.Context, pipeline interface{},
 		registry:       db.registry,
 		streamType:     DatabaseStream,
 		databaseName:   db.Name(),
-		crypt:          db.client.crypt,
+		crypt:          db.client.cryptFLE,
 	}
 	return newChangeStream(ctx, csConfig, pipeline, opts...)
 }
@@ -611,7 +611,7 @@ func (db *Database) executeCreateOperation(ctx context.Context, op *operation.Cr
 		ClusterClock(db.client.clock).
 		Database(db.name).
 		Deployment(db.client.deployment).
-		Crypt(db.client.crypt)
+		Crypt(db.client.cryptFLE)
 
 	return replaceErrors(op.Execute(ctx))
 }

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -726,7 +726,7 @@ func (c *ClientOptions) SetServerAPIOptions(opts *ServerAPIOptions) *ClientOptio
 }
 
 // MergeClientOptions combines the given *ClientOptions into a single *ClientOptions in a last one wins fashion.
-// The specified options are merged with the existing options on the collection, with the specified options taking
+// The specified options are merged with the existing options on the client, with the specified options taking
 // precedence.
 func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 	c := Client()


### PR DESCRIPTION
This adds an internal `MongoClient` to prevent possible deadlocks for clients configured with automatic encryption. The internal client is used for the following operations:
1. Running `listCollections` to determine if a collection has a schema containing encrypted fields.
2. Running a find on the key vault collection to obtain key vault documents (if an external key vault client was not passed in).

An internal client is only created if necessary. The rules are described in the pseudocode here: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#keyvaultclient-metadataclient-and-the-internal-mongoclient

The spec test changes are on the first commit so you can view the range of commits after when reviewing to avoid scrolling.