### PR TITLE
GODRIVER-1919 Add object id decoder awareness of string hex

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -740,6 +740,9 @@ func (dvd DefaultValueDecoders) objectIDDecodeType(dc DecodeContext, vr bsonrw.V
 		if err != nil {
 			return emptyValue, err
 		}
+		if oid, err = primitive.ObjectIDFromHex(str); err == nil {
+			break
+		}
 		if len(str) != 12 {
 			return emptyValue, fmt.Errorf("an ObjectID string must be exactly 12 bytes long (got %v)", len(str))
 		}

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -718,6 +718,7 @@ func (dvd DefaultValueDecoders) UndefinedDecodeValue(dc DecodeContext, vr bsonrw
 	return nil
 }
 
+// Accept both 12-byte string and pretty-printed 24-byte hex string formats.
 func (dvd DefaultValueDecoders) objectIDDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tOID {
 		return emptyValue, ValueDecoderError{

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -1119,6 +1119,17 @@ func TestDefaultValueDecoders(t *testing.T) {
 					nil,
 				},
 				{
+					"success/string-hex",
+					primitive.ObjectID{0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61, 0x62},
+					nil,
+					&bsonrwtest.ValueReaderWriter{
+						BSONType: bsontype.String,
+						Return:   "303132333435363738396162",
+					},
+					bsonrwtest.ReadString,
+					nil,
+				},
+				{
 					"decode null",
 					primitive.ObjectID{},
 					nil,


### PR DESCRIPTION
Try to run this code
```
type Entity struct {
	ID primitive.ObjectID `bson:"_id"`
}

func main() {
	var e Entity
	err := bson.UnmarshalExtJSON([]byte(`{"_id":"5ef7fdd91c19e3222b41b839"}`), true, &e)
	if err != nil {
		log.Fatal(err)
	}
}
```

You'll get an `ObjectID string must be exactly 12 bytes long`. Obvious bug

