### PR TITLE
GODRIVER-1925 Surface cursor errors in DownloadStream fillBuffer

### DIFF
--- a/mongo/gridfs/download_stream.go
+++ b/mongo/gridfs/download_stream.go
@@ -118,8 +118,11 @@ func (ds *DownloadStream) Close() error {
 		return ErrStreamClosed
 	}
 
-	ds.closed = true
-	return nil
+	err := ds.cursor.Close(context.Background())
+	if err != nil {
+		ds.closed = true
+	}
+	return err
 }
 
 // SetReadDeadline sets the read deadline for this download stream.
@@ -228,7 +231,7 @@ func (ds *DownloadStream) fillBuffer(ctx context.Context) error {
 		ds.done = true
 		// Check for cursor error, otherwise there are no more chunks.
 		if ds.cursor.Err() != nil {
-			ds.cursor.Close(ctx)
+			_ = ds.cursor.Close(ctx)
 			return ds.cursor.Err()
 		}
 		return errNoMoreChunks

--- a/mongo/gridfs/download_stream.go
+++ b/mongo/gridfs/download_stream.go
@@ -118,11 +118,11 @@ func (ds *DownloadStream) Close() error {
 		return ErrStreamClosed
 	}
 
-	err := ds.cursor.Close(context.Background())
-	if err != nil {
-		ds.closed = true
+	ds.closed = true
+	if ds.cursor != nil {
+		return ds.cursor.Close(context.Background())
 	}
-	return err
+	return nil
 }
 
 // SetReadDeadline sets the read deadline for this download stream.

--- a/mongo/gridfs/download_stream.go
+++ b/mongo/gridfs/download_stream.go
@@ -226,6 +226,11 @@ func (ds *DownloadStream) GetFile() *File {
 func (ds *DownloadStream) fillBuffer(ctx context.Context) error {
 	if !ds.cursor.Next(ctx) {
 		ds.done = true
+		// Check for cursor error, otherwise there are no more chunks.
+		if ds.cursor.Err() != nil {
+			ds.cursor.Close(ctx)
+			return ds.cursor.Err()
+		}
 		return errNoMoreChunks
 	}
 

--- a/mongo/integration/gridfs_test.go
+++ b/mongo/integration/gridfs_test.go
@@ -375,29 +375,23 @@ func TestGridFS(x *testing.T) {
 			// so Read() will actually execute a getMore against the server. Since the ReadDeadline is
 			// set in the past, this should cause a timeout.
 
-			// Create file to upload.
 			fileName := "read-error-test"
 			fileData := make([]byte, 17000000)
 
-			// Create bucket.
 			bucket, err := gridfs.NewBucket(mt.DB)
 			assert.Nil(mt, err, "NewBucket error: %v", err)
 			defer func() { _ = bucket.Drop() }()
 
-			// Open data reader from file and upload to bucket.
 			dataReader := bytes.NewReader(fileData)
 			_, err = bucket.UploadFromStream(fileName, dataReader)
 			assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
-			// Open a download stream to fileName.
 			ds, err := bucket.OpenDownloadStreamByName(fileName)
 			assert.Nil(mt, err, "OpenDownloadStreamByName error: %v", err)
 
-			// Set a read deadline in the past to cause a timeout.
 			err = ds.SetReadDeadline(time.Now().Add(-1 * time.Second))
 			assert.Nil(mt, err, "SetReadDeadline error: %v", err)
 
-			// Try to read.
 			p := make([]byte, 17000000)
 			_, err = ds.Read(p)
 			assert.NotNil(mt, err, "expected error from Read, got nil")

--- a/mongo/integration/gridfs_test.go
+++ b/mongo/integration/gridfs_test.go
@@ -392,7 +392,7 @@ func TestGridFS(x *testing.T) {
 			err = ds.SetReadDeadline(time.Now().Add(-1 * time.Second))
 			assert.Nil(mt, err, "SetReadDeadline error: %v", err)
 
-			p := make([]byte, 17000000)
+			p := make([]byte, len(fileData))
 			_, err = ds.Read(p)
 			assert.NotNil(mt, err, "expected error from Read, got nil")
 			assert.True(mt, strings.Contains(err.Error(), "context deadline exceeded"),


### PR DESCRIPTION
GODRIVER-1925

Checks for a possible cursor error in `DownloadStream#FillBuffer` instead of always returning `errNoMoreChunks` when `ds.cursor.Next` returns false. If there is a cursor error, closes the cursor and returns the underlying error.

Adds a test to simulate a timeout during `DownloadStream#Read` and assert that `context deadline exceeded` is returned instead of `io.EOF`.