### PR TITLE
GODRIVER-1946 Add BSON, extJSON, and JSON benchmarks.

### DIFF
--- a/bson/benchmark_test.go
+++ b/bson/benchmark_test.go
@@ -129,7 +129,10 @@ var nestedInstance = nestedtest1{
 
 const extendedBSONDir = "../data/extended_bson"
 
-func mustReadBSONTestData(filename string) map[string]interface{} {
+// readExtJSONFile reads the GZIP-compressed extended JSON document from the given filename in the
+// "extended BSON" test data directory (../data/extended_bson) and returns it as a
+// map[string]interface{}. It panics on any errors.
+func readExtJSONFile(filename string) map[string]interface{} {
 	filePath := path.Join(extendedBSONDir, filename)
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -176,15 +179,15 @@ func BenchmarkMarshal(b *testing.B) {
 		},
 		{
 			desc:  "deep_bson.json.gz",
-			value: mustReadBSONTestData("deep_bson.json.gz"),
+			value: readExtJSONFile("deep_bson.json.gz"),
 		},
 		{
 			desc:  "flat_bson.json.gz",
-			value: mustReadBSONTestData("flat_bson.json.gz"),
+			value: readExtJSONFile("flat_bson.json.gz"),
 		},
 		{
 			desc:  "full_bson.json.gz",
-			value: mustReadBSONTestData("full_bson.json.gz"),
+			value: readExtJSONFile("full_bson.json.gz"),
 		},
 	}
 
@@ -235,15 +238,15 @@ func BenchmarkUnmarshal(b *testing.B) {
 		},
 		{
 			desc:  "deep_bson.json.gz",
-			value: mustReadBSONTestData("deep_bson.json.gz"),
+			value: readExtJSONFile("deep_bson.json.gz"),
 		},
 		{
 			desc:  "flat_bson.json.gz",
-			value: mustReadBSONTestData("flat_bson.json.gz"),
+			value: readExtJSONFile("flat_bson.json.gz"),
 		},
 		{
 			desc:  "full_bson.json.gz",
-			value: mustReadBSONTestData("full_bson.json.gz"),
+			value: readExtJSONFile("full_bson.json.gz"),
 		},
 	}
 

--- a/bson/benchmark_test.go
+++ b/bson/benchmark_test.go
@@ -7,6 +7,12 @@
 package bson
 
 import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 )
 
@@ -121,14 +127,178 @@ var nestedInstance = nestedtest1{
 	},
 }
 
-func BenchmarkEncoding(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, _ = Marshal(encodetestInstance)
+const extendedBSONDir = "../data/extended_bson"
+
+func mustReadBSONTestData(filename string) map[string]interface{} {
+	filePath := path.Join(extendedBSONDir, filename)
+	file, err := os.Open(filePath)
+	if err != nil {
+		panic(fmt.Sprintf("error opening file %q: %s", filePath, err))
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		panic(fmt.Sprintf("error creating GZIP reader: %s", err))
+	}
+	defer func() {
+		_ = gz.Close()
+	}()
+
+	data, err := ioutil.ReadAll(gz)
+	if err != nil {
+		panic(fmt.Sprintf("error reading GZIP contents of file: %s", err))
+	}
+
+	var v map[string]interface{}
+	err = UnmarshalExtJSON(data, false, &v)
+	if err != nil {
+		panic(fmt.Sprintf("error unmarshalling extended JSON: %s", err))
+	}
+
+	return v
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	cases := []struct {
+		desc  string
+		value interface{}
+	}{
+		{
+			desc:  "simple struct",
+			value: encodetestInstance,
+		},
+		{
+			desc:  "nested struct",
+			value: nestedInstance,
+		},
+		{
+			desc:  "deep_bson.json.gz",
+			value: mustReadBSONTestData("deep_bson.json.gz"),
+		},
+		{
+			desc:  "flat_bson.json.gz",
+			value: mustReadBSONTestData("flat_bson.json.gz"),
+		},
+		{
+			desc:  "full_bson.json.gz",
+			value: mustReadBSONTestData("full_bson.json.gz"),
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.desc, func(b *testing.B) {
+			b.Run("BSON", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, err := Marshal(tc.value)
+					if err == nil {
+						b.Errorf("error marshalling BSON: %s", err)
+					}
+				}
+			})
+
+			b.Run("extJSON", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, err := MarshalExtJSON(tc.value, true, false)
+					if err != nil {
+						b.Errorf("error marshalling extended JSON: %s", err)
+					}
+				}
+			})
+
+			b.Run("JSON", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, err := json.Marshal(tc.value)
+					if err != nil {
+						b.Errorf("error marshalling JSON: %s", err)
+					}
+				}
+			})
+		})
 	}
 }
 
