### PR TITLE
GODRIVER-1894 Add support for loadBalanced URI option

### DIFF
--- a/internal/uri_validation_errors.go
+++ b/internal/uri_validation_errors.go
@@ -1,0 +1,18 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import "errors"
+
+var (
+	// ErrLoadBalancedWithMultipleHosts is returned when loadBalanced=true is specified in a URI with multiple hosts.
+	ErrLoadBalancedWithMultipleHosts = errors.New("loadBalanced cannot be set to true if multiple hosts are specified")
+	// ErrLoadBalancedWithReplicaSet is returned when loadBalanced=true is specified in a URI with the replicaSet option.
+	ErrLoadBalancedWithReplicaSet = errors.New("loadBalanced cannot be set to true if a replica set name is specified")
+	// ErrLoadBalancedWithDirectConnection is returned when loadBalanced=true is specified in a URI with the directConnection option.
+	ErrLoadBalancedWithDirectConnection = errors.New("loadBalanced cannot be set to true if the direct connection option is specified")
+)

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -629,6 +629,22 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		)
 	}
 
+	// LoadBalanced
+	if opts.LoadBalanced != nil {
+		topologyOpts = append(
+			topologyOpts,
+			topology.WithLoadBalanced(func(bool) bool { return *opts.LoadBalanced }),
+		)
+		serverOpts = append(
+			serverOpts,
+			topology.WithServerLoadBalanced(func(bool) bool { return *opts.LoadBalanced }),
+		)
+		connOpts = append(
+			connOpts,
+			topology.WithConnectionLoadBalanced(func(bool) bool { return *opts.LoadBalanced }),
+		)
+	}
+
 	serverOpts = append(
 		serverOpts,
 		topology.WithClock(func(*session.ClusterClock) *session.ClusterClock { return c.clock }),

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -83,6 +83,7 @@ func TestClientOptions(t *testing.T) {
 			{"WriteConcern", (*ClientOptions).SetWriteConcern, writeconcern.New(writeconcern.WMajority()), "WriteConcern", false},
 			{"ZlibLevel", (*ClientOptions).SetZlibLevel, 6, "ZlibLevel", true},
 			{"DisableOCSPEndpointCheck", (*ClientOptions).SetDisableOCSPEndpointCheck, true, "DisableOCSPEndpointCheck", true},
+			{"LoadBalanced", (*ClientOptions).SetLoadBalanced, true, "LoadBalanced", true},
 		}
 
 		opt1, opt2, optResult := Client(), Client(), Client()
@@ -494,6 +495,16 @@ func TestClientOptions(t *testing.T) {
 					err:   errors.New("the specified CA file does not contain any valid certificates"),
 				},
 			},
+			{
+				"loadBalanced=true",
+				"mongodb://localhost/?loadBalanced=true",
+				baseClient().SetLoadBalanced(true),
+			},
+			{
+				"loadBalanced=false",
+				"mongodb://localhost/?loadBalanced=false",
+				baseClient().SetLoadBalanced(false),
+			},
 		}
 
 		for _, tc := range testCases {
@@ -550,6 +561,35 @@ func TestClientOptions(t *testing.T) {
 			assert.NotNil(t, err, "expected errror, got nil")
 			assert.Equal(t, expectedErr.Error(), err.Error(), "expected error %v, got %v", expectedErr, err)
 		})
