### PR TITLE
GODRIVER-1926 Fix Reason field in GetFailed CMAP events

### DIFF
--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -467,7 +467,7 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 					p.monitor.Event(&event.PoolEvent{
 						Type:    event.GetFailed,
 						Address: p.address.String(),
-						Reason:  reason,
+						Reason:  event.ReasonConnectionErrored,
 					})
 				}
 				return nil, err


### PR DESCRIPTION
This was found when implementing LB tests. I've opted not to add unit/integration tests here as it will be tested there already.