### PR TITLE
GODRIVER-1846 Add bsoncore.Array type with new codec

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -203,15 +203,15 @@ func TestExtJSONEscapeKey(t *testing.T) {
 	}
 }
 
-type BSONDocumentArray struct {
-	Array []D `bson:"array"`
-}
-
-type BSONArray struct {
-	Array bsoncore.Array `bson:"array"`
-}
-
 func TestBsoncoreArray(t *testing.T) {
+	type BSONDocumentArray struct {
+		Array []D `bson:"array"`
+	}
+
+	type BSONArray struct {
+		Array bsoncore.Array `bson:"array"`
+	}
+
 	bda := BSONDocumentArray{
 		Array: []D{
 			{{"x", 1}},

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -202,3 +202,34 @@ func TestExtJSONEscapeKey(t *testing.T) {
 		t.Errorf("Unmarshaled documents do not match. got %v; want %v", got, doc)
 	}
 }
+
+type BSONDocumentArray struct {
+	Array []D `bson:"array"`
+}
+
+type BSONArray struct {
+	Array bsoncore.Array `bson:"array"`
+}
+
+func TestBsoncoreArray(t *testing.T) {
+	bda := BSONDocumentArray{
+		Array: []D{
+			{{"x", 1}},
+			{{"x", 2}},
+			{{"x", 3}},
+		},
+	}
+
+	expectedBSON, err := Marshal(bda)
+	assert.Nil(t, err, "Marshal bsoncore.Document array error: %v", err)
+
+	var ba BSONArray
+	err = Unmarshal(expectedBSON, &ba)
+	assert.Nil(t, err, "Unmarshal error: %v", err)
+
+	actualBSON, err := Marshal(ba)
+	assert.Nil(t, err, "Marshal bsoncore.Array error: %v", err)
+
+	assert.Equal(t, expectedBSON, actualBSON,
+		"expected BSON to be %v after Marshalling again; got %v", expectedBSON, actualBSON)
+}

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
@@ -232,4 +233,8 @@ func TestBsoncoreArray(t *testing.T) {
 
 	assert.Equal(t, expectedBSON, actualBSON,
 		"expected BSON to be %v after Marshalling again; got %v", expectedBSON, actualBSON)
+
+	doc := bsoncore.Document(actualBSON)
+	v := doc.Lookup("array")
+	assert.Equal(t, bsontype.Array, v.Type, "expected type array, got %v", v.Type)
 }

--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -1,0 +1,52 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncodec
+
+import (
+	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// ArrayCodec is the Codec used for bsoncore.Array values.
+type ArrayCodec struct{}
+
+var defaultArrayCodec = NewArrayCodec()
+
+// NewArrayCodec returns an ArrayCodec.
+func NewArrayCodec() *ArrayCodec {
+	return &ArrayCodec{}
+}
+
+// EncodeValue is the ValueEncoder for bsoncore.Array values.
+func (ac *ArrayCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Type() != tCoreArray {
+		return ValueEncoderError{Name: "CoreArrayEncodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
+	}
+
+	arr := val.Interface().(bsoncore.Array)
+
+	return bsonrw.Copier{}.CopyArrayFromBytes(vw, arr)
+}
+
+// DecodeValue is the ValueDecoder for bsoncore.Array values.
+func (ac *ArrayCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Type() != tCoreArray {
+		return ValueDecoderError{Name: "CoreArrayDecodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
+	}
+
+	if val.IsNil() {
+		val.Set(reflect.MakeSlice(val.Type(), 0, 0))
+	}
+
+	val.SetLen(0)
+
+	_, arr, err := bsonrw.Copier{}.AppendValueBytes(val.Interface().(bsoncore.Array), vr)
+	val.Set(reflect.ValueOf(arr))
+	return err
+}

--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -44,7 +44,7 @@ func (ac *ArrayCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val r
 	}
 
 	val.SetLen(0)
-	_, arr, err := bsonrw.Copier{}.AppendValueBytes(val.Interface().(bsoncore.Array), vr)
+	arr, err := bsonrw.Copier{}.AppendArrayBytes(val.Interface().(bsoncore.Array), vr)
 	val.Set(reflect.ValueOf(arr))
 	return err
 }

--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -30,7 +30,6 @@ func (ac *ArrayCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val r
 	}
 
 	arr := val.Interface().(bsoncore.Array)
-
 	return bsonrw.Copier{}.CopyArrayFromBytes(vw, arr)
 }
 
@@ -45,7 +44,6 @@ func (ac *ArrayCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val r
 	}
 
 	val.SetLen(0)
-
 	_, arr, err := bsonrw.Copier{}.AppendValueBytes(val.Interface().(bsoncore.Array), vr)
 	val.Set(reflect.ValueOf(arr))
 	return err

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -80,12 +80,12 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 		RegisterTypeDecoder(tByteSlice, defaultByteSliceCodec).
 		RegisterTypeDecoder(tTime, defaultTimeCodec).
 		RegisterTypeDecoder(tEmpty, defaultEmptyInterfaceCodec).
+		RegisterTypeDecoder(tCoreArray, defaultArrayCodec).
 		RegisterTypeDecoder(tOID, decodeAdapter{dvd.ObjectIDDecodeValue, dvd.objectIDDecodeType}).
 		RegisterTypeDecoder(tDecimal, decodeAdapter{dvd.Decimal128DecodeValue, dvd.decimal128DecodeType}).
 		RegisterTypeDecoder(tJSONNumber, decodeAdapter{dvd.JSONNumberDecodeValue, dvd.jsonNumberDecodeType}).
 		RegisterTypeDecoder(tURL, decodeAdapter{dvd.URLDecodeValue, dvd.urlDecodeType}).
 		RegisterTypeDecoder(tCoreDocument, ValueDecoderFunc(dvd.CoreDocumentDecodeValue)).
-		RegisterTypeDecoder(tCoreArray, ValueDecoderFunc(dvd.CoreArrayDecodeValue)).
 		RegisterTypeDecoder(tCodeWithScope, decodeAdapter{dvd.CodeWithScopeDecodeValue, dvd.codeWithScopeDecodeType}).
 		RegisterDefaultDecoder(reflect.Bool, decodeAdapter{dvd.BooleanDecodeValue, dvd.booleanDecodeType}).
 		RegisterDefaultDecoder(reflect.Int, intDecoder).
@@ -1562,23 +1562,6 @@ func (DefaultValueDecoders) CoreDocumentDecodeValue(dc DecodeContext, vr bsonrw.
 
 	cdoc, err := bsonrw.Copier{}.AppendDocumentBytes(val.Interface().(bsoncore.Document), vr)
 	val.Set(reflect.ValueOf(cdoc))
-	return err
-}
-
-// CoreArrayDecodeValue is the ValueDecoderFunc for bsoncore.Array.
-func (DefaultValueDecoders) CoreArrayDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
-	if !val.CanSet() || val.Type() != tCoreArray {
-		return ValueDecoderError{Name: "CoreArrayDecodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
-	}
-
-	if val.IsNil() {
-		val.Set(reflect.MakeSlice(val.Type(), 0, 0))
-	}
-
-	val.SetLen(0)
-
-	_, arr, err := bsonrw.Copier{}.AppendValueBytes(val.Interface().(bsoncore.Array), vr)
-	val.Set(reflect.ValueOf(arr))
 	return err
 }
 

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -2290,6 +2290,36 @@ func TestDefaultValueDecoders(t *testing.T) {
 				},
 			},
 		},
+		{
+			"CoreArrayDecodeValue",
+			defaultArrayCodec,
+			[]subtest{
+				{
+					"wrong type",
+					wrong,
+					nil,
+					&bsonrwtest.ValueReaderWriter{},
+					bsonrwtest.Nothing,
+					ValueDecoderError{
+						Name:     "CoreArrayDecodeValue",
+						Types:    []reflect.Type{tCoreArray},
+						Received: reflect.ValueOf(wrong),
+					},
+				},
+				{
+					"*bsoncore.Array is nil",
+					(*bsoncore.Array)(nil),
+					nil,
+					nil,
+					bsonrwtest.Nothing,
+					ValueDecoderError{
+						Name:     "CoreArrayDecodeValue",
+						Types:    []reflect.Type{tCoreArray},
+						Received: reflect.ValueOf((*bsoncore.Array)(nil)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -86,6 +86,7 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		RegisterTypeEncoder(tMinKey, ValueEncoderFunc(dve.MinKeyEncodeValue)).
 		RegisterTypeEncoder(tMaxKey, ValueEncoderFunc(dve.MaxKeyEncodeValue)).
 		RegisterTypeEncoder(tCoreDocument, ValueEncoderFunc(dve.CoreDocumentEncodeValue)).
+		RegisterTypeEncoder(tCoreArray, ValueEncoderFunc(dve.CoreArrayEncodeValue)).
 		RegisterTypeEncoder(tCodeWithScope, ValueEncoderFunc(dve.CodeWithScopeEncodeValue)).
 		RegisterDefaultEncoder(reflect.Bool, ValueEncoderFunc(dve.BooleanEncodeValue)).
 		RegisterDefaultEncoder(reflect.Int, ValueEncoderFunc(dve.IntEncodeValue)).
@@ -723,6 +724,17 @@ func (DefaultValueEncoders) CoreDocumentEncodeValue(ec EncodeContext, vw bsonrw.
 	cdoc := val.Interface().(bsoncore.Document)
 
 	return bsonrw.Copier{}.CopyDocumentFromBytes(vw, cdoc)
+}
+
+// CoreArrayEncodeValue is the ValueEncoderFunc for bsoncore.Array.
+func (DefaultValueEncoders) CoreArrayEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Type() != tCoreArray {
+		return ValueEncoderError{Name: "CoreArrayEncodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
+	}
+
+	arr := val.Interface().(bsoncore.Array)
+
+	return bsonrw.Copier{}.CopyArrayFromBytes(vw, arr)
 }
 
 // CodeWithScopeEncodeValue is the ValueEncoderFunc for CodeWithScope.

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -70,6 +70,7 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		RegisterTypeEncoder(tByteSlice, defaultByteSliceCodec).
 		RegisterTypeEncoder(tTime, defaultTimeCodec).
 		RegisterTypeEncoder(tEmpty, defaultEmptyInterfaceCodec).
+		RegisterTypeEncoder(tCoreArray, defaultArrayCodec).
 		RegisterTypeEncoder(tOID, ValueEncoderFunc(dve.ObjectIDEncodeValue)).
 		RegisterTypeEncoder(tDecimal, ValueEncoderFunc(dve.Decimal128EncodeValue)).
 		RegisterTypeEncoder(tJSONNumber, ValueEncoderFunc(dve.JSONNumberEncodeValue)).
@@ -86,7 +87,6 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 		RegisterTypeEncoder(tMinKey, ValueEncoderFunc(dve.MinKeyEncodeValue)).
 		RegisterTypeEncoder(tMaxKey, ValueEncoderFunc(dve.MaxKeyEncodeValue)).
 		RegisterTypeEncoder(tCoreDocument, ValueEncoderFunc(dve.CoreDocumentEncodeValue)).
-		RegisterTypeEncoder(tCoreArray, ValueEncoderFunc(dve.CoreArrayEncodeValue)).
 		RegisterTypeEncoder(tCodeWithScope, ValueEncoderFunc(dve.CodeWithScopeEncodeValue)).
 		RegisterDefaultEncoder(reflect.Bool, ValueEncoderFunc(dve.BooleanEncodeValue)).
 		RegisterDefaultEncoder(reflect.Int, ValueEncoderFunc(dve.IntEncodeValue)).
@@ -724,17 +724,6 @@ func (DefaultValueEncoders) CoreDocumentEncodeValue(ec EncodeContext, vw bsonrw.
 	cdoc := val.Interface().(bsoncore.Document)
 
 	return bsonrw.Copier{}.CopyDocumentFromBytes(vw, cdoc)
-}
-
-// CoreArrayEncodeValue is the ValueEncoderFunc for bsoncore.Array.
-func (DefaultValueEncoders) CoreArrayEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
-	if !val.IsValid() || val.Type() != tCoreArray {
-		return ValueEncoderError{Name: "CoreArrayEncodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
-	}
-
-	arr := val.Interface().(bsoncore.Array)
-
-	return bsonrw.Copier{}.CopyArrayFromBytes(vw, arr)
 }
 
 // CodeWithScopeEncodeValue is the ValueEncoderFunc for CodeWithScope.

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -1140,6 +1140,53 @@ func TestDefaultValueEncoders(t *testing.T) {
 				},
 			},
 		},
+		{
+			"CoreArrayEncodeValue",
+			defaultArrayCodec,
+			[]subtest{
+				{
+					"wrong type",
+					wrong,
+					nil,
+					nil,
+					bsonrwtest.Nothing,
+					ValueEncoderError{
+						Name:     "CoreArrayEncodeValue",
+						Types:    []reflect.Type{tCoreArray},
+						Received: reflect.ValueOf(wrong),
+					},
+				},
+
+				{
+					"WriteArray Error",
+					bsoncore.Array{},
+					nil,
+					&bsonrwtest.ValueReaderWriter{Err: errors.New("wa error"), ErrAfter: bsonrwtest.WriteArray},
+					bsonrwtest.WriteArray,
+					errors.New("wa error"),
+				},
+				{
+					"WriteArrayElement Error",
+					bsoncore.Array(buildDocumentArray(func(doc []byte) []byte {
+						return bsoncore.AppendNullElement(nil, "foo")
+					})),
+					nil,
+					&bsonrwtest.ValueReaderWriter{Err: errors.New("wae error"), ErrAfter: bsonrwtest.WriteArrayElement},
+					bsonrwtest.WriteArrayElement,
+					errors.New("wae error"),
+				},
+				{
+					"encodeValue error",
+					bsoncore.Array(buildDocumentArray(func(doc []byte) []byte {
+						return bsoncore.AppendNullElement(nil, "foo")
+					})),
+					nil,
+					&bsonrwtest.ValueReaderWriter{Err: errors.New("ev error"), ErrAfter: bsonrwtest.WriteNull},
+					bsonrwtest.WriteNull,
+					errors.New("ev error"),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bson/bsoncodec/types.go
+++ b/bson/bsoncodec/types.go
@@ -79,3 +79,4 @@ var tA = reflect.TypeOf(primitive.A{})
 var tE = reflect.TypeOf(primitive.E{})
 
 var tCoreDocument = reflect.TypeOf(bsoncore.Document{})
+var tCoreArray = reflect.TypeOf(bsoncore.Array{})

--- a/bson/bsonrw/copier.go
+++ b/bson/bsonrw/copier.go
@@ -172,6 +172,23 @@ func (c Copier) AppendDocumentBytes(dst []byte, src ValueReader) ([]byte, error)
 	return dst, err
 }
 
+// AppendArrayBytes copies an array from the ValueReader to dst.
+func (c Copier) AppendArrayBytes(dst []byte, src ValueReader) ([]byte, error) {
+	if br, ok := src.(BytesReader); ok {
+		_, dst, err := br.ReadValueBytes(dst)
+		return dst, err
+	}
+
+	vw := vwPool.Get().(*valueWriter)
+	defer vwPool.Put(vw)
+
+	vw.reset(dst)
+
+	err := c.copyArray(vw, src)
+	dst = vw.buf
+	return dst, err
+}
+
 // CopyValueFromBytes will write the value represtend by t and src to dst.
 func (c Copier) CopyValueFromBytes(dst ValueWriter, t bsontype.Type, src []byte) error {
 	if wvb, ok := dst.(BytesWriter); ok {

--- a/bson/raw_test.go
+++ b/bson/raw_test.go
@@ -47,7 +47,7 @@ func TestRaw(t *testing.T) {
 			}
 		})
 		t.Run("InvalidLength", func(t *testing.T) {
-			want := bsoncore.DocumentValidationError("document length exceeds available bytes. length=200 remainingBytes=5")
+			want := bsoncore.ValidationError("document length exceeds available bytes. length=200 remainingBytes=5")
 			r := make(Raw, 5)
 			binary.LittleEndian.PutUint32(r[0:4], 200)
 			got := r.Validate()

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -429,34 +429,3 @@ func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
 		})
 	}
 }
-
-type BSONDocumentArray struct {
-	Array []D `bson:"array"`
-}
-
-type BSONArray struct {
-	Array bsoncore.Array `bson:"array"`
-}
-
-func TestBsoncoreArrayMarshal(t *testing.T) {
-	bda := BSONDocumentArray{
-		Array: []D{
-			D{{"x", 1}},
-			D{{"x", 2}},
-			D{{"x", 3}},
-		},
-	}
-
-	expectedBSON, err := Marshal(bda)
-	assert.Nil(t, err, "Marshal bsoncore.Document array error: %v", err)
-
-	var ba BSONArray
-	err = Unmarshal(expectedBSON, &ba)
-	assert.Nil(t, err, "Unmarshal error: %v", err)
-
-	actualBSON, err := Marshal(ba)
-	assert.Nil(t, err, "Marshal bsoncore.Array error: %v", err)
-
-	assert.Equal(t, expectedBSON, actualBSON,
-		"expected BSON to be %v after Marshalling again; got %v", expectedBSON, actualBSON)
-}

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -429,3 +429,34 @@ func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
 		})
 	}
 }
