### PR TITLE
GODRIVER-1918 Check for zero length in readstring

### DIFF
--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -818,7 +818,7 @@ func readstring(src []byte) (string, []byte, bool) {
 	if !ok {
 		return "", src, false
 	}
-	if len(src[4:]) < int(l) {
+	if len(src[4:]) < int(l) || l == 0 {
 		return "", src, false
 	}
 

--- a/x/bsonx/bsoncore/value_test.go
+++ b/x/bsonx/bsoncore/value_test.go
@@ -110,6 +110,11 @@ func TestValue(t *testing.T) {
 			nil,
 		},
 		{
+			"StringValue/Zero Length", Value.StringValue, Value{Type: bsontype.String, Data: []byte{0x00, 0x00, 0x00, 0x00}},
+			NewInsufficientBytesError([]byte{0x00, 0x00, 0x00, 0x00}, []byte{0x00, 0x00, 0x00, 0x00}),
+			nil,
+		},
+		{
 			"StringValue/Success", Value.StringValue, Value{Type: bsontype.String, Data: AppendString(nil, "hello, world!")},
 			nil,
 			[]interface{}{string("hello, world!")},
@@ -121,6 +126,11 @@ func TestValue(t *testing.T) {
 		},
 		{
 			"StringValueOK/Insufficient Bytes", Value.StringValueOK, Value{Type: bsontype.String, Data: []byte{0x01, 0x02, 0x03, 0x04}},
+			nil,
+			[]interface{}{string(""), false},
+		},
+		{
+			"StringValueOK/Zero Length", Value.StringValueOK, Value{Type: bsontype.String, Data: []byte{0x00, 0x00, 0x00, 0x00}},
 			nil,
 			[]interface{}{string(""), false},
 		},


### PR DESCRIPTION
[GODRIVER-1918](https://jira.mongodb.org/browse/GODRIVER-1918)

Adds a check for zero length strings in readstring to ensure that a malformed string such as `{0x0, 0x0, 0x0, 0x0}` will not panic with `StringValue()` and `StringValueOk()`.

Adds two new tests to verify no panic in the case of zero-length strings.