### PR TITLE
GODRIVER-1992 Implement ServerErrors interface for driver errors

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -202,13 +202,13 @@ type ServerError interface {
 	HasErrorMessage(string) bool
 	// HasErrorCodeWithMessage returns true if any of the contained errors have the specified code and message.
 	HasErrorCodeWithMessage(int, string) bool
-
-	serverError()
 }
 
 var _ ServerError = CommandError{}
 var _ ServerError = WriteException{}
 var _ ServerError = BulkWriteException{}
+var _ ServerError = driver.WriteCommandError{}
+var _ ServerError = driver.WriteConcernError{}
 
 // CommandError represents a server error during execution of a command. This can be returned by any operation.
 type CommandError struct {
@@ -263,9 +263,6 @@ func (e CommandError) HasErrorCodeWithMessage(code int, message string) bool {
 func (e CommandError) IsMaxTimeMSExpiredError() bool {
 	return e.Code == 50 || e.Name == "MaxTimeMSExpired"
 }
-
-// serverError implements the ServerError interface.
-func (e CommandError) serverError() {}
 
 // WriteError is an error that occurred during execution of a write operation. This error type is only returned as part
 // of a WriteException or BulkWriteException.
@@ -395,9 +392,6 @@ func (mwe WriteException) HasErrorCodeWithMessage(code int, message string) bool
 	return false
 }
 
-// serverError implements the ServerError interface.
-func (mwe WriteException) serverError() {}
-
 func convertDriverWriteConcernError(wce *driver.WriteConcernError) *WriteConcernError {
 	if wce == nil {
 		return nil
@@ -497,9 +491,6 @@ func (bwe BulkWriteException) HasErrorCodeWithMessage(code int, message string) 
 	}
 	return false
 }
-
-// serverError implements the ServerError interface.
-func (bwe BulkWriteException) serverError() {}
 
 // returnResult is used to determine if a function calling processWriteError should return
 // the result or return nil. Since the processWriteError function is used by many different

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -209,6 +209,7 @@ var _ ServerError = WriteException{}
 var _ ServerError = BulkWriteException{}
 var _ ServerError = driver.WriteCommandError{}
 var _ ServerError = driver.WriteConcernError{}
+var _ ServerError = driver.Error{}
 
 // CommandError represents a server error during execution of a command. This can be returned by any operation.
 type CommandError struct {

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -387,6 +387,33 @@ func TestErrors(t *testing.T) {
 				false,
 				false,
 			},
+			{
+				"driver Error all true",
+				driver.Error{matchCode, "foo", []string{label}, "e", matchWrapped, nil},
+				true,
+				true,
+				true,
+				true,
+				true,
+			},
+			{
+				"driver Error all false",
+				driver.Error{otherCode, "bar", []string{"otherError"}, "e", otherWrapped, nil},
+				false,
+				false,
+				false,
+				false,
+				false,
+			},
+			{
+				"driver Error has code not message",
+				driver.Error{matchCode, "bar", []string{"otherError"}, "e", nil, nil},
+				true,
+				false,
+				false,
+				false,
+				false,
+			},
 		}
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -22,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 type netErr struct {
@@ -297,6 +298,92 @@ func TestErrors(t *testing.T) {
 				true,
 				false,
 				true,
+				false,
+				false,
+			},
+			{
+				"driver WriteCommandError all in writeConcernErorr",
+				driver.WriteCommandError{
+					&driver.WriteConcernError{"name", matchCode, "foo", nil, []string{label}, nil},
+					nil,
+					[]string{"otherError"},
+				},
+				true,
+				true,
+				true,
+				true,
+				false,
+			},
+			{
+				"driver WriteCommandError all in writeError",
+				driver.WriteCommandError{
+					nil,
+					driver.WriteErrors{
+						driver.WriteError{0, matchCode, "foo"},
+						driver.WriteError{0, otherCode, "bar"},
+					},
+					[]string{"otherError"},
+				},
+				true,
+				false,
+				true,
+				true,
+				false,
+			},
+			{
+				"driver WriteCommandError all false",
+				driver.WriteCommandError{
+					&driver.WriteConcernError{"name", otherCode, "bar", nil, []string{"otherError"}, nil},
+					driver.WriteErrors{
+						driver.WriteError{0, otherCode, "baz"},
+					},
+					[]string{"otherError"},
+				},
+				false,
+				false,
+				false,
+				false,
+				false,
+			},
+			{
+				"driver WriteCommandError HasErrorCodeAndMessage false",
+				driver.WriteCommandError{
+					&driver.WriteConcernError{"name", matchCode, "bar", nil, []string{}, nil},
+					driver.WriteErrors{
+						driver.WriteError{0, otherCode, "foo"},
+					},
+					[]string{"otherError"},
+				},
+				true,
+				false,
+				true,
+				false,
+				false,
+			},
+			{
+				"driver WriteConcernError all true",
+				driver.WriteConcernError{"wce", matchCode, "foo", nil, []string{label}, nil},
+				true,
+				true,
+				true,
+				true,
+				false,
+			},
+			{
+				"driver WriteConcernError all false",
+				driver.WriteConcernError{"wce", otherCode, "bar", nil, []string{"otherError"}, nil},
+				false,
+				false,
+				false,
+				false,
+				false,
+			},
+			{
+				"driver WriteConcernError has code not message",
+				driver.WriteConcernError{"wce", matchCode, "bar", nil, []string{"otherError"}, nil},
+				true,
+				false,
+				false,
 				false,
 				false,
 			},

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -119,6 +119,58 @@ func (wce WriteCommandError) Retryable(wireVersion *description.VersionRange) bo
 	return (*wce.WriteConcernError).Retryable()
 }
 
+// HasErrorCode returns true if the error has the specified code.
+func (wce WriteCommandError) HasErrorCode(code int) bool {
+	if wce.WriteConcernError != nil && int(wce.WriteConcernError.Code) == code {
+		return true
+	}
+	for _, we := range wce.WriteErrors {
+		if int(we.Code) == code {
+			return true
+		}
+	}
+	return false
+}
+
+// HasErrorLabel returns true if the error contains the specified label.
+func (wce WriteCommandError) HasErrorLabel(label string) bool {
+	if wce.Labels != nil {
+		for _, l := range wce.Labels {
+			if l == label {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasErrorMessage returns true if the error contains the specified message.
+func (wce WriteCommandError) HasErrorMessage(message string) bool {
+	if wce.WriteConcernError != nil && strings.Contains(wce.WriteConcernError.Message, message) {
+		return true
+	}
+	for _, we := range wce.WriteErrors {
+		if strings.Contains(we.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasErrorCodeWithMessage returns true if any of the contained errors have the specified code and message.
+func (wce WriteCommandError) HasErrorCodeWithMessage(code int, message string) bool {
+	if wce.WriteConcernError != nil &&
+		int(wce.WriteConcernError.Code) == code && strings.Contains(wce.WriteConcernError.Message, message) {
+		return true
+	}
+	for _, we := range wce.WriteErrors {
+		if int(we.Code) == code && strings.Contains(we.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
 // WriteConcernError is a write concern failure that occurred as a result of a
 // write operation.
 type WriteConcernError struct {
@@ -179,6 +231,33 @@ func (wce WriteConcernError) NotMaster() bool {
 	}
 	hasNoCode := wce.Code == 0
 	return hasNoCode && strings.Contains(wce.Message, "not master")
+}
+
+// HasErrorCode returns true if the error has the specified code.
+func (wce WriteConcernError) HasErrorCode(code int) bool {
+	return int(wce.Code) == code
+}
+
+// HasErrorLabel returns true if the error contains the specified label.
+func (wce WriteConcernError) HasErrorLabel(label string) bool {
+	if wce.Labels != nil {
+		for _, l := range wce.Labels {
+			if l == label {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasErrorMessage returns true if the error contains the specified message.
+func (wce WriteConcernError) HasErrorMessage(message string) bool {
+	return strings.Contains(wce.Message, message)
+}
+
+// HasErrorCodeWithMessage returns true if the error has the specified code and Message contains the specified message.
+func (wce WriteConcernError) HasErrorCodeWithMessage(code int, message string) bool {
+	return int(wce.Code) == code && strings.Contains(wce.Message, message)
 }
 
 // WriteError is a non-write concern failure that occurred as a result of a write

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -121,7 +121,7 @@ func (wce WriteCommandError) Retryable(wireVersion *description.VersionRange) bo
 
 // HasErrorCode returns true if the error has the specified code.
 func (wce WriteCommandError) HasErrorCode(code int) bool {
-	if wce.WriteConcernError != nil && int(wce.WriteConcernError.Code) == code {
+	if wce.WriteConcernError != nil && wce.WriteConcernError.HasErrorCode(code) {
 		return true
 	}
 	for _, we := range wce.WriteErrors {
@@ -134,6 +134,9 @@ func (wce WriteCommandError) HasErrorCode(code int) bool {
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (wce WriteCommandError) HasErrorLabel(label string) bool {
+	if wce.WriteConcernError != nil && wce.WriteConcernError.HasErrorLabel(label) {
+		return true
+	}
 	if wce.Labels != nil {
 		for _, l := range wce.Labels {
 			if l == label {
@@ -146,7 +149,7 @@ func (wce WriteCommandError) HasErrorLabel(label string) bool {
 
 // HasErrorMessage returns true if the error contains the specified message.
 func (wce WriteCommandError) HasErrorMessage(message string) bool {
-	if wce.WriteConcernError != nil && strings.Contains(wce.WriteConcernError.Message, message) {
+	if wce.WriteConcernError != nil && wce.WriteConcernError.HasErrorMessage(message) {
 		return true
 	}
 	for _, we := range wce.WriteErrors {
@@ -159,8 +162,7 @@ func (wce WriteCommandError) HasErrorMessage(message string) bool {
 
 // HasErrorCodeWithMessage returns true if any of the contained errors have the specified code and message.
 func (wce WriteCommandError) HasErrorCodeWithMessage(code int, message string) bool {
-	if wce.WriteConcernError != nil &&
-		int(wce.WriteConcernError.Code) == code && strings.Contains(wce.WriteConcernError.Message, message) {
+	if wce.WriteConcernError != nil && wce.WriteConcernError.HasErrorCodeWithMessage(code, message) {
 		return true
 	}
 	for _, we := range wce.WriteErrors {

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -317,6 +317,11 @@ func (e Error) Unwrap() error {
 	return e.Wrapped
 }
 
+// HasErrorCode returns true if the error has the specified code.
+func (e Error) HasErrorCode(code int) bool {
+	return int(e.Code) == code
+}
+
 // HasErrorLabel returns true if the error contains the specified label.
 func (e Error) HasErrorLabel(label string) bool {
 	if e.Labels != nil {
@@ -327,6 +332,16 @@ func (e Error) HasErrorLabel(label string) bool {
 		}
 	}
 	return false
+}
+
+// HasErrorMessage returns true if the error contains the specified message.
+func (e Error) HasErrorMessage(message string) bool {
+	return strings.Contains(e.Message, message)
+}
+
+// HasErrorCodeWithMessage returns true if the error has the specified code and Message contains the specified message.
+func (e Error) HasErrorCodeWithMessage(code int, message string) bool {
+	return int(e.Code) == code && strings.Contains(e.Message, message)
 }
 
 // RetryableRead returns true if the error is retryable for a read operation


### PR DESCRIPTION
GODRIVER-1992

Implements the `ServerError` interface for `driver.WriteCommandError` and `driver.WriteConcernError`, so users will have access to the error helpers `HasErrorCode`, `HasErrorLabel`, `HasErrorMessage` and `HasErrorCodeWithMessage` for those driver errors.

Adds tests for these new functions in `errors_test.go`.