### PR TITLE
GODRIVER-1931 Sync retryable reads spec tests

### DIFF
--- a/data/retryable-reads/aggregate-merge.json
+++ b/data/retryable-reads/aggregate-merge.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "minServerVersion": "4.1.11"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/data/retryable-reads/aggregate-merge.yml
+++ b/data/retryable-reads/aggregate-merge.yml
@@ -1,6 +1,6 @@
 runOn:
   -
-    minServerVersion: "4.2.0"
+    minServerVersion: "4.1.11"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/data/retryable-reads/changeStreams-client.watch-serverErrors.json
+++ b/data/retryable-reads/changeStreams-client.watch-serverErrors.json
@@ -59,7 +59,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -76,7 +75,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -116,7 +114,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -133,7 +130,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -173,7 +169,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -190,7 +185,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -230,7 +224,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -247,7 +240,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -287,7 +279,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -304,7 +295,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -344,7 +334,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -361,7 +350,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -401,7 +389,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -418,7 +405,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -458,7 +444,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -475,7 +460,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -515,7 +499,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -532,7 +515,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -572,7 +554,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -589,7 +570,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -629,7 +609,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -646,7 +625,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -687,7 +665,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -704,7 +681,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -748,7 +724,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }

--- a/data/retryable-reads/changeStreams-client.watch-serverErrors.yml
+++ b/data/retryable-reads/changeStreams-client.watch-serverErrors.yml
@@ -31,7 +31,7 @@ tests:
                     command:
                         aggregate: 1
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default", allChangesForCluster: true } } ]
+                        pipeline: [ { $changeStream: { allChangesForCluster: true } } ]
                     database_name: admin
             - *retryable_command_started_event
     -

--- a/data/retryable-reads/changeStreams-client.watch.json
+++ b/data/retryable-reads/changeStreams-client.watch.json
@@ -39,7 +39,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -79,7 +78,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -96,7 +94,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -140,7 +137,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -181,7 +177,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }
@@ -198,7 +193,6 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
                     "allChangesForCluster": true
                   }
                 }

--- a/data/retryable-reads/changeStreams-client.watch.yml
+++ b/data/retryable-reads/changeStreams-client.watch.yml
@@ -25,7 +25,7 @@ tests:
                     command:
                         aggregate: 1
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default", "allChangesForCluster": true } } ]
+                        pipeline: [ { $changeStream: { "allChangesForCluster": true } } ]
                     database_name: admin
     -
         description: "client.watch succeeds on second attempt"

--- a/data/retryable-reads/changeStreams-db.coll.watch-serverErrors.json
+++ b/data/retryable-reads/changeStreams-db.coll.watch-serverErrors.json
@@ -58,9 +58,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -74,9 +72,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -113,9 +109,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -129,9 +123,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -168,9 +160,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -184,9 +174,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -223,9 +211,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -239,9 +225,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -278,9 +262,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -294,9 +276,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -333,9 +313,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -349,9 +327,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -388,9 +364,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -404,9 +378,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -443,9 +415,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -459,9 +429,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -498,9 +466,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -514,9 +480,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -553,9 +517,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -569,9 +531,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -608,9 +568,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -624,9 +582,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -664,9 +620,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -680,9 +634,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -723,9 +675,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },

--- a/data/retryable-reads/changeStreams-db.coll.watch-serverErrors.yml
+++ b/data/retryable-reads/changeStreams-db.coll.watch-serverErrors.yml
@@ -31,7 +31,7 @@ tests:
                     command:
                         aggregate: *collection_name
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default" } } ]
+                        pipeline: [ { $changeStream: { } } ]
                     database_name: *database_name
             - *retryable_command_started_event
     -

--- a/data/retryable-reads/changeStreams-db.coll.watch.json
+++ b/data/retryable-reads/changeStreams-db.coll.watch.json
@@ -38,9 +38,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -77,9 +75,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -93,9 +89,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -136,9 +130,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -176,9 +168,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -192,9 +182,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },

--- a/data/retryable-reads/changeStreams-db.coll.watch.yml
+++ b/data/retryable-reads/changeStreams-db.coll.watch.yml
@@ -25,7 +25,7 @@ tests:
                     command:
                         aggregate: *collection_name
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default" } } ]
+                        pipeline: [ { $changeStream: { } } ]
                     database_name: *database_name
     -
         description: "db.coll.watch succeeds on second attempt"

--- a/data/retryable-reads/changeStreams-db.watch-serverErrors.json
+++ b/data/retryable-reads/changeStreams-db.watch-serverErrors.json
@@ -58,9 +58,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -74,9 +72,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -113,9 +109,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -129,9 +123,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -168,9 +160,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -184,9 +174,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -223,9 +211,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -239,9 +225,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -278,9 +262,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -294,9 +276,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -333,9 +313,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -349,9 +327,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -388,9 +364,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -404,9 +378,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -443,9 +415,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -459,9 +429,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -498,9 +466,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -514,9 +480,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -553,9 +517,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -569,9 +531,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -608,9 +568,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -624,9 +582,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -664,9 +620,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -680,9 +634,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -723,9 +675,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },

--- a/data/retryable-reads/changeStreams-db.watch-serverErrors.yml
+++ b/data/retryable-reads/changeStreams-db.watch-serverErrors.yml
@@ -31,7 +31,7 @@ tests:
                     command:
                         aggregate: 1
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default" } } ]
+                        pipeline: [ { $changeStream: { } } ]
                     database_name: *database_name
             - *retryable_command_started_event
     -

