### PR TITLE
GODRIVER-2025 Stop replacing the bsonrw.valueWriter buffer when given a SliceWriter destination.

### DIFF
--- a/bson/bsonrw/value_writer.go
+++ b/bson/bsonrw/value_writer.go
@@ -47,11 +47,9 @@ func NewBSONValueWriterPool() *BSONValueWriterPool {
 // Get retrieves a BSON ValueWriter from the pool and resets it to use w as the destination.
 func (bvwp *BSONValueWriterPool) Get(w io.Writer) ValueWriter {
 	vw := bvwp.pool.Get().(*valueWriter)
-	if writer, ok := w.(*SliceWriter); ok {
-		vw.reset(*writer)
-		vw.w = writer
-		return vw
-	}
+
+	// TODO: Having to call reset here with the same buffer doesn't really make sense.
+	vw.reset(vw.buf)
 	vw.buf = vw.buf[:0]
 	vw.w = w
 	return vw
@@ -71,11 +69,6 @@ func (bvwp *BSONValueWriterPool) Put(vw ValueWriter) (ok bool) {
 	if !ok {
 		return false
 	}
-
-	if _, ok := bvw.w.(*SliceWriter); ok {
-		bvw.buf = nil
-	}
-	bvw.w = nil
 
 	bvwp.pool.Put(bvw)
 	return true
@@ -549,10 +542,6 @@ func (vw *valueWriter) Flush() error {
 		return nil
 	}
 
-	if sw, ok := vw.w.(*SliceWriter); ok {
-		*sw = vw.buf
-		return nil
-	}
 	if _, err := vw.w.Write(vw.buf); err != nil {
 		return err
 	}

--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -52,14 +52,14 @@ func MarshalAppend(dst []byte, val interface{}) ([]byte, error) {
 // MarshalWithRegistry returns the BSON encoding of val as a BSON document. If val is not a type that can be transformed
 // into a document, MarshalValueWithRegistry should be used instead.
 func MarshalWithRegistry(r *bsoncodec.Registry, val interface{}) ([]byte, error) {
-	dst := make([]byte, 0, 256) // TODO: make the default cap a constant
+	dst := make([]byte, 0)
 	return MarshalAppendWithRegistry(r, dst, val)
 }
 
 // MarshalWithContext returns the BSON encoding of val as a BSON document using EncodeContext ec. If val is not a type
 // that can be transformed into a document, MarshalValueWithContext should be used instead.
 func MarshalWithContext(ec bsoncodec.EncodeContext, val interface{}) ([]byte, error) {
-	dst := make([]byte, 0, 256) // TODO: make the default cap a constant
+	dst := make([]byte, 0)
 	return MarshalAppendWithContext(ec, dst, val)
 }
 
@@ -115,13 +115,13 @@ func MarshalValueAppend(dst []byte, val interface{}) (bsontype.Type, []byte, err
 
 // MarshalValueWithRegistry returns the BSON encoding of val using Registry r.
 func MarshalValueWithRegistry(r *bsoncodec.Registry, val interface{}) (bsontype.Type, []byte, error) {
-	dst := make([]byte, 0, defaultDstCap)
+	dst := make([]byte, 0)
 	return MarshalValueAppendWithRegistry(r, dst, val)
 }
 
 // MarshalValueWithContext returns the BSON encoding of val using EncodeContext ec.
 func MarshalValueWithContext(ec bsoncodec.EncodeContext, val interface{}) (bsontype.Type, []byte, error) {
-	dst := make([]byte, 0, defaultDstCap)
+	dst := make([]byte, 0)
 	return MarshalValueAppendWithContext(ec, dst, val)
 }
 


### PR DESCRIPTION
Currently, a `bsonrw.valueWriter` will use a new byte slice as the write buffer for each document written if one is passed in as the writer (if it is a `SliceWriter`). The result is that the write buffer capacity must be grown many times, each resulting in an allocate-then-copy operation. Instead, reuse the write buffer for every document written, only allocating a new byte slice when flushing the full document from the buffer (or when the write buffer needs to grow).

Before and after benchmark results:
```
❯ benchstat old.txt new.txt                         
name                                 old time/op    new time/op    delta
Marshal/simple_struct/BSON-12          1.50µs ± 1%    1.44µs ± 0%   -4.34%  (p=0.016 n=5+4)
Marshal/nested_struct/BSON-12          3.16µs ± 1%    3.06µs ± 0%   -3.33%  (p=0.016 n=5+4)
Marshal/deep_bson.json.gz/BSON-12      47.7µs ± 2%    46.0µs ± 0%   -3.54%  (p=0.008 n=5+5)
Marshal/flat_bson.json.gz/BSON-12      45.2µs ± 0%    40.3µs ± 0%  -10.90%  (p=0.016 n=5+4)
Marshal/full_bson.json.gz/BSON-12      49.2µs ± 0%    45.4µs ± 1%   -7.75%  (p=0.008 n=5+5)
Unmarshal/simple_struct/BSON-12        5.65µs ± 1%    5.58µs ± 1%   -1.18%  (p=0.048 n=5+5)
Unmarshal/nested_struct/BSON-12        14.5µs ± 5%    14.0µs ± 0%   -3.10%  (p=0.008 n=5+5)
Unmarshal/deep_bson.json.gz/BSON-12    70.8µs ± 0%    71.1µs ± 1%     ~     (p=0.730 n=4+5)
Unmarshal/flat_bson.json.gz/BSON-12    67.1µs ± 1%    66.5µs ± 0%   -0.92%  (p=0.032 n=5+5)
Unmarshal/full_bson.json.gz/BSON-12    81.2µs ± 1%    81.1µs ± 1%     ~     (p=0.548 n=5+5)

name                                 old alloc/op   new alloc/op   delta
Marshal/simple_struct/BSON-12            792B ± 0%      312B ± 0%  -60.61%  (p=0.008 n=5+5)
Marshal/nested_struct/BSON-12            793B ± 0%      440B ± 0%  -44.51%  (p=0.008 n=5+5)
Marshal/deep_bson.json.gz/BSON-12      20.3kB ± 0%    15.2kB ± 0%  -25.21%  (p=0.016 n=4+5)
Marshal/flat_bson.json.gz/BSON-12      35.4kB ± 0%    15.0kB ± 0%  -57.53%  (p=0.008 n=5+5)
Marshal/full_bson.json.gz/BSON-12      26.6kB ± 0%    11.7kB ± 0%  -55.97%  (p=0.008 n=5+5)
Unmarshal/simple_struct/BSON-12        1.09kB ± 0%    1.09kB ± 0%     ~     (all equal)
Unmarshal/nested_struct/BSON-12        8.12kB ± 0%    8.12kB ± 0%     ~     (all equal)
Unmarshal/deep_bson.json.gz/BSON-12    30.9kB ± 0%    30.9kB ± 0%     ~     (p=0.206 n=5+5)
Unmarshal/flat_bson.json.gz/BSON-12    13.4kB ± 0%    13.4kB ± 0%     ~     (p=0.556 n=5+4)
Unmarshal/full_bson.json.gz/BSON-12    19.9kB ± 0%    19.9kB ± 0%     ~     (all equal)

name                                 old allocs/op  new allocs/op  delta
Marshal/simple_struct/BSON-12            3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
Marshal/nested_struct/BSON-12            3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
Marshal/deep_bson.json.gz/BSON-12         385 ± 0%       380 ± 0%   -1.30%  (p=0.008 n=5+5)
Marshal/flat_bson.json.gz/BSON-12         303 ± 0%       294 ± 0%   -2.97%  (p=0.008 n=5+5)
Marshal/full_bson.json.gz/BSON-12         257 ± 0%       249 ± 0%   -3.11%  (p=0.008 n=5+5)
Unmarshal/simple_struct/BSON-12          62.0 ± 0%      62.0 ± 0%     ~     (all equal)
Unmarshal/nested_struct/BSON-12           143 ± 0%       143 ± 0%     ~     (all equal)
Unmarshal/deep_bson.json.gz/BSON-12       822 ± 0%       822 ± 0%     ~     (all equal)
Unmarshal/flat_bson.json.gz/BSON-12       740 ± 0%       740 ± 0%     ~     (all equal)
Unmarshal/full_bson.json.gz/BSON-12       791 ± 0%       791 ± 0%     ~     (all equal)
```

https://jira.mongodb.org/browse/GODRIVER-2025