### PR TITLE
GODRIVER-1888 Append test server API version in CSE prose test

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -988,6 +988,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					SetKmsProviders(kmsProviders).
 					SetBypassAutoEncryption(tc.bypassAutoEncryption)
 				if tc.keyVaultClientSet {
+					testutil.AddTestServerAPIVersion(d.clientKeyVaultOpts)
 					aeOpts.SetKeyVaultClientOptions(d.clientKeyVaultOpts)
 				}
 
@@ -1005,6 +1006,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					SetMaxPoolSize(tc.maxPoolSize).
 					SetAutoEncryptionOptions(aeOpts)
 
+				testutil.AddTestServerAPIVersion(ceOpts)
 				clientEncrypted, err := mongo.Connect(mtest.Background, ceOpts)
 				defer clientEncrypted.Disconnect(mtest.Background)
 				assert.Nil(mt, err, "Connect error: %v", err)
@@ -1160,6 +1162,7 @@ func newDeadlockTest(mt *mtest.T) *deadlockTest {
 	var err error
 
 	clientTestOpts := options.Client().ApplyURI(mtest.ClusterURI()).SetWriteConcern(mtest.MajorityWc)
+	testutil.AddTestServerAPIVersion(clientTestOpts)
 	if d.clientTest, err = mongo.Connect(mtest.Background, clientTestOpts); err != nil {
 		mt.Fatalf("Connect error: %v", err)
 	}


### PR DESCRIPTION
[GODRIVER-1888](https://jira.mongodb.org/browse/GODRIVER-1888)

Appends the latest server API version in the recently edited CSE prose tests using `testutil.AddTestServerAPIVersion()`.

This fixes some failing versioned API tasks on Ubuntu and Windows. It also fixes some on MacOS, but there are remaining failures due to a server bug ([SERVER-54508](https://jira.mongodb.org/browse/SERVER-54508)). Here is a [patch](https://spruce.mongodb.com/version/602c4155850e610b329f0a5c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) showing success on all versioned API tasks except for failures due to the aforementioned server bug on latest MacOS.

To avoid missing server API version appends in the future, we should probably be running the versioned API tasks as part of regular PR CI. Will reach out offline on how to do this.