### PR TITLE
GODRIVER-1958 Rename ServerID to ServiceID

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -22,7 +22,7 @@ type CommandStartedEvent struct {
 	CommandName  string
 	RequestID    int64
 	ConnectionID string
-	ServerID     *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
+	ServiceID    *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
 }
 
 // CommandFinishedEvent represents a generic command finishing.
@@ -31,7 +31,7 @@ type CommandFinishedEvent struct {
 	CommandName   string
 	RequestID     int64
 	ConnectionID  string
-	ServerID      *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
+	ServiceID     *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
 }
 
 // CommandSucceededEvent represents an event generated when a command's execution succeeds.
@@ -89,9 +89,9 @@ type PoolEvent struct {
 	ConnectionID uint64              `json:"connectionId"`
 	PoolOptions  *MonitorPoolOptions `json:"options"`
 	Reason       string              `json:"reason"`
-	// ServerID is only set if the Type is PoolCleared and the server is deployed behind a load balancer. This field
+	// ServiceID is only set if the Type is PoolCleared and the server is deployed behind a load balancer. This field
 	// can be used to distinguish between individual servers in a load balanced deployment.
-	ServerID *primitive.ObjectID `json:"serverId"`
+	ServiceID *primitive.ObjectID `json:"serviceId"`
 }
 
 // PoolMonitor is a function that allows the user to gain access to events occurring in the pool

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -22,7 +22,9 @@ type CommandStartedEvent struct {
 	CommandName  string
 	RequestID    int64
 	ConnectionID string
-	ServiceID    *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
+	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
+	// Otherwise, it is unset.
+	ServiceID *primitive.ObjectID
 }
 
 // CommandFinishedEvent represents a generic command finishing.
@@ -31,7 +33,9 @@ type CommandFinishedEvent struct {
 	CommandName   string
 	RequestID     int64
 	ConnectionID  string
-	ServiceID     *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
+	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
+	// Otherwise, it is unset.
+	ServiceID *primitive.ObjectID
 }
 
 // CommandSucceededEvent represents an event generated when a command's execution succeeds.

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -49,7 +49,7 @@ type Server struct {
 	Passives              []string
 	Primary               address.Address
 	ReadOnly              bool
-	ServerID              *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
+	ServiceID             *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
 	SessionTimeoutMinutes uint32
 	SetName               string
 	SetVersion            uint32
@@ -228,12 +228,12 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				desc.LastError = fmt.Errorf("expected 'secondary' to be a boolean but it's a BSON %s", element.Value().Type)
 				return desc
 			}
-		case "serverId":
+		case "serviceId":
 			oid, ok := element.Value().ObjectIDOK()
 			if !ok {
-				desc.LastError = fmt.Errorf("expected 'serverId' to be an ObjectId but it's a BSON %s", element.Value().Type)
+				desc.LastError = fmt.Errorf("expected 'serviceId' to be an ObjectId but it's a BSON %s", element.Value().Type)
 			}