+
+type BSONDocumentArray struct {
+	Array []D `bson:"array"`
+}
+
+type BSONArray struct {
+	Array bsoncore.Array `bson:"array"`
+}
+
+func TestBsoncoreArrayMarshal(t *testing.T) {
+	bda := BSONDocumentArray{
+		Array: []D{
+			D{{"x", 1}},
+			D{{"x", 2}},
+			D{{"x", 3}},
+		},
+	}
+
+	expectedBSON, err := Marshal(bda)
+	assert.Nil(t, err, "Marshal bsoncore.Document array error: %v", err)
+
+	var ba BSONArray
+	err = Unmarshal(expectedBSON, &ba)
+	assert.Nil(t, err, "Unmarshal error: %v", err)
+
+	actualBSON, err := Marshal(ba)
+	assert.Nil(t, err, "Marshal bsoncore.Array error: %v", err)
+
+	assert.Equal(t, expectedBSON, actualBSON,
+		"expected BSON to be %v after Marshalling again; got %v", expectedBSON, actualBSON)
+}

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -19,42 +19,13 @@ type Array []byte
 // NewArrayFromReader reads an array from r. This function will only validate the length is
 // correct and that the array ends with a null byte.
 func NewArrayFromReader(r io.Reader) (Array, error) {
-	if r == nil {
-		return nil, ErrNilReader
-	}
-
-	var lengthBytes [4]byte
-
-	// ReadFull guarantees that we will have read at least len(lengthBytes) if err == nil
-	_, err := io.ReadFull(r, lengthBytes[:])
-	if err != nil {
-		return nil, err
-	}
-
-	length, _, _ := readi32(lengthBytes[:]) // ignore ok since we always have enough bytes to read a length
-	if length < 0 {
-		return nil, ErrInvalidLength
-	}
-	array := make([]byte, length)
-
-	copy(array, lengthBytes[:])
-
-	_, err = io.ReadFull(r, array[4:])
-	if err != nil {
-		return nil, err
-	}
-
-	if array[length-1] != 0x00 {
-		return nil, ErrMissingNull
-	}
-
-	return array, nil
+	return newBufferFromReader(r)
 }
 
 // Index searches for and retrieves the element at the given index. This method will panic if
 // the array is invalid or if the index is out of bounds.
 func (a Array) Index(index uint) Element {
-	elem, err := a.IndexErr(index)
+	elem, err := indexErr(a, index)
 	if err != nil {
 		panic(err)
 	}
@@ -63,28 +34,7 @@ func (a Array) Index(index uint) Element {
 
 // IndexErr searches for and retrieves the element at the given index.
 func (a Array) IndexErr(index uint) (Element, error) {
-	length, rem, ok := ReadLength(a)
-	if !ok {
-		return nil, NewInsufficientBytesError(a, rem)
-	}
-
-	length -= 4
-
-	var current uint
-	var elem Element
-	for length > 1 {
-		elem, rem, ok = ReadElement(rem)
-		length -= int32(len(elem))
-		if !ok {
-			return nil, NewInsufficientBytesError(a, rem)
-		}
-		if current != index {
-			current++
-			continue
-		}
-		return elem, nil
-	}
-	return nil, ErrOutOfBounds
+	return indexErr(a, index)
 }
 
 // DebugString outputs a human readable version of Array. It will attempt to stringify the
@@ -96,7 +46,7 @@ func (a Array) DebugString() string {
 	var buf bytes.Buffer
 	buf.WriteString("Array")
 	length, rem, _ := ReadLength(a) // We know we have enough bytes to read the length
-	buf.WriteByte('[')
+	buf.WriteByte('(')
 	buf.WriteString(strconv.Itoa(int(length)))
 	length -= 4
 	buf.WriteString(")[")
@@ -149,58 +99,11 @@ func (a Array) String() string {
 	return buf.String()
 }
 
-// Elements returns this array as a slice of elements. The returned slice will contain valid
-// elements. If the array is not valid, the elements up to the invalid point will be returned
-// along with an error.
-func (a Array) Elements() ([]Element, error) {
-	length, rem, ok := ReadLength(a)
-	if !ok {
-		return nil, NewInsufficientBytesError(a, rem)
-	}
-
-	length -= 4
-
-	var elem Element
-	var elems []Element
-	for length > 1 {
-		elem, rem, ok = ReadElement(rem)
-		length -= int32(len(elem))
-		if !ok {
-			return elems, NewInsufficientBytesError(a, rem)
-		}
-		if err := elem.Validate(); err != nil {
-			return elems, err
-		}
-		elems = append(elems, elem)
-	}
-	return elems, nil
-}
-
 // Values returns this array as a slice of values. The returned slice will contain valid values.
 // If the array is not valid, the values up to the invalid point will be returned along with an
 // error.
 func (a Array) Values() ([]Value, error) {
-	length, rem, ok := ReadLength(a)
-	if !ok {
-		return nil, NewInsufficientBytesError(a, rem)
-	}
-
-	length -= 4
-
-	var elem Element
-	var vals []Value
-	for length > 1 {
-		elem, rem, ok = ReadElement(rem)
-		length -= int32(len(elem))
-		if !ok {
-			return vals, NewInsufficientBytesError(a, rem)
-		}
-		if err := elem.Value().Validate(); err != nil {
-			return vals, err
-		}
-		vals = append(vals, elem.Value())
-	}
-	return vals, nil
+	return values(a)
 }
 
 // Validate validates the array and ensures the elements contained within are valid.
@@ -210,7 +113,7 @@ func (a Array) Validate() error {
 		return NewInsufficientBytesError(a, rem)
 	}
 	if int(length) > len(a) {
-		return a.lengtherror(int(length), len(a))
+		return lengthError("array", int(length), len(a))
 	}
 	if a[length-1] != 0x00 {
 		return ErrMissingNull
@@ -235,8 +138,4 @@ func (a Array) Validate() error {
 		return ErrMissingNull
 	}
 	return nil
-}
-
-func (Array) lengtherror(length, rem int) error {
-	return DocumentValidationError(fmt.Sprintf("array length exceeds available bytes. length=%d remainingBytes=%d", length, rem))
 }

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -28,19 +28,20 @@ func NewArrayFromReader(r io.Reader) (Array, error) {
 	return newBufferFromReader(r)
 }
 
-// Index searches for and retrieves the element at the given index. This method will panic if
+// Index searches for and retrieves the value at the given index. This method will panic if
 // the array is invalid or if the index is out of bounds.
-func (a Array) Index(index uint) Element {
-	elem, err := indexErr(a, index)
+func (a Array) Index(index uint) Value {
+	value, err := a.IndexErr(index)
 	if err != nil {
 		panic(err)
 	}
-	return elem
+	return value
 }
 
-// IndexErr searches for and retrieves the element at the given index.
-func (a Array) IndexErr(index uint) (Element, error) {
-	return indexErr(a, index)
+// IndexErr searches for and retrieves the value at the given index.
+func (a Array) IndexErr(index uint) (Value, error) {
+	elem, err := indexErr(a, index)
+	return elem.Value(), err
 }
 
 // DebugString outputs a human readable version of Array. It will attempt to stringify the
@@ -65,7 +66,10 @@ func (a Array) DebugString() string {
 			buf.WriteString(fmt.Sprintf("<malformed (%d)>", length))
 			break
 		}
-		fmt.Fprintf(&buf, "%s ", elem.DebugString())
+		fmt.Fprintf(&buf, "%s", elem.Value().DebugString())
+		if length != 1 {
+			buf.WriteByte(',')
+		}
 	}
 	buf.WriteByte(']')
 
@@ -87,18 +91,16 @@ func (a Array) String() string {
 
 	var elem Element
 	var ok bool
-	first := true
 	for length > 1 {
-		if !first {
-			buf.WriteByte(',')
-		}
 		elem, rem, ok = ReadElement(rem)
 		length -= int32(len(elem))
 		if !ok {
 			return ""
 		}
-		fmt.Fprintf(&buf, "%s", elem.String())
-		first = false
+		fmt.Fprintf(&buf, "%s", elem.Value().String())
+		if length != 1 {
+			buf.WriteByte(',')
+		}
 	}
 	buf.WriteByte(']')
 

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -101,12 +101,19 @@ func (a Array) String() string {
 			return ""
 		}
 		fmt.Fprintf(&buf, "%s", elem.Value().String())
-		if length != 1 {
+		if length < 1 {
+			return ""
+		} else if length == 1 {
+			break
+		} else {
 			buf.WriteByte(',')
 		}
 	}
-	buf.WriteByte(']')
+	if length != 1 { // Missing final null byte or inaccurate length
+		return ""
+	}
 
+	buf.WriteByte(']')
 	return buf.String()
 }
 

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -101,11 +101,7 @@ func (a Array) String() string {
 			return ""
 		}
 		fmt.Fprintf(&buf, "%s", elem.Value().String())
-		if length < 1 {
-			return ""
-		} else if length == 1 {
-			break
-		} else {
+		if length > 1 {
 			buf.WriteByte(',')
 		}
 	}

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -1,0 +1,242 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncore
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// Array is a raw bytes representation of a BSON array.
+type Array []byte
+
+// NewArrayFromReader reads an array from r. This function will only validate the length is
+// correct and that the array ends with a null byte.
+func NewArrayFromReader(r io.Reader) (Array, error) {
+	if r == nil {
+		return nil, ErrNilReader
+	}
+
+	var lengthBytes [4]byte
+
+	// ReadFull guarantees that we will have read at least len(lengthBytes) if err == nil
+	_, err := io.ReadFull(r, lengthBytes[:])
+	if err != nil {
+		return nil, err
+	}
+
+	length, _, _ := readi32(lengthBytes[:]) // ignore ok since we always have enough bytes to read a length
+	if length < 0 {
+		return nil, ErrInvalidLength
+	}
+	array := make([]byte, length)
+
+	copy(array, lengthBytes[:])
+
+	_, err = io.ReadFull(r, array[4:])
+	if err != nil {
+		return nil, err
+	}
+
+	if array[length-1] != 0x00 {
+		return nil, ErrMissingNull
+	}
+
+	return array, nil
+}
+
+// Index searches for and retrieves the element at the given index. This method will panic if
+// the array is invalid or if the index is out of bounds.
+func (a Array) Index(index uint) Element {
+	elem, err := a.IndexErr(index)
+	if err != nil {
+		panic(err)
+	}
+	return elem
+}
+
+// IndexErr searches for and retrieves the element at the given index.
+func (a Array) IndexErr(index uint) (Element, error) {
+	length, rem, ok := ReadLength(a)
+	if !ok {
+		return nil, NewInsufficientBytesError(a, rem)
+	}
+
+	length -= 4
+
+	var current uint
+	var elem Element
+	for length > 1 {
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			return nil, NewInsufficientBytesError(a, rem)
+		}
+		if current != index {
+			current++
+			continue
+		}
+		return elem, nil
+	}
+	return nil, ErrOutOfBounds
+}
+
+// DebugString outputs a human readable version of Array. It will attempt to stringify the
+// valid components of the array even if the entire array is not valid.
+func (a Array) DebugString() string {
+	if len(a) < 5 {
+		return "<malformed>"
+	}
+	var buf bytes.Buffer
+	buf.WriteString("Array")
+	length, rem, _ := ReadLength(a) // We know we have enough bytes to read the length
+	buf.WriteByte('[')
+	buf.WriteString(strconv.Itoa(int(length)))
+	length -= 4
+	buf.WriteString(")[")
+	var elem Element
+	var ok bool
+	for length > 1 {
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			buf.WriteString(fmt.Sprintf("<malformed (%d)>", length))
+			break
+		}
+		fmt.Fprintf(&buf, "%s ", elem.DebugString())
+	}
+	buf.WriteByte(']')
+
+	return buf.String()
+}
+
+// String outputs an ExtendedJSON version of Array. If the Array is not valid, this method
+// returns an empty string.
+func (a Array) String() string {
+	if len(a) < 5 {
+		return ""
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+
+	length, rem, _ := ReadLength(a) // We know we have enough bytes to read the length
+
+	length -= 4
+
+	var elem Element
+	var ok bool
+	first := true
+	for length > 1 {
+		if !first {
+			buf.WriteByte(',')
+		}
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			return ""
+		}
+		fmt.Fprintf(&buf, "%s", elem.String())
+		first = false
+	}
+	buf.WriteByte(']')
+
+	return buf.String()
+}
+
+// Elements returns this array as a slice of elements. The returned slice will contain valid
+// elements. If the array is not valid, the elements up to the invalid point will be returned
+// along with an error.
+func (a Array) Elements() ([]Element, error) {
+	length, rem, ok := ReadLength(a)
+	if !ok {
+		return nil, NewInsufficientBytesError(a, rem)
+	}
+
+	length -= 4
+
+	var elem Element
+	var elems []Element
+	for length > 1 {
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			return elems, NewInsufficientBytesError(a, rem)
+		}
+		if err := elem.Validate(); err != nil {
+			return elems, err
+		}
+		elems = append(elems, elem)
+	}
+	return elems, nil
+}
+
+// Values returns this array as a slice of values. The returned slice will contain valid values.
+// If the array is not valid, the values up to the invalid point will be returned along with an
+// error.
+func (a Array) Values() ([]Value, error) {
+	length, rem, ok := ReadLength(a)
+	if !ok {
+		return nil, NewInsufficientBytesError(a, rem)
+	}
+
+	length -= 4
+
+	var elem Element
+	var vals []Value
+	for length > 1 {
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			return vals, NewInsufficientBytesError(a, rem)
+		}
+		if err := elem.Value().Validate(); err != nil {
+			return vals, err
+		}
+		vals = append(vals, elem.Value())
+	}
+	return vals, nil
+}
+
+// Validate validates the array and ensures the elements contained within are valid.
+func (a Array) Validate() error {
+	length, rem, ok := ReadLength(a)
+	if !ok {
+		return NewInsufficientBytesError(a, rem)
+	}
+	if int(length) > len(a) {
+		return a.lengtherror(int(length), len(a))
+	}
+	if a[length-1] != 0x00 {
+		return ErrMissingNull
+	}
+
+	length -= 4
+	var elem Element
+
+	for length > 1 {
+		elem, rem, ok = ReadElement(rem)
+		length -= int32(len(elem))
+		if !ok {
+			return NewInsufficientBytesError(a, rem)
+		}
+		err := elem.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(rem) < 1 || rem[0] != 0x00 {
+		return ErrMissingNull
+	}
+	return nil
+}
+
+func (Array) lengtherror(length, rem int) error {
+	return DocumentValidationError(fmt.Sprintf("array length exceeds available bytes. length=%d remainingBytes=%d", length, rem))
+}

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -41,6 +41,9 @@ func (a Array) Index(index uint) Value {
 // IndexErr searches for and retrieves the value at the given index.
 func (a Array) IndexErr(index uint) (Value, error) {
 	elem, err := indexErr(a, index)
+	if err != nil {
+		return Value{}, err
+	}
 	return elem.Value(), err
 }
 

--- a/x/bsonx/bsoncore/array_test.go
+++ b/x/bsonx/bsoncore/array_test.go
@@ -1,0 +1,239 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsoncore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestArray(t *testing.T) {
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("TooShort", func(t *testing.T) {
+			want := NewInsufficientBytesError(nil, nil)
+			got := Array{'\x00', '\x00'}.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
+		t.Run("InvalidLength", func(t *testing.T) {
+			want := Array{}.lengtherror(200, 5)
+			r := make(Array, 5)
+			binary.LittleEndian.PutUint32(r[0:4], 200)
+			got := r.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
+		t.Run("Invalid Element", func(t *testing.T) {
+			want := NewInsufficientBytesError(nil, nil)
+			r := make(Array, 9)
+			binary.LittleEndian.PutUint32(r[0:4], 9)
+			r[4], r[5], r[6], r[7], r[8] = 0x02, 'f', 'o', 'o', 0x00
+			got := r.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
+		t.Run("Missing Null Terminator", func(t *testing.T) {
+			want := ErrMissingNull
+			r := make(Array, 8)
+			binary.LittleEndian.PutUint32(r[0:4], 8)
+			r[4], r[5], r[6], r[7] = 0x0A, 'f', 'o', 'o'
+			got := r.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
+		testCases := []struct {
+			name string
+			r    Array
+			want error
+		}{
+			{"null", Array{'\x08', '\x00', '\x00', '\x00', '\x0A', 'x', '\x00', '\x00'}, nil},
+			{"subarray",
+				Array{
+					'\x15', '\x00', '\x00', '\x00',
+					'\x03',
+					'f', 'o', 'o', '\x00',
+					'\x0B', '\x00', '\x00', '\x00', '\x0A', 'a', '\x00',
+					'\x0A', 'b', '\x00', '\x00', '\x00',
+				},
+				nil,
+			},
+			{"array",
+				Array{
+					'\x15', '\x00', '\x00', '\x00',
+					'\x04',
+					'f', 'o', 'o', '\x00',
+					'\x0B', '\x00', '\x00', '\x00', '\x0A', '1', '\x00',
+					'\x0A', '2', '\x00', '\x00', '\x00',
+				},
+				nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := tc.r.Validate()
+				if !compareErrors(got, tc.want) {
+					t.Errorf("Returned error does not match. got %v; want %v", got, tc.want)
+				}
+			})
+		}
+	})
+	t.Run("Index", func(t *testing.T) {
+		t.Run("Out of bounds", func(t *testing.T) {
+			rdr := Array{0xe, 0x0, 0x0, 0x0, 0xa, 0x78, 0x0, 0xa, 0x79, 0x0, 0xa, 0x7a, 0x0, 0x0}
+			_, err := rdr.IndexErr(3)
+			if err != ErrOutOfBounds {
+				t.Errorf("Out of bounds should be returned when accessing element beyond end of Array. got %v; want %v", err, ErrOutOfBounds)
+			}
+		})
+		t.Run("Validation Error", func(t *testing.T) {
+			rdr := Array{0x07, 0x00, 0x00, 0x00, 0x00}
+			_, got := rdr.IndexErr(1)
+			want := NewInsufficientBytesError(nil, nil)
+			if !compareErrors(got, want) {
+				t.Errorf("Did not receive expected error. got %v; want %v", got, want)
+			}
+		})
+		testCases := []struct {
+			name  string
+			rdr   Array
+			index uint
+			want  Element
+		}{
+			{"first",
+				Array{0xe, 0x0, 0x0, 0x0, 0xa, 0x78, 0x0, 0xa, 0x79, 0x0, 0xa, 0x7a, 0x0, 0x0},
+				0, Element{0x0a, 0x78, 0x00},
+			},
+			{"second",
+				Array{0xe, 0x0, 0x0, 0x0, 0xa, 0x78, 0x0, 0xa, 0x79, 0x0, 0xa, 0x7a, 0x0, 0x0},
+				1, Element{0x0a, 0x79, 0x00},
+			},
+			{"third",
+				Array{0xe, 0x0, 0x0, 0x0, 0xa, 0x78, 0x0, 0xa, 0x79, 0x0, 0xa, 0x7a, 0x0, 0x0},
+				2, Element{0x0a, 0x7a, 0x00},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Run("IndexErr", func(t *testing.T) {
+					got, err := tc.rdr.IndexErr(tc.index)
+					if err != nil {
+						t.Errorf("Unexpected error from IndexErr: %s", err)
+					}
+					if diff := cmp.Diff(got, tc.want); diff != "" {
+						t.Errorf("Arrays differ: (-got +want)\n%s", diff)
+					}
+				})
+				t.Run("Index", func(t *testing.T) {
+					defer func() {
+						if err := recover(); err != nil {
+							t.Errorf("Unexpected error: %v", err)
+						}
+					}()
+					got := tc.rdr.Index(tc.index)
+					if diff := cmp.Diff(got, tc.want); diff != "" {
+						t.Errorf("Arrays differ: (-got +want)\n%s", diff)
+					}
+				})
+			})
+		}
+	})
+	t.Run("NewArrayFromReader", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			ioReader io.Reader
+			arr      Array
+			err      error
+		}{
+			{
+				"nil reader",
+				nil,
+				nil,
+				ErrNilReader,
+			},
+			{
+				"premature end of reader",
+				bytes.NewBuffer([]byte{}),
+				nil,
+				io.EOF,
+			},
+			{
+				"empty Array",
+				bytes.NewBuffer([]byte{5, 0, 0, 0, 0}),
+				[]byte{5, 0, 0, 0, 0},
+				nil,
+			},
+			{
+				"non-empty Array",
+				bytes.NewBuffer([]byte{
+					// length
+					0x17, 0x0, 0x0, 0x0,
+
+					// type - string
+					0x2,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string "bar"
+					0x62, 0x61, 0x72, 0x0,
+
+					// type - null
+					0xa,
+					// key - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+				}),
+				[]byte{
+					// length
+					0x17, 0x0, 0x0, 0x0,
+
+					// type - string
+					0x2,
+					// key - "foo"
+					0x66, 0x6f, 0x6f, 0x0,
+					// value - string length
+					0x4, 0x0, 0x0, 0x0,
+					// value - string "bar"
+					0x62, 0x61, 0x72, 0x0,
+
+					// type - null
+					0xa,
+					// key - "baz"
+					0x62, 0x61, 0x7a, 0x0,
+
+					// null terminator
+					0x0,
+				},
+				nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				arr, err := NewArrayFromReader(tc.ioReader)
+				if !compareErrors(err, tc.err) {
+					t.Errorf("errors do not match. got %v; want %v", err, tc.err)
+				}
+				if !bytes.Equal(tc.arr, arr) {
+					t.Errorf("Arrays differ. got %v; want %v", tc.arr, arr)
+				}
+			})
+		}
+	})
+}

--- a/x/bsonx/bsoncore/array_test.go
+++ b/x/bsonx/bsoncore/array_test.go
@@ -302,13 +302,31 @@ func TestArray(t *testing.T) {
 				`Array(19)[[null ,null ]]`,
 			},
 			{
-				"malformed",
+				"malformed--length too small",
+				Array{
+					'\x04', '\x00', '\x00', '\x00',
+					'\x00',
+				},
+				``,
+				`Array(4)[]`,
+			},
+			{
+				"malformed--length too large",
 				Array{
 					'\x13', '\x00', '\x00', '\x00',
 					'\x00',
 				},
 				``,
 				`Array(19)[<malformed (15)>]`,
+			},
+			{
+				"malformed--missing null byte",
+				Array{
+					'\x06', '\x00', '\x00', '\x00',
+					'\x02', '0',
+				},
+				``,
+				`Array(6)[<malformed (2)>]`,
 			},
 		}
 

--- a/x/bsonx/bsoncore/array_test.go
+++ b/x/bsonx/bsoncore/array_test.go
@@ -25,7 +25,7 @@ func TestArray(t *testing.T) {
 			}
 		})
 		t.Run("InvalidLength", func(t *testing.T) {
-			want := Array{}.lengtherror(200, 5)
+			want := lengthError("array", 200, 5)
 			r := make(Array, 5)
 			binary.LittleEndian.PutUint32(r[0:4], 200)
 			got := r.Validate()

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -217,7 +217,7 @@ func (d Document) LookupErr(key ...string) (Value, error) {
 // Index searches for and retrieves the element at the given index. This method will panic if
 // the document is invalid or if the index is out of bounds.
 func (d Document) Index(index uint) Element {
-	elem, err := indexErr(d, index)
+	elem, err := d.IndexErr(index)
 	if err != nil {
 		panic(err)
 	}

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -115,9 +115,6 @@ var ErrOutOfBounds = errors.New("out of bounds")
 // Document is a raw bytes representation of a BSON document.
 type Document []byte
 
-// Array is a raw bytes representation of a BSON array.
-type Array []byte
-
 // NewDocumentFromReader reads a document from r. This function will only validate the length is
 // correct and that the document ends with a null byte.
 func NewDocumentFromReader(r io.Reader) (Document, error) {

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -116,7 +116,7 @@ var ErrOutOfBounds = errors.New("out of bounds")
 type Document []byte
 
 // Array is a raw bytes representation of a BSON array.
-type Array = Document
+type Array []byte
 
 // NewDocumentFromReader reads a document from r. This function will only validate the length is
 // correct and that the document ends with a null byte.

--- a/x/bsonx/bsoncore/document_test.go
+++ b/x/bsonx/bsoncore/document_test.go
@@ -44,7 +44,7 @@ func TestDocument(t *testing.T) {
 			}
 		})
 		t.Run("InvalidLength", func(t *testing.T) {
-			want := Document{}.lengtherror(200, 5)
+			want := lengthError("document", 200, 5)
 			r := make(Document, 5)
 			binary.LittleEndian.PutUint32(r[0:4], 200)
 			got := r.Validate()

--- a/x/bsonx/bsoncore/document_test.go
+++ b/x/bsonx/bsoncore/document_test.go
@@ -44,7 +44,7 @@ func TestDocument(t *testing.T) {
 			}
 		})
 		t.Run("InvalidLength", func(t *testing.T) {
-			want := lengthError("document", 200, 5)
+			want := NewDocumentLengthError(200, 5)
 			r := make(Document, 5)
 			binary.LittleEndian.PutUint32(r[0:4], 200)
 			got := r.Validate()


### PR DESCRIPTION
[GODRIVER-1846](https://jira.mongodb.org/browse/GODRIVER-1846)

Currently, `bsoncore.Array` is defined as `type Array = Document`, when it should really be a separate type that can be encoded as type 4 (array) in BSON instead of type 3 (embedded document). A new codec is required.

Adds a new `ArrayCodec`, a `tCoreArray` type, and adds `copier#CopyBytesToArrayWriter()`.

Adds a test to ensure that `[]bson.D` can be marshalled, unmarshalled to `bsoncore.Array`, and marshalled again without modifying the original BSON.