### PR TITLE
GODRIVER-1898 SDAM error handling changes for LB mode

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -89,6 +89,9 @@ type PoolEvent struct {
 	ConnectionID uint64              `json:"connectionId"`
 	PoolOptions  *MonitorPoolOptions `json:"options"`
 	Reason       string              `json:"reason"`
+	// ServerID is only set if the Type is PoolCleared and the server is deployed behind a load balancer. This field
+	// can be used to distinguish between individual servers in a load balanced deployment.
+	ServerID *primitive.ObjectID `json:"serverId"`
 }
 
 // PoolMonitor is a function that allows the user to gain access to events occurring in the pool

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -419,7 +419,7 @@ func runOperationInThread(t *testing.T, operation map[string]interface{}, testIn
 		}
 		return c.Close()
 	case "clear":
-		s.pool.clear()
+		s.pool.clear(nil)
 	case "close":
 		return s.pool.disconnect(context.Background())
 	default:

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -129,7 +129,7 @@ func (c *connection) hasGenerationNumber() bool {
 		return true
 	}
 
-	// For LB clusters, we set the generation after the initial handshake, so we know its set if the connection
+	// For LB clusters, we set the generation after the initial handshake, so we know it's set if the connection
 	// description has been updated to reflect that it's behind an LB.
 	return c.desc.LoadBalanced()
 }

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -91,6 +91,11 @@ func newConnection(addr address.Address, opts ...ConnectionOption) (*connection,
 		cancellationListener: internal.NewCancellationListener(),
 		poolMonitor:          cfg.poolMonitor,
 	}
+	// Connections to non-load balanced deployments should eagerly set the generation numbers so errors encountered
+	// at any point during connection establishment can be processed without the connection being considered stale.
+	if !c.config.loadBalanced {
+		c.setGenerationNumber()
+	}
 	atomic.StoreInt32(&c.connected, initialized)
 
 	return c, nil
@@ -104,8 +109,29 @@ func (c *connection) processInitializationError(err error) {
 
 	c.connectErr = ConnectionError{Wrapped: err, init: true}
 	if c.config.errorHandlingCallback != nil {
-		c.config.errorHandlingCallback(c.connectErr, c.generation)
+		c.config.errorHandlingCallback(c.connectErr, c.generation, c.desc.ServerID)
 	}
+}
+
+// setGenerationNumber sets the connection's generation number if a callback has been provided to do so in connection
+// configuration.
+func (c *connection) setGenerationNumber() {
+	if c.config.getGenerationFn != nil {
+		c.generation = c.config.getGenerationFn(c.desc.ServerID)
+	}
+}
+
+// hasGenerationNumber returns true if the connection has set its generation number. If so, this indicates that the
+// generationNumberFn provided via the connection options has been called exactly once.
+func (c *connection) hasGenerationNumber() bool {
+	if !c.config.loadBalanced {
+		// The generation is known for all non-LB clusters once the connection object has been created.
+		return true
+	}
+
+	// For LB clusters, we set the generation after the initial handshake, so we know its set if the connection
+	// description has been updated to reflect that it's behind an LB.
+	return c.desc.LoadBalanced()
 }
 
 // connect handles the I/O for a connection. It will dial, configure TLS, and perform
@@ -212,6 +238,13 @@ func (c *connection) connect(ctx context.Context) {
 		}
 	}
 	if err == nil {
+		// For load-balanced connections, the generation number depends on the server ID, which isn't known until the
+		// initial MongoDB handshake is done. To account for this, we don't attempt to set the connection's generation
+		// number unless GetHandshakeInformation succeeds.
+		if c.config.loadBalanced {
+			c.setGenerationNumber()
+		}
+
 		// If we successfully finished the first part of the handshake and verified LB state, continue with the rest of
 		// the handshake.
 		err = handshaker.FinishHandshake(handshakeCtx, handshakeConn)

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/ocsp"
@@ -35,6 +36,9 @@ var DefaultDialer Dialer = &net.Dialer{}
 // initialization. Implementations must be goroutine safe.
 type Handshaker = driver.Handshaker
 
+// generationNumberFn is a callback type used by a connection to fetch its generation number given its server ID.
+type generationNumberFn func(serverID *primitive.ObjectID) uint64
+
 type connectionConfig struct {
 	appName                  string
 	connectTimeout           time.Duration
@@ -51,9 +55,10 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(error, uint64)
+	errorHandlingCallback    func(error, uint64, *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
+	getGenerationFn          generationNumberFn
 }
 
 func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
@@ -87,7 +92,7 @@ func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) C
 	}
 }
 
