### PR TITLE
GODRIVER-1987 Pass API version to getMore and transaction commands

### DIFF
--- a/data/versioned-api/crud-api-version-1-strict.json
+++ b/data/versioned-api/crud-api-version-1-strict.json
@@ -713,7 +713,7 @@
                     ]
                   },
                   "apiVersion": "1",
-                  "apiStrict": "true",
+                  "apiStrict": true,
                   "apiDeprecationErrors": {
                     "$$unsetOrMatches": false
                   }

--- a/data/versioned-api/crud-api-version-1-strict.json
+++ b/data/versioned-api/crud-api-version-1-strict.json
@@ -651,7 +651,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -712,14 +712,10 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
+                  "apiStrict": "true",
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/data/versioned-api/crud-api-version-1-strict.yml
+++ b/data/versioned-api/crud-api-version-1-strict.yml
@@ -240,7 +240,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -264,9 +264,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/data/versioned-api/crud-api-version-1.json
+++ b/data/versioned-api/crud-api-version-1.json
@@ -643,7 +643,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -704,15 +704,11 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
+                  "apiDeprecationErrors": true
                 }
               }
             }

--- a/data/versioned-api/crud-api-version-1.yml
+++ b/data/versioned-api/crud-api-version-1.yml
@@ -234,7 +234,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -258,9 +258,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/data/versioned-api/transaction-handling.json
+++ b/data/versioned-api/transaction-handling.json
@@ -54,17 +54,6 @@
         "apiDeprecationErrors": {
           "$$unsetOrMatches": false
         }
-      },
-      {
-        "apiVersion": {
-          "$$exists": false
-        },
-        "apiStrict": {
-          "$$exists": false
-        },
-        "apiDeprecationErrors": {
-          "$$exists": false
-        }
       }
     ]
   },
@@ -98,7 +87,7 @@
   ],
   "tests": [
     {
-      "description": "Only the first command in a transaction declares an API version",
+      "description": "All commands in a transaction declare an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -195,120 +184,6 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Committing a transaction twice does not append server API options",
-      "runOnRequirements": [
-        {
-          "topologies": [
-            "replicaset",
-            "sharded-replicaset",
-            "load-balanced"
-          ]
-        }
-      ],
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 6,
-              "x": 66
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 6
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 7,
-              "x": 77
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 7
-              }
-            }
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 6,
-                      "x": 66
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "startTransaction": true,
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -322,62 +197,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 7,
-                      "x": 77
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
                   "commitTransaction": 1,
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -387,7 +216,7 @@
       ]
     },
     {
-      "description": "abortTransaction does not include an API version",
+      "description": "abortTransaction includes an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -484,14 +313,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -503,14 +330,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/data/versioned-api/transaction-handling.yml
+++ b/data/versioned-api/transaction-handling.yml
@@ -31,10 +31,6 @@ _yamlAnchors:
       apiVersion: "1"
       apiStrict: { $$unsetOrMatches: false }
       apiDeprecationErrors: { $$unsetOrMatches: false }
-    - &noApiVersion
-      apiVersion: { $$exists: false }
-      apiStrict: { $$exists: false }
-      apiDeprecationErrors: { $$exists: false }
 
 
 initialData:
@@ -48,7 +44,7 @@ initialData:
       - { _id: 5, x: 55 }
 
 tests:
-  - description: "Only the first command in a transaction declares an API version"
+  - description: "All commands in a transaction declare an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
@@ -83,61 +79,13 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "Committing a transaction twice does not append server API options"
-    runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
-    operations:
-      - name: startTransaction
-        object: *session
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 6, x: 66 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 7, x: 77 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
-      - name: commitTransaction
-        object: *session
-      - name: commitTransaction
-        object: *session
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                insert: *collectionName
-                documents: [ { _id: 6, x: 66 } ]
-                lsid: { $$sessionLsid: *session }
-                startTransaction: true
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
-                insert: *collectionName
-                documents: [ { _id: 7, x: 77 } ]
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "abortTransaction does not include an API version"
+                <<: *expectedApiVersion
+  - description: "abortTransaction includes an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
@@ -172,9 +120,9 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion
           - commandStartedEvent:
               command:
                 abortTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -270,7 +270,7 @@ func (s *sessionImpl) AbortTransaction(ctx context.Context) error {
 	_ = operation.NewAbortTransaction().Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").
 		Deployment(s.deployment).WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).
 		Retry(driver.RetryOncePerCommand).CommandMonitor(s.client.monitor).
-		RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).Execute(ctx)
+		RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).ServerAPI(s.client.serverAPI).Execute(ctx)
 
 	s.clientSession.Aborting = false
 	_ = s.clientSession.AbortTransaction()