-			desc.ServerID = &oid
+			desc.ServiceID = &oid
 		case "setName":
 			desc.SetName, ok = element.Value().StringValueOK()
 			if !ok {
@@ -338,7 +338,7 @@ func (s Server) DataBearing() bool {
 
 // LoadBalanced returns true if the server is a load balancer or is behind a load balancer.
 func (s Server) LoadBalanced() bool {
-	return s.Kind == LoadBalancer || s.ServerID != nil
+	return s.Kind == LoadBalancer || s.ServiceID != nil
 }
 
 // String implements the Stringer interface

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -71,7 +71,7 @@ type startedInformation struct {
 	documentSequenceIncluded bool
 	connID                   string
 	redacted                 bool
-	serverID                 *primitive.ObjectID
+	serviceID                *primitive.ObjectID
 }
 
 // finishedInformation keeps track of all of the information necessary for monitoring success and failure events.
@@ -83,7 +83,7 @@ type finishedInformation struct {
 	connID    string
 	startTime time.Time
 	redacted  bool
-	serverID  *primitive.ObjectID
+	serviceID *primitive.ObjectID
 }
 
 // ResponseInfo contains the context required to parse a server response.
@@ -385,7 +385,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		startedInfo.connID = conn.ID()
 		startedInfo.cmdName = op.getCommandName(startedInfo.cmd)
 		startedInfo.redacted = op.redactCommand(startedInfo.cmdName, startedInfo.cmd)
-		startedInfo.serverID = conn.Description().ServerID
+		startedInfo.serviceID = conn.Description().ServiceID
 		op.publishStartedEvent(ctx, startedInfo)
 
 		// get the moreToCome flag information before we compress
@@ -405,7 +405,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 			startTime: time.Now(),
 			connID:    startedInfo.connID,
 			redacted:  startedInfo.redacted,
-			serverID:  startedInfo.serverID,
+			serviceID: startedInfo.serviceID,
 		}
 
 		// roundtrip using either the full roundTripper or a special one for when the moreToCome
@@ -1475,7 +1475,7 @@ func (op Operation) publishStartedEvent(ctx context.Context, info startedInforma
 		CommandName:  info.cmdName,
 		RequestID:    int64(info.requestID),
 		ConnectionID: info.connID,
-		ServerID:     info.serverID,
+		ServiceID:    info.serviceID,
 	}
 	op.CommandMonitor.Started(ctx, started)
 }
@@ -1502,7 +1502,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		RequestID:     int64(info.requestID),
 		ConnectionID:  info.connID,
 		DurationNanos: durationNanos,
