### PR TITLE
GODRIVER-1882 Use new AWS setup script in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -598,6 +598,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -626,15 +627,8 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          # The aws_e2e_assume_role script requires python3 with boto3.
-          virtualenv -p ${PYTHON3} mongovenv
-          if [ "Windows_NT" = "$OS" ]; then
-            . mongovenv/Scripts/activate
-          else
-            . mongovenv/bin/activate
-          fi
-          pip install boto3
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -669,17 +663,12 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          if [ "${SKIP_EC2_AUTH_TEST}" == "true" ]; then
+          if [ "${SKIP_EC2_AUTH_TEST}" = "true" ]; then
             echo "This platform does not support the EC2 auth test, skipping..."
             exit 0
           fi
-          # The mongovenv was created earlier in run-aws-auth-test-with-assume-role-credentials.
-          if [ "Windows_NT" = "$OS" ]; then
-            . mongovenv/Scripts/activate
-          else
-            . mongovenv/bin/activate
-          fi
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -687,7 +676,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          if [ "${SKIP_EC2_AUTH_TEST}" == "true" ]; then
+          if [ "${SKIP_EC2_AUTH_TEST}" = "true" ]; then
             exit 0
           fi
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
@@ -741,7 +730,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          if [ "${SKIP_ECS_AUTH_TEST}" == "true" ]; then
+          if [ "${SKIP_ECS_AUTH_TEST}" = "true" ]; then
             echo "This platform does not support the ECS auth test, skipping..."
             exit 0
           fi
@@ -752,7 +741,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          if [ "${SKIP_ECS_AUTH_TEST}" == "true" ]; then
+          if [ "${SKIP_ECS_AUTH_TEST}" = "true" ]; then
             exit 0
           fi
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
@@ -763,6 +752,7 @@ functions:
           cp ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
           cd $AUTH_AWS_DIR
+          . ./activate_venv.sh
           cat <<EOF > setup.js
             const mongo_binaries = "$MONGODB_BINARIES";
             const project_dir = "$ECS_SRC_DIR";


### PR DESCRIPTION
[GODRIVER-1882](https://jira.mongodb.org/browse/GODRIVER-1882)

Uses new drivers tools `activate_venv.sh` [script](https://github.com/mongodb-labs/drivers-evergreen-tools/pull/138/files) in place of manual calls to "activate" scripts. This new script also installs the latest version of boto3, the AWS SDK for python.

This change fixes failing AWS Auth tests on Ubuntu (I've added these tests to the linked evg patch). The failure was due to an outdated version of the boto3 dependency.