### PR TITLE
GODRIVER-1901 Add details to wait queue timeout errors

### DIFF
--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -62,16 +62,23 @@ func (e ServerSelectionError) Unwrap() error {
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool
 type WaitQueueTimeoutError struct {
-	Wrapped error
+	Wrapped                      error
+	PinnedCursorConnections      uint64
+	PinnedTransactionConnections uint64
+	maxPoolSize                  uint64
 }
 
 // Error implements the error interface.
 func (w WaitQueueTimeoutError) Error() string {
 	errorMsg := "timed out while checking out a connection from connection pool"
 	if w.Wrapped != nil {
-		return fmt.Sprintf("%s: %s", errorMsg, w.Wrapped.Error())
+		errorMsg = fmt.Sprintf("%s: %s", errorMsg, w.Wrapped.Error())
 	}
-	return errorMsg
+
+	errorMsg = fmt.Sprintf("%s; maxPoolSize: %d, connections in use by cursors: %d, connections in use by transactions: %d",
+		errorMsg, w.maxPoolSize, w.PinnedCursorConnections, w.PinnedTransactionConnections)
+	return fmt.Sprintf("%s, connections in use by regular operations: %d", errorMsg,
+		w.maxPoolSize-(w.PinnedCursorConnections+w.PinnedTransactionConnections))
 }
 
 // Unwrap returns the underlying error.

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -77,7 +77,7 @@ func (w WaitQueueTimeoutError) Error() string {
 
 	errorMsg = fmt.Sprintf("%s; maxPoolSize: %d, connections in use by cursors: %d, connections in use by transactions: %d",
 		errorMsg, w.maxPoolSize, w.PinnedCursorConnections, w.PinnedTransactionConnections)
-	return fmt.Sprintf("%s, connections in use by regular operations: %d", errorMsg,
+	return fmt.Sprintf("%s, connections in use by other operations: %d", errorMsg,
 		w.maxPoolSize-(w.PinnedCursorConnections+w.PinnedTransactionConnections))
 }
 


### PR DESCRIPTION
This PR modifies the `pool` type to track the number of connections that are checked out for cursors and transactions. The `Connection` type increments these statistics when a `Pin*` function is called and decrements when the connection is expired or returned to the pool. Per the spec, I've also updated the `WaitQueueTimeoutError` type to include these statistics. They're accessible in code via exported fields on the error type and in the error message generated by the type's `Error` function.