### PR TITLE
GODRIVER-1877 Skip getParameter in ADL int test setup

### DIFF
--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -193,10 +193,13 @@ func Setup() error {
 		}
 	}
 
-	db := testContext.client.Database("admin")
-	testContext.serverParameters, err = db.RunCommand(Background, bson.D{{"getParameter", "*"}}).DecodeBytes()
-	if err != nil {
-		return fmt.Errorf("error getting serverParameters: %v", err)
+	// Get server parameters if test is not adl integration; ADL does not have "getParameter" command.
+	if !testContext.dataLake {
+		db := testContext.client.Database("admin")
+		testContext.serverParameters, err = db.RunCommand(Background, bson.D{{"getParameter", "*"}}).DecodeBytes()
+		if err != nil {
+			return fmt.Errorf("error getting serverParameters: %v", err)
+		}
 	}
 	return nil
 }

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -193,7 +193,7 @@ func Setup() error {
 		}
 	}
 
-	// Get server parameters if test is not adl integration; ADL does not have "getParameter" command.
+	// Get server parameters if test is not running against ADL; ADL does not have "getParameter" command.
 	if !testContext.dataLake {
 		db := testContext.client.Database("admin")
 		testContext.serverParameters, err = db.RunCommand(Background, bson.D{{"getParameter", "*"}}).DecodeBytes()


### PR DESCRIPTION
[GODRIVER-1877](https://jira.mongodb.org/browse/GODRIVER-1877)

Fixes Atlas Data Lake integration test, which was failing because "getParameter" was being run against the data lake instance even though data lake does not support "getParameter".

Here's a small [patch](https://spruce.mongodb.com/version/602325dfe3c331145aae5e56/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) showing the fix, and that tests like versioned API that do use "getParameter" are unaffected.