### PR TITLE
GODRIVER-1916 Test that KMS TLS connections verify peer certificates

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -126,7 +126,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone -b addKmsMockServer.1791 git@github.com:benjirewis/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec
@@ -807,6 +807,52 @@ functions:
           EOF
           cat setup.js
           mongo --nodb setup.js aws_e2e_ecs.js
+
+  start-kms-mock-server:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        background: true
+        script: |
+          ${PREPARE_SHELL}
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          cat <<EOF > kms_setup.json
+          {
+              "kms_ca_file": "${KMS_CA_FILE}",
+              "kms_cert_file": "${KMS_CERT_FILE}"
+          }
+          EOF
+          mongo --nodb mock_kms.js
+
+  run-kms-tls-test:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+          export KMS_TLS_INVALID_CERT="${KMS_TLS_INVALID_CERT}"
+          export KMS_TLS_INVALID_HOSTNAME="${KMS_TLS_INVALID_HOSTNAME}"
+
+          export GOFLAGS=-mod=vendor
+          set +o xtrace
+          AUTH="${AUTH}" \
+          SSL="${SSL}" \
+          MONGODB_URI="${MONGODB_URI}" \
+          TOPOLOGY="${TOPOLOGY}" \
+          MONGO_GO_DRIVER_COMPRESSOR=${MONGO_GO_DRIVER_COMPRESSOR} \
+          BUILD_TAGS="-tags cse" \
+          AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}" \
+          AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key}" \
+          AZURE_TENANT_ID="${cse_azure_tenant_id}" \
+          AZURE_CLIENT_ID="${cse_azure_client_id}" \
+          AZURE_CLIENT_SECRET="${cse_azure_client_secret}" \
+          GCP_EMAIL="${cse_gcp_email}" \
+          GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
+          make evg-test-kms \
+          PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 pre:
   - func: fetch-source
@@ -1625,6 +1671,46 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
 
