### PR TITLE
GODRIVER-1897 Pin cursors to a connection in LB mode

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -133,7 +133,7 @@ func (db *Database) Aggregate(ctx context.Context, pipeline interface{},
 }
 
 func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
-	createCursor bool, opts ...*options.RunCmdOptions) (*operation.Command, *session.Client, error) {
+	cursorCommand bool, opts ...*options.RunCmdOptions) (*operation.Command, *session.Client, error) {
 	sess := sessionFromContext(ctx)
 	if sess == nil && db.client.sessionPool != nil {
 		var err error
@@ -166,7 +166,7 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	}
 
 	createCmdFn := operation.NewCommand
-	if createCursor {
+	if cursorCommand {
 		createCmdFn = operation.NewCursorCommand
 	}
 	return createCmdFn(runCmdDoc).

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -336,6 +336,11 @@ func (s Server) DataBearing() bool {
 		s.Kind == Standalone
 }
 
+// LoadBalanced returns true if the server is a load balancer or is behind a load balancer.
+func (s Server) LoadBalanced() bool {
+	return s.Kind == LoadBalancer || s.ServerID != nil
+}
+
 // String implements the Stringer interface
 func (s Server) String() string {
 	str := fmt.Sprintf("Addr: %s, Type: %s",

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -102,7 +102,7 @@ func NewCursorResponse(info ResponseInfo) (CursorResponse, error) {
 
 	// If the deployment is behind a load balancer and the cursor has a non-zero ID, pin the cursor to a connection and
 	// use the same connection to execute getMore and killCursors commands.
-	if curresp.Desc.ServerID != nil && curresp.ID != 0 {
+	if curresp.Desc.LoadBalanced() && curresp.ID != 0 {
 		// Cache the server as an ErrorProcessor to use when constructing deployments for cursor commands.
 		ep, ok := curresp.Server.(ErrorProcessor)
 		if !ok {
@@ -112,7 +112,7 @@ func NewCursorResponse(info ResponseInfo) (CursorResponse, error) {
 
 		refConn, ok := info.Connection.(PinnedConnection)
 		if !ok {
-			return CursorResponse{}, fmt.Errorf("expected Connection used to establish a cursor to implement ReferencedConnection, but got %T", info.Connection)
+			return CursorResponse{}, fmt.Errorf("expected Connection used to establish a cursor to implement PinnedConnection, but got %T", info.Connection)
 		}
 		if err := refConn.PinToCursor(); err != nil {
 			return CursorResponse{}, fmt.Errorf("error incrementing connection reference count when creating a cursor: %v", err)

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -55,6 +55,24 @@ type Connection interface {
 	Stale() bool
 }
 
+// PinnedConnection represents a Connection that can be pinned by one or more cursors or transactions. Implementations
+// of this interface should maintain the following invariants:
+//
+// 1. Each Pin* call should increment the number of references for the connection.
+// 2. Each Unpin* call should decrement the number of references for the connection.
+// 3. Calls to Close() should be ignored until all resources have unpinned the connection.
+// 4. Calls to Expire() should forcefully close the connection even if there are references that have not been unpinned.
+// This method should be used to indicate that a PinnedConnection is no longer valid. Unpin* calls after Expire has
+// been called should be ignored.
+type PinnedConnection interface {
+	Connection
+	Expirable
+	PinToCursor() error
+	PinToTransaction() error
+	UnpinFromCursor() error
+	UnpinFromTransaction() error
+}
+
 // LocalAddresser is a type that is able to supply its local address
 type LocalAddresser interface {
 	LocalAddress() address.Address

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -74,7 +74,7 @@ func (a *Aggregate) ResultCursorResponse() driver.CursorResponse {
 func (a *Aggregate) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	a.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
+	a.result, err = driver.NewCursorResponse(info)
 	return err
 
 }

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -76,7 +76,7 @@ func (f *Find) Result(opts driver.CursorOptions) (*driver.BatchCursor, error) {
 
 func (f *Find) processResponse(info driver.ResponseInfo) error {
 	var err error
-	f.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
+	f.result, err = driver.NewCursorResponse(info)
 	return err
 }
 

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -61,7 +61,7 @@ func (lc *ListCollections) Result(opts driver.CursorOptions) (*driver.ListCollec
 
 func (lc *ListCollections) processResponse(info driver.ResponseInfo) error {
 	var err error
-	lc.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
+	lc.result, err = driver.NewCursorResponse(info)
 	return err
 }
 

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -55,7 +55,7 @@ func (li *ListIndexes) Result(opts driver.CursorOptions) (*driver.BatchCursor, e
 func (li *ListIndexes) processResponse(info driver.ResponseInfo) error {
 	var err error
 
-	li.result, err = driver.NewCursorResponse(info.ServerResponse, info.Server, info.ConnectionDescription)
+	li.result, err = driver.NewCursorResponse(info)
 	return err
 
 }


### PR DESCRIPTION
Summary of changes:

1. Introduce a `driver.PinnedConnection` interface to represent the fact that connections can be pinned by cursors and transactions. Currently, only the cursor functionality is used. A future PR will utilize the transaction functions as well. Note that this interface has separate `PinToCursor` and `PinToTransaction` methods rather than a generic `Pin` method because this project requires us to track the reason for which a connection is pinned. This PR only sets us up to do that; a future PR will plumb these statistics down to the connection pool and use them in error messages (GODRIVER-1901).
2. `BatchCursor` holds on to a connection if it detects that the server is behind an LB. It uses this connection to execute `getMore` and `killCursors` commands. The connection is unpinned either when the cursor is explicitly closed via the `Close` function, once all cursor batches have been retrieved, or when a `getMore` command encounters a network error. In the last case, we rely on the server's reaper thread to clean up the cursor.
3. A `loadBalancedCursorDeployment` has been introduced to use for `getMore` and `killCursors` commands when pinning to a connection.
4. The `Command` operation has been changed to have separate `NewCommand` and `NewCursorCommand` constructors. Previously, `RunCommandCursor` would use the `NewCommand` constructor and the operation wouldn't create a cursor until `ResultCursor` was called. However, in LB mode, we need access to the connection used for the operation, which would already have been returned to the pool by that time, so the operation eagerly constructs the cursor if the right constructor is used.