### PR TITLE
GODRIVER-1890 Add nil Client checks

### DIFF
--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -458,9 +458,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 			operationErr.Labels = tt.Labels
 		case Error:
 			if tt.HasErrorLabel(TransientTransactionError) || tt.HasErrorLabel(UnknownTransactionCommitResult) {
-				if op.Client != nil {
-					op.Client.ClearPinnedServer()
-				}
+				op.Client.ClearPinnedServer()
 			}
 			if e := err.(Error); retryable && op.Type == Write && e.UnsupportedStorageEngine() {
 				return ErrUnsupportedStorageEngine
@@ -638,9 +636,7 @@ func (op Operation) readWireMessage(ctx context.Context, conn Connection, wm []b
 	// everything.
 	op.updateClusterTimes(res)
 	op.updateOperationTime(res)
-	if op.Client != nil {
-		op.Client.UpdateRecoveryToken(bson.Raw(res))
-	}
+	op.Client.UpdateRecoveryToken(bson.Raw(res))
 
 	if err != nil {
 		return res, err


### PR DESCRIPTION
[GODRIVER-1890](https://jira.mongodb.org/browse/GODRIVER-1890)

Adds extra, missing checks for a `nil` `Client` value on an `Operation` to avoid an accidental panic when `Client` is not set on an `Operation`.