### PR TITLE
GODRIVER-1934 Ensure correct CursorOptions are used

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -108,7 +108,7 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 		streamType:    config.streamType,
 		options:       options.MergeChangeStreamOptions(opts...),
 		selector:      description.ReadPrefSelector(config.readPreference),
-		cursorOptions: createBaseCursorOptions(config.client),
+		cursorOptions: config.client.createBaseCursorOptions(),
 	}
 
 	cs.sess = sessionFromContext(ctx)

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -103,11 +103,12 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 	}
 
 	cs := &ChangeStream{
-		client:     config.client,
-		registry:   config.registry,
-		streamType: config.streamType,
-		options:    options.MergeChangeStreamOptions(opts...),
-		selector:   description.ReadPrefSelector(config.readPreference),
+		client:        config.client,
+		registry:      config.registry,
+		streamType:    config.streamType,
+		options:       options.MergeChangeStreamOptions(opts...),
+		selector:      description.ReadPrefSelector(config.readPreference),
+		cursorOptions: createBaseCursorOptions(config.client),
 	}
 
 	cs.sess = sessionFromContext(ctx)
@@ -128,9 +129,6 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 		CommandMonitor(cs.client.monitor).Session(cs.sess).ServerSelector(cs.selector).Retry(driver.RetryNone).
 		ServerAPI(cs.client.serverAPI).Crypt(config.crypt)
 
-	if config.crypt != nil {
-		cs.cursorOptions.Crypt = config.crypt
-	}
 	if cs.options.Collation != nil {
 		cs.aggregate.Collation(bsoncore.Document(cs.options.Collation.ToDocument()))
 	}
@@ -141,8 +139,6 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 	if cs.options.MaxAwaitTime != nil {
 		cs.cursorOptions.MaxTimeMS = int64(time.Duration(*cs.options.MaxAwaitTime) / time.Millisecond)
 	}
-	cs.cursorOptions.CommandMonitor = cs.client.monitor
-	cs.cursorOptions.ServerAPI = cs.client.serverAPI
 
 	switch cs.streamType {
 	case ClientStream:

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -976,3 +976,11 @@ func (c *Client) Watch(ctx context.Context, pipeline interface{},
 func (c *Client) NumberSessionsInProgress() int {
 	return c.sessionPool.CheckedOut()
 }
+
+func createBaseCursorOptions(c *Client) driver.CursorOptions {
+	return driver.CursorOptions{
+		CommandMonitor: c.monitor,
+		Crypt:          c.cryptFLE,
+		ServerAPI:      c.serverAPI,
+	}
+}

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -977,7 +977,7 @@ func (c *Client) NumberSessionsInProgress() int {
 	return c.sessionPool.CheckedOut()
 }
 
-func createBaseCursorOptions(c *Client) driver.CursorOptions {
+func (c *Client) createBaseCursorOptions() driver.CursorOptions {
 	return driver.CursorOptions{
 		CommandMonitor: c.monitor,
 		Crypt:          c.cryptFLE,

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -782,10 +782,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 	}
 
 	ao := options.MergeAggregateOptions(a.opts...)
-	cursorOpts := driver.CursorOptions{
-		CommandMonitor: a.client.monitor,
-		Crypt:          a.client.cryptFLE,
-	}
+	cursorOpts := createBaseCursorOptions(a.client)
 
 	op := operation.NewAggregate(pipelineArr).
 		Session(sess).
@@ -1142,10 +1139,7 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI)
 
 	fo := options.MergeFindOptions(opts...)
-	cursorOpts := driver.CursorOptions{
-		CommandMonitor: coll.client.monitor,
-		Crypt:          coll.client.cryptFLE,
-	}
+	cursorOpts := createBaseCursorOptions(coll.client)
 
 	if fo.AllowDiskUse != nil {
 		op.AllowDiskUse(*fo.AllowDiskUse)

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -782,7 +782,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 	}
 
 	ao := options.MergeAggregateOptions(a.opts...)
-	cursorOpts := createBaseCursorOptions(a.client)
+	cursorOpts := a.client.createBaseCursorOptions()
 
 	op := operation.NewAggregate(pipelineArr).
 		Session(sess).
@@ -1139,7 +1139,7 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI)
 
 	fo := options.MergeFindOptions(opts...)
-	cursorOpts := createBaseCursorOptions(coll.client)
+	cursorOpts := coll.client.createBaseCursorOptions()
 
 	if fo.AllowDiskUse != nil {
 		op.AllowDiskUse(*fo.AllowDiskUse)

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -168,7 +168,7 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	var op *operation.Command
 	switch cursorCommand {
 	case true:
-		cursorOpts := createBaseCursorOptions(db.client)
+		cursorOpts := db.client.createBaseCursorOptions()
 		op = operation.NewCursorCommand(runCmdDoc, cursorOpts)
 	default:
 		op = operation.NewCommand(runCmdDoc)
@@ -374,7 +374,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI)
 
-	cursorOpts := createBaseCursorOptions(db.client)
+	cursorOpts := db.client.createBaseCursorOptions()
 	if lco.NameOnly != nil {
 		op = op.NameOnly(*lco.NameOnly)
 	}

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -165,12 +165,15 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 		readSelect = makePinnedSelector(sess, readSelect)
 	}
 
-	createCmdFn := operation.NewCommand
-	if cursorCommand {
-		createCmdFn = operation.NewCursorCommand
+	var op *operation.Command
+	switch cursorCommand {
+	case true:
+		cursorOpts := createBaseCursorOptions(db.client)
+		op = operation.NewCursorCommand(runCmdDoc, cursorOpts)
+	default:
+		op = operation.NewCommand(runCmdDoc)
 	}
-	return createCmdFn(runCmdDoc).
-		Session(sess).CommandMonitor(db.client.monitor).
+	return op.Session(sess).CommandMonitor(db.client.monitor).
 		ServerSelector(readSelect).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).ReadConcern(db.readConcern).
 		Crypt(db.client.cryptFLE).ReadPreference(ro.ReadPreference).ServerAPI(db.client.serverAPI), sess, nil
@@ -370,10 +373,13 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		ServerSelector(selector).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI)
+
+	cursorOpts := createBaseCursorOptions(db.client)
 	if lco.NameOnly != nil {
 		op = op.NameOnly(*lco.NameOnly)
 	}
 	if lco.BatchSize != nil {
+		cursorOpts.BatchSize = *lco.BatchSize
 		op = op.BatchSize(*lco.BatchSize)
 	}
 
@@ -389,7 +395,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		return nil, replaceErrors(err)
 	}
 
