### PR TITLE
GODRIVER-1879 - Apply the connectTimeout to the entirety of the topology.connection.connect method, rather than the individual dials and handshakes

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -116,7 +116,7 @@ func (c *connection) connect(ctx context.Context) {
 	defer close(c.connectDone)
 
 	c.connectContextMutex.Lock()
-	ctx, c.cancelConnectContext = context.WithCancel(ctx)
+	ctx, c.cancelConnectContext = context.WithTimeout(ctx, c.config.connectTimeout)
 	c.connectContextMutex.Unlock()
 
 	defer func() {


### PR DESCRIPTION
This change alters the context that wraps `connection.connect()` to use a timeout (the `connectTimeout`) rather than just a cancel.

This is needed in situations the remote server is alive but the `mongod` process is not responding. The initial `dialer.DialContext` call succeeds, but the tls `Handshake` method hangs since no timeout is attached.

https://jira.mongodb.org/browse/GODRIVER-1879 has additional context.