### PR TITLE
GODRIVER-1899 Remove unexported method from Session interface.

### DIFF
--- a/mongo/session.go
+++ b/mongo/session.go
@@ -125,8 +125,6 @@ type Session interface {
 	// Functions to modify mutable session properties.
 	AdvanceClusterTime(bson.Raw) error
 	AdvanceOperationTime(*primitive.Timestamp) error
-
-	session()
 }
 
 // XSession is an unstable interface for internal use only.
@@ -342,10 +340,6 @@ func (s *sessionImpl) AdvanceOperationTime(ts *primitive.Timestamp) error {
 // Client implements the Session interface.
 func (s *sessionImpl) Client() *Client {
 	return s.client
-}
-
-// session implements the Session interface.
-func (*sessionImpl) session() {
 }
 
 // sessionFromContext checks for a sessionImpl in the argued context and returns the session if it


### PR DESCRIPTION
As I stated in [GODRIVER-1899:
](https://jira.mongodb.org/projects/GODRIVER/issues/GODRIVER-1899)
> This makes mocking the interface tricky, since any imported mock will miss method `session`.

Let me know if I'm missing a good reason to keep this method.

Thank you all for your effort ❤️