### PR TITLE
GODRIVER-1960 Replace acceptAPIVersion2 with acceptApiVersion2

### DIFF
--- a/data/versioned-api/README.rst
+++ b/data/versioned-api/README.rst
@@ -12,7 +12,7 @@ Notes
 This directory contains tests for the Versioned API specification. They are
 implemented in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__,
 and require schema version 1.1. Note that to run these tests, the server must be
-started with both ``enableTestCommands`` and ``acceptAPIVersion2`` parameters
+started with both ``enableTestCommands`` and ``acceptApiVersion2`` parameters
 set to true.
 
 Testing with required API version

--- a/data/versioned-api/test-commands-deprecation-errors.json
+++ b/data/versioned-api/test-commands-deprecation-errors.json
@@ -6,7 +6,7 @@
       "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true,
+        "acceptApiVersion2": true,
         "requireApiVersion": false
       }
     }

--- a/data/versioned-api/test-commands-deprecation-errors.yml
+++ b/data/versioned-api/test-commands-deprecation-errors.yml
@@ -6,7 +6,7 @@ runOnRequirements:
   - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
-      acceptAPIVersion2: true
+      acceptApiVersion2: true
       requireApiVersion: false
 
 createEntities:


### PR DESCRIPTION
GODRIVER-1960

Replaces all instances of `acceptAPIVersion2` with `acceptApiVersion2` in spec test code. (The server recently changed the parameter to comply with acronym style guidelines).

This should stop us from skipping the versioned api `test-commands-deprecation-errors` spec test unintentionally.