-		ServerID:      info.serverID,
+		ServiceID:     info.serviceID,
 	}
 
 	if success {

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -109,7 +109,7 @@ func (c *connection) processInitializationError(err error) {
 
 	c.connectErr = ConnectionError{Wrapped: err, init: true}
 	if c.config.errorHandlingCallback != nil {
-		c.config.errorHandlingCallback(c.connectErr, c.generation, c.desc.ServerID)
+		c.config.errorHandlingCallback(c.connectErr, c.generation, c.desc.ServiceID)
 	}
 }
 
@@ -117,7 +117,7 @@ func (c *connection) processInitializationError(err error) {
 // configuration.
 func (c *connection) setGenerationNumber() {
 	if c.config.getGenerationFn != nil {
-		c.generation = c.config.getGenerationFn(c.desc.ServerID)
+		c.generation = c.config.getGenerationFn(c.desc.ServiceID)
 	}
 }
 
@@ -231,9 +231,9 @@ func (c *connection) connect(ctx context.Context) {
 		c.desc = handshakeInfo.Description
 		c.isMasterRTT = time.Since(handshakeStartTime)
 
-		// If the application has indicated that the cluster is load balanced, ensure the server has included serverId
+		// If the application has indicated that the cluster is load balanced, ensure the server has included serviceId
 		// in its handshake response to signal that it knows it's behind an LB as well.
-		if c.config.loadBalanced && c.desc.ServerID == nil {
+		if c.config.loadBalanced && c.desc.ServiceID == nil {
 			err = errLoadBalancedStateMismatch
 		}
 	}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -238,7 +238,7 @@ func (c *connection) connect(ctx context.Context) {
 		}
 	}
 	if err == nil {
-		// For load-balanced connections, the generation number depends on the server ID, which isn't known until the
+		// For load-balanced connections, the generation number depends on the service ID, which isn't known until the
 		// initial MongoDB handshake is done. To account for this, we don't attempt to set the connection's generation
 		// number unless GetHandshakeInformation succeeds.
 		if c.config.loadBalanced {

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -37,7 +37,7 @@ var DefaultDialer Dialer = &net.Dialer{}
 type Handshaker = driver.Handshaker
 
 // generationNumberFn is a callback type used by a connection to fetch its generation number given its server ID.
-type generationNumberFn func(serverID *primitive.ObjectID) uint64
+type generationNumberFn func(serviceID *primitive.ObjectID) uint64
 
 type connectionConfig struct {
 	appName                  string

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -36,7 +36,7 @@ var DefaultDialer Dialer = &net.Dialer{}
 // initialization. Implementations must be goroutine safe.
 type Handshaker = driver.Handshaker
 
-// generationNumberFn is a callback type used by a connection to fetch its generation number given its server ID.
+// generationNumberFn is a callback type used by a connection to fetch its generation number given its service ID.
 type generationNumberFn func(serviceID *primitive.ObjectID) uint64
 
 type connectionConfig struct {

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -196,7 +196,7 @@ func newPool(config poolConfig, connOpts ...ConnectionOption) (*pool, error) {
 
 // stale checks if a given connection's generation is below the generation of the pool
 func (p *pool) stale(c *connection) bool {
-	return c == nil || p.generation.stale(c.desc.ServerID, c.generation)
+	return c == nil || p.generation.stale(c.desc.ServiceID, c.generation)
 }
 
 // connect puts the pool into the connected state, allowing it to be used and will allow items to begin being processed from the wait queue
@@ -511,8 +511,8 @@ func (p *pool) closeConnection(c *connection) error {
 	return nil
 }
 
-func (p *pool) getGenerationForNewConnection(serverID *primitive.ObjectID) uint64 {
-	return p.generation.addConnection(serverID)
+func (p *pool) getGenerationForNewConnection(serviceID *primitive.ObjectID) uint64 {
+	return p.generation.addConnection(serviceID)
 }
 
 // removeConnection removes a connection from the pool.
@@ -532,7 +532,7 @@ func (p *pool) removeConnection(c *connection, reason string) error {
 	// Only update the generation numbers map if the connection has retrieved its generation number. Otherwise, we'd
 	// decrement the count for the generation even though it had never been incremented.
 	if c.hasGenerationNumber() {
-		p.generation.removeConnection(c.desc.ServerID)
+		p.generation.removeConnection(c.desc.ServiceID)
 	}
 
 	if publishEvent && p.monitor != nil {
@@ -579,13 +579,13 @@ func (p *pool) put(c *connection) error {
 }
 
 // clear clears the pool by incrementing the generation
-func (p *pool) clear(serverID *primitive.ObjectID) {
+func (p *pool) clear(serviceID *primitive.ObjectID) {
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
-			Type:     event.PoolCleared,
-			Address:  p.address.String(),
-			ServerID: serverID,
+			Type:      event.PoolCleared,
+			Address:   p.address.String(),
+			ServiceID: serviceID,
 		})
 	}
-	p.generation.clear(serverID)
+	p.generation.clear(serviceID)
 }

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -20,9 +20,9 @@ type generationStats struct {
 	numConns   uint64
 }
 
-// poolGenerationMap tracks the version for each server ID present in a pool. For deployments that are not behind a load
-// balancer, there is only one server ID: primitive.NilObjectID. For load-balanced deployments, each server behind the
-// load balancer will have a unique server ID.
+// poolGenerationMap tracks the version for each service ID present in a pool. For deployments that are not behind a
+// load balancer, there is only one service ID: primitive.NilObjectID. For load-balanced deployments, each server behind
+// the load balancer will have a unique service ID.
 type poolGenerationMap struct {
 	// state must be accessed using the atomic package.
 	state         int32
@@ -47,7 +47,7 @@ func (p *poolGenerationMap) disconnect() {
 	atomic.StoreInt32(&p.state, disconnected)
 }
 
-// addConnection increments the connection count for the generation associated with the given server ID and returns the
+// addConnection increments the connection count for the generation associated with the given service ID and returns the
 // generation number for the connection.
 func (p *poolGenerationMap) addConnection(serviceIDPtr *primitive.ObjectID) uint64 {
 	serviceID := getServiceID(serviceIDPtr)

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -49,83 +49,83 @@ func (p *poolGenerationMap) disconnect() {
 
 // addConnection increments the connection count for the generation associated with the given server ID and returns the
 // generation number for the connection.
-func (p *poolGenerationMap) addConnection(serverIDPtr *primitive.ObjectID) uint64 {
-	serverID := getServerID(serverIDPtr)
+func (p *poolGenerationMap) addConnection(serviceIDPtr *primitive.ObjectID) uint64 {
+	serviceID := getServiceID(serviceIDPtr)
 	p.Lock()
 	defer p.Unlock()
 
-	stats, ok := p.generationMap[serverID]
+	stats, ok := p.generationMap[serviceID]
 	if ok {
-		// If the serverID is already being tracked, we only need to increment the connection count.
+		// If the serviceID is already being tracked, we only need to increment the connection count.
 		stats.numConns++
 		return stats.generation
 	}
 
-	// If the serverID is untracked, create a new entry with a starting generation number of 0.
+	// If the serviceID is untracked, create a new entry with a starting generation number of 0.
 	stats = &generationStats{
 		numConns: 1,
 	}
-	p.generationMap[serverID] = stats
+	p.generationMap[serviceID] = stats
 	return 0
 }
 
-func (p *poolGenerationMap) removeConnection(serverIDPtr *primitive.ObjectID) {
-	serverID := getServerID(serverIDPtr)
+func (p *poolGenerationMap) removeConnection(serviceIDPtr *primitive.ObjectID) {
+	serviceID := getServiceID(serviceIDPtr)
 	p.Lock()
 	defer p.Unlock()
 
-	stats, ok := p.generationMap[serverID]
+	stats, ok := p.generationMap[serviceID]
 	if !ok {
 		return
 	}
 
-	// If the serverID is being tracked, decrement the connection count and delete this serverID to prevent the map
+	// If the serviceID is being tracked, decrement the connection count and delete this serviceID to prevent the map
 	// from growing unboundedly. This case would happen if a server behind a load-balancer was permanently removed
 	// and its connections were pruned after a network error or idle timeout.
 	stats.numConns--
 	if stats.numConns == 0 {
-		delete(p.generationMap, serverID)
+		delete(p.generationMap, serviceID)
 	}
 }
 
-func (p *poolGenerationMap) clear(serverIDPtr *primitive.ObjectID) {
-	serverID := getServerID(serverIDPtr)
+func (p *poolGenerationMap) clear(serviceIDPtr *primitive.ObjectID) {
+	serviceID := getServiceID(serviceIDPtr)
 	p.Lock()
 	defer p.Unlock()
 
-	if stats, ok := p.generationMap[serverID]; ok {
+	if stats, ok := p.generationMap[serviceID]; ok {
 		stats.generation++
 	}
 }
 
-func (p *poolGenerationMap) stale(serverIDPtr *primitive.ObjectID, knownGeneration uint64) bool {
+func (p *poolGenerationMap) stale(serviceIDPtr *primitive.ObjectID, knownGeneration uint64) bool {
 	// If the map has been disconnected, all connections should be considered stale to ensure that they're closed.
 	if atomic.LoadInt32(&p.state) == disconnected {
 		return true
 	}
 
-	serverID := getServerID(serverIDPtr)
+	serviceID := getServiceID(serviceIDPtr)
 	p.Lock()
 	defer p.Unlock()
 
-	if stats, ok := p.generationMap[serverID]; ok {
+	if stats, ok := p.generationMap[serviceID]; ok {
 		return knownGeneration < stats.generation
 	}
 	return false
 }
 
-func (p *poolGenerationMap) getGeneration(serverIDPtr *primitive.ObjectID) uint64 {
-	serverID := getServerID(serverIDPtr)
+func (p *poolGenerationMap) getGeneration(serviceIDPtr *primitive.ObjectID) uint64 {
+	serviceID := getServiceID(serviceIDPtr)
 	p.Lock()
 	defer p.Unlock()
 
-	if stats, ok := p.generationMap[serverID]; ok {
+	if stats, ok := p.generationMap[serviceID]; ok {
 		return stats.generation
 	}
 	return 0
 }
 
-func getServerID(oid *primitive.ObjectID) primitive.ObjectID {
+func getServiceID(oid *primitive.ObjectID) primitive.ObjectID {
 	if oid == nil {
 		return primitive.NilObjectID
 	}

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -274,9 +274,9 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 
 // ProcessHandshakeError implements SDAM error handling for errors that occur before a connection finishes handshaking.
 func (s *Server) ProcessHandshakeError(err error, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
-	// Ignore the error if the server is behind a load balancer but the server ID is unknown. This indicates that the
-	// error happened when dialing the connection or during the MongoDB handshake, so we don't know the server ID to use
-	// for clearing the pool.
+	// Ignore the error if the server is behind a load balancer but the service ID is unknown. This indicates that the
+	// error happened when dialing the connection or during the MongoDB handshake, so we don't know the service ID to
+	// use for clearing the pool.
 	if err == nil || s.cfg.loadBalanced && serviceID == nil {
 		return
 	}
@@ -528,8 +528,9 @@ func (s *Server) update() {
 
 		s.updateDescription(desc)
 		if desc.LastError != nil {
-			// Clear the pool once the description has been updated to Unknown. Pass in a nil server ID to clear because
-			// the monitoring routine only runs for non-load balanced deployments in which servers don't return IDs.
+			// Clear the pool once the description has been updated to Unknown. Pass in a nil service ID to clear
+			// because the monitoring routine only runs for non-load balanced deployments in which servers don't return
+			// IDs.
 			s.pool.clear(nil)
 		}
 

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -273,15 +273,15 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 }
 
 // ProcessHandshakeError implements SDAM error handling for errors that occur before a connection finishes handshaking.
-func (s *Server) ProcessHandshakeError(err error, startingGenerationNumber uint64, serverID *primitive.ObjectID) {
+func (s *Server) ProcessHandshakeError(err error, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
 	// Ignore the error if the server is behind a load balancer but the server ID is unknown. This indicates that the
 	// error happened when dialing the connection or during the MongoDB handshake, so we don't know the server ID to use
 	// for clearing the pool.
-	if err == nil || s.cfg.loadBalanced && serverID == nil {
+	if err == nil || s.cfg.loadBalanced && serviceID == nil {
 		return
 	}
 	// Ignore the error if the connection is stale.
-	if startingGenerationNumber < s.pool.generation.getGeneration(serverID) {
+	if startingGenerationNumber < s.pool.generation.getGeneration(serviceID) {
 		return
 	}
 
@@ -294,7 +294,7 @@ func (s *Server) ProcessHandshakeError(err error, startingGenerationNumber uint6
 	// the description.Server appropriately. The description should not have a TopologyVersion because the staleness
 	// checking logic above has already determined that this description is not stale.
 	s.updateDescription(description.NewServerFromError(s.address, wrappedConnErr, nil))
-	s.pool.clear(serverID)
+	s.pool.clear(serviceID)
 	s.cancelCheck()
 }
 
@@ -398,7 +398,7 @@ func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessE
 		// If the node is shutting down or is older than 4.2, we synchronously clear the pool
 		if cerr.NodeIsShuttingDown() || desc.WireVersion == nil || desc.WireVersion.Max < 8 {
 			res = driver.ConnectionPoolCleared
-			s.pool.clear(desc.ServerID)
+			s.pool.clear(desc.ServiceID)
 		}
 		return res
 	}
@@ -416,7 +416,7 @@ func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessE
 		// If the node is shutting down or is older than 4.2, we synchronously clear the pool
 		if wcerr.NodeIsShuttingDown() || desc.WireVersion == nil || desc.WireVersion.Max < 8 {
 			res = driver.ConnectionPoolCleared
-			s.pool.clear(desc.ServerID)
+			s.pool.clear(desc.ServiceID)
 		}
 		return res
 	}
@@ -438,7 +438,7 @@ func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessE
 	// monitoring check. The check is cancelled last to avoid a post-cancellation reconnect racing with
 	// updateDescription.
 	s.updateDescription(description.NewServerFromError(s.address, err, nil))
-	s.pool.clear(desc.ServerID)
+	s.pool.clear(desc.ServiceID)
 	s.cancelCheck()
 	return driver.ConnectionPoolCleared
 }


### PR DESCRIPTION
This change is to keep us in sync with a recent change in the LB spec.