### PR TITLE
GODRIVER-1897 Pin transactions to a connection in LB mode

### DIFF
--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -6,6 +6,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
 // Deployment is implemented by types that can select a server from a deployment.
@@ -72,6 +73,11 @@ type PinnedConnection interface {
 	UnpinFromCursor() error
 	UnpinFromTransaction() error
 }
+
+// The session.LoadBalancedTransactionConnection type is a copy of PinnedConnection that was introduced to avoid
+// import cycles. This compile-time assertion ensures that these types remain in sync if the PinnedConnection interface
+// is changed in the future.
+var _ PinnedConnection = (session.LoadBalancedTransactionConnection)(nil)
 
 // LocalAddresser is a type that is able to supply its local address
 type LocalAddresser interface {

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -419,7 +419,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 			_ = ep.ProcessError(err, conn)
 		}
 
-		// If we're executing a load-balanced transcation and encountered a network error, the pinned connection should
+		// If we're executing a load-balanced transaction and encounter a network error, the pinned connection should
 		// be unpinned. We call ExpirePinnedConnection to ensure that the connection is closed and returned to the
 		// pool for bookkeeping. Future AbortTransaction calls will check out a new connection, which is desired. We
 		// do this before any other checks to make sure we release the invalidated connection even though other


### PR DESCRIPTION
This PR adds functionality to pin transactions to a connection for load-balanced deployments. It is the last of the connection pinning PRs for load balancer support.

Summary of changes:

1. A new `session.LoadBalancedTransactionConnection` interface has been added. This interface is a copy of `driver.PinnedConnection`. It exists only because using `driver.Connection` directly creates an import cycle (`driver.Operation` depends on `session.Client`, so `session.Client` can't also depend on `driver.PinnedConnection`). Ideally, we'd put the `PinnedConnection` interface in another package along with the related `Connection` and `Expirable` interfaces, but this is a bigger refactoring than I'd like to take on for this project and would be a breaking change for low-level driver users like BIC.
2. `Operation` will update the session to pin to a connection if we're in load-balanced mode and starting a transaction.
3. Once we run a `commitTransaction` or `abortTransaction` in this mode, we unpin the connection from the session. If the command fails, it will be retried on a different connection.
4. If we encounter a network error during a transaction, we `Expire` the pinned connection. Unlike cursors, which can't be cleaned up via `killCursors` after a network error, we can still run `abortTransaction` after the network error happens. The attempt will get a new connection from the pool. This is OK because `abortTransaction` and `commitTransaction` can be serviced by a different mongos than the one that serviced the other transaction commands.

Open questions:

1. I'd like to put a compile-time assertion to ensure that `session.LoadBalancedTransactionConnection` implements `driver.PinnedConnection`. It can't go in the `session` package, where it really should be, due to import cycles. Would it be OK to put this assertion in `driver` even though it's kind of awkward?