### PR TITLE
GODRIVER-1934 Ensure correct CursorOptions are used (#625)

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -926,3 +926,10 @@ func (c *Client) Watch(ctx context.Context, pipeline interface{},
 func (c *Client) NumberSessionsInProgress() int {
 	return c.sessionPool.CheckedOut()
 }
+
+func (c *Client) createBaseCursorOptions() driver.CursorOptions {
+	return driver.CursorOptions{
+		CommandMonitor: c.monitor,
+		Crypt:          c.cryptFLE,
+	}
+}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -780,10 +780,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 	}
 
 	ao := options.MergeAggregateOptions(a.opts...)
-	cursorOpts := driver.CursorOptions{
-		CommandMonitor: a.client.monitor,
-		Crypt:          a.client.cryptFLE,
-	}
+	cursorOpts := a.client.createBaseCursorOptions()
 
 	op := operation.NewAggregate(pipelineArr).
 		Session(sess).
@@ -1139,10 +1136,7 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE)
 
 	fo := options.MergeFindOptions(opts...)
-	cursorOpts := driver.CursorOptions{
-		CommandMonitor: coll.client.monitor,
-		Crypt:          coll.client.cryptFLE,
-	}
+	cursorOpts := coll.client.createBaseCursorOptions()
 
 	if fo.AllowDiskUse != nil {
 		op.AllowDiskUse(*fo.AllowDiskUse)

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -97,7 +97,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment)
 
-	var cursorOpts driver.CursorOptions
+	cursorOpts := iv.coll.client.createBaseCursorOptions()
 	lio := options.MergeListIndexesOptions(opts...)
 	if lio.BatchSize != nil {
 		op = op.BatchSize(*lio.BatchSize)

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -30,9 +30,44 @@ func TestIndexView(t *testing.T) {
 	defer mt.Close()
 
 	mt.Run("list", func(mt *mtest.T) {
-		verifyIndexExists(mt, mt.Coll.Indexes(), index{
-			Key:  bson.D{{"_id", int32(1)}},
-			Name: "_id_",
+		createIndexes := func(mt *mtest.T, numIndexes int) {
+			mt.Helper()
+
+			models := make([]mongo.IndexModel, 0, numIndexes)
+			for i, key := 0, 'a'; i < numIndexes; i, key = i+1, key+1 {
+				models = append(models, mongo.IndexModel{
+					Keys: bson.M{string(key): 1},
+				})
+			}
+
+			_, err := mt.Coll.Indexes().CreateMany(mtest.Background, models)
+			assert.Nil(mt, err, "CreateMany error: %v", err)
+		}
+
+		// For server versions below 3.0, we internally execute List() as a legacy OP_QUERY against the system.indexes
+		// collection. Command monitoring upconversions translate this to a "find" command rather than "listIndexes".
+		cmdName := "listIndexes"
+		if mtest.CompareServerVersions(mtest.ServerVersion(), "3.0") < 0 {
+			cmdName = "find"
+		}
+
+		mt.Run("_id index is always listed", func(mt *mtest.T) {
+			verifyIndexExists(mt, mt.Coll.Indexes(), index{
+				Key:  bson.D{{"_id", int32(1)}},
+				Name: "_id_",
+			})
+		})
+		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
+			createIndexes(mt, 2)
+			assertGetMoreCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
+				return mt.Coll.Indexes().List(mtest.Background, options.ListIndexes().SetBatchSize(2))
+			})
+		})
+		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
+			createIndexes(mt, 2)
+			assertKillCursorsCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
+				return mt.Coll.Indexes().List(mtest.Background, options.ListIndexes().SetBatchSize(2))
+			})
 		})
 	})
 	mt.RunOpts("create one", noClientOpts, func(mt *mtest.T) {


### PR DESCRIPTION
This is a PR for the backport of GODRIVER-1934 because there were merge conflicts when backporting because the `RunCommandCursor` code has changed when implementing LB support.