### PR TITLE
GODRIVER-1897 Add a ResponseInfo type for processing server responses

### DIFF
--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -270,7 +270,8 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		},
 		Database:   bc.database,
 		Deployment: SingleServerDeployment{Server: bc.server},
-		ProcessResponseFn: func(response bsoncore.Document, srvr Server, desc description.Server, currIndex int) error {
+		ProcessResponseFn: func(info ResponseInfo) error {
+			response := info.ServerResponse
 			id, ok := response.Lookup("cursor", "id").Int64OK()
 			if !ok {
 				return fmt.Errorf("cursor.id should be an int64 but is a BSON %s", response.Lookup("cursor", "id").Type)

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -40,7 +40,7 @@ func NewAbortTransaction() *AbortTransaction {
 	return &AbortTransaction{}
 }
 
-func (at *AbortTransaction) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, currIndex int) error {
+func (at *AbortTransaction) processResponse(driver.ResponseInfo) error {
 	var err error
 	return err
 }

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -71,10 +71,10 @@ func (a *Aggregate) ResultCursorResponse() driver.CursorResponse {
 	return a.result
 }
 
-func (a *Aggregate) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, currIndex int) error {
+func (a *Aggregate) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	a.result, err = driver.NewCursorResponse(response, srvr, desc)
+	a.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
 	return err
 
 }

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -60,10 +60,10 @@ func (c *Command) Execute(ctx context.Context) error {
 		CommandFn: func(dst []byte, desc description.SelectedServer) ([]byte, error) {
 			return append(dst, c.command[4:len(c.command)-1]...), nil
 		},
-		ProcessResponseFn: func(resp bsoncore.Document, srvr driver.Server, desc description.Server, currIndex int) error {
-			c.result = resp
-			c.srvr = srvr
-			c.desc = desc
+		ProcessResponseFn: func(info driver.ResponseInfo) error {
+			c.result = info.ServerResponse
+			c.srvr = info.Server
+			c.desc = info.ConnectionDescription
 			return nil
 		},
 		Client:         c.session,

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -40,7 +40,7 @@ func NewCommitTransaction() *CommitTransaction {
 	return &CommitTransaction{}
 }
 
-func (ct *CommitTransaction) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (ct *CommitTransaction) processResponse(driver.ResponseInfo) error {
 	var err error
 	return err
 }

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -97,9 +97,9 @@ func NewCount() *Count {
 // Result returns the result of executing this operation.
 func (c *Count) Result() CountResult { return c.result }
 
-func (c *Count) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (c *Count) processResponse(info driver.ResponseInfo) error {
 	var err error
-	c.result, err = buildCountResult(response, srvr)
+	c.result, err = buildCountResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -52,7 +52,7 @@ func NewCreate(collectionName string) *Create {
 	}
 }
 
-func (c *Create) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (c *Create) processResponse(driver.ResponseInfo) error {
 	var err error
 	return err
 }

--- a/x/mongo/driver/operation/createIndexes.go
+++ b/x/mongo/driver/operation/createIndexes.go
@@ -90,9 +90,9 @@ func NewCreateIndexes(indexes bsoncore.Document) *CreateIndexes {
 // Result returns the result of executing this operation.
 func (ci *CreateIndexes) Result() CreateIndexesResult { return ci.result }
 
-func (ci *CreateIndexes) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (ci *CreateIndexes) processResponse(info driver.ResponseInfo) error {
 	var err error
-	ci.result, err = buildCreateIndexesResult(response, srvr)
+	ci.result, err = buildCreateIndexesResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -74,8 +74,8 @@ func NewDelete(deletes ...bsoncore.Document) *Delete {
 // Result returns the result of executing this operation.
 func (d *Delete) Result() DeleteResult { return d.result }
 
-func (d *Delete) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
-	dr, err := buildDeleteResult(response, srvr)
+func (d *Delete) processResponse(info driver.ResponseInfo) error {
+	dr, err := buildDeleteResult(info.ServerResponse, info.Server)
 	d.result.N += dr.N
 	return err
 }

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -73,9 +73,9 @@ func NewDistinct(key string, query bsoncore.Document) *Distinct {
 // Result returns the result of executing this operation.
 func (d *Distinct) Result() DistinctResult { return d.result }
 
-func (d *Distinct) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (d *Distinct) processResponse(info driver.ResponseInfo) error {
 	var err error
-	d.result, err = buildDistinctResult(response, srvr)
+	d.result, err = buildDistinctResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -76,9 +76,9 @@ func NewDropCollection() *DropCollection {
 // Result returns the result of executing this operation.
 func (dc *DropCollection) Result() DropCollectionResult { return dc.result }
 
-func (dc *DropCollection) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (dc *DropCollection) processResponse(info driver.ResponseInfo) error {
 	var err error
-	dc.result, err = buildDropCollectionResult(response, srvr)
+	dc.result, err = buildDropCollectionResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -67,9 +67,9 @@ func NewDropDatabase() *DropDatabase {
 // Result returns the result of executing this operation.
 func (dd *DropDatabase) Result() DropDatabaseResult { return dd.result }
 
-func (dd *DropDatabase) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (dd *DropDatabase) processResponse(info driver.ResponseInfo) error {
 	var err error
-	dd.result, err = buildDropDatabaseResult(response, srvr)
+	dd.result, err = buildDropDatabaseResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -72,9 +72,9 @@ func NewDropIndexes(index string) *DropIndexes {
 // Result returns the result of executing this operation.
 func (di *DropIndexes) Result() DropIndexesResult { return di.result }
 
-func (di *DropIndexes) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (di *DropIndexes) processResponse(info driver.ResponseInfo) error {
 	var err error
-	di.result, err = buildDropIndexesResult(response, srvr)
+	di.result, err = buildDropIndexesResult(info.ServerResponse, info.Server)
 	return err
 }
 

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -39,7 +39,7 @@ func NewEndSessions(sessionIDs bsoncore.Document) *EndSessions {
 	}
 }
 
-func (es *EndSessions) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (es *EndSessions) processResponse(driver.ResponseInfo) error {
 	var err error
 	return err
 }

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -74,9 +74,9 @@ func (f *Find) Result(opts driver.CursorOptions) (*driver.BatchCursor, error) {
 	return driver.NewBatchCursor(f.result, f.session, f.clock, opts)
 }
 
-func (f *Find) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (f *Find) processResponse(info driver.ResponseInfo) error {
 	var err error
-	f.result, err = driver.NewCursorResponse(response, srvr, desc)
+	f.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
 	return err
 }
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -108,10 +108,10 @@ func NewFindAndModify(query bsoncore.Document) *FindAndModify {
 // Result returns the result of executing this operation.
 func (fam *FindAndModify) Result() FindAndModifyResult { return fam.result }
 
-func (fam *FindAndModify) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (fam *FindAndModify) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	fam.result, err = buildFindAndModifyResult(response, srvr)
+	fam.result, err = buildFindAndModifyResult(info.ServerResponse, info.Server)
 	return err
 
 }

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -74,8 +74,8 @@ func NewInsert(documents ...bsoncore.Document) *Insert {
 // Result returns the result of executing this operation.
 func (i *Insert) Result() InsertResult { return i.result }
 
-func (i *Insert) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, insert int) error {
-	ir, err := buildInsertResult(response, srvr)
+func (i *Insert) processResponse(info driver.ResponseInfo) error {
+	ir, err := buildInsertResult(info.ServerResponse, info.Server)
 	i.result.N += ir.N
 	return err
 }

--- a/x/mongo/driver/operation/ismaster.go
+++ b/x/mongo/driver/operation/ismaster.go
@@ -237,8 +237,8 @@ func (im *IsMaster) createOperation() driver.Operation {
 		CommandFn:  im.command,
 		Database:   "admin",
 		Deployment: im.d,
-		ProcessResponseFn: func(response bsoncore.Document, _ driver.Server, _ description.Server, _ int) error {
-			im.res = response
+		ProcessResponseFn: func(info driver.ResponseInfo) error {
+			im.res = info.ServerResponse
 			return nil
 		},
 		ServerAPI: im.serverAPI,
@@ -253,8 +253,8 @@ func (im *IsMaster) GetHandshakeInformation(ctx context.Context, _ address.Addre
 		CommandFn:  im.handshakeCommand,
 		Deployment: driver.SingleConnectionDeployment{c},
 		Database:   "admin",
-		ProcessResponseFn: func(response bsoncore.Document, _ driver.Server, _ description.Server, _ int) error {
-			im.res = response
+		ProcessResponseFn: func(info driver.ResponseInfo) error {
+			im.res = info.ServerResponse
 			return nil
 		},
 		ServerAPI: im.serverAPI,

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -144,10 +144,10 @@ func NewListDatabases(filter bsoncore.Document) *ListDatabases {
 // Result returns the result of executing this operation.
 func (ld *ListDatabases) Result() ListDatabasesResult { return ld.result }
 
-func (ld *ListDatabases) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (ld *ListDatabases) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	ld.result, err = buildListDatabasesResult(response, srvr)
+	ld.result, err = buildListDatabasesResult(info.ServerResponse, info.Server)
 	return err
 
 }

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -59,9 +59,9 @@ func (lc *ListCollections) Result(opts driver.CursorOptions) (*driver.ListCollec
 	return driver.NewListCollectionsBatchCursor(bc)
 }
 
-func (lc *ListCollections) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (lc *ListCollections) processResponse(info driver.ResponseInfo) error {
 	var err error
-	lc.result, err = driver.NewCursorResponse(response, srvr, desc)
+	lc.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
 	return err
 }
 

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -52,10 +52,10 @@ func (li *ListIndexes) Result(opts driver.CursorOptions) (*driver.BatchCursor, e
 	return driver.NewBatchCursor(li.result, clientSession, clock, opts)
 }
 
-func (li *ListIndexes) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, _ int) error {
+func (li *ListIndexes) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	li.result, err = driver.NewCursorResponse(response, srvr, desc)
+	li.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
 	return err
 
 }

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -122,14 +122,14 @@ func NewUpdate(updates ...bsoncore.Document) *Update {
 // Result returns the result of executing this operation.
 func (u *Update) Result() UpdateResult { return u.result }
 
-func (u *Update) processResponse(response bsoncore.Document, srvr driver.Server, desc description.Server, currIndex int) error {
-	ur, err := buildUpdateResult(response, srvr)
+func (u *Update) processResponse(info driver.ResponseInfo) error {
+	ur, err := buildUpdateResult(info.ServerResponse, info.Server)
 
 	u.result.N += ur.N
 	u.result.NModified += ur.NModified
-	if currIndex > 0 {
+	if info.CurrentIndex > 0 {
 		for ind := range ur.Upserted {
-			ur.Upserted[ind].Index += int64(currIndex)
+			ur.Upserted[ind].Index += int64(info.CurrentIndex)
 		}
 	}
 	u.result.Upserted = append(u.result.Upserted, ur.Upserted...)

--- a/x/mongo/driver/operation_exhaust.go
+++ b/x/mongo/driver/operation_exhaust.go
@@ -9,8 +9,6 @@ package driver
 import (
 	"context"
 	"errors"
-
-	"go.mongodb.org/mongo-driver/mongo/description"
 )
 
 // ExecuteExhaust reads a response from the provided StreamerConnection. This will error if the connection's
@@ -26,7 +24,12 @@ func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection,
 		return err
 	}
 	if op.ProcessResponseFn != nil {
-		if err = op.ProcessResponseFn(res, nil, description.Server{}, 0); err != nil {
+		// Server, ConnectionDescription, and CurrentIndex are unused in this mode.
+		info := ResponseInfo{
+			ServerResponse: res,
+			Connection:     conn,
+		}
+		if err = op.ProcessResponseFn(info); err != nil {
 			return err
 		}
 	}

--- a/x/mongo/driver/operation_legacy.go
+++ b/x/mongo/driver/operation_legacy.go
@@ -55,7 +55,14 @@ func (op Operation) legacyFind(ctx context.Context, dst []byte, srvr Server, con
 	}
 
 	if op.ProcessResponseFn != nil {
-		return op.ProcessResponseFn(finishedInfo.response, srvr, desc.Server, 0)
+		// CurrentIndex is always 0 in this mode.
+		info := ResponseInfo{
+			ServerResponse:        finishedInfo.response,
+			Server:                srvr,
+			Connection:            conn,
+			ConnectionDescription: desc.Server,
+		}
+		return op.ProcessResponseFn(info)
 	}
 	return nil
 }
@@ -225,7 +232,14 @@ func (op Operation) legacyGetMore(ctx context.Context, dst []byte, srvr Server, 
 	}
 
 	if op.ProcessResponseFn != nil {
-		return op.ProcessResponseFn(finishedInfo.response, srvr, desc.Server, 0)
+		// CurrentIndex is always 0 in this mode.
+		info := ResponseInfo{
+			ServerResponse:        finishedInfo.response,
+			Server:                srvr,
+			Connection:            conn,
+			ConnectionDescription: desc.Server,
+		}
+		return op.ProcessResponseFn(info)
 	}
 	return nil
 }
@@ -393,7 +407,14 @@ func (op Operation) legacyListCollections(ctx context.Context, dst []byte, srvr 
 	}
 
 	if op.ProcessResponseFn != nil {
-		return op.ProcessResponseFn(finishedInfo.response, srvr, desc.Server, 0)
+		// CurrentIndex is always 0 in this mode.
+		info := ResponseInfo{
+			ServerResponse:        finishedInfo.response,
+			Server:                srvr,
+			Connection:            conn,
+			ConnectionDescription: desc.Server,
+		}
+		return op.ProcessResponseFn(info)
 	}
 	return nil
 }
@@ -520,7 +541,14 @@ func (op Operation) legacyListIndexes(ctx context.Context, dst []byte, srvr Serv
 	}
 
 	if op.ProcessResponseFn != nil {
-		return op.ProcessResponseFn(finishedInfo.response, srvr, desc.Server, 0)
+		// CurrentIndex is always 0 in this mode.
+		info := ResponseInfo{
+			ServerResponse:        finishedInfo.response,
+			Server:                srvr,
+			Connection:            conn,
+			ConnectionDescription: desc.Server,
+		}
+		return op.ProcessResponseFn(info)
 	}
 	return nil
 }


### PR DESCRIPTION
To support load balanced clusters, we need to sometimes pin resources like connections and transactions to a single connection. We can do this by modifying the [response processing function](https://github.com/mongodb/mongo-go-driver/blob/9f796d93bf13a28aa074b573df1dac4e41bd47d5/x/mongo/driver/operation.go#L116) that gets called when an operation is executed to take a new `driver.Connection` argument. However, that function already takes four arguments, so this PR introduces a new `ResponseInfo` type to hold all of these arguments along with a new `Connection` field. In my opinion, this makes the API much cleaner.

Note that this PR doesn't change individual operations to actually pin connections to resources. That will come in a later PR for the same ticket.