### PR TITLE
GODRIVER-1979 Use array.Values instead of array.Elements

### DIFF
--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -347,12 +347,12 @@ func getError(rdr bsoncore.Document) error {
 			}
 		case "errorLabels":
 			if arr, okay := elem.Value().ArrayOK(); okay {
-				elems, err := arr.Elements()
+				vals, err := arr.Values()
 				if err != nil {
 					continue
 				}
-				for _, elem := range elems {
-					if str, ok := elem.Value().StringValueOK(); ok {
+				for _, val := range vals {
+					if str, ok := val.StringValueOK(); ok {
 						labels = append(labels, str)
 					}
 				}
@@ -404,12 +404,12 @@ func getError(rdr bsoncore.Document) error {
 				copy(wcError.WriteConcernError.Details, info)
 			}
 			if errLabels, exists := doc.Lookup("errorLabels").ArrayOK(); exists {
-				elems, err := errLabels.Elements()
+				vals, err := errLabels.Values()
 				if err != nil {
 					continue
 				}
-				for _, elem := range elems {
-					if str, ok := elem.Value().StringValueOK(); ok {
+				for _, val := range vals {
+					if str, ok := val.StringValueOK(); ok {
 						labels = append(labels, str)
 					}
 				}


### PR DESCRIPTION
GODRIVER-1979

Removes a few lingering usages of `bsoncore.Array#Elements()` and replaces them with `bsoncore.Array#Values()`.