### PR TITLE
GODRIVER-1944 Use "hello" command when API version is declared

### DIFF
--- a/data/server-discovery-and-monitoring/integration/connectTimeoutMS.json
+++ b/data/server-discovery-and-monitoring/integration/connectTimeoutMS.json
@@ -42,7 +42,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "connectTimeoutMS=0",
                 "blockConnection": true,

--- a/data/server-discovery-and-monitoring/integration/connectTimeoutMS.yml
+++ b/data/server-discovery-and-monitoring/integration/connectTimeoutMS.yml
@@ -33,7 +33,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: connectTimeoutMS=0
                 blockConnection: true
                 blockTimeMS: 550

--- a/data/server-discovery-and-monitoring/integration/isMaster-command-error.json
+++ b/data/server-discovery-and-monitoring/integration/isMaster-command-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "commandErrorHandshakeTest",
           "closeConnection": false,
@@ -128,7 +129,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "commandErrorCheckTest",
                 "closeConnection": false,

--- a/data/server-discovery-and-monitoring/integration/isMaster-command-error.yml
+++ b/data/server-discovery-and-monitoring/integration/isMaster-command-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: commandErrorHandshakeTest
           closeConnection: false
           errorCode: 91 # ShutdownInProgress
@@ -99,7 +99,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: commandErrorCheckTest
                 closeConnection: false
                 blockConnection: true

--- a/data/server-discovery-and-monitoring/integration/isMaster-network-error.json
+++ b/data/server-discovery-and-monitoring/integration/isMaster-network-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "networkErrorHandshakeTest",
           "closeConnection": true
@@ -127,7 +128,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "networkErrorCheckTest",
                 "closeConnection": true

--- a/data/server-discovery-and-monitoring/integration/isMaster-network-error.yml
+++ b/data/server-discovery-and-monitoring/integration/isMaster-network-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: networkErrorHandshakeTest
           closeConnection: true
     clientOptions:
@@ -98,7 +98,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: networkErrorCheckTest
                 closeConnection: true
       # The network error on the next check should mark the server Unknown and

--- a/data/server-discovery-and-monitoring/integration/isMaster-timeout.json
+++ b/data/server-discovery-and-monitoring/integration/isMaster-timeout.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "timeoutMonitorHandshakeTest",
           "blockConnection": true,
@@ -128,7 +129,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "timeoutMonitorCheckTest",
                 "blockConnection": true,

--- a/data/server-discovery-and-monitoring/integration/isMaster-timeout.yml
+++ b/data/server-discovery-and-monitoring/integration/isMaster-timeout.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: timeoutMonitorHandshakeTest
           blockConnection: true
           blockTimeMS: 1000
@@ -98,7 +98,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: timeoutMonitorCheckTest
                 blockConnection: true
                 blockTimeMS: 1000

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -417,7 +418,12 @@ func TestClient(t *testing.T) {
 		// First two messages should be connection handshakes: one for the heartbeat connection and the other for the
 		// application connection.
 		for idx, pair := range msgPairs[:2] {
-			assert.Equal(mt, pair.CommandName, "isMaster", "expected command name isMaster at index %d, got %s", idx,
+			helloCommand := "isMaster"
+			//  Expect "hello" command name with API version.
+			if os.Getenv("REQUIRE_API_VERSION") == "true" {
+				helloCommand = "hello"
+			}
+			assert.Equal(mt, pair.CommandName, helloCommand, "expected command name %s at index %d, got %s", helloCommand, idx,
 				pair.CommandName)
 
 			sent := pair.Sent

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -77,14 +77,14 @@ func TestSDAMProse(t *testing.T) {
 				}
 			}
 
-			// Force isMaster requests to block for 500ms and wait until a server's average RTT goes over 250ms.
+			// Force isMaster and hello requests to block for 500ms and wait until a server's average RTT goes over 250ms.
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
 				Mode: mtest.FailPointMode{
 					Times: 1000,
 				},
 				Data: mtest.FailPointData{
-					FailCommands:    []string{"isMaster"},
+					FailCommands:    []string{"isMaster", "hello"},
 					BlockConnection: true,
 					BlockTimeMS:     500,
 					AppName:         "streamingRttTest",

--- a/x/mongo/driver/operation/ismaster.go
+++ b/x/mongo/driver/operation/ismaster.go
@@ -195,7 +195,11 @@ func (im *IsMaster) handshakeCommand(dst []byte, desc description.SelectedServer
 
 // command appends all necessary command fields.
 func (im *IsMaster) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
-	dst = bsoncore.AppendInt32Element(dst, "isMaster", 1)
+	if im.serverAPI != nil {
+		dst = bsoncore.AppendInt32Element(dst, "hello", 1)
+	} else {
+		dst = bsoncore.AppendInt32Element(dst, "isMaster", 1)
+	}
 
 	if tv := im.topologyVersion; tv != nil {
 		var tvIdx int32


### PR DESCRIPTION
GODRIVER-1944

Uses "hello" instead of "isMaster" when an API version is declared.

This is a temporary fix to avoid erroring on API strict since `isMaster` is no longer a part of API version 1. We will remove occurrences of `isMaster` in the Go driver as part of GODRIVER-1862.