### PR TITLE
GODRIVER-1849 Add new WaitQueueTimeoutError to wrap context error

### DIFF
--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -162,7 +162,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 			for len(testInfo.backgroundThreadErrors) > 0 {
 				bgErr := <-testInfo.backgroundThreadErrors
 				errs = append(errs, bgErr)
-				if bgErr != nil && strings.ToLower(test.Error.Message) == bgErr.Error() {
+				if bgErr != nil && strings.Contains(bgErr.Error(), strings.ToLower(test.Error.Message)) {
 					erroredCorrectly = true
 					break
 				}

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -62,15 +62,15 @@ func (e ServerSelectionError) Unwrap() error {
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool
 type WaitQueueTimeoutError struct {
-	Message string
 	Wrapped error
 }
 
 func (w WaitQueueTimeoutError) Error() string {
+	errorMsg := "timed out while checking out a connection from connection pool"
 	if w.Wrapped != nil {
-		return fmt.Sprintf("%s: %s", w.Message, w.Wrapped.Error())
+		return fmt.Sprintf("%s: %s", errorMsg, w.Wrapped.Error())
 	}
-	return w.Message
+	return errorMsg
 }
 
 func (w WaitQueueTimeoutError) Unwrap() error {

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -59,3 +59,20 @@ func (e ServerSelectionError) Error() string {
 func (e ServerSelectionError) Unwrap() error {
 	return e.Wrapped
 }
+
+// WaitQueueTimeoutError represents a timeout when requesting a connection from the pool
+type WaitQueueTimeoutError struct {
+	Message string
+	Wrapped error
+}
+
+func (w WaitQueueTimeoutError) Error() string {
+	if w.Wrapped != nil {
+		return fmt.Sprintf("%s: %s", w.Message, w.Wrapped.Error())
+	}
+	return w.Message
+}
+
+func (w WaitQueueTimeoutError) Unwrap() error {
+	return w.Wrapped
+}

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -341,7 +341,6 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 			})
 		}
 		ErrWaitQueueTimeout := WaitQueueTimeoutError{
-			Message: "timed out while checking out a connection from connection pool",
 			Wrapped: ctx.Err(),
 		}
 		return nil, ErrWaitQueueTimeout

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -31,9 +31,6 @@ var ErrConnectionClosed = ConnectionError{ConnectionID: "<closed>", message: "co
 // ErrWrongPool is return when a connection is returned to a pool it doesn't belong to.
 var ErrWrongPool = PoolError("connection does not belong to this pool")
 
-// ErrWaitQueueTimeout is returned when the request to get a connection from the pool timesout when on the wait queue
-var ErrWaitQueueTimeout = PoolError("timed out while checking out a connection from connection pool")
-
 // PoolError is an error returned from a Pool method.
 type PoolError string
 
@@ -342,6 +339,10 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 				Address: p.address.String(),
 				Reason:  event.ReasonTimedOut,
 			})
+		}
+		ErrWaitQueueTimeout := WaitQueueTimeoutError{
+			Message: "timed out while checking out a connection from connection pool",
+			Wrapped: ctx.Err(),
 		}
 		return nil, ErrWaitQueueTimeout
 	}

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -340,10 +340,10 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 				Reason:  event.ReasonTimedOut,
 			})
 		}
-		ErrWaitQueueTimeout := WaitQueueTimeoutError{
+		errWaitQueueTimeout := WaitQueueTimeoutError{
 			Wrapped: ctx.Err(),
 		}
-		return nil, ErrWaitQueueTimeout
+		return nil, errWaitQueueTimeout
 	}
 
 	// This loop is so that we don't end up with more than maxPoolSize connections if p.conns.Maintain runs between


### PR DESCRIPTION
[GODRIVER-1849](https://jira.mongodb.org/browse/GODRIVER-1849)

Adds a new timeout error `WaitQueueTimeoutError` to wrap `ctx.Err()` so that users can detect a timeout error with `errors.Is(err, context.DeadlineExceeded)` or `mongo.IsTimeout()`.