### PR TITLE
GODRIVER-1961 Run OCSP tests against RHEL 7.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1895,6 +1895,16 @@ axes:
           GO_DIST: "/opt/golang/go1.16"
           PYTHON3_BINARY: python3
 
+  - id: ocsp-rhel-70
+    display_name: OS
+    values:
+      - id: "rhel70-go-1-16"
+        display_name: "RHEL 7.0"
+        run_on: rhel70-build
+        variables:
+          GO_DIST: "/opt/golang/go1.16"
+          PYTHON3_BINARY: "/opt/python/3.6/bin/python3"
+
   - id: os-aws-auth
     display_name: OS
     values:
@@ -2023,25 +2033,24 @@ buildvariants:
     tasks:
       - name: "aws-auth-test"
 
-  # GODRIVER-1961 Upgrade OCSP tests to use os-ssl-40 and Ubuntu 18.04.
   - matrix_name: "ocsp-test"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["ubuntu1604-64-go-1-16"] }
-    display_name: "OCSP ${version} ${os-ssl-32}"
+    matrix_spec: { version: ["4.4", "latest"], ocsp-rhel-70: ["rhel70-go-1-16"] }
+    display_name: "OCSP ${version} ${ocsp-rhel-70}"
     batchtime: 20160 # 14 days
     tasks:
       - name: ".ocsp"
 
   - matrix_name: "ocsp-test-windows"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["windows-64-go-1-16"] }
-    display_name: "OCSP ${version} ${os-ssl-32}"
+    matrix_spec: { version: ["4.4", "latest"], os-ssl-40: ["windows-64-go-1-16"] }
+    display_name: "OCSP ${version} ${os-ssl-40}"
     batchtime: 20160 # 14 days
     tasks:
       # Windows MongoDB servers do not staple OCSP responses and only support RSA.
       - name: ".ocsp-rsa !.ocsp-staple"
 
   - matrix_name: "ocsp-test-macos"
-    matrix_spec: { version: ["4.4", "latest"], os-ssl-32: ["osx-go-1-16"] }
-    display_name: "OCSP ${version} ${os-ssl-32}"
+    matrix_spec: { version: ["4.4", "latest"], os-ssl-40: ["osx-go-1-16"] }
+    display_name: "OCSP ${version} ${os-ssl-40}"
     batchtime: 20160 # 14 days
     tasks:
       # macos MongoDB servers do not staple OCSP responses and only support RSA.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1895,6 +1895,7 @@ axes:
           GO_DIST: "/opt/golang/go1.16"
           PYTHON3_BINARY: python3
 
+  # OCSP linux tasks need to run against this OS since stapling is disabled on Ubuntu 18.04 (SERVER-51364)
   - id: ocsp-rhel-70
     display_name: OS
     values:


### PR DESCRIPTION
GODRIVER-1961

Runs OCSP linux tests against RHEL 7.0 with go1.16 instead of Ubuntu 16.04 with go1.15. 