-func withErrorHandlingCallback(fn func(error, uint64)) ConnectionOption {
+func withErrorHandlingCallback(fn func(error, uint64, *primitive.ObjectID)) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.errorHandlingCallback = fn
 		return nil
@@ -214,6 +219,13 @@ func WithDisableOCSPEndpointCheck(fn func(bool) bool) ConnectionOption {
 func WithConnectionLoadBalanced(fn func(bool) bool) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.loadBalanced = fn(c.loadBalanced)
+		return nil
+	}
+}
+
+func withGenerationNumberFn(fn func(generationNumberFn) generationNumberFn) ConnectionOption {
+	return func(c *connectionConfig) error {
+		c.getGenerationFn = fn(c.getGenerationFn)
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/mongo/address"
@@ -128,7 +129,7 @@ func TestConnection(t *testing.T) {
 							return &net.TCPConn{}, nil
 						})
 					}),
-					withErrorHandlingCallback(func(err error, _ uint64) {
+					withErrorHandlingCallback(func(err error, _ uint64, _ *primitive.ObjectID) {
 						got = err
 					}),
 				)

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -1,0 +1,133 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package topology
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// generationStats represents the version of a pool. It tracks the generation number as well as the number of
+// connections that have been created in the generation.
+type generationStats struct {
+	generation uint64
+	numConns   uint64
+}
+
+// poolGenerationMap tracks the version for each server ID present in a pool. For deployments that are not behind a load
+// balancer, there is only one server ID: primitive.NilObjectID. For load-balanced deployments, each server behind the
+// load balancer will have a unique server ID.
+type poolGenerationMap struct {
+	// state must be accessed using the atomic package.
+	state         int32
+	generationMap map[primitive.ObjectID]*generationStats
+
+	sync.Mutex
+}
+
+func newPoolGenerationMap() *poolGenerationMap {
+	pgm := &poolGenerationMap{
+		generationMap: make(map[primitive.ObjectID]*generationStats),
+	}
+	pgm.generationMap[primitive.NilObjectID] = &generationStats{}
+	return pgm
+}
+
+func (p *poolGenerationMap) connect() {
+	atomic.StoreInt32(&p.state, connected)
+}
+
+func (p *poolGenerationMap) disconnect() {
+	atomic.StoreInt32(&p.state, disconnected)
+}
+
+// addConnection increments the connection count for the generation associated with the given server ID and returns the
+// generation number for the connection.
+func (p *poolGenerationMap) addConnection(serverIDPtr *primitive.ObjectID) uint64 {
+	serverID := getServerID(serverIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	stats, ok := p.generationMap[serverID]
+	if ok {
+		// If the serverID is already being tracked, we only need to increment the connection count.
+		stats.numConns++
+		return stats.generation
+	}
+
+	// If the serverID is untracked, create a new entry with a starting generation number of 0.
+	stats = &generationStats{
+		numConns: 1,
+	}
+	p.generationMap[serverID] = stats
+	return 0
+}
+
+func (p *poolGenerationMap) removeConnection(serverIDPtr *primitive.ObjectID) {
+	serverID := getServerID(serverIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	stats, ok := p.generationMap[serverID]
+	if !ok {
+		return
+	}
+
+	// If the serverID is being tracked, decrement the connection count and delete this serverID to prevent the map
+	// from growing unboundedly. This case would happen if a server behind a load-balancer was permanently removed
+	// and its connections were pruned after a network error or idle timeout.
+	stats.numConns--
+	if stats.numConns == 0 {
+		delete(p.generationMap, serverID)
+	}
+}
+
+func (p *poolGenerationMap) clear(serverIDPtr *primitive.ObjectID) {
+	serverID := getServerID(serverIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	if stats, ok := p.generationMap[serverID]; ok {
+		stats.generation++
+	}
+}
+
+func (p *poolGenerationMap) stale(serverIDPtr *primitive.ObjectID, knownGeneration uint64) bool {
+	// If the map has been disconnected, all connections should be considered stale to ensure that they're closed.
+	if atomic.LoadInt32(&p.state) == disconnected {
+		return true
+	}
+
+	serverID := getServerID(serverIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	if stats, ok := p.generationMap[serverID]; ok {
+		return knownGeneration < stats.generation
+	}
+	return false
+}
+
+func (p *poolGenerationMap) getGeneration(serverIDPtr *primitive.ObjectID) uint64 {
+	serverID := getServerID(serverIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	if stats, ok := p.generationMap[serverID]; ok {
+		return stats.generation
+	}
+	return 0
+}
+
+func getServerID(oid *primitive.ObjectID) primitive.ObjectID {
+	if oid == nil {
+		return primitive.NilObjectID
+	}
+	return *oid
+}

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -296,10 +296,6 @@ func TestPool(t *testing.T) {
 
 			c, err = p.get(context.Background())
 			noerr(t, err)
-			gen = atomic.LoadUint64(&c.generation)
-			if gen != 1 {
-				t.Errorf("Connection should have a newer generation. got %d; want %d", gen, 1)
-			}
 			err = p.put(c)
 			noerr(t, err)
 			if d.lenopened() != 2 {
@@ -687,7 +683,7 @@ func TestPool(t *testing.T) {
 
 			// Increment the pool's generation number so the connection will be considered stale and will be closed by
 			// get().
-			p.clear()
+			p.clear(nil)
 			_, err = p.get(context.Background())
 			noerr(t, err)
 		})

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -167,8 +167,8 @@ func TestServer(t *testing.T) {
 			{"post-handshake errors are not ignored for load balancers", true, nil, nil, netErr.Wrapped, 2, 0},
 
 			// For non-LB clusters, all errors are processed.
-			{"dial errors are ignored for non-lb clusters", false, netErr.Wrapped, nil, nil, 2, 0},
-			{"initial handshake errors are ignored for non-lb clusters", false, nil, netErr.Wrapped, nil, 2, 0},
+			{"dial errors are not ignored for non-lb clusters", false, netErr.Wrapped, nil, nil, 2, 0},
+			{"initial handshake errors are not ignored for non-lb clusters", false, nil, netErr.Wrapped, nil, 2, 0},
 			{"post-handshake errors are not ignored for non-lb clusters", false, nil, nil, netErr.Wrapped, 2, 0},
 		}
 		for _, tc := range testCases {
@@ -221,6 +221,11 @@ func TestServer(t *testing.T) {
 					}),
 					WithConnectionOptions(func(...ConnectionOption) []ConnectionOption {
 						return connOpts
+					}),
+					// Disable the monitoring routine because we're only testing pooled connections and we don't want
+					// errors in monitoring to clear the pool and make this test flaky.
+					withMonitoringDisabled(func(bool) bool {
+						return true
 					}),
 				}
 


### PR DESCRIPTION
Summary of changes:

1. Instead of tracking a pool's generation number as a single `uint64`, use a map from `serverID` (which is an ObjectID) to a tuple of `(generation number, connection count)`. In this new map type, `primitive.NilObjectID` is used to store the generation and connection count for servers that do not return a `serverId` field in `ismaster` responses (i.e. servers in non-load balanced deployments).
2. When clearing the pool, only clear connections for a specific server ID.
3. Add a `ServerID` field to `PoolCleared` events.
4. Ignore connection establishment errors that occur before the server ID is known for connections to LBs.