### PR TITLE
GODRIVER-1895 SDAM, server selection, and handshake changes for LB mode

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -411,10 +411,16 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			func(opts ...string) []string { return append(opts, comps...) },
 		))
 	}
+
+	var loadBalanced bool
+	if opts.LoadBalanced != nil {
+		loadBalanced = *opts.LoadBalanced
+	}
+
 	// Handshaker
 	var handshaker = func(driver.Handshaker) driver.Handshaker {
 		return operation.NewIsMaster().AppName(appName).Compressors(comps).ClusterClock(c.clock).
-			ServerAPI(c.serverAPI)
+			ServerAPI(c.serverAPI).LoadBalanced(loadBalanced)
 	}
 	// Auth & Database & Password & Username
 	if opts.Auth != nil {
@@ -447,6 +453,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			Compressors:   comps,
 			ClusterClock:  c.clock,
 			ServerAPI:     c.serverAPI,
+			LoadBalanced:  loadBalanced,
 		}
 		if mechanism == "" {
 			// Required for SASL mechanism negotiation during handshake

--- a/mongo/description/server_kind.go
+++ b/mongo/description/server_kind.go
@@ -11,13 +11,14 @@ type ServerKind uint32
 
 // These constants are the possible types of servers.
 const (
-	Standalone  ServerKind = 1
-	RSMember    ServerKind = 2
-	RSPrimary   ServerKind = 4 + RSMember
-	RSSecondary ServerKind = 8 + RSMember
-	RSArbiter   ServerKind = 16 + RSMember
-	RSGhost     ServerKind = 32 + RSMember
-	Mongos      ServerKind = 256
+	Standalone   ServerKind = 1
+	RSMember     ServerKind = 2
+	RSPrimary    ServerKind = 4 + RSMember
+	RSSecondary  ServerKind = 8 + RSMember
+	RSArbiter    ServerKind = 16 + RSMember
+	RSGhost      ServerKind = 32 + RSMember
+	Mongos       ServerKind = 256
+	LoadBalancer ServerKind = 512
 )
 
 // String returns a stringified version of the kind or "Unknown" if the kind is invalid.
@@ -37,6 +38,8 @@ func (kind ServerKind) String() string {
 		return "RSGhost"
 	case Mongos:
 		return "Mongos"
+	case LoadBalancer:
+		return "LoadBalancer"
 	}
 
 	return "Unknown"

--- a/mongo/description/topology_kind.go
+++ b/mongo/description/topology_kind.go
@@ -16,6 +16,7 @@ const (
 	ReplicaSetNoPrimary   TopologyKind = 4 + ReplicaSet
 	ReplicaSetWithPrimary TopologyKind = 8 + ReplicaSet
 	Sharded               TopologyKind = 256
+	LoadBalanced          TopologyKind = 512
 )
 
 // String implements the fmt.Stringer interface.
@@ -31,6 +32,8 @@ func (kind TopologyKind) String() string {
 		return "ReplicaSetWithPrimary"
 	case Sharded:
 		return "Sharded"
+	case LoadBalanced:
+		return "LoadBalanced"
 	}
 
 	return "Unknown"

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -60,6 +60,7 @@ type HandshakeOptions struct {
 	PerformAuthentication func(description.Server) bool
 	ClusterClock          *session.ClusterClock
 	ServerAPI             *driver.ServerAPIOptions
+	LoadBalanced          bool
 }
 
 type authHandshaker struct {
@@ -84,7 +85,8 @@ func (ah *authHandshaker) GetHandshakeInformation(ctx context.Context, addr addr
 		Compressors(ah.options.Compressors).
 		SASLSupportedMechs(ah.options.DBUser).
 		ClusterClock(ah.options.ClusterClock).
-		ServerAPI(ah.options.ServerAPI)
+		ServerAPI(ah.options.ServerAPI).
+		LoadBalanced(ah.options.LoadBalanced)
 
 	if ah.options.Authenticator != nil {
 		if speculativeAuth, ok := ah.options.Authenticator.(SpeculativeAuthenticator); ok {


### PR DESCRIPTION
Summary of changes:

1. Send `loadBalanced: true` in application connection handshakes.
2. Record the new `serverId` field when parsing `isMaster` responses.
3. Add a new `LoadBalanced` TopologyKind type and `LoadBalancer` ServerKind.
4. Ensure the LB is always selected during server selection.
5. Do not start a monitoring connection in LB mode and instead publish a pre-determined set of SDAM events at configuration time.

Additional notes:

1. For server selection, I modified each exported server selector implementation (e.g. `ReadPrefSelector`, `WriteSelector`, etc) as well as the top-level `Topology#SelectServer` function. We need to modify each selector individually because server selection spec tests will use these selectors directly.
2. I changed `description.Server#String` to only include `AverageRTT` in the stringified output if it is set because it was being shown as 0 for the LB in SDAM events, which is incorrect.