### PR TITLE
GODRIVER-1924 Remove skipReason from estimatedDocumentCount test for versioned API

### DIFF
--- a/data/versioned-api/crud-api-version-1-strict.json
+++ b/data/versioned-api/crud-api-version-1-strict.json
@@ -608,7 +608,6 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
-      "skipReason": "DRIVERS-1561 collStats is not in API version 1",
       "operations": [
         {
           "name": "estimatedDocumentCount",

--- a/data/versioned-api/crud-api-version-1-strict.yml
+++ b/data/versioned-api/crud-api-version-1-strict.yml
@@ -225,7 +225,6 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "estimatedDocumentCount appends declared API version"
-    skipReason: "DRIVERS-1561 collStats is not in API version 1"
     operations:
       - name: estimatedDocumentCount
         object: *collection


### PR DESCRIPTION
[GODRIVER-1924](https://jira.mongodb.org/browse/GODRIVER-1924)

The now un-skipped test won't pass until the "latest" server version compiles on this [commit](https://evergreen.mongodb.com/version/mongodb_mongo_master_075e51fefecc54e219c56e75c3ba08c993b5c187#%230), so I won't merge until the test passes in CI.