@@ -301,7 +301,8 @@ func (s *sessionImpl) CommitTransaction(ctx context.Context) error {
 	op := operation.NewCommitTransaction().
 		Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").Deployment(s.deployment).
 		WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).Retry(driver.RetryOncePerCommand).
-		CommandMonitor(s.client.monitor).RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken))
+		CommandMonitor(s.client.monitor).RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).
+		ServerAPI(s.client.serverAPI)
 	if s.clientSession.CurrentMct != nil {
 		op.MaxTimeMS(int64(*s.clientSession.CurrentMct / time.Millisecond))
 	}

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -354,6 +354,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		Legacy:         LegacyGetMore,
 		CommandMonitor: bc.cmdMonitor,
 		Crypt:          bc.crypt,
+		ServerAPI:      bc.serverAPI,
 	}.Execute(ctx, nil)
 
 	// Once the cursor has been drained, we can unpin the connection if one is currently pinned.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -843,18 +843,13 @@ func (op Operation) createQueryWireMessage(dst []byte, desc description.Selected
 		return dst, info, err
 	}
 
-	// Add server API information before calling addSession() because it will modify
-	// transaction state.
-	if op.Client == nil || !op.Client.TransactionInProgress() {
-		dst = op.addServerAPI(dst)
-	}
-
 	dst, err = op.addSession(dst, desc)
 	if err != nil {
 		return dst, info, err
 	}
 
 	dst = op.addClusterTime(dst, desc)
+	dst = op.addServerAPI(dst)
 
 	dst, _ = bsoncore.AppendDocumentEnd(dst, idx)
 	// Command monitoring only reports the document inside $query
@@ -909,19 +904,13 @@ func (op Operation) createMsgWireMessage(ctx context.Context, dst []byte, desc d
 	if err != nil {
 		return dst, info, err
 	}
-
-	// Add server API information before calling addSession() because it will modify
-	// transaction state.
-	if op.Client == nil || !op.Client.TransactionInProgress() {
-		dst = op.addServerAPI(dst)
-	}
-
 	dst, err = op.addSession(dst, desc)
 	if err != nil {
 		return dst, info, err
 	}
 
 	dst = op.addClusterTime(dst, desc)
+	dst = op.addServerAPI(dst)
 
 	dst = bsoncore.AppendStringElement(dst, "$db", op.Database)
 	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, false)

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -33,6 +33,7 @@ type AbortTransaction struct {
 	selector      description.ServerSelector
 	writeConcern  *writeconcern.WriteConcern
 	retry         *driver.RetryMode
+	serverAPI     *driver.ServerAPIOptions
 }
 
 // NewAbortTransaction constructs and returns a new AbortTransaction.
@@ -64,6 +65,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 		Deployment:        at.deployment,
 		Selector:          at.selector,
 		WriteConcern:      at.writeConcern,
+		ServerAPI:         at.serverAPI,
 	}.Execute(ctx, nil)
 
 }
@@ -185,5 +187,15 @@ func (at *AbortTransaction) Retry(retry driver.RetryMode) *AbortTransaction {
 	}
 
 	at.retry = &retry
+	return at
+}
+
+// ServerAPI sets the server API version for this operation.
+func (at *AbortTransaction) ServerAPI(serverAPI *driver.ServerAPIOptions) *AbortTransaction {
+	if at == nil {
+		at = new(AbortTransaction)
+	}
+
+	at.serverAPI = serverAPI
 	return at
 }

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -33,6 +33,7 @@ type CommitTransaction struct {
 	selector      description.ServerSelector
 	writeConcern  *writeconcern.WriteConcern
 	retry         *driver.RetryMode
+	serverAPI     *driver.ServerAPIOptions
 }
 
 // NewCommitTransaction constructs and returns a new CommitTransaction.
@@ -64,6 +65,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 		Deployment:        ct.deployment,
 		Selector:          ct.selector,
 		WriteConcern:      ct.writeConcern,
+		ServerAPI:         ct.serverAPI,
 	}.Execute(ctx, nil)
 
 }
@@ -188,5 +190,15 @@ func (ct *CommitTransaction) Retry(retry driver.RetryMode) *CommitTransaction {
 	}
 
 	ct.retry = &retry
+	return ct
+}
+
+// ServerAPI sets the server API version for this operation.
+func (ct *CommitTransaction) ServerAPI(serverAPI *driver.ServerAPIOptions) *CommitTransaction {
+	if ct == nil {
+		ct = new(CommitTransaction)
+	}
+
+	ct.serverAPI = serverAPI
 	return ct
 }


### PR DESCRIPTION
GODRIVER-1987

Appends API version to `getMore` and transaction-continuing commands.

Previously, the server required no API version on `getMore` and transaction-continuing commands as the API version was inferred from the original `find` or `startTransaction` respectively. For the sake of simplicity and consistency, the server now expects API version on all commands.