### PR TITLE
GODRIVER-1981 Sync new transactions tests

### DIFF
--- a/data/transactions/unified/mongos-unpin.json
+++ b/data/transactions/unified/mongos-unpin.json
@@ -186,6 +186,55 @@
       ]
     },
     {
+      "description": "unpin after non-transient error on abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
       "description": "unpin when a new transaction is started",
       "operations": [
         {

--- a/data/transactions/unified/mongos-unpin.yml
+++ b/data/transactions/unified/mongos-unpin.yml
@@ -93,6 +93,23 @@ tests:
       - *abortTransaction
       - *assertNoPinnedServer
 
+  - description: unpin after non-transient error on abort
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: 91 # ShutdownInProgress
+      - *abortTransaction
+      - *assertNoPinnedServer
+
   - description: unpin when a new transaction is started
     operations:
       - *startTransaction


### PR DESCRIPTION
This ticket requires syncing the new tests added in https://github.com/mongodb/specifications/commit/ec326862be443d11f0233cee2de32a95751144df. I tried syncing the whole test file, but it has been changed to require version 1.4 of the unified test format in the `master` branch of the specs repo due to https://github.com/mongodb/specifications/commit/3586db8b1ed90d835737f6226bb3ff9012cfc5de. We don't support this version of the format yet as that will be done in GODRIVER-1861, so I manually synced over the new `unpin after non-transient error on abort` test.