+	})
+	t.Run("loadBalanced validation", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			opts *ClientOptions
+			err  error
+		}{
+			{"multiple hosts in URI", Client().ApplyURI("mongodb://foo,bar"), internal.ErrLoadBalancedWithMultipleHosts},
+			{"multiple hosts in options", Client().SetHosts([]string{"foo", "bar"}), internal.ErrLoadBalancedWithMultipleHosts},
+			{"replica set name", Client().SetReplicaSet("foo"), internal.ErrLoadBalancedWithReplicaSet},
+			{"directConnection=true", Client().SetDirect(true), internal.ErrLoadBalancedWithDirectConnection},
+			{"directConnection=false", Client().SetDirect(false), internal.ErrLoadBalancedWithDirectConnection},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// The loadBalanced option should not be validated if it is false or unset.
+				tc.opts.SetLoadBalanced(false)
+				err := tc.opts.Validate()
+				assert.Nil(t, err, "Validate error when loadBalanced=false: %v", err)
+
+				tc.opts.LoadBalanced = nil
+				err = tc.opts.Validate()
+				assert.Nil(t, err, "Validate error when loadBalanced is unset: %v", err)
+
+				tc.opts.SetLoadBalanced(true)
+				err = tc.opts.Validate()
+				assert.Equal(t, tc.err, err, "expected error %v when loadBalanced=true, got %v", tc.err, err)
+			})
+		}
 	})
 }
 

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -576,14 +576,13 @@ func TestClientOptions(t *testing.T) {
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				// The loadBalanced option should not be validated if it is false or unset.
-				tc.opts.SetLoadBalanced(false)
+				// The loadBalanced option should not be validated if it is unset or false.
 				err := tc.opts.Validate()
-				assert.Nil(t, err, "Validate error when loadBalanced=false: %v", err)
-
-				tc.opts.LoadBalanced = nil
-				err = tc.opts.Validate()
 				assert.Nil(t, err, "Validate error when loadBalanced is unset: %v", err)
+
+				tc.opts.SetLoadBalanced(false)
+				err = tc.opts.Validate()
+				assert.Nil(t, err, "Validate error when loadBalanced=false: %v", err)
 
 				tc.opts.SetLoadBalanced(true)
 				err = tc.opts.Validate()

--- a/x/mongo/driver/dns/dns.go
+++ b/x/mongo/driver/dns/dns.go
@@ -120,8 +120,9 @@ func validateSRVResult(recordFromSRV, inputHostName string) error {
 }
 
 var allowedTXTOptions = map[string]struct{}{
-	"authsource": {},
-	"replicaset": {},
+	"authsource":   {},
+	"replicaset":   {},
+	"loadbalanced": {},
 }
 
 func validateTXTResult(paramsFromTXT []string) error {

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -53,6 +53,7 @@ type connectionConfig struct {
 	disableOCSPEndpointCheck bool
 	errorHandlingCallback    func(error, uint64)
 	tlsConnectionSource      tlsConnectionSource
+	loadBalanced             bool
 }
 
 func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
@@ -205,6 +206,14 @@ func WithOCSPCache(fn func(ocsp.Cache) ocsp.Cache) ConnectionOption {
 func WithDisableOCSPEndpointCheck(fn func(bool) bool) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.disableOCSPEndpointCheck = fn(c.disableOCSPEndpointCheck)
+		return nil
+	}
+}
+
+// WithConnectionLoadBalanced specifies whether or not the connection is to a server behind a load balancer.
+func WithConnectionLoadBalanced(fn func(bool) bool) ConnectionOption {
+	return func(c *connectionConfig) error {
+		c.loadBalanced = fn(c.loadBalanced)
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -33,6 +33,7 @@ type serverConfig struct {
 	registry                  *bsoncodec.Registry
 	monitoringDisabled        bool
 	serverAPI                 *driver.ServerAPIOptions
+	loadBalanced              bool
 }
 
 func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
@@ -170,6 +171,14 @@ func WithRegistry(fn func(*bsoncodec.Registry) *bsoncodec.Registry) ServerOption
 func WithServerAPI(fn func(serverAPI *driver.ServerAPIOptions) *driver.ServerAPIOptions) ServerOption {
 	return func(cfg *serverConfig) error {
 		cfg.serverAPI = fn(cfg.serverAPI)
+		return nil
+	}
+}
+
+// WithServerLoadBalanced specifies whether or not the server is behind a load balancer.
+func WithServerLoadBalanced(fn func(bool) bool) ServerOption {
+	return func(cfg *serverConfig) error {
+		cfg.loadBalanced = fn(cfg.loadBalanced)
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -133,7 +133,7 @@ func New(opts ...Option) (*Topology, error) {
 	}
 
 	if t.cfg.uri != "" {
-		t.pollingRequired = strings.HasPrefix(t.cfg.uri, "mongodb+srv://")
+		t.pollingRequired = strings.HasPrefix(t.cfg.uri, "mongodb+srv://") && !t.cfg.loadBalanced
 	}
 
 	t.publishTopologyOpeningEvent()

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -86,7 +86,7 @@ func TestLoadBalancedFromConnString(t *testing.T) {
 	}{
 		{"loadBalanced=true", "loadBalanced=true", true},
 		{"loadBalanced=false", "loadBalanced=false", false},
-		{"loadBalanced", "", false},
+		{"loadBalanced unset", "", false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -7,6 +7,7 @@
 package topology
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -73,6 +74,37 @@ func TestDirectConnectionFromConnString(t *testing.T) {
 			topo, err := New(WithConnString(func(connstring.ConnString) connstring.ConnString { return tc.cs }))
 			assert.Nil(t, err, "topology.New error: %v", err)
 			assert.Equal(t, tc.mode, topo.cfg.mode, "expected mode %v, got %v", tc.mode, topo.cfg.mode)
+		})
+	}
+}
+
+func TestLoadBalancedFromConnString(t *testing.T) {
+	testCases := []struct {
+		name         string
+		uriOptions   string
+		loadBalanced bool
+	}{
+		{"loadBalanced=true", "loadBalanced=true", true},
+		{"loadBalanced=false", "loadBalanced=false", false},
+		{"loadBalanced", "", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			uri := fmt.Sprintf("mongodb://localhost/?%s", tc.uriOptions)
+			cs, err := connstring.ParseAndValidate(uri)
+			assert.Nil(t, err, "connstring.ParseAndValidate error: %v", err)
+
+			topo, err := New(WithConnString(func(connstring.ConnString) connstring.ConnString { return cs }))
+			assert.Nil(t, err, "topology.New error: %v", err)
+			assert.Equal(t, tc.loadBalanced, topo.cfg.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, topo.cfg.loadBalanced)
+
+			srvr, err := NewServer("", topo.id, topo.cfg.serverOpts...)
+			assert.Nil(t, err, "NewServer error: %v", err)
+			assert.Equal(t, tc.loadBalanced, srvr.cfg.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, srvr.cfg.loadBalanced)
+
+			conn, err := newConnection("", srvr.cfg.connectionOpts...)
+			assert.Nil(t, err, "newConnection error: %v", err)
+			assert.Equal(t, tc.loadBalanced, conn.config.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, conn.config.loadBalanced)
 		})
 	}
 }


### PR DESCRIPTION
The full design doc is linked in the main [epic ticket](https://jira.mongodb.org/browse/GODRIVER-1856). Summary of changes:

1. Add a `loadBalanced` URI option and an equivalent `ClientOptions#SetLoadBalanced` function.
2. Allow `loadBalanced` to be specified via TXT records.
3. Validate combinations of options when `loadBalanced=true`.
4. Do not start the SRV polling goroutine if `loadBalanced=true`.

Additional notes for reviewers:

1. Use of TXT records and validation of `loadBalanced=true` with SRV records that resolve to multiple hostnames is untested. I expect upstream spec tests to be added for these as the project progresses.
2. The validation code is duplicated in `ClientOptions#Validate` and `Connstring#Validate`. Ideally, it would only happen in `ClientOptions#Validate`, but it's required in the URI parsing code because URI options spec tests do not go through `ClientOptions`. This is mitigated by defining the validation errors in the `internal` package, but we should fully address this in the GODRIVER-1588 project.
3. I opted to support load balancing via the `topology.WithConnString` function so users of the low-level API can use the feature with a URI.