-	bc, err := op.Result(driver.CursorOptions{Crypt: db.client.cryptFLE})
+	bc, err := op.Result(cursorOpts)
 	if err != nil {
 		closeImplicitSession(sess)
 		return nil, replaceErrors(err)

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -97,7 +97,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI)
 
-	var cursorOpts driver.CursorOptions
+	cursorOpts := createBaseCursorOptions(iv.coll.client)
 	lio := options.MergeListIndexesOptions(opts...)
 	if lio.BatchSize != nil {
 		op = op.BatchSize(*lio.BatchSize)

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -97,7 +97,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI)
 
-	cursorOpts := createBaseCursorOptions(iv.coll.client)
+	cursorOpts := iv.coll.client.createBaseCursorOptions()
 	lio := options.MergeListIndexesOptions(opts...)
 	if lio.BatchSize != nil {
 		op = op.BatchSize(*lio.BatchSize)

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1921,10 +1921,12 @@ func assertGetMoreCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn fun
 	err = cursor.All(mtest.Background, &docs)
 	assert.Nil(mt, err, "All error: %v", err)
 
-	events := mt.GetAllStartedEvents()
-	assert.Equal(mt, 2, len(events), "expected 2 events to be sent, got events %v", events)
-	assert.Equal(mt, cmdName, events[0].CommandName, "expected %q event, got %q", cmdName, events[0].CommandName)
-	assert.Equal(mt, "getMore", events[1].CommandName, "expected 'getMore' event, got %q", events[1].CommandName)
+	// Only assert that the initial command and at least one getMore were sent. The exact number of getMore's required
+	// is not important.
+	evt := mt.GetStartedEvent()
+	assert.Equal(mt, cmdName, evt.CommandName, "expected command %q, got %q", cmdName, evt.CommandName)
+	evt = mt.GetStartedEvent()
+	assert.Equal(mt, "getMore", evt.CommandName, "expected command 'getMore', got %q", evt.CommandName)
 }
 
 func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn func() (*mongo.Cursor, error)) {
@@ -1936,8 +1938,8 @@ func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn
 	err = cursor.Close(mtest.Background)
 	assert.Nil(mt, err, "Close error: %v", err)
 
-	events := mt.GetAllStartedEvents()
-	assert.Equal(mt, 2, len(events), "expected 2 events to be sent, got events %v", events)
-	assert.Equal(mt, cmdName, events[0].CommandName, "expected %q event, got %q", cmdName, events[0].CommandName)
-	assert.Equal(mt, "killCursors", events[1].CommandName, "expected 'killCursors' event, got %q", events[1].CommandName)
+	evt := mt.GetStartedEvent()
+	assert.Equal(mt, cmdName, evt.CommandName, "expected command %q, got %q", cmdName, evt.CommandName)
+	evt = mt.GetStartedEvent()
+	assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
 }

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1924,7 +1924,7 @@ func assertGetMoreCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn fun
 	events := mt.GetAllStartedEvents()
 	assert.Equal(mt, 2, len(events), "expected 2 events to be sent, got events %v", events)
 	assert.Equal(mt, cmdName, events[0].CommandName, "expected %q event, got %q", cmdName, events[0].CommandName)
