### PR TITLE
GODRIVER-1923 Error if BSON cstrings contain null bytes

### DIFF
--- a/bson/bsonrw/value_writer.go
+++ b/bson/bsonrw/value_writer.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 	"sync"
 
 	"go.mongodb.org/mongo-driver/bson/bsontype"
@@ -247,7 +248,12 @@ func (vw *valueWriter) invalidTransitionError(destination mode, name string, mod
 func (vw *valueWriter) writeElementHeader(t bsontype.Type, destination mode, callerName string, addmodes ...mode) error {
 	switch vw.stack[vw.frame].mode {
 	case mElement:
-		vw.buf = bsoncore.AppendHeader(vw.buf, t, vw.stack[vw.frame].key)
+		key := vw.stack[vw.frame].key
+		if !isValidCString(key) {
+			return errors.New("BSON element key cannot contain null bytes")
+		}
+
+		vw.buf = bsoncore.AppendHeader(vw.buf, t, key)
 	case mValue:
 		// TODO: Do this with a cache of the first 1000 or so array keys.
 		vw.buf = bsoncore.AppendHeader(vw.buf, t, strconv.Itoa(vw.stack[vw.frame].arrkey))
@@ -430,6 +436,9 @@ func (vw *valueWriter) WriteObjectID(oid primitive.ObjectID) error {
 }
 
 func (vw *valueWriter) WriteRegex(pattern string, options string) error {
+	if !isValidCString(pattern) || !isValidCString(options) {
+		return errors.New("BSON regex values cannot contain null bytes")
+	}
 	if err := vw.writeElementHeader(bsontype.Regex, mode(0), "WriteRegex"); err != nil {
 		return err
 	}
@@ -601,4 +610,8 @@ func (vw *valueWriter) writeLength() error {
 	vw.buf[start+2] = byte(length >> 16)
 	vw.buf[start+3] = byte(length >> 24)
 	return nil
+}
+
+func isValidCString(cs string) bool {
+	return !strings.ContainsRune(cs, '\x00')
 }

--- a/bson/extjson_prose_test.go
+++ b/bson/extjson_prose_test.go
@@ -45,3 +45,11 @@ func TestExtJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestExtJSONNullBytes(t *testing.T) {
+	t.Run("element keys", func(t *testing.T) {
+		doc := D{{"a\x00", "foo"}}
+		res, err := MarshalExtJSON(doc, false, false)
+		assert.NotNil(t, err, "expected MarshalExtJSON error but got nil with result %v", string(res))
+	})
+}

--- a/bson/extjson_prose_test.go
+++ b/bson/extjson_prose_test.go
@@ -45,11 +45,3 @@ func TestExtJSON(t *testing.T) {
 		})
 	}
 }
-
-func TestExtJSONNullBytes(t *testing.T) {
-	t.Run("element keys", func(t *testing.T) {
-		doc := D{{"a\x00", "foo"}}
-		res, err := MarshalExtJSON(doc, false, false)
-		assert.NotNil(t, err, "expected MarshalExtJSON error but got nil with result %v", string(res))
-	})
-}

--- a/bson/marshal_test.go
+++ b/bson/marshal_test.go
@@ -8,6 +8,7 @@ package bson
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -265,5 +266,37 @@ func TestCachingEncodersNotSharedAcrossRegistries(t *testing.T) {
 		verifyResults(t, M{
 			"x": &i32,
 		})
+	})
+}
+
+func TestNullBytes(t *testing.T) {
+	t.Run("element keys", func(t *testing.T) {
+		doc := D{{"a\x00", "foobar"}}
+		res, err := Marshal(doc)
+		want := errors.New("BSON element key cannot contain null bytes")
+		assert.Equal(t, want, err, "expected Marshal error %v, got error %v with result %q", want, err, Raw(res))
+	})
+
+	t.Run("regex values", func(t *testing.T) {
+		wantErr := errors.New("BSON regex values cannot contain null bytes")
+
+		testCases := []struct {
+			name    string
+			pattern string
+			options string
+		}{
+			{"null bytes in pattern", "a\x00", "i"},
+			{"null bytes in options", "pattern", "i\x00"},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				regex := primitive.Regex{
+					Pattern: tc.pattern,
+					Options: tc.options,
+				}
+				res, err := Marshal(D{{"foo", regex}})
+				assert.Equal(t, wantErr, err, "expected Marshal error %v, got error %v with result %q", wantErr, err, Raw(res))
+			})
+		}
 	})
 }

--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -30,17 +30,21 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// EmptyDocumentLength is the length of a document that has been started/ended but has no elements.
-const EmptyDocumentLength = 5
-
-// nullTerminator is a string version of the 0 byte that is appended at the end of cstrings.
-const nullTerminator = string(byte(0))
+const (
+	// EmptyDocumentLength is the length of a document that has been started/ended but has no elements.
+	EmptyDocumentLength = 5
+	// nullTerminator is a string version of the 0 byte that is appended at the end of cstrings.
+	nullTerminator       = string(byte(0))
+	invalidKeyPanicMsg   = "BSON element keys cannot contain null bytes"
+	invalidRegexPanicMsg = "BSON regex values cannot contain null bytes"
+)
 
 // AppendType will append t to dst and return the extended buffer.
 func AppendType(dst []byte, t bsontype.Type) []byte { return append(dst, byte(t)) }