--- a/data/retryable-reads/changeStreams-db.watch.json
+++ b/data/retryable-reads/changeStreams-db.watch.json
@@ -38,9 +38,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -77,9 +75,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -93,9 +89,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -136,9 +130,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -176,9 +168,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },
@@ -192,9 +182,7 @@
               "cursor": {},
               "pipeline": [
                 {
-                  "$changeStream": {
-                    "fullDocument": "default"
-                  }
+                  "$changeStream": {}
                 }
               ]
             },

--- a/data/retryable-reads/changeStreams-db.watch.yml
+++ b/data/retryable-reads/changeStreams-db.watch.yml
@@ -25,7 +25,7 @@ tests:
                     command:
                         aggregate: 1
                         cursor: {}
-                        pipeline: [ { $changeStream: { fullDocument: "default" } } ]
+                        pipeline: [ { $changeStream: { } } ]
                     database_name: *database_name
     -
         description: "db.watch succeeds on second attempt"

--- a/data/retryable-reads/estimatedDocumentCount-4.9.json
+++ b/data/retryable-reads/estimatedDocumentCount-4.9.json
@@ -1,246 +1,246 @@
 {
-    "runOn": [
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "EstimatedDocumentCount succeeds on first attempt",
+      "operations": [
         {
-            "minServerVersion": "4.9.0"
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
         }
-    ],
-    "database_name": "retryable-reads-tests",
-    "collection_name": "coll",
-    "data": [
+      ],
+      "expectations": [
         {
-            "_id": 1,
-            "x": 11
-        },
-        {
-            "_id": 2,
-            "x": 22
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
         }
-    ],
-    "tests": [
-        {
-            "description": "EstimatedDocumentCount succeeds on first attempt",
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
         },
-        {
-            "description": "EstimatedDocumentCount succeeds on second attempt",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails on first attempt",
-            "clientOptions": {
-                "retryReads": false
-            },
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails on second attempt",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 2
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "closeConnection": true
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
         }
-    ]
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails on first attempt",
+      "clientOptions": {
+        "retryReads": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails on second attempt",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/data/retryable-reads/estimatedDocumentCount-serverErrors-4.9.json
+++ b/data/retryable-reads/estimatedDocumentCount-serverErrors-4.9.json
@@ -1,911 +1,911 @@
 {
-    "runOn": [
-        {
-            "minServerVersion": "4.9.0"
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "database_name": "retryable-reads-tests",
+  "collection_name": "coll",
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 11600
         }
-    ],
-    "database_name": "retryable-reads-tests",
-    "collection_name": "coll",
-    "data": [
+      },
+      "operations": [
         {
-            "_id": 1,
-            "x": 11
-        },
-        {
-            "_id": 2,
-            "x": 22
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
         }
-    ],
-    "tests": [
+      ],
+      "expectations": [
         {
-            "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
                 },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 11600
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
                 }
+              ]
             },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+            "database_name": "retryable-reads-tests"
+          }
         },
         {
-            "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
                 },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 11602
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
                 }
+              ]
             },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMaster",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 13435
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 13436
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 189
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 91
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after HostNotFound",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 7
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after HostUnreachable",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 6
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 89
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount succeeds after SocketException",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 9001
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "result": 2
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails after two NotMaster errors",
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 2
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                },
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
-        },
-        {
-            "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
-            "clientOptions": {
-                "retryReads": false
-            },
-            "failPoint": {
-                "configureFailPoint": "failCommand",
-                "mode": {
-                    "times": 1
-                },
-                "data": {
-                    "failCommands": [
-                        "aggregate"
-                    ],
-                    "errorCode": 10107
-                }
-            },
-            "operations": [
-                {
-                    "name": "estimatedDocumentCount",
-                    "object": "collection",
-                    "error": true
-                }
-            ],
-            "expectations": [
-                {
-                    "command_started_event": {
-                        "command": {
-                            "aggregate": "coll",
-                            "pipeline": [
-                                {
-                                    "$collStats": {
-                                        "count": {}
-                                    }
-                                },
-                                {
-                                    "$group": {
-                                        "_id": 1,
-                                        "n": {
-                                            "$sum": "$count"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "database_name": "retryable-reads-tests"
-                    }
-                }
-            ]
+            "database_name": "retryable-reads-tests"
+          }
         }
-    ]
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 11602
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotMaster",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 13435
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 13436
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 189
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 91
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after HostNotFound",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 7
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after HostUnreachable",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 6
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 89
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount succeeds after SocketException",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 9001
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails after two NotMaster errors",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    },
+    {
+      "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
+      "clientOptions": {
+        "retryReads": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 10107
+        }
+      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "coll",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "database_name": "retryable-reads-tests"
+          }
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
As part of LB testing, we'll need to run some of the existing spec tests against LB clusters. These spec tests will require some modifications to ensure they can run (e.g. the `topology` arrays will need to include `load-balanced`). Those changes are described in https://github.com/mongodb/specifications/pull/961. This PR syncs the retryable reads spec tests with the ones present in the `master` branch of the specs repo to ensure that we can easily pull in the new changes from the linked spec PR when it is merged.