### PR TITLE
GODRIVER-1991 Replace all errors from driver package

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -117,3 +117,7 @@ func (e *wrappedError) Error() string {
 func (e *wrappedError) Inner() error {
 	return e.inner
 }
+
+func (e *wrappedError) Unwrap() error {
+	return e.inner
+}

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -52,16 +52,7 @@ func replaceErrors(err error) error {
 		return nil
 	}
 
-	var w error
-	// Unwrap logic copied from Go1.13 source: https://golang.org/src/errors/wrap.go?s=372:400#L4
-	u, ok := err.(interface {
-		Unwrap() error
-	})
-	if !ok {
-		w = nil
-	} else {
-		w = replaceErrors(u.Unwrap())
-	}
+	w := replaceErrors(unwrap(err))
 
 	if err == topology.ErrTopologyClosed {
 		return ErrClientDisconnected

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
@@ -109,7 +110,7 @@ func replaceErrors(err error) error {
 		return MongocryptError{Code: me.Code, Message: me.Message}
 	}
 
-	return fmt.Errorf("%s: %w", err.Error(), w)
+	return internal.WrapErrorf(w, err.Error())
 }
 
 // IsDuplicateKeyError returns true if err is a duplicate key error

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -48,9 +48,18 @@ func (e ErrMapForOrderedArgument) Error() string {
 
 // replaceErrors replaces errors (including wrapped errors) from the x package with errors from the mongo package.
 func replaceErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	var w error
-	if w = errors.Unwrap(err); w != nil {
-		w = replaceErrors(w)
+	u, ok := err.(interface {
+		Unwrap() error
+	})
+	if !ok {
+		w = nil
+	} else {
+		w = replaceErrors(u.Unwrap())
 	}
 
 	if err == topology.ErrTopologyClosed {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -53,6 +53,7 @@ func replaceErrors(err error) error {
 	}
 
 	var w error
+	// Unwrap logic copied from Go1.13 source: https://golang.org/src/errors/wrap.go?s=372:400#L4
 	u, ok := err.(interface {
 		Unwrap() error
 	})


### PR DESCRIPTION
GODRIVER-1991

Updates `replaceErrors` to replace wrapped errors (recursively), and replace missing `driver` errors: `driver.ResponseError`, `driver.WriteCommandError`, `driver.WriteConcernError`, and `driver.WriteError`.