### PR TITLE
GODRIVER-1852 Add commitTransaction error check for timeout

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -116,6 +116,16 @@ func IsTimeout(err error) bool {
 	return false
 }
 
+// IsDeadlineExceededError returns true if err is context deadline exceeded
+func IsDeadlineExceededError(err error) bool {
+	for ; err != nil; err = unwrap(err) {
+		if err == context.DeadlineExceeded {
+			return true
+		}
+	}
+	return false
+}
+
 // unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
 func unwrap(err error) error {
 	u, ok := err.(interface {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -116,16 +116,6 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// IsDeadlineExceededError returns true if err is context deadline exceeded
-func IsDeadlineExceededError(err error) bool {
-	for ; err != nil; err = unwrap(err) {
-		if err == context.DeadlineExceeded {
-			return true
-		}
-	}
-	return false
-}
-
 // unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
 func unwrap(err error) error {
 	u, ok := err.(interface {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -309,6 +309,8 @@ func (s *sessionImpl) CommitTransaction(ctx context.Context) error {
 	}
 
 	err = op.Execute(ctx)
+	// Return error without updating transaction state if it is a timeout, as the transaction has not
+	// actually been committed.
 	if IsTimeout(err) {
 		return replaceErrors(err)
 	}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -307,6 +307,9 @@ func (s *sessionImpl) CommitTransaction(ctx context.Context) error {
 	}
 
 	err = op.Execute(ctx)
+	if err != nil && IsTimeout(err) {
+		return replaceErrors(err)
+	}
 	s.clientSession.Committing = false
 	commitErr := s.clientSession.CommitTransaction()
 

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -209,8 +209,8 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 	CommitLoop:
 		for {
 			err = s.CommitTransaction(ctx)
-			if err == nil {
-				return res, nil
+			if err == nil || IsTimeout(err) {
+				return res, err
 			}
 
 			select {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -209,7 +209,9 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 	CommitLoop:
 		for {
 			err = s.CommitTransaction(ctx)
-			if err == nil || IsTimeout(err) {
+			// End when error is nil (transaction has been committed), or when context deadline is exceeded as retrying
+			// has no chance of success.
+			if err == nil || IsDeadlineExceededError(err) {
 				return res, err
 			}
 

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -292,6 +292,10 @@ func TestConvenientTransactions(t *testing.T) {
 			assert.True(t, IsTimeout(commitErr),
 				"expected timeout error error; got %v", commitErr)
 
+			// assert session state is not Committed
+			clientSession := session.(XSession).ClientSession()
+			assert.False(t, clientSession.TransactionCommitted(), "expected session state to not be Committed")
+
 			// abortTransaction without error
 			abortErr := session.AbortTransaction(context.Background())
 			assert.Nil(t, abortErr, "AbortTransaction error: %v", abortErr)

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -288,7 +288,10 @@ func TestConvenientTransactions(t *testing.T) {
 		client := setupConvenientTransactions(t, options.Client().SetMonitor(monitor))
 		db := client.Database("foo")
 		coll := db.Collection("test")
-		defer coll.Drop(bgCtx)
+		defer func() {
+			_ = coll.Drop(bgCtx)
+		}()
+
 		err := db.RunCommand(bgCtx, bson.D{{"create", coll.Name()}}).Err()
 		assert.Nil(t, err, "error creating collection on server: %v", err)
 


### PR DESCRIPTION
[GODRIVER-1852](https://jira.mongodb.org/browse/GODRIVER-1852)

Adds a check for network timeout after executing the operation within a commitTransaction. Avoids incorrectly updating transaction state to "Committed" in the case of a timeout. 

Adds test to make sure a transaction can still be aborted after a timed-out commitTransaction.