### PR TITLE
GODRIVER-1946 Fix bson.BenchmarkMarshal error nil check.

### DIFF
--- a/bson/benchmark_test.go
+++ b/bson/benchmark_test.go
@@ -196,7 +196,7 @@ func BenchmarkMarshal(b *testing.B) {
 			b.Run("BSON", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					_, err := Marshal(tc.value)
-					if err == nil {
+					if err != nil {
 						b.Errorf("error marshalling BSON: %s", err)
 					}
 				}


### PR DESCRIPTION
Fix erroneous `error` nil check in recently added `bson.BenchmarkMarshal` benchmark.

https://jira.mongodb.org/browse/GODRIVER-1946