-func BenchmarkEncodingNested(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, _ = Marshal(nestedInstance)
+func BenchmarkUnmarshal(b *testing.B) {
+	cases := []struct {
+		desc  string
+		value interface{}
+	}{
+		{
+			desc:  "simple struct",
+			value: encodetestInstance,
+		},
+		{
+			desc:  "nested struct",
+			value: nestedInstance,
+		},
+		{
+			desc:  "deep_bson.json.gz",
+			value: mustReadBSONTestData("deep_bson.json.gz"),
+		},
+		{
+			desc:  "flat_bson.json.gz",
+			value: mustReadBSONTestData("flat_bson.json.gz"),
+		},
+		{
+			desc:  "full_bson.json.gz",
+			value: mustReadBSONTestData("full_bson.json.gz"),
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.desc, func(b *testing.B) {
+			b.Run("BSON", func(b *testing.B) {
+				data, err := Marshal(tc.value)
+				if err != nil {
+					b.Errorf("error marshalling BSON: %s", err)
+					return
+				}
+
+				b.ResetTimer()
+				var v2 map[string]interface{}
+				for i := 0; i < b.N; i++ {
+					err := Unmarshal(data, &v2)
+					if err != nil {
+						b.Errorf("error unmarshalling BSON: %s", err)
+					}
+				}
+			})
+
+			b.Run("extJSON", func(b *testing.B) {
+				data, err := MarshalExtJSON(tc.value, true, false)
+				if err != nil {
+					b.Errorf("error marshalling extended JSON: %s", err)
+					return
+				}
+
+				b.ResetTimer()
+				var v2 map[string]interface{}
+				for i := 0; i < b.N; i++ {
+					err := UnmarshalExtJSON(data, true, &v2)
+					if err != nil {
+						b.Errorf("error unmarshalling extended JSON: %s", err)
+					}
+				}
+			})
+
+			b.Run("JSON", func(b *testing.B) {
+				data, err := json.Marshal(tc.value)
+				if err != nil {
+					b.Errorf("error marshalling JSON: %s", err)
+					return
+				}
+
+				b.ResetTimer()
+				var v2 map[string]interface{}
+				for i := 0; i < b.N; i++ {
+					err := json.Unmarshal(data, &v2)
+					if err != nil {
+						b.Errorf("error unmarshalling JSON: %s", err)
+					}
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
Add benchmarks that use the test data in `./data/extended_bson/` to test marshalling and unmarshalling performance using the BSON, extJSON, and `encoding/json` libraries.

E.g. benchmark output:
```
❯ go test ./bson/... -run=X -bench='Marshal|Unmarshal' -benchmem
goos: darwin
goarch: amd64
pkg: go.mongodb.org/mongo-driver/bson
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkMarshal/simple_struct/BSON-12            816336              1466 ns/op             792 B/op          3 allocs/op
BenchmarkMarshal/simple_struct/extJSON-12         185301              6385 ns/op            3476 B/op         88 allocs/op
BenchmarkMarshal/simple_struct/JSON-12           1358628               881.6 ns/op           240 B/op          1 allocs/op
BenchmarkMarshal/nested_struct/BSON-12            384160              3053 ns/op             793 B/op          3 allocs/op
BenchmarkMarshal/nested_struct/extJSON-12         118544             10109 ns/op            4630 B/op        132 allocs/op
BenchmarkMarshal/nested_struct/JSON-12           1000000              1213 ns/op             352 B/op          1 allocs/op
BenchmarkMarshal/deep_bson.json.gz/BSON-12                 25648             46931 ns/op           20314 B/op        385 allocs/op
BenchmarkMarshal/deep_bson.json.gz/extJSON-12              16948             70596 ns/op           36026 B/op        953 allocs/op
BenchmarkMarshal/deep_bson.json.gz/JSON-12                 22030             54607 ns/op           27508 B/op        631 allocs/op
BenchmarkMarshal/flat_bson.json.gz/BSON-12                 26632             45194 ns/op           35383 B/op        303 allocs/op
BenchmarkMarshal/flat_bson.json.gz/extJSON-12              10000            110695 ns/op           91808 B/op       1336 allocs/op
BenchmarkMarshal/flat_bson.json.gz/JSON-12                 17212             69570 ns/op           22007 B/op        301 allocs/op
BenchmarkMarshal/full_bson.json.gz/BSON-12                 24844             48093 ns/op           26564 B/op        257 allocs/op
BenchmarkMarshal/full_bson.json.gz/extJSON-12              10000            112300 ns/op           81801 B/op       1254 allocs/op
BenchmarkMarshal/full_bson.json.gz/JSON-12                 18704             64191 ns/op           18791 B/op        277 allocs/op
BenchmarkUnmarshal/simple_struct/BSON-12                  207730              5618 ns/op            1088 B/op         62 allocs/op
BenchmarkUnmarshal/simple_struct/extJSON-12                65708             18096 ns/op            7379 B/op        236 allocs/op
BenchmarkUnmarshal/simple_struct/JSON-12                  189424              6382 ns/op            1040 B/op         58 allocs/op
BenchmarkUnmarshal/nested_struct/BSON-12                   85399             14358 ns/op            8117 B/op        143 allocs/op
BenchmarkUnmarshal/nested_struct/extJSON-12                36458             31801 ns/op           16729 B/op        384 allocs/op
BenchmarkUnmarshal/nested_struct/JSON-12                  175102              6819 ns/op            5250 B/op         74 allocs/op
BenchmarkUnmarshal/deep_bson.json.gz/BSON-12               17038             70089 ns/op           30861 B/op        822 allocs/op
BenchmarkUnmarshal/deep_bson.json.gz/extJSON-12             7994            137519 ns/op           64508 B/op       1776 allocs/op
BenchmarkUnmarshal/deep_bson.json.gz/JSON-12               37994             31570 ns/op           23600 B/op        388 allocs/op
BenchmarkUnmarshal/flat_bson.json.gz/BSON-12               18081             66425 ns/op           13431 B/op        740 allocs/op
BenchmarkUnmarshal/flat_bson.json.gz/extJSON-12             5192            229140 ns/op           82200 B/op       2659 allocs/op
BenchmarkUnmarshal/flat_bson.json.gz/JSON-12               12586             95447 ns/op           13729 B/op        680 allocs/op
BenchmarkUnmarshal/full_bson.json.gz/BSON-12               14929             80038 ns/op           19929 B/op        791 allocs/op
BenchmarkUnmarshal/full_bson.json.gz/extJSON-12             4069            284898 ns/op          111868 B/op       3489 allocs/op
BenchmarkUnmarshal/full_bson.json.gz/JSON-12               12540             95819 ns/op           32785 B/op        844 allocs/op
```

https://jira.mongodb.org/browse/GODRIVER-1946