### PR TITLE
GODRIVER-2001 Do not retry transaction after expired or canceled context

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -116,6 +116,17 @@ func IsTimeout(err error) bool {
 	return false
 }
 
+// IsDeadlineExceededError returns true if err is from an expired or canceled context
+func IsDeadlineExceededError(err error) bool {
+	for ; err != nil; err = unwrap(err) {
+		if err == context.DeadlineExceeded || err == context.Canceled {
+			return true
+		}
+	}
+
+	return false
+}
+
 // unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
 func unwrap(err error) error {
 	u, ok := err.(interface {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -116,8 +116,8 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// IsDeadlineExceededError returns true if err is from an expired or canceled context
-func IsDeadlineExceededError(err error) bool {
+// isNonRetryableTransactionContextError returns true if err is from an expired or canceled context
+func isNonRetryableTransactionContextError(err error) bool {
 	for ; err != nil; err = unwrap(err) {
 		if err == context.DeadlineExceeded || err == context.Canceled {
 			return true

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -116,17 +116,6 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// isNonRetryableTransactionContextError returns true if err is from an expired or canceled context
-func isNonRetryableTransactionContextError(err error) bool {
-	for ; err != nil; err = unwrap(err) {
-		if err == context.DeadlineExceeded || err == context.Canceled {
-			return true
-		}
-	}
-
-	return false
-}
-
 // unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
 func unwrap(err error) error {
 	u, ok := err.(interface {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -193,6 +193,10 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			default:
 			}
 
+			// End if context has timed out or been canceled, as retrying has no chance of success.
+			if IsTimeout(err) {
+				return res, err
+			}
 			if errorHasLabel(err, driver.TransientTransactionError) {
 				continue
 			}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -194,8 +194,10 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			}
 
 			// End if context has timed out or been canceled, as retrying has no chance of success.
-			if IsTimeout(err) {
-				return res, err
+			for ; err != nil; err = unwrap(err) {
+				if err == context.DeadlineExceeded {
+					return res, err
+				}
 			}
 			if errorHasLabel(err, driver.TransientTransactionError) {
 				continue

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -194,7 +194,7 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			}
 
 			// End if context has timed out or been canceled, as retrying has no chance of success.
-			if isNonRetryableTransactionContextError(err) {
+			if ctx.Err() != nil {
 				return res, err
 			}
 			if errorHasLabel(err, driver.TransientTransactionError) {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -194,10 +194,8 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			}
 
 			// End if context has timed out or been canceled, as retrying has no chance of success.
-			for ; err != nil; err = unwrap(err) {
-				if err == context.DeadlineExceeded {
-					return res, err
-				}
+			if IsDeadlineExceededError(err) {
+				return res, err
 			}
 			if errorHasLabel(err, driver.TransientTransactionError) {
 				continue

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -194,7 +194,7 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			}
 
 			// End if context has timed out or been canceled, as retrying has no chance of success.
-			if IsDeadlineExceededError(err) {
+			if isNonRetryableTransactionContextError(err) {
 				return res, err
 			}
 			if errorHasLabel(err, driver.TransientTransactionError) {

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -417,17 +417,41 @@ func TestConvenientTransactions(t *testing.T) {
 		assert.True(t, ok, "expected result type %T, got %T", false, res)
 		assert.False(t, resBool, "expected result false, got %v", resBool)
 	})
-	t.Run("timeout before commitTransaction does not retry", func(t *testing.T) {
+	t.Run("expired context before commitTransaction does not retry", func(t *testing.T) {
 		withTransactionTimeout = 2 * time.Second
 
 		sess, err := client.StartSession()
-		assert.Nil(t, err, "StartSession erro: %v", err)
+		assert.Nil(t, err, "StartSession error: %v", err)
 		defer sess.EndSession(context.Background())
 
 		callback := func() {
 			_, _ = sess.WithTransaction(context.Background(), func(sessCtx SessionContext) (interface{}, error) {
 				c, cancel := context.WithTimeout(sessCtx, time.Nanosecond)
 				defer cancel()
+
+				_, err := client.Database("test").
+					Collection("test").
+					InsertOne(c, bson.D{{}})
+
+				return nil, err
+			})
+		}
+
+		// Assert that transaction fails within 500ms and not 2 seconds.
+		assert.Soon(t, callback, 500*time.Millisecond)
+	})
+	t.Run("canceled context before commitTransaction does not retry", func(t *testing.T) {
+		withTransactionTimeout = 2 * time.Second
+
+		sess, err := client.StartSession()
+		assert.Nil(t, err, "StartSession error: %v", err)
+		defer sess.EndSession(context.Background())
+
+		callback := func() {
+			_, _ = sess.WithTransaction(context.Background(), func(sessCtx SessionContext) (interface{}, error) {
+				c, cancel := context.WithTimeout(sessCtx, withTransactionTimeout)
+				// cancel immediately.
+				cancel()
 
 				_, err := client.Database("test").
 					Collection("test").

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -492,7 +492,7 @@ func TestConvenientTransactions(t *testing.T) {
 		defer sess.EndSession(context.Background())
 
 		callback := func() {
-			_, _ = sess.WithTransaction(context.Background(), func(sessCtx SessionContext) (interface{}, error) {
+			_, err = sess.WithTransaction(context.Background(), func(sessCtx SessionContext) (interface{}, error) {
 				// Set a timeout of 300ms to cause a timeout on first insertOne
 				// and force a retry.
 				c, cancel := context.WithTimeout(sessCtx, 300*time.Millisecond)
@@ -504,6 +504,7 @@ func TestConvenientTransactions(t *testing.T) {
 
 				return nil, err
 			})
+			assert.Nil(t, err, "WithTransaction error: %v", err)
 		}
 
 		// Assert that transaction passes within 2 seconds.


### PR DESCRIPTION
GODRIVER-2001

Checks for a context deadline exceeded or canceled error during transactions (before `commitTransaction`) in `WithTransaction` and returns early in either case.

Adds two new tests to ensure expired and canceled contexts will return early in `WithTransaction`.

If the context for `WithTransaction` has expired or been canceled, the commands within the transaction have no chance of succeeding, so we should simply simply return instead of waiting for the `withTransactionTimeout` `timer` to `Stop` (120 seconds). 