### PR TITLE
GODRIVER-1197 Remove selectServerLegacy function

### DIFF
--- a/internal/testutil/ops.go
+++ b/internal/testutil/ops.go
@@ -96,7 +96,7 @@ func DisableMaxTimeFailPoint(t *testing.T, s *topology.Server) {
 }
 
 // RunCommand runs an arbitrary command on a given database of target server
-func RunCommand(t *testing.T, s *topology.Server, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
+func RunCommand(t *testing.T, s driver.Server, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
 	op := operation.NewCommand(cmd).
 		Database(db).Deployment(driver.SingleServerDeployment{Server: s})
 	err := op.Execute(context.Background())

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -180,5 +180,6 @@ func getServerByAddress(address string, topo *topology.Topology) (description.Se
 	if err != nil {
 		return description.Server{}, err
 	}
+	defer selectedServerConnection.Close()
 	return selectedServerConnection.Description(), nil
 }

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -172,9 +172,13 @@ func getServerByAddress(address string, topo *topology.Topology) (description.Se
 		return []description.Server{}, nil
 	})
 
-	selectedServer, err := topo.SelectServerLegacy(context.Background(), selectByName)
+	selectedServer, err := topo.SelectServer(context.Background(), selectByName)
 	if err != nil {
 		return description.Server{}, err
 	}
-	return selectedServer.Server.Description(), nil
+	selectedServerConnection, err := selectedServer.Connection(context.Background())
+	if err != nil {
+		return description.Server{}, err
+	}
+	return selectedServerConnection.Description(), nil
 }

--- a/x/mongo/driver/integration/aggregate_test.go
+++ b/x/mongo/driver/integration/aggregate_test.go
@@ -37,11 +37,11 @@ func setUpMonitor() (*event.CommandMonitor, chan *event.CommandStartedEvent, cha
 }
 
 func skipIfBelow32(ctx context.Context, t *testing.T, topo *topology.Topology) {
-	server, err := topo.SelectServerLegacy(ctx, description.WriteSelector())
+	server, err := topo.SelectServer(ctx, description.WriteSelector())
 	noerr(t, err)
 
 	versionCmd := bsoncore.BuildDocument(nil, bsoncore.AppendInt32Element(nil, "serverStatus", 1))
-	serverStatus, err := testutil.RunCommand(t, server.Server, dbName, versionCmd)
+	serverStatus, err := testutil.RunCommand(t, server, dbName, versionCmd)
 	version, err := serverStatus.LookupErr("version")
 
 	if testutil.CompareVersions(t, version.StringValue(), "3.2") < 0 {

--- a/x/mongo/driver/integration/scram_test.go
+++ b/x/mongo/driver/integration/scram_test.go
@@ -31,6 +31,7 @@ func TestSCRAM(t *testing.T) {
 	noerr(t, err)
 	serverConnection, err := server.Connection(context.Background())
 	noerr(t, err)
+	defer serverConnection.Close()
 
 	if !serverConnection.Description().WireVersion.Includes(7) {
 		t.Skip("Skipping because MongoDB 4.0 is needed for SCRAM-SHA-256")
@@ -135,11 +136,11 @@ func testScramUserAuthWithMech(t *testing.T, c scramTestCase, mech string) error
 func runScramAuthTest(t *testing.T, cs connstring.ConnString) error {
 	t.Helper()
 	topology := testutil.TopologyWithConnString(t, cs)
-	ss, err := topology.SelectServer(context.Background(), description.WriteSelector())
+	server, err := topology.SelectServer(context.Background(), description.WriteSelector())
 	noerr(t, err)
 
 	cmd := bsoncore.BuildDocument(nil, bsoncore.AppendInt32Element(nil, "dbstats", 1))
-	_, err = testutil.RunCommand(t, ss, testutil.DBName(t), cmd)
+	_, err = testutil.RunCommand(t, server, testutil.DBName(t), cmd)
 	return err
 }
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -378,50 +378,6 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 	}
 }
 
-// SelectServerLegacy selects a server with given a selector. SelectServerLegacy complies with the
-// server selection spec, and will time out after severSelectionTimeout or when the
-// parent context is done.
-func (t *Topology) SelectServerLegacy(ctx context.Context, ss description.ServerSelector) (*SelectedServer, error) {
-	if atomic.LoadInt32(&t.connectionstate) != connected {
-		return nil, ErrTopologyClosed
-	}
-	var ssTimeoutCh <-chan time.Time
-
-	if t.cfg.serverSelectionTimeout > 0 {
-		ssTimeout := time.NewTimer(t.cfg.serverSelectionTimeout)
-		ssTimeoutCh = ssTimeout.C
-		defer ssTimeout.Stop()
-	}
-
-	sub, err := t.Subscribe()
-	if err != nil {
-		return nil, err
-	}
-	defer t.Unsubscribe(sub)
-
-	selectionState := newServerSelectionState(ss, ssTimeoutCh)
-	for {
-		suitable, err := t.selectServerFromSubscription(ctx, sub.Updates, selectionState)
-		if err != nil {
-			return nil, err
-		}
-
-		selected := suitable[rand.Intn(len(suitable))]
-		selectedS, err := t.FindServer(selected)
-		switch {
-		case err != nil:
-			return nil, err
-		case selectedS != nil:
-			return selectedS, nil
-		default:
-			// We don't have an actual server for the provided description.
-			// This could happen for a number of reasons, including that the
-			// server has since stopped being a part of this topology, or that
-			// the server selector returned no suitable servers.
-		}
-	}
-}
-
 // FindServer will attempt to find a server that fits the given server description.
 // This method will return nil, nil if a matching server could not be found.
 func (t *Topology) FindServer(selected description.Server) (*SelectedServer, error) {


### PR DESCRIPTION
[GODRIVER-1197](https://jira.mongodb.org/browse/GODRIVER-1197)

Removes the `topology.SelectServerLegacy()` function and replaces all occurrences with `topology.SelectServer()`.

Updates `testutil.RunCommand()` (a helper used alongside `topology.SelectServerLegacy()`) to use a `driver.Server`, the return type of `topology.SelectServer()`