### PR TITLE
GODRIVER-1931 Run tests against LBs in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -518,6 +518,33 @@ functions:
           PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
+  run-load-balancer-tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+
+          if [ ${SSL} = "ssl" ]; then
+              export MONGO_GO_DRIVER_CA_FILE="$PROJECT_DIRECTORY/data/certificates/ca.pem"
+              if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
+                  export MONGO_GO_DRIVER_CA_FILE=$(cygpath -m $MONGO_GO_DRIVER_CA_FILE)
+              fi
+          fi
+
+          export GOFLAGS=-mod=vendor
+          set +o xtrace
+          AUTH="${AUTH}" \
+          SSL="${SSL}" \
+          MONGODB_URI="${SINGLE_MONGOS_LB_URI}" \
+          SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}" \
+          MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}" \
+          TOPOLOGY="${TOPOLOGY}" \
+          MONGO_GO_DRIVER_COMPRESSOR=${MONGO_GO_DRIVER_COMPRESSOR} \
+          BUILD_TAGS="-tags cse" \
+          make evg-test-load-balancers
+
   run-atlas-data-lake-test:
     - command: shell.exec
       type: test
@@ -611,6 +638,21 @@ functions:
           -p 8100 \
           -v \
           --fault revoked
+
+  run-load-balancer:
+    - command: shell.exec
+      params:
+        script: |
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh start
+    - command: expansions.update
+      params:
+        file: lb-expansion.yml
+
+  stop-load-balancer:
+    - command: shell.exec
+      params:
+        script: |
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop
 
   add-aws-auth-variables-to-file:
     - command: shell.exec
@@ -866,6 +908,7 @@ post:
       files:
         - "src/go.mongodb.org/mongo-driver/*.suite"
   - func: upload-mo-artifacts
+  - func: stop-load-balancer
   - func: cleanup
 
 tasks:
@@ -1378,6 +1421,28 @@ tasks:
     commands:
       - func: bootstrap-mongohoused
       - func: run-atlas-data-lake-test
+
+  - name: test-load-balancer-noauth-nossl
+    tags: ["load-balancer"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: run-load-balancer
+      - func: run-load-balancer-tests
+
+  - name: test-load-balancer-auth-ssl
+    tags: ["load-balancer"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "auth"
+          SSL: "ssl"
+      - func: run-load-balancer
+      - func: run-load-balancer-tests
 
   - name: test-replicaset-noauth-nossl
     tags: ["test", "replicaset"]
@@ -1968,6 +2033,12 @@ buildvariants:
     display_name: "API Version ${os-ssl-40}"
     tasks:
       - name: ".versioned-api"
+
+  - matrix_name: "load-balancer-test"
+    matrix_spec: { version: ["latest"], os-ssl-40: ["ubuntu1804-64-go-1-15"] }
+    display_name: "Load Balancer Version ${os-ssl-40}"
+    tasks:
+      - name: ".load-balancer"
 
   - matrix_name: "kms-tls-test"
     matrix_spec: { version: ["latest"], os-ssl-40: ["ubuntu1804-64-go-1-15"] }

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,14 @@ evg-test-versioned-api:
 		go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s $$TEST_PKG >> test.suite ; \
 	done
 
+.PHONY: evg-test-load-balancers
+evg-test-load-balancers:
+	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/retryable-reads -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestRetryableWritesSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestChangeStreamSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BULID_TAGS) ./mongo/integration -run TestInitialDNSSeedlistDiscoverySpec/load_balanced -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
+
 .PHONY: evg-test-kms
 evg-test-kms:
 	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/kms_tls_tests >> test.suite

--- a/internal/const.go
+++ b/internal/const.go
@@ -8,3 +8,8 @@ package internal // import "go.mongodb.org/mongo-driver/internal"
 
 // Version is the current version of the driver.
 var Version = "local build"
+
+// SetServiceID enables a mode in which the driver mocks server support for returning a "serviceId" field in "hello"
+// command responses by using the value of "topologyVersion.processId". This is used for testing load balancer
+// support until an upstream service can support running behind a load balancer.
+var SetServiceID = false

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -266,6 +266,10 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				desc.LastError = err
 				return desc
 			}
+
+			if internal.SetServiceID {
+				desc.ServiceID = &desc.TopologyVersion.ProcessID
+			}
 		}
 	}
 

--- a/mongo/integration/main_test.go
+++ b/mongo/integration/main_test.go
@@ -9,12 +9,22 @@ package integration
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 func TestMain(m *testing.M) {
+	// If the cluster is behind a load balancer, enable the SetServiceID flag to mock server-side LB support.
+	if strings.Contains(os.Getenv("MONGODB_URI"), "loadBalanced=true") {
+		internal.SetServiceID = true
+		defer func() {
+			internal.SetServiceID = false
+		}()
+	}
+
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -35,6 +35,18 @@ func ClusterURI() string {
 	return testContext.connString.Original
 }
 
+// SingleMongosLoadBalancerURI returns the URI for a load balancer fronting a single mongos. This will only be set
+// if the cluster is load balanced.
+func SingleMongosLoadBalancerURI() string {
+	return testContext.singleMongosLoadBalancerURI
+}
+
+// MultiMongosLoadBalancerURI returns the URI for a load balancer fronting multiple mongoses. This will only be set
+// if the cluster is load balanced.
+func MultiMongosLoadBalancerURI() string {
+	return testContext.multiMongosLoadBalancerURI
+}
+
 // ClusterConnString returns the parsed ConnString for the cluster.
 func ClusterConnString() connstring.ConnString {
 	return testContext.connString

--- a/mongo/integration/unified/database_operation_execution.go
+++ b/mongo/integration/unified/database_operation_execution.go
@@ -89,7 +89,7 @@ func executeListCollections(ctx context.Context, operation *operation) (*operati
 	defer cursor.Close(ctx)
 
 	var docs []bson.Raw
-	if err := cursor.All(ctx, &cursor); err != nil {
+	if err := cursor.All(ctx, &docs); err != nil {
 		return newErrorResult(err), nil
 	}
 	return newCursorResult(docs), nil

--- a/mongo/integration/unified/main_test.go
+++ b/mongo/integration/unified/main_test.go
@@ -9,12 +9,22 @@ package unified
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 func TestMain(m *testing.M) {
+	// If the cluster is behind a load balancer, enable the SetServiceID flag to mock server-side LB support.
+	if strings.Contains(os.Getenv("MONGODB_URI"), "loadBalanced=true") {
+		internal.SetServiceID = true
+		defer func() {
+			internal.SetServiceID = false
+		}()
+	}
+
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/integration/unified/operation.go
+++ b/mongo/integration/unified/operation.go
@@ -131,6 +131,8 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 		return executeInsertMany(ctx, op)
 	case "insertOne":
 		return executeInsertOne(ctx, op)
+	case "listIndexes":
+		return executeListIndexes(ctx, op)
 	case "replaceOne":
 		return executeReplaceOne(ctx, op)
 	case "updateOne":

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -19,6 +19,7 @@ var (
 		"versioned-api",
 		"crud/unified",
 		"change-streams/unified",
+		"load-balancers",
 	}
 )
 


### PR DESCRIPTION
This PR contains the changes needed to run load balanced clusters in Evergreen and some changes to the `mtest` package to handle receiving load balancer URIs.