### PR TITLE
GODRIVER-1921 Add zero case in decimal128 String

### DIFF
--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -127,7 +127,10 @@ Loop:
 		return string(repr[last+posSign:]) + "E+" + strconv.Itoa(exp)
 	}
 	if exp < 0 {
-		return string(repr[last+posSign:]) + "E" + strconv.Itoa(exp)
+		// If exponent is still -6176 decimal value could just be 0.
+		if !(exp == MinDecimal128Exp && low == 0 && high == 0) {
+			return string(repr[last+posSign:]) + "E" + strconv.Itoa(exp)
+		}
 	}
 	return string(repr[last+posSign:])
 }


### PR DESCRIPTION
[GODRIVER-1921](https://jira.mongodb.org/browse/GODRIVER-1921)

Adds a check in `decimal128#String()` to avoid printing `0E-6176` instead of just `0`.

On [L81](https://github.com/mongodb/mongo-go-driver/blob/master/bson/primitive/decimal.go#L81), `exp` is set to `MinDecimal128Exp`, which is -6176. When `low` and `high` are 0, `exp` is never set to another value. We should verify the decimal128 is not zero when printing in scientific notation with a negative exponent.