### PR TITLE
GODRIVER-1937 Update legacy ListCollections to support the BatchSize option for server version 2.6

### DIFF
--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -237,18 +237,32 @@ func TestDatabase(t *testing.T) {
 			assert.Nil(mt, err, "expected command %s to contain key 'batchSize'", evt.Command)
 		})
 
-		// The BatchSize option is not honored for ListCollections operations on server version 2.6 due to an
-		// inconsistency in the legacy OP_QUERY code path (GODRIVER-1937).
-		cmdMonitoringMtOpts := mtest.NewOptions().MinServerVersion("3.0")
+		cmdMonitoringMtOpts := mtest.NewOptions().MinServerVersion("2.6")
 		mt.RunOpts("getMore commands are monitored", cmdMonitoringMtOpts, func(mt *mtest.T) {
 			createCollections(mt, 2)
-			assertGetMoreCommandsAreMonitored(mt, "listCollections", func() (*mongo.Cursor, error) {
+
+			// For server versions below 3.0, we internally execute ListCollections() as a legacy
+			// OP_QUERY against the system.namespaces collection. Command monitoring upconversions
+			// translate this to a "find" command rather than "listCollections".
+			cmdName := "listCollections"
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.0") < 0 {
+				cmdName = "find"
+			}
+			assertGetMoreCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
 				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
 			})
 		})
 		mt.RunOpts("killCursors commands are monitored", cmdMonitoringMtOpts, func(mt *mtest.T) {
 			createCollections(mt, 2)
-			assertKillCursorsCommandsAreMonitored(mt, "listCollections", func() (*mongo.Cursor, error) {
+
+			// For server versions below 3.0, we internally execute ListCollections() as a legacy
+			// OP_QUERY against the system.namespaces collection. Command monitoring upconversions
+			// translate this to a "find" command rather than "listCollections".
+			cmdName := "listCollections"
+			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.0") < 0 {
+				cmdName = "find"
+			}
+			assertKillCursorsCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
 				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
 			})
 		})

--- a/x/mongo/driver/operation_legacy.go
+++ b/x/mongo/driver/operation_legacy.go
@@ -459,12 +459,17 @@ func (op Operation) createLegacyListCollectionsWiremessage(dst []byte, desc desc
 		optsElems = bsoncore.AppendDocumentElement(optsElems, "$readPreference", rp)
 	}
 
+	var batchSize int32
+	if val, ok := cmdDoc.Lookup("cursor", "batchSize").AsInt32OK(); ok {
+		batchSize = val
+	}
+
 	var wmIdx int32
 	wmIdx, dst = wiremessage.AppendHeaderStart(dst, info.requestID, 0, wiremessage.OpQuery)
 	dst = wiremessage.AppendQueryFlags(dst, op.slaveOK(desc))
 	dst = wiremessage.AppendQueryFullCollectionName(dst, op.getFullCollectionName(listCollectionsNamespace))
 	dst = wiremessage.AppendQueryNumberToSkip(dst, 0)
-	dst = wiremessage.AppendQueryNumberToReturn(dst, 0)
+	dst = wiremessage.AppendQueryNumberToReturn(dst, batchSize)
 	dst = op.appendLegacyQueryDocument(dst, filter, optsElems)
 	// leave out returnFieldsSelector because it is optional
 


### PR DESCRIPTION
Support the `BatchSize` option for the `ListCollections` call for server version 2.6

Changes:
- Use the `cursor.batchSize` field to set the `NumberToReturn` in the legacy list collections command for server version 2.6
- Re-enable getMore/killCursors command tests for server version 2.6