+  - name: "test-kms-tls-invalid-cert"
+    tags: ["kms-tls"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: start-kms-mock-server
+        vars:
+          KMS_CA_FILE: "ca.pem"
+          KMS_CERT_FILE: "expired.pem"
+      - func: run-kms-tls-test
+        vars:
+          KMS_TLS_INVALID_CERT: "true"
+          KMS_TLS_INVALID_HOSTNAME: "false"
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+
+  - name: "test-kms-tls-invalid-hostname"
+    tags: ["kms-tls"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: start-kms-mock-server
+        vars:
+          KMS_CA_FILE: "ca.pem"
+          KMS_CERT_FILE: "wrong-host.pem"
+      - func: run-kms-tls-test
+        vars:
+          KMS_TLS_INVALID_CERT: "false"
+          KMS_TLS_INVALID_HOSTNAME: "true"
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+
 axes:
   - id: version
     display_name: MongoDB Version
@@ -1852,3 +1938,9 @@ buildvariants:
     display_name: "API Version ${os-ssl-32}"
     tasks:
       - name: ".versioned-api"
+
+  - matrix_name: "kms-tls-test"
+    matrix_spec: { version: ["4.2", "4.4", "latest"], os-ssl-32: ["ubuntu1604-64-go-1-15"] }
+    display_name: "KMS TLS ${version} ${os-ssl-32}"
+    tasks:
+      - name: ".kms-tls"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -832,8 +832,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          export KMS_TLS_INVALID_CERT="${KMS_TLS_INVALID_CERT}"
-          export KMS_TLS_INVALID_HOSTNAME="${KMS_TLS_INVALID_HOSTNAME}"
+          export KMS_TLS_TESTCASE="${KMS_TLS_TESTCASE}"
 
           export GOFLAGS=-mod=vendor
           set +o xtrace
@@ -1674,19 +1673,13 @@ tasks:
   - name: "test-kms-tls-invalid-cert"
     tags: ["kms-tls"]
     commands:
-      - func: bootstrap-mongo-orchestration
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "noauth"
-          SSL: "nossl"
       - func: start-kms-mock-server
         vars:
           KMS_CA_FILE: "ca.pem"
           KMS_CERT_FILE: "expired.pem"
       - func: run-kms-tls-test
         vars:
-          KMS_TLS_INVALID_CERT: "true"
-          KMS_TLS_INVALID_HOSTNAME: "false"
+          KMS_TLS_TESTCASE: "INVALID_CERT"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
@@ -1694,19 +1687,13 @@ tasks:
   - name: "test-kms-tls-invalid-hostname"
     tags: ["kms-tls"]
     commands:
-      - func: bootstrap-mongo-orchestration
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "noauth"
-          SSL: "nossl"
       - func: start-kms-mock-server
         vars:
           KMS_CA_FILE: "ca.pem"
           KMS_CERT_FILE: "wrong-host.pem"
       - func: run-kms-tls-test
         vars:
-          KMS_TLS_INVALID_CERT: "false"
-          KMS_TLS_INVALID_HOSTNAME: "true"
+          KMS_TLS_TESTCASE: "INVALID_HOSTNAME"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -126,7 +126,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone -b addKmsMockServer.1791 git@github.com:benjirewis/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1673,6 +1673,11 @@ tasks:
   - name: "test-kms-tls-invalid-cert"
     tags: ["kms-tls"]
     commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
       - func: start-kms-mock-server
         vars:
           KMS_CA_FILE: "ca.pem"
@@ -1687,6 +1692,11 @@ tasks:
   - name: "test-kms-tls-invalid-hostname"
     tags: ["kms-tls"]
     commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
       - func: start-kms-mock-server
         vars:
           KMS_CA_FILE: "ca.pem"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1937,7 +1937,7 @@ buildvariants:
       - name: ".versioned-api"
 
   - matrix_name: "kms-tls-test"
-    matrix_spec: { version: ["4.2", "4.4", "latest"], os-ssl-32: ["ubuntu1604-64-go-1-15"] }
+    matrix_spec: { version: ["latest"], os-ssl-32: ["ubuntu1604-64-go-1-15"] }
     display_name: "KMS TLS ${version} ${os-ssl-32}"
     tasks:
       - name: ".kms-tls"

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ evg-test-versioned-api:
 		go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s $$TEST_PKG >> test.suite ; \
 	done
 
+.PHONY: evg-test-kms
+evg-test-kms:
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/kms_tls_tests >> test.suite
+
 # benchmark specific targets and support
 perf:driver-test-data.tar.gz
 	tar -zxf $< $(if $(eq $(UNAME_S),Darwin),-s , --transform=s)/data/perf/

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1040,18 +1040,18 @@ func TestClientSideEncryptionProse(t *testing.T) {
 	// These tests only run when a KMS mock server is running on localhost:8000.
 	mt.RunOpts("kms tls tests", noClientOpts, func(mt *mtest.T) {
 		testcases := []struct {
-			name             string
-			runOnEnvVariable string
-			errMessage       string
+			name       string
+			envValue   string
+			errMessage string
 		}{
 			{
 				"invalid certificate",
-				"KMS_TLS_INVALID_CERT",
+				"INVALID_CERT",
 				"expired",
 			},
 			{
 				"invalid hostname",
-				"KMS_TLS_INVALID_HOSTNAME",
+				"INVALID_HOSTNAME",
 				"SANs",
 			},
 		}
@@ -1059,7 +1059,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		for _, tc := range testcases {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				// Only run test if correct KMS mock server is running.
-				if os.Getenv(tc.runOnEnvVariable) == "true" {
+				if os.Getenv("KMS_TLS_TESTCASE") == tc.envValue {
 					ceo := options.ClientEncryption().
 						SetKmsProviders(fullKmsProvidersMap).
 						SetKeyVaultNamespace(kvNamespace)
@@ -1075,7 +1075,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					assert.True(mt, strings.Contains(err.Error(), tc.errMessage),
 						"expected CreateDataKey error to contain %v, got %v", tc.errMessage, err.Error())
 				} else {
-					mt.Skipf("Skipping test as %v is set to %q, expected true", tc.runOnEnvVariable, os.Getenv(tc.runOnEnvVariable))
+					mt.Skipf("Skipping test as KMS_TLS_TESTCASE is set to %q, expected %v", os.Getenv("KMS_TLS_TESTCASE"), tc.envValue)
 				}
 			})
 		}

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1039,6 +1039,11 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 	// These tests only run when a KMS mock server is running on localhost:8000.
 	mt.RunOpts("kms tls tests", noClientOpts, func(mt *mtest.T) {
+		kmsTlsTestcase := os.Getenv("KMS_TLS_TESTCASE")
+		if kmsTlsTestcase == "" {
+			mt.Skipf("Skipping test as KMS_TLS_TESTCASE is not set")
+		}
+
 		testcases := []struct {
 			name       string
 			envValue   string
@@ -1059,24 +1064,26 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		for _, tc := range testcases {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				// Only run test if correct KMS mock server is running.
-				if os.Getenv("KMS_TLS_TESTCASE") == tc.envValue {
-					ceo := options.ClientEncryption().
-						SetKmsProviders(fullKmsProvidersMap).
-						SetKeyVaultNamespace(kvNamespace)
-					cpt := setup(mt, nil, nil, ceo)
-
-					_, err := cpt.clientEnc.CreateDataKey(context.Background(), "aws", options.DataKey().SetMasterKey(
-						bson.D{
-							{"region", "us-east-1"},
-							{"key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"},
-							{"endpoint", "mongodb://127.0.0.1:8000"},
-						},
-					))
-					assert.True(mt, strings.Contains(err.Error(), tc.errMessage),
-						"expected CreateDataKey error to contain %v, got %v", tc.errMessage, err.Error())
-				} else {
-					mt.Skipf("Skipping test as KMS_TLS_TESTCASE is set to %q, expected %v", os.Getenv("KMS_TLS_TESTCASE"), tc.envValue)
+				if kmsTlsTestcase != tc.envValue {
+					mt.Skipf("Skipping test as KMS_TLS_TESTCASE is set to %q, expected %v", kmsTlsTestcase, tc.envValue)
 				}
+
+				ceo := options.ClientEncryption().
+					SetKmsProviders(fullKmsProvidersMap).
+					SetKeyVaultNamespace(kvNamespace)
+				cpt := setup(mt, nil, nil, ceo)
+				defer cpt.teardown(mt)
+
+				_, err := cpt.clientEnc.CreateDataKey(context.Background(), "aws", options.DataKey().SetMasterKey(
+					bson.D{
+						{"region", "us-east-1"},
+						{"key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"},
+						{"endpoint", os.Getenv("KMS_URI")},
+					},
+				))
+				assert.NotNil(mt, err, "expected CreateDataKey error, got nil")
+				assert.True(mt, strings.Contains(err.Error(), tc.errMessage),
+					"expected CreateDataKey error to contain %v, got %v", tc.errMessage, err.Error())
 			})
 		}
 	})

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1078,7 +1078,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					bson.D{
 						{"region", "us-east-1"},
 						{"key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"},
-						{"endpoint", os.Getenv("KMS_URI")},
+						{"endpoint", "mongodb://127.0.0.1:8000"},
 					},
 				))
 				assert.NotNil(mt, err, "expected CreateDataKey error, got nil")


### PR DESCRIPTION
[GODRIVER-1916](https://jira.mongodb.org/browse/GODRIVER-1916)

Adds two new CSFLE prose tests to test that TLS connections to KMS servers actually verify peer certificates.

Updates Evergreen config to launch KMS mock servers for testing.