### PR TITLE
GODRIVER-1180 Remove legacy transform functions from mongo

### DIFF
--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -168,7 +168,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 	var i int
 	for _, model := range batch.models {
 		converted := model.(*InsertOneModel)
-		doc, _, err := transformAndEnsureIDv2(bw.collection.registry, converted.Document)
+		doc, _, err := transformAndEnsureID(bw.collection.registry, converted.Document)
 		if err != nil {
 			return operation.InsertResult{}, err
 		}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -244,7 +244,7 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 
 	for i, doc := range documents {
 		var err error
-		docs[i], result[i], err = transformAndEnsureIDv2(coll.registry, doc)
+		docs[i], result[i], err = transformAndEnsureID(coll.registry, doc)
 		if err != nil {
 			return nil, err
 		}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -746,7 +746,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 		a.ctx = context.Background()
 	}
 
-	pipelineArr, hasOutputStage, err := transformAggregatePipelinev2(a.registry, a.pipeline)
+	pipelineArr, hasOutputStage, err := transformAggregatePipeline(a.registry, a.pipeline)
 	if err != nil {
 		return nil, err
 	}

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -572,7 +572,7 @@ func (db *Database) CreateCollection(ctx context.Context, name string, opts ...*
 func (db *Database) CreateView(ctx context.Context, viewName, viewOn string, pipeline interface{},
 	opts ...*options.CreateViewOptions) error {
 
-	pipelineArray, _, err := transformAggregatePipelinev2(db.registry, pipeline)
+	pipelineArray, _, err := transformAggregatePipeline(db.registry, pipeline)
 	if err != nil {
 		return err
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -72,8 +72,8 @@ func (me MarshalError) Error() string {
 //
 type Pipeline []bson.D
 
-// transformAndEnsureID is a hack that makes it easy to get a RawValue as the _id value. This will
-// be removed when we switch from using bsonx to bsoncore for the driver package.
+// transformAndEnsureID is a hack that makes it easy to get a RawValue as the _id value.
+// It will also add an ObjectID _id as the first key if it not already present in the passed-in val.
 func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsoncore.Document, interface{}, error) {
 	if registry == nil {
 		registry = bson.NewRegistryBuilder().Build()

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -196,39 +196,7 @@ func ensureNoDollarKey(doc bsoncore.Document) error {
 	return nil
 }
 
-func transformAggregatePipeline(registry *bsoncodec.Registry, pipeline interface{}) (bsonx.Arr, error) {
-	pipelineArr := bsonx.Arr{}
-	switch t := pipeline.(type) {
-	case bsoncodec.ValueMarshaler:
-		btype, val, err := t.MarshalBSONValue()
-		if err != nil {
-			return nil, err
-		}
-		if btype != bsontype.Array {
-			return nil, fmt.Errorf("ValueMarshaler returned a %v, but was expecting %v", btype, bsontype.Array)
-		}
-		err = pipelineArr.UnmarshalBSONValue(btype, val)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		val := reflect.ValueOf(t)
-		if !val.IsValid() || (val.Kind() != reflect.Slice && val.Kind() != reflect.Array) {
-			return nil, fmt.Errorf("can only transform slices and arrays into aggregation pipelines, but got %v", val.Kind())
-		}
-		for idx := 0; idx < val.Len(); idx++ {
-			elem, err := transformDocument(registry, val.Index(idx).Interface())
-			if err != nil {
-				return nil, err
-			}
-			pipelineArr = append(pipelineArr, bsonx.Document(elem))
-		}
-	}
-
-	return pipelineArr, nil
-}
-
-func transformAggregatePipelinev2(registry *bsoncodec.Registry, pipeline interface{}) (bsoncore.Document, bool, error) {
+func transformAggregatePipeline(registry *bsoncodec.Registry, pipeline interface{}) (bsoncore.Document, bool, error) {
 	switch t := pipeline.(type) {
 	case bsoncodec.ValueMarshaler:
 		btype, val, err := t.MarshalBSONValue()

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -176,17 +176,7 @@ func ensureID(d bsonx.Doc) (bsonx.Doc, interface{}) {
 	return d, id
 }
 
-func ensureDollarKey(doc bsonx.Doc) error {
-	if len(doc) == 0 {
-		return errors.New("update document must have at least one element")
-	}
-	if !strings.HasPrefix(doc[0].Key, "$") {
-		return errors.New("update document must contain key beginning with '$'")
-	}
-	return nil
-}
-
-func ensureDollarKeyv2(doc bsoncore.Document) error {
+func ensureDollarKey(doc bsoncore.Document) error {
 	firstElem, err := doc.IndexErr(0)
 	if err != nil {
 		return errors.New("update document must have at least one element")
@@ -289,7 +279,7 @@ func transformAggregatePipelinev2(registry *bsoncodec.Registry, pipeline interfa
 }
 
 func transformUpdateValue(registry *bsoncodec.Registry, update interface{}, dollarKeysAllowed bool) (bsoncore.Value, error) {
-	documentCheckerFunc := ensureDollarKeyv2
+	documentCheckerFunc := ensureDollarKey
 	if !dollarKeysAllowed {
 		documentCheckerFunc = ensureNoDollarKey
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -74,68 +74,7 @@ type Pipeline []bson.D
 
 // transformAndEnsureID is a hack that makes it easy to get a RawValue as the _id value. This will
 // be removed when we switch from using bsonx to bsoncore for the driver package.
-func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsonx.Doc, interface{}, error) {
-	// TODO: performance is going to be pretty bad for bsonx.Doc here since we turn it into a []byte
-	// only to turn it back into a bsonx.Doc. We can fix this post beta1 when we refactor the driver
-	// package to use bsoncore.Document instead of bsonx.Doc.
-	if registry == nil {
-		registry = bson.NewRegistryBuilder().Build()
-	}
-	switch tt := val.(type) {
-	case nil:
-		return nil, nil, ErrNilDocument
-	case bsonx.Doc:
-		val = tt.Copy()
-	case []byte:
-		// Slight optimization so we'll just use MarshalBSON and not go through the codec machinery.
-		val = bson.Raw(tt)
-	}
-
-	// TODO(skriptble): Use a pool of these instead.
-	buf := make([]byte, 0, 256)
-	b, err := bson.MarshalAppendWithRegistry(registry, buf, val)
-	if err != nil {
-		return nil, nil, MarshalError{Value: val, Err: err}
-	}
-
-	d, err := bsonx.ReadDoc(b)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var id interface{}
-
-	idx := d.IndexOf("_id")
-	var idElem bsonx.Elem
-	switch idx {
-	case -1:
-		idElem = bsonx.Elem{"_id", bsonx.ObjectID(primitive.NewObjectID())}
-		d = append(d, bsonx.Elem{})
-		copy(d[1:], d)
-		d[0] = idElem
-	default:
-		idElem = d[idx]
-		copy(d[1:idx+1], d[0:idx])
-		d[0] = idElem
-	}
-
-	idBuf := make([]byte, 0, 256)
-	t, data, err := idElem.Value.MarshalAppendBSONValue(idBuf[:0])
-	if err != nil {
-		return nil, nil, err
-	}
-
-	err = bson.RawValue{Type: t, Value: data}.UnmarshalWithRegistry(registry, &id)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return d, id, nil
-}
-
-// transformAndEnsureIDv2 is a hack that makes it easy to get a RawValue as the _id value. This will
-// be removed when we switch from using bsonx to bsoncore for the driver package.
-func transformAndEnsureIDv2(registry *bsoncodec.Registry, val interface{}) (bsoncore.Document, interface{}, error) {
+func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsoncore.Document, interface{}, error) {
 	if registry == nil {
 		registry = bson.NewRegistryBuilder().Build()
 	}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -85,6 +85,17 @@ func TestMongoHelpers(t *testing.T) {
 			want := bsoncore.Document(wantBSON)
 			assert.Equal(t, want, got, "expected document %v, got %v", want, got)
 		})
+		t.Run("existing _id as should remain in place", func(t *testing.T) {
+			doc := bson.D{{"foo", "bar"}, {"_id", 3.14159}, {"baz", "qux"}, {"hello", "world"}}
+			got, id, err := transformAndEnsureID(bson.DefaultRegistry, doc)
+			assert.Nil(t, err, "transformAndEnsureID error: %v", err)
+			_, ok := id.(float64)
+			assert.True(t, ok, "expected returned id type %T, got %T", float64(0), id)
+			_, wantBSON, err := bson.MarshalValue(doc)
+			assert.Nil(t, err, "MarshalValue error: %v", err)
+			want := bsoncore.Document(wantBSON)
+			assert.Equal(t, want, got, "expected document %v, got %v", want, got)
+		})
 		t.Run("existing _id as first element should remain first element", func(t *testing.T) {
 			doc := bson.D{{"_id", 3.14159}, {"foo", "bar"}, {"baz", "qux"}, {"hello", "world"}}
 			got, id, err := transformAndEnsureID(bson.DefaultRegistry, doc)

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -80,7 +80,8 @@ func TestMongoHelpers(t *testing.T) {
 				{"_id", oid}, {"foo", "bar"},
 				{"baz", "qux"}, {"hello", "world"},
 			}
-			_, wantBSON, _ := bson.MarshalValue(wantDoc)
+			_, wantBSON, err := bson.MarshalValue(wantDoc)
+			assert.Nil(t, err, "MarshalValue error: %v", err)
 			want := bsoncore.Document(wantBSON)
 			assert.Equal(t, want, got, "expected document %v, got %v", want, got)
 		})
@@ -90,7 +91,8 @@ func TestMongoHelpers(t *testing.T) {
 			assert.Nil(t, err, "transformAndEnsureID error: %v", err)
 			_, ok := id.(float64)
 			assert.True(t, ok, "expected returned id type %T, got %T", float64(0), id)
-			_, wantBSON, _ := bson.MarshalValue(doc)
+			_, wantBSON, err := bson.MarshalValue(doc)
+			assert.Nil(t, err, "MarshalValue error: %v", err)
 			want := bsoncore.Document(wantBSON)
 			assert.Equal(t, want, got, "expected document %v, got %v", want, got)
 		})
@@ -100,7 +102,8 @@ func TestMongoHelpers(t *testing.T) {
 			assert.Nil(t, err, "transformAndEnsureID error: %v", err)
 			_, ok := id.(string)
 			assert.True(t, ok, "expected returned id type string, got %T", id)
-			_, wantBSON, _ := bson.MarshalValue(doc)
+			_, wantBSON, err := bson.MarshalValue(doc)
+			assert.Nil(t, err, "MarshalValue error: %v", err)
 			want := bsoncore.Document(wantBSON)
 			assert.Equal(t, want, got, "expected document %v, got %v", want, got)
 		})
@@ -223,10 +226,10 @@ func TestMongoHelpers(t *testing.T) {
 			},
 			{
 				"bsoncodec.ValueMarshaler/UnmarshalBSONValue error",
-				bvMarsh{t: bsontype.Array, err: bsoncore.NewInsufficientBytesError(nil, nil)},
+				bvMarsh{err: errors.New("UnmarshalBSONValue error")},
 				nil,
 				false,
-				bsoncore.NewInsufficientBytesError(nil, nil),
+				errors.New("UnmarshalBSONValue error"),
 			},
 			{
 				"bsoncodec.ValueMarshaler/success",
@@ -234,6 +237,13 @@ func TestMongoHelpers(t *testing.T) {
 				bson.A{
 					bson.D{{"$limit", int32(12345)}},
 				},
+				false,
+				nil,
+			},
+			{
+				"bsoncodec.ValueMarshaler/success nil",
+				bvMarsh{t: bsontype.Array},
+				nil,
 				false,
 				nil,
 			},
@@ -332,7 +342,8 @@ func TestMongoHelpers(t *testing.T) {
 
 				var expected bsoncore.Document
 				if tc.arr != nil {
-					_, expectedBSON, _ := bson.MarshalValue(tc.arr)
+					_, expectedBSON, err := bson.MarshalValue(tc.arr)
+					assert.Nil(t, err, "MarshalValue error: %v", err)
 					expected = bsoncore.Document(expectedBSON)
 				}
 				assert.Equal(t, expected, arr, "expected array %v, got %v", expected, arr)

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -123,147 +123,166 @@ func TestMongoHelpers(t *testing.T) {
 		testCases := []struct {
 			name     string
 			pipeline interface{}
-			arr      bsonx.Arr
+			arr      bson.A
 			err      error
 		}{
 			{
 				"Pipeline/error",
-				Pipeline{{{"hello", func() {}}}}, bsonx.Arr{},
+				Pipeline{{{"hello", func() {}}}},
+				nil,
 				MarshalError{Value: primitive.D{}, Err: errors.New("no encoder found for func()")},
 			},
 			{
 				"Pipeline/success",
 				Pipeline{{{"hello", "world"}}, {{"pi", 3.14159}}},
-				bsonx.Arr{
-					bsonx.Document(bsonx.Doc{{"hello", bsonx.String("world")}}),
-					bsonx.Document(bsonx.Doc{{"pi", bsonx.Double(3.14159)}}),
+				bson.A{
+					bson.D{{"hello", "world"}},
+					bson.D{{"pi", 3.14159}},
 				},
 				nil,
 			},
 			{
-				"bsonx.Arr",
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}})},
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}})},
+				"bson.A",
+				bson.A{
+					bson.D{{"$limit", 12345}},
+				},
+				bson.A{
+					bson.D{{"$limit", 12345}},
+				},
 				nil,
 			},
 			{
-				"[]bsonx.Doc",
-				[]bsonx.Doc{{{"$limit", bsonx.Int32(12345)}}},
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}})},
+				"[]bson.D",
+				[]bson.D{{{"$limit", 12345}}},
+				bson.A{
+					bson.D{{"$limit", 12345}},
+				},
 				nil,
 			},
 			{
 				"primitive.A/error",
 				primitive.A{"5"},
-				bsonx.Arr{},
+				nil,
 				MarshalError{Value: string(""), Err: errors.New("WriteString can only write while positioned on a Element or Value but is positioned on a TopLevel")},
 			},
 			{
 				"primitive.A/success",
 				primitive.A{bson.D{{"$limit", int32(12345)}}, map[string]interface{}{"$count": "foobar"}},
-				bsonx.Arr{
-					bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}}),
-					bsonx.Document(bsonx.Doc{{"$count", bsonx.String("foobar")}}),
+				bson.A{
+					bson.D{{"$limit", int(12345)}},
+					bson.D{{"$count", "foobar"}},
 				},
 				nil,
 			},
 			{
 				"bson.A/error",
 				bson.A{"5"},
-				bsonx.Arr{},
+				nil,
 				MarshalError{Value: string(""), Err: errors.New("WriteString can only write while positioned on a Element or Value but is positioned on a TopLevel")},
 			},
 			{
 				"bson.A/success",
 				bson.A{bson.D{{"$limit", int32(12345)}}, map[string]interface{}{"$count": "foobar"}},
-				bsonx.Arr{
-					bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}}),
-					bsonx.Document(bsonx.Doc{{"$count", bsonx.String("foobar")}}),
+				bson.A{
+					bson.D{{"$limit", int32(12345)}},
+					bson.D{{"$count", "foobar"}},
 				},
 				nil,
 			},
 			{
 				"[]interface{}/error",
 				[]interface{}{"5"},
-				bsonx.Arr{},
+				nil,
 				MarshalError{Value: string(""), Err: errors.New("WriteString can only write while positioned on a Element or Value but is positioned on a TopLevel")},
 			},
 			{
 				"[]interface{}/success",
 				[]interface{}{bson.D{{"$limit", int32(12345)}}, map[string]interface{}{"$count": "foobar"}},
-				bsonx.Arr{
-					bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}}),
-					bsonx.Document(bsonx.Doc{{"$count", bsonx.String("foobar")}}),
+				bson.A{
+					bson.D{{"$limit", int32(12345)}},
+					bson.D{{"$count", "foobar"}},
 				},
 				nil,
 			},
 			{
 				"bsoncodec.ValueMarshaler/MarshalBSONValue error",
 				bvMarsh{err: errors.New("MarshalBSONValue error")},
-				bsonx.Arr{},
+				nil,
 				errors.New("MarshalBSONValue error"),
 			},
 			{
 				"bsoncodec.ValueMarshaler/not array",
 				bvMarsh{t: bsontype.String},
-				bsonx.Arr{},
+				nil,
 				fmt.Errorf("ValueMarshaler returned a %v, but was expecting %v", bsontype.String, bsontype.Array),
 			},
 			{
 				"bsoncodec.ValueMarshaler/UnmarshalBSONValue error",
-				bvMarsh{t: bsontype.Array},
-				bsonx.Arr{},
+				bvMarsh{t: bsontype.Array, err: bsoncore.NewInsufficientBytesError(nil, nil)},
+				nil,
 				bsoncore.NewInsufficientBytesError(nil, nil),
 			},
 			{
 				"bsoncodec.ValueMarshaler/success",
 				bvMarsh{t: bsontype.Array, data: arr},
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int32(12345)}})},
+				bson.A{
+					bson.D{{"$limit", int32(12345)}},
+				},
 				nil,
 			},
 			{
 				"nil",
 				nil,
-				bsonx.Arr{},
+				nil,
 				errors.New("can only transform slices and arrays into aggregation pipelines, but got invalid"),
 			},
 			{
 				"not array or slice",
 				int64(42),
-				bsonx.Arr{},
+				nil,
 				errors.New("can only transform slices and arrays into aggregation pipelines, but got int64"),
 			},
 			{
 				"array/error",
 				[1]interface{}{int64(42)},
-				bsonx.Arr{},
+				nil,
 				MarshalError{Value: int64(0), Err: errors.New("WriteInt64 can only write while positioned on a Element or Value but is positioned on a TopLevel")},
 			},
 			{
 				"array/success",
 				[1]interface{}{primitive.D{{"$limit", int64(12345)}}},
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int64(12345)}})},
+				bson.A{
+					bson.D{{"$limit", int64(12345)}},
+				},
 				nil,
 			},
 			{
 				"slice/error",
 				[]interface{}{int64(42)},
-				bsonx.Arr{},
+				nil,
 				MarshalError{Value: int64(0), Err: errors.New("WriteInt64 can only write while positioned on a Element or Value but is positioned on a TopLevel")},
 			},
 			{
 				"slice/success",
 				[]interface{}{primitive.D{{"$limit", int64(12345)}}},
-				bsonx.Arr{bsonx.Document(bsonx.Doc{{"$limit", bsonx.Int64(12345)}})},
+				bson.A{
+					bson.D{{"$limit", int64(12345)}},
+				},
 				nil,
 			},
 		}
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				arr, err := transformAggregatePipeline(bson.NewRegistryBuilder().Build(), tc.pipeline)
+				arr, _, err := transformAggregatePipeline(bson.NewRegistryBuilder().Build(), tc.pipeline)
 				assert.Equal(t, tc.err, err, "expected error %v, got %v", tc.err, err)
-				assert.Equal(t, tc.arr, arr, "expected array %v, got %v", tc.arr, arr)
+
+				var expected bsoncore.Document
+				if tc.arr != nil {
+					_, expectedBSON, _ := bson.MarshalValue(tc.arr)
+					expected = bsoncore.Document(expectedBSON)
+				}
+				assert.Equal(t, expected, arr, "expected array %v, got %v", expected, arr)
 			})
 		}
 	})


### PR DESCRIPTION
[GODRIVER-1180](https://jira.mongodb.org/browse/GODRIVER-1180)

Removes the no longer used `transformAndEnsureID`, `ensureDollarKey`, and `transformAggregatePipeline` functions and renames their v2 variants to the now available names.

Updates `mongo_test#TestMongoHelpers` to account for changes.