### PR TITLE
Update Versioned API Spec Tests

### DIFF
--- a/data/versioned-api/crud-api-version-1-strict.json
+++ b/data/versioned-api/crud-api-version-1-strict.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -301,6 +301,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,7 +359,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -396,6 +405,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -597,11 +609,6 @@
     {
       "description": "estimatedDocumentCount appends declared API version",
       "skipReason": "DRIVERS-1561 collStats is not in API version 1",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -972,6 +979,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1027,7 +1037,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1077,6 +1090,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/data/versioned-api/crud-api-version-1-strict.yml
+++ b/data/versioned-api/crud-api-version-1-strict.yml
@@ -3,7 +3,7 @@ description: "CRUD Api Version 1 (strict)"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
 
 createEntities:
   - client:
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -217,8 +226,6 @@ tests:
 
   - description: "estimatedDocumentCount appends declared API version"
     skipReason: "DRIVERS-1561 collStats is not in API version 1"
-    runOnRequirements:
-      - minServerVersion: "4.9.0" # $collStats is not used in estimatedDocumentCount on < 4.9
     operations:
       - name: estimatedDocumentCount
         object: *collection
@@ -362,7 +369,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -379,7 +389,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -396,5 +409,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/data/versioned-api/crud-api-version-1.json
+++ b/data/versioned-api/crud-api-version-1.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -298,6 +298,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -350,7 +356,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -393,6 +402,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -587,46 +599,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection",
-          "arguments": {}
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "count": "test",
-                  "apiVersion": "1",
-                  "apiStrict": {
-                    "$$unsetOrMatches": false
-                  },
-                  "apiDeprecationErrors": true
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -997,6 +970,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1052,7 +1028,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1102,6 +1081,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/data/versioned-api/crud-api-version-1.yml
+++ b/data/versioned-api/crud-api-version-1.yml
@@ -3,7 +3,7 @@ description: "CRUD Api Version 1"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
 
 createEntities:
   - client:
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -209,24 +218,7 @@ tests:
                 key: x
                 <<: *expectedApiVersion
 
-  - description: "estimatedDocumentCount appends declared API version on less than 4.9.0"
-    runOnRequirements:
-      - maxServerVersion: "4.8.99"
-    operations:
-      - name: estimatedDocumentCount
-        object: *collection
-        arguments: {}
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                count: *collectionName
-                <<: *expectedApiVersion
-
   - description: "estimatedDocumentCount appends declared API version on 4.9.0 or greater"
-    runOnRequirements:
-      - minServerVersion: "4.9.0"
     operations:
       - name: estimatedDocumentCount
         object: *collection
@@ -370,7 +362,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -387,7 +382,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -404,5 +402,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/data/versioned-api/runcommand-helper-no-api-version-declared.json
+++ b/data/versioned-api/runcommand-helper-no-api-version-declared.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "requireApiVersion": false
       }

--- a/data/versioned-api/runcommand-helper-no-api-version-declared.yml
+++ b/data/versioned-api/runcommand-helper-no-api-version-declared.yml
@@ -3,7 +3,7 @@ description: "RunCommand helper: No API version declared"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       requireApiVersion: false
 

--- a/data/versioned-api/test-commands-deprecation-errors.json
+++ b/data/versioned-api/test-commands-deprecation-errors.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
         "acceptAPIVersion2": true,

--- a/data/versioned-api/test-commands-deprecation-errors.yml
+++ b/data/versioned-api/test-commands-deprecation-errors.yml
@@ -3,7 +3,7 @@ description: "Test commands: deprecation errors"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
       acceptAPIVersion2: true

--- a/data/versioned-api/test-commands-strict-mode.json
+++ b/data/versioned-api/test-commands-strict-mode.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true
       }

--- a/data/versioned-api/test-commands-strict-mode.yml
+++ b/data/versioned-api/test-commands-strict-mode.yml
@@ -3,7 +3,7 @@ description: "Test commands: strict mode"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
 

--- a/data/versioned-api/transaction-handling.json
+++ b/data/versioned-api/transaction-handling.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "topologies": [
         "replicaset",
         "sharded-replicaset"

--- a/data/versioned-api/transaction-handling.json
+++ b/data/versioned-api/transaction-handling.json
@@ -382,6 +382,138 @@
           ]
         }
       ]
+    },
+    {
+      "description": "abortTransaction does not include an API version",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 6,
+              "x": 66
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 6
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 7,
+              "x": 77
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 6,
+                      "x": 66
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "startTransaction": true,
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 7,
+                      "x": 77
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/data/versioned-api/transaction-handling.yml
+++ b/data/versioned-api/transaction-handling.yml
@@ -3,7 +3,7 @@ description: "Transaction handling"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     topologies: [ replicaset, sharded-replicaset ]
 
 createEntities:

--- a/data/versioned-api/transaction-handling.yml
+++ b/data/versioned-api/transaction-handling.yml
@@ -137,3 +137,44 @@ tests:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
                 <<: *noApiVersion
+  - description: "abortTransaction does not include an API version"
+    runOnRequirements:
+      - topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: startTransaction
+        object: *session
+      - name: insertOne
+        object: *collection
+        arguments:
+          session: *session
+          document: { _id: 6, x: 66 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
+      - name: insertOne
+        object: *collection
+        arguments:
+          session: *session
+          document: { _id: 7, x: 77 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
+      - name: abortTransaction
+        object: *session
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 6, x: 66 } ]
+                lsid: { $$sessionLsid: *session }
+                startTransaction: true
+                <<: *expectedApiVersion
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 7, x: 77 } ]
+                lsid: { $$sessionLsid: *session }
+                <<: *noApiVersion
+          - commandStartedEvent:
+              command:
+                abortTransaction: 1
+                lsid: { $$sessionLsid: *session }
+                <<: *noApiVersion


### PR DESCRIPTION
[GODRIVER-1907](https://jira.mongodb.org/browse/GODRIVER-1907)
[GODRIVER-1908](https://jira.mongodb.org/browse/GODRIVER-1908)

Syncs versioned API tests. Adds a new test to ensure abortTransaction does not send API version and updates all versioned API tests to run on only 4.9+.