-	assert.Equal(mt, "getMore", events[1].CommandName, "expected 'getMore' event, got %q", events[0].CommandName)
+	assert.Equal(mt, "getMore", events[1].CommandName, "expected 'getMore' event, got %q", events[1].CommandName)
 }
 
 func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn func() (*mongo.Cursor, error)) {
@@ -1939,5 +1939,5 @@ func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn
 	events := mt.GetAllStartedEvents()
 	assert.Equal(mt, 2, len(events), "expected 2 events to be sent, got events %v", events)
 	assert.Equal(mt, cmdName, events[0].CommandName, "expected %q event, got %q", cmdName, events[0].CommandName)
-	assert.Equal(mt, "killCursors", events[1].CommandName, "expected 'killCursors' event, got %q", events[0].CommandName)
+	assert.Equal(mt, "killCursors", events[1].CommandName, "expected 'killCursors' event, got %q", events[1].CommandName)
 }

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1911,6 +1911,9 @@ func create16MBDocument(mt *mtest.T) bsoncore.Document {
 	return doc
 }
 
+// This is a helper function to ensure that sending getMore commands for a cursor results in command monitoring events
+// being published. The cursorFn parameter should be a function that yields a cursor which is open on the server and
+// requires at least one getMore to be fully iterated.
 func assertGetMoreCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn func() (*mongo.Cursor, error)) {
 	mt.Helper()
 	mt.ClearEvents()
@@ -1929,6 +1932,8 @@ func assertGetMoreCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn fun
 	assert.Equal(mt, "getMore", evt.CommandName, "expected command 'getMore', got %q", evt.CommandName)
 }
 
+// This is a helper function to ensure that sending killCursors commands for a cursor results in command monitoring
+// events being published. The cursorFn parameter should be a function that yields a cursor which is open on the server.
 func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn func() (*mongo.Cursor, error)) {
 	mt.Helper()
 	mt.ClearEvents()

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -170,6 +170,14 @@ func TestDatabase(t *testing.T) {
 	})
 
 	mt.RunOpts("list collections", noClientOpts, func(mt *mtest.T) {
+		createCollections := func(mt *mtest.T, numCollections int) {
+			for i := 0; i < numCollections; i++ {
+				mt.CreateCollection(mtest.Collection{
+					Name: fmt.Sprintf("list-collections-test-%d", i),
+				}, true)
+			}
+		}
+
 		mt.RunOpts("verify results", noClientOpts, func(mt *mtest.T) {
 			testCases := []struct {
 				name             string
@@ -213,11 +221,7 @@ func TestDatabase(t *testing.T) {
 		})
 		mt.RunOpts("batch size", mtest.NewOptions().MinServerVersion("3.0"), func(mt *mtest.T) {
 			// Create two new collections so there will be three total.
-			for i := 0; i < 2; i++ {
-				mt.CreateCollection(mtest.Collection{
-					Name: fmt.Sprintf("list-collections-batchSize-%d", i),
-				}, true)
-			}
+			createCollections(mt, 2)
 
 			mt.ClearEvents()
 			lcOpts := options.ListCollections().SetBatchSize(2)
@@ -229,6 +233,18 @@ func TestDatabase(t *testing.T) {
 				evt.CommandName)
 			_, err = evt.Command.LookupErr("cursor", "batchSize")
 			assert.Nil(mt, err, "expected command %s to contain key 'batchSize'", evt.Command)
+		})
+		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
+			createCollections(mt, 2)
+			assertGetMoreCommandsAreMonitored(mt, "listCollections", func() (*mongo.Cursor, error) {
+				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
+			})
+		})
+		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
+			createCollections(mt, 2)
+			assertKillCursorsCommandsAreMonitored(mt, "listCollections", func() (*mongo.Cursor, error) {
+				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
+			})
 		})
 	})
 
