### PR TITLE
GODRIVER-1955 create labeledError interface

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -106,8 +106,8 @@ func IsTimeout(err error) bool {
 			return ne.Timeout()
 		}
 		//timeout error labels
-		if se, ok := err.(labeledError); ok {
-			if se.HasErrorLabel("NetworkTimeoutError") || se.HasErrorLabel("ExceededTimeLimitError") {
+		if le, ok := err.(labeledError); ok {
+			if le.HasErrorLabel("NetworkTimeoutError") || le.HasErrorLabel("ExceededTimeLimitError") {
 				return true
 			}
 		}
@@ -130,7 +130,7 @@ func unwrap(err error) error {
 // errorHasLabel returns true if err contains the specified label
 func errorHasLabel(err error, label string) bool {
 	for ; err != nil; err = unwrap(err) {
-		if e, ok := err.(labeledError); ok && e.HasErrorLabel(label) {
+		if le, ok := err.(labeledError); ok && le.HasErrorLabel(label) {
 			return true
 		}
 	}
@@ -193,7 +193,9 @@ type labeledError interface {
 // ServerError is the interface implemented by errors returned from the server. Custom implementations of this
 // interface should not be used in production.
 type ServerError interface {
-	labeledError
+	error
+	// HasErrorLabel returns true if the error contains the specified label.
+	HasErrorLabel(string) bool
 	// HasErrorCode returns true if the error has the specified code.
 	HasErrorCode(int) bool
 	// HasErrorMessage returns true if the error contains the specified message.

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -194,10 +194,10 @@ type labeledError interface {
 // interface should not be used in production.
 type ServerError interface {
 	error
-	// HasErrorLabel returns true if the error contains the specified label.
-	HasErrorLabel(string) bool
 	// HasErrorCode returns true if the error has the specified code.
 	HasErrorCode(int) bool
+	// HasErrorLabel returns true if the error contains the specified label.
+	HasErrorLabel(string) bool
 	// HasErrorMessage returns true if the error contains the specified message.
 	HasErrorMessage(string) bool
 	// HasErrorCodeWithMessage returns true if any of the contained errors have the specified code and message.

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -85,6 +85,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				_, err := mt.Coll.InsertOne(timeoutCtx, bson.D{{"test", 1}})
 				assert.NotNil(mt, err, "expected InsertOne error, got nil")
 				assert.True(mt, mongo.IsTimeout(err), "expected timeout error, got %v", err)
+				assert.True(mt, mongo.IsNetworkError(err), "expected network error, got %v", err)
 				assert.True(mt, isPoolCleared(), "expected pool to be cleared but was not")
 			})
 			mt.RunOpts("pool cleared on non-timeout network error", noClientOpts, func(mt *mtest.T) {


### PR DESCRIPTION
I could technically make labeledError a public interface, but I don't think users get much benefit from it.