### PR TITLE
GODRIVER-1853 Document versioned API usage

### DIFF
--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -316,18 +316,18 @@ func ExampleConnect_aWS() {
 }
 
 func ExampleConnect_versionedAPI() {
-	// Configure a client with versioned API.
+	// Configure a Client with versioned API.
 	//
 	// Versioned API is a new feature in MongoDB 5.0 that allows user-selectable API versions, subsets of MongoDB
-	// server semantics, to be declared on a client. During communication with a server, clients with a declared
+	// server semantics, to be declared on a Client. During communication with a server, Clients with a declared
 	// API version will force that server to behave in a manner compatible with the API version. Declaring an API
-	// version on your client can be used to ensure consistent responses from a server, providing long term API
+	// version on your Client can be used to ensure consistent responses from a server, providing long term API
 	// stability for an application.
 	//
-	// The declared API version is applied to all commands run through the client, including those sent through
-	// the generic command helper. Specifying versioned API options in the command document AND declaring an API
-	// version on the client is not supported and will lead to undefined behaviour. To run any command with a different
-	// API version or without declaring one, create a separate client that declares the appropriate API version.
+	// The declared API version is applied to all commands run through the Client, including those sent through
+	// the generic RunCommand helper. Specifying versioned API options in the command document AND declaring an API
+	// version on the Client is not supported and will lead to undefined behaviour. To run any command with a different
+	// API version or without declaring one, create a separate Client that declares the appropriate API version.
 
 	// ServerAPIOptions must be declared with an API version. ServerAPIVersion1 is a constant equal to "1".
 	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
@@ -339,7 +339,7 @@ func ExampleConnect_versionedAPI() {
 
 	// ServerAPIOptions can be declared with a Strict option. Declaring a strict API version will cause the MongoDB server
 	// to reject all commands that are not part of the declared API version. This includes command options and
-	// aggregation pipeline stages. For example, the following distinct call would fail because the distinct command is
+	// aggregation pipeline stages. For example, the following Distinct call would fail because the distinct command is
 	// not part of API version 1:
 	serverAPIStrict := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
 	serverAPIStrictClient, err := mongo.Connect(context.TODO(), options.Client().SetServerAPIOptions(serverAPIStrict))
@@ -347,13 +347,13 @@ func ExampleConnect_versionedAPI() {
 		panic(err)
 	}
 
+	coll := serverAPIStrictClient.Database("db").Collection("coll")
 	// Fails with error: (APIStrictError) Provided apiStrict:true, but the command distinct is not in API Version 1
-	_, err = serverAPIStrictClient.Database("db").Collection("coll").
-		Distinct(context.TODO(), "distinct", bson.D{})
+	_, err = coll.Distinct(context.TODO(), "distinct", bson.D{})
 
 	// ServerAPIOptions can be declared with a DeprecationErrors option. DeprecationErrors can be used to enable command
-	// failures when using functionality that is deprecated from that version. Note that at the time of this writing,
-	// no deprecations in version 1 exist.
+	// failures when using functionality that is deprecated in the declared API version. Note that at the time of this writing,
+	// no deprecations in API version 1 exist.
 	serverAPIDeprecation := options.ServerAPI(options.ServerAPIVersion1).SetDeprecationErrors(true)
 	serverAPIDeprecationClient, err := mongo.Connect(context.TODO(), options.Client().SetServerAPIOptions(serverAPIDeprecation))
 	if err != nil {

--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -326,7 +326,7 @@ func ExampleConnect_versionedAPI() {
 	//
 	// The declared API version is applied to all commands run through the Client, including those sent through
 	// the generic RunCommand helper. Specifying versioned API options in the command document AND declaring an API
-	// version on the Client is not supported and will lead to undefined behaviour. To run any command with a different
+	// version on the Client is not supported and will lead to undefined behavior. To run any command with a different
 	// API version or without declaring one, create a separate Client that declares the appropriate API version.
 
 	// ServerAPIOptions must be declared with an API version. ServerAPIVersion1 is a constant equal to "1".


### PR DESCRIPTION
[GODRIVER-1853](https://jira.mongodb.org/browse/GODRIVER-1853)

Adds documentation in `client_examples_test` under `Connect` for creating a mongo client with `ServerAPIOptions`.