@@ -51,6 +55,10 @@ func AppendKey(dst []byte, key string) []byte { return append(dst, key+nullTermi
 // AppendHeader will append Type t and key to dst and return the extended
 // buffer.
 func AppendHeader(dst []byte, t bsontype.Type, key string) []byte {
+	if !isValidCString(key) {
+		panic(invalidKeyPanicMsg)
+	}
+
 	dst = AppendType(dst, t)
 	dst = append(dst, key...)
 	return append(dst, 0x00)
@@ -430,6 +438,10 @@ func AppendNullElement(dst []byte, key string) []byte { return AppendHeader(dst,
 
 // AppendRegex will append pattern and options to dst and return the extended buffer.
 func AppendRegex(dst []byte, pattern, options string) []byte {
+	if !isValidCString(pattern) || !isValidCString(options) {
+		panic(invalidRegexPanicMsg)
+	}
+
 	return append(dst, pattern+nullTerminator+options+nullTerminator...)
 }
 
@@ -843,4 +855,8 @@ func appendBinarySubtype2(dst []byte, subtype byte, b []byte) []byte {
 	dst = append(dst, subtype)
 	dst = appendLength(dst, int32(len(b)))
 	return append(dst, b...)
+}
+
+func isValidCString(cs string) bool {
+	return !strings.ContainsRune(cs, '\x00')
 }

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 )
 
 func noerr(t *testing.T, err error) {
@@ -897,6 +898,60 @@ func TestBuild(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestNullBytes(t *testing.T) {
+	// Helper function to execute the provided callback and assert that it panics with the expected message. The
+	// createBSONFn callback should create a BSON document/array/value and return the stringified version.
+	assertDocumentCreationPanics := func(t *testing.T, createBSONFn func() string, expected string) {
+		t.Helper()
+
+		var res string
+		defer func() {
+			got := recover()
+			assert.Equal(t, expected, got, "expected panic with error %v, got error %v with result %q", expected, got, res)
+		}()
+		res = createBSONFn()
+	}
+
+	t.Run("element keys", func(t *testing.T) {
+		createDocFn := func() string {
+			return NewDocumentBuilder().AppendString("a\x00", "foo").Build().String()
+		}
+		assertDocumentCreationPanics(t, createDocFn, invalidKeyPanicMsg)
+	})
+	t.Run("regex values", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			pattern string
+			options string
+		}{
+			{"null bytes in pattern", "a\x00", "i"},
+			{"null bytes in options", "pattern", "i\x00"},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name+"-AppendRegexElement", func(t *testing.T) {
+				createDocFn := func() string {
+					docBytes := BuildDocumentFromElements(
+						nil,
+						AppendRegexElement(nil, "foo", tc.pattern, tc.options),
+					)
+					return Document(docBytes).String()
+				}
+				assertDocumentCreationPanics(t, createDocFn, invalidRegexPanicMsg)
+			})
+			t.Run(tc.name+"-AppendRegex", func(t *testing.T) {
+				createValFn := func() string {
+					valBytes := Value{
+						Type: bsontype.Regex,
+						Data: AppendRegex(nil, tc.pattern, tc.options),
+					}
+					return Value(valBytes).String()
+				}
+				assertDocumentCreationPanics(t, createValFn, invalidRegexPanicMsg)
+			})
+		}
+	})
 }
 
 func compareDecimal128(d1, d2 primitive.Decimal128) bool {

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -903,7 +903,7 @@ func TestBuild(t *testing.T) {
 func TestNullBytes(t *testing.T) {
 	// Helper function to execute the provided callback and assert that it panics with the expected message. The
 	// createBSONFn callback should create a BSON document/array/value and return the stringified version.
-	assertDocumentCreationPanics := func(t *testing.T, createBSONFn func() string, expected string) {
+	assertBSONCreationPanics := func(t *testing.T, createBSONFn func() string, expected string) {
 		t.Helper()
 
 		var res string
@@ -918,7 +918,7 @@ func TestNullBytes(t *testing.T) {
 		createDocFn := func() string {
 			return NewDocumentBuilder().AppendString("a\x00", "foo").Build().String()
 		}
-		assertDocumentCreationPanics(t, createDocFn, invalidKeyPanicMsg)
+		assertBSONCreationPanics(t, createDocFn, invalidKeyPanicMsg)
 	})
 	t.Run("regex values", func(t *testing.T) {
 		testCases := []struct {
@@ -938,7 +938,7 @@ func TestNullBytes(t *testing.T) {
 					)
 					return Document(docBytes).String()
 				}
-				assertDocumentCreationPanics(t, createDocFn, invalidRegexPanicMsg)
+				assertBSONCreationPanics(t, createDocFn, invalidRegexPanicMsg)
 			})
 			t.Run(tc.name+"-AppendRegex", func(t *testing.T) {
 				createValFn := func() string {
@@ -948,7 +948,7 @@ func TestNullBytes(t *testing.T) {
 					}
 					return Value(valBytes).String()
 				}
-				assertDocumentCreationPanics(t, createValFn, invalidRegexPanicMsg)
+				assertBSONCreationPanics(t, createValFn, invalidRegexPanicMsg)
 			})
 		}
 	})


### PR DESCRIPTION
Per bsonspec.org, cstrings are only used for BSON key names and for the pattern/options fields in a BSON regex value so this PR applies validation to those types. This validation does not apply to regular BSON strings, which can have null bytes because they're prefixed with a 4-byte length. It also does not apply to extended JSON because the JSON specification allows null bytes and other unicode code points as long as they are properly escaped (e.g. in JSON, this would look like `{"foo\u0000": "bar"}`.