### PR TITLE
GODRIVER-1879 Apply connectTimeoutMS to TLS handshake

### DIFF
--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -70,7 +70,7 @@ func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
 	}
 
 	if cfg.dialer == nil {
-		cfg.dialer = &net.Dialer{Timeout: cfg.connectTimeout}
+		cfg.dialer = &net.Dialer{}
 	}
 
 	return cfg, nil

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -359,6 +359,9 @@ func TestConnection(t *testing.T) {
 						}
 
 						connOpts := []ConnectionOption{
+							WithConnectTimeout(func(time.Duration) time.Duration {
+								return tc.connectTimeout
+							}),
 							WithDialer(func(Dialer) Dialer {
 								return DialerFunc(func(context.Context, string, string) (net.Conn, error) {
 									return &net.TCPConn{}, nil


### PR DESCRIPTION
This PR modifies the connection code to apply the `connectTimeoutMS` option to both socket establishment and the TLS handshake. Previously, it was only applied to the former. To aid in testing, I also modified the existing `tlsConnectionSource` interface to return a new `tlsConn` interface rather than directly returning a concrete `tls.Conn`. This allows us to provide a custom implementation for TLS handshaking in our tests.

The alternate approach considered was to use [tls.Dialer](https://golang.org/pkg/crypto/tls/#Dialer) or [tls.DialWithDialer](https://golang.org/pkg/crypto/tls/#DialWithDialer). These aren't flexible enough because they require us to specify a [net.Dialer](https://golang.org/pkg/net/#Dialer) as the dialer for the underlying network socket, but we actually accept a custom interface to dial connections, which defaults to `net.Dialer` but can be something else (e.g. we have seen this option used to dial TLS connections via openssl rather than crytp/tls).