### PR TITLE
GODRIVER-2012 Fix AWS auth Evergreen test failures with Go 1.16+

### DIFF
--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -30,4 +30,6 @@ export MONGODB_URI="$MONGODB_URI"
 # show test output
 set -x
 
-go run "${PROJECT_DIRECTORY}/mongo/testaws/main.go"
+# For Go 1.16+, Go builds requires a go.mod file in the current working directory or a parent
+# directory. Spawn a new subshell, "cd" to the project directory, then run "go run".
+(cd ${PROJECT_DIRECTORY} && go run "./mongo/testaws/main.go")


### PR DESCRIPTION
Since updating Evergreen to run with Go 1.16, the AWS auth tests have been failing with errors like
```
go.mongodb.org/mongo-driver/mongo/testaws/main.go:14:2: no required module provides package go.mongodb.org/mongo-driver/bson: go.mod file not found in current directory or any parent directory
```

Resolve that error by running `go run` from the project directory root, which contains a `go.mod` file.

https://jira.mongodb.org/browse/GODRIVER-2012