### PR TITLE
Clarify omitempty documentation

### DIFF
--- a/bson/doc.go
+++ b/bson/doc.go
@@ -103,9 +103,13 @@
 // to configure behavior:
 //
 //     1. omitempty: If the omitempty struct tag is specified on a field, the field will not be marshalled if it is set to
-//     the zero value. By default, a struct field is only considered empty if the field's type implements the Zeroer
-//     interface and the IsZero method returns true. Struct fields of types that do not implement Zeroer are always
-//     marshalled as embedded documents. This tag should be used for all slice and map values.
+//     the zero value. Fields with language primitive types such as integers, booleans, and strings are considered empty if
+//     their value is equal to the zero value for the type (i.e. 0 for integers, false for booleans, and "" for strings).
+//     Slices, maps, and arrays are considered empty if they are of length zero. Interfaces and pointers are considered
+//     empty if their value is nil. By default, structs are only considered empty if the struct type implements the
+//     bsoncodec.Zeroer interface and the IsZero method returns true. Struct fields whose types do not implement Zeroer are
+//     never considered empty and will be marshalled as embedded documents.
+//     NOTE: It is recommended that this tag be used for all slice and map fields.
 //
 //     2. minsize: If the minsize struct tag is specified on a field of type int64, uint, uint32, or uint64 and the value of
 //     the field can fit in a signed int32, the field will be serialized as a BSON int32 rather than a BSON int64. For other


### PR DESCRIPTION
There was some confusion about the existing documentation for `omitempty` on the [MongoDB developer forums](https://developer.mongodb.com/community/forums/t/golang-mongo-driver-getting-omitempty-struct-tag-to-evaluate-golang-primitives/14354). This PR clarifies the documentation and explicitly outlines how empty-ness is determined for struct fields of different types. If there are no objections, I also plan on backporting this to the release/1.5 and release/1.4 branches when merging so the updated docs will show up in pkg.go.dev for releases on those branches.