@@ -356,6 +372,27 @@ func TestDatabase(t *testing.T) {
 				assert.Equal(mt, tc.numExpected, count, "expected document count %v, got %v", tc.numExpected, count)
 			})
 		}
+
+		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
+			initCollection(mt, mt.Coll)
+			assertGetMoreCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
+				findCmd := bson.D{
+					{"find", mt.Coll.Name()},
+					{"batchSize", 2},
+				}
+				return mt.DB.RunCommandCursor(mtest.Background, findCmd)
+			})
+		})
+		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
+			initCollection(mt, mt.Coll)
+			assertKillCursorsCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
+				findCmd := bson.D{
+					{"find", mt.Coll.Name()},
+					{"batchSize", 2},
+				}
+				return mt.DB.RunCommandCursor(mtest.Background, findCmd)
+			})
+		})
 	})
 
 	mt.RunOpts("create collection", noClientOpts, func(mt *mtest.T) {

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -377,7 +377,9 @@ func TestDatabase(t *testing.T) {
 			})
 		}
 
-		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
+		// The find command does not exist on server versions below 3.2.
+		cmdMonitoringMtOpts := mtest.NewOptions().MinServerVersion("3.2")
+		mt.RunOpts("getMore commands are monitored", cmdMonitoringMtOpts, func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertGetMoreCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
 				findCmd := bson.D{
@@ -387,7 +389,7 @@ func TestDatabase(t *testing.T) {
 				return mt.DB.RunCommandCursor(mtest.Background, findCmd)
 			})
 		})
-		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
+		mt.RunOpts("killCursors commands are monitored", cmdMonitoringMtOpts, func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertKillCursorsCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
 				findCmd := bson.D{

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -171,6 +171,8 @@ func TestDatabase(t *testing.T) {
 
 	mt.RunOpts("list collections", noClientOpts, func(mt *mtest.T) {
 		createCollections := func(mt *mtest.T, numCollections int) {
+			mt.Helper()
+
 			for i := 0; i < numCollections; i++ {
 				mt.CreateCollection(mtest.Collection{
 					Name: fmt.Sprintf("list-collections-test-%d", i),

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -33,6 +33,7 @@ type Command struct {
 	crypt          *driver.Crypt
 	serverAPI      *driver.ServerAPIOptions
 	createCursor   bool
+	cursorOpts     driver.CursorOptions
 }
 
 // NewCommand constructs and returns a new Command. Once the operation is executed, the result may only be accessed via
@@ -45,9 +46,10 @@ func NewCommand(command bsoncore.Document) *Command {
 
 // NewCursorCommand constructs a new Command. Once the operation is executed, the server response will be used to
 // construct a cursor, which can be accessed via the ResultCursor() function.
-func NewCursorCommand(command bsoncore.Document) *Command {
+func NewCursorCommand(command bsoncore.Document, cursorOpts driver.CursorOptions) *Command {
 	return &Command{
 		command:      command,
+		cursorOpts:   cursorOpts,
 		createCursor: true,
 	}
 }
@@ -84,10 +86,7 @@ func (c *Command) Execute(ctx context.Context) error {
 					return err
 				}
 
-				opts := driver.CursorOptions{
-					ServerAPI: c.serverAPI,
-				}
-				c.resultCursor, err = driver.NewBatchCursor(cursorRes, c.session, c.clock, opts)
+				c.resultCursor, err = driver.NewBatchCursor(cursorRes, c.session, c.clock, c.cursorOpts)
 				return err
 			}
 


### PR DESCRIPTION
This PR adds a new `mongo.createBaseCursorOptions` function to ensure that options that apply to all cursor-related commands are set before being passed down to the operations layer. I've also re-introduced a `CursorOptions` paramter to the `operation.Command` type. This was removed when doing the LB support work because it was always empty, but the empty options was actually a bug.