### PR TITLE
feat(README.md): more accurate error handling for using FindOne

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,7 @@ defer cur.Close(ctx)
 for cur.Next(ctx) {
    var result bson.D
    err := cur.Decode(&result)
-    if err == mongo.ErrNoDocuments {
-        // Do something when no record was found
-        fmt.Println("record does not exist")
-    } else {
-        log.Fatal(err)
-    }
+   if err != nil { log.Fatal(err) }
    // do something with result....
 }
 if err := cur.Err(); err != nil {
@@ -142,7 +137,10 @@ filter := bson.D{{"name", "pi"}}
 ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 defer cancel()
 err = collection.FindOne(ctx, filter).Decode(&result)
-if err != nil {
+if err == mongo.ErrNoDocuments {
+    // Do something when no record was found
+    fmt.Println("record does not exist")
+} else {
     log.Fatal(err)
 }
 // Do something with result...

--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ defer cur.Close(ctx)
 for cur.Next(ctx) {
    var result bson.D
    err := cur.Decode(&result)
-   if err != nil { log.Fatal(err) }
+    if err == mongo.ErrNoDocuments {
+        // Do something when no record was found
+        fmt.Println("record does not exist")
+    } else {
+        log.Fatal(err)
+    }
    // do something with result....
 }
 if err := cur.Err(); err != nil {


### PR DESCRIPTION
Hi, I found the case of error handling in the README was inaccurate. We need to handle the case that error is `ErrNoDocuments` separately. [go-redis](https://github.com/go-redis/redis#quickstart) has a similar design. So I changed `README` to point out this case. 