### PR TITLE
GODRIVER-1848 Only test versioned API tasks against standalone and use noauth

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1556,18 +1556,18 @@ tasks:
       - func: run-aws-auth-test-with-aws-EC2-credentials
       - func: run-aws-ECS-auth-test
 
-  - name: "test-replicaset-versioned-api"
+  - name: "test-standalone-versioned-api"
     tags: ["versioned-api"]
     commands:
       - func: bootstrap-mongo-orchestration
         vars:
-          TOPOLOGY: "replica_set"
+          TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "nossl"
           REQUIRE_API_VERSION: true
       - func: run-versioned-api-test
         vars:
-          TOPOLOGY: "replica_set"
+          TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "nossl"
           REQUIRE_API_VERSION: true
@@ -1578,13 +1578,13 @@ tasks:
       - func: bootstrap-mongo-orchestration
         vars:
           TOPOLOGY: "server"
-          AUTH: "auth"
+          AUTH: "noauth"
           SSL: "nossl"
           ORCHESTRATION_FILE: "versioned-api-testing.json"
       - func: run-versioned-api-test
         vars:
           TOPOLOGY: "server"
-          AUTH: "auth"
+          AUTH: "noauth"
           SSL: "nossl"
 
 axes:


### PR DESCRIPTION
[GODRIVER-1848](https://jira.mongodb.org/browse/GODRIVER-1848)

Fixes the currently broken versioned API tests `test-replicaset-versioned-api` (now `standalone`) and `test-standalone-versioned-api-test-commands`.

The new versioned API tests do not need to be run against replica sets. There is no way to enable `requireAPIVersion` on replica sets through mongo orchestration currently, so we can only test against standalone. And, only the `transaction-handling` spec test needs a replica set, but it will be run in other tasks anyway. 

The separate `test-standalone-versioned-api-test-commands` task does not need to be run with auth, either. Running with auth was causing an error because the [versioned-api-testing.json](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/orchestration/configs/servers/versioned-api-testing.json) orchestration file does not actually set auth.