### PR TITLE
GODRIVER-2013 Security-sensitive command-monitoring redactions

### DIFF
--- a/data/command-monitoring/unified/redacted-commands.json
+++ b/data/command-monitoring/unified/redacted-commands.json
@@ -1,9 +1,10 @@
 {
   "description": "redacted-commands",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.5",
   "runOnRequirements": [
     {
-      "minServerVersion": "5.0"
+      "minServerVersion": "5.0",
+      "auth": false
     }
   ],
   "createEntities": [
@@ -12,7 +13,8 @@
         "id": "client",
         "observeEvents": [
           "commandStartedEvent"
-        ]
+        ],
+        "observeSensitiveCommands": true
       }
     },
     {

--- a/data/command-monitoring/unified/redacted-commands.json
+++ b/data/command-monitoring/unified/redacted-commands.json
@@ -337,7 +337,7 @@
       ]
     },
     {
-      "description": "hello with speculativeAuth",
+      "description": "hello with speculative authenticate",
       "operations": [
         {
           "name": "runCommand",
@@ -413,6 +413,72 @@
                   "isMaster": {
                     "$$exists": false
                   }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello without speculative authenticate is not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": "public"
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": "public"
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": "public"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": "public"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": "public"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": "public"
                 }
               }
             }

--- a/data/command-monitoring/unified/redacted-commands.json
+++ b/data/command-monitoring/unified/redacted-commands.json
@@ -46,7 +46,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "authenticate",
+                "command": {
+                  "authenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -74,7 +81,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "saslStart",
+                "command": {
+                  "saslStart": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -102,7 +116,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "saslContinue",
+                "command": {
+                  "saslContinue": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -127,7 +148,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "getnonce",
+                "command": {
+                  "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -155,7 +183,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "createUser",
+                "command": {
+                  "createUser": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -183,7 +218,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "updateUser",
+                "command": {
+                  "updateUser": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -211,7 +253,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "copydbgetnonce",
+                "command": {
+                  "copydbgetnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -239,7 +288,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "copydbsaslstart",
+                "command": {
+                  "copydbsaslstart": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -267,7 +323,14 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "copydb",
+                "command": {
+                  "copydb": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }
@@ -324,13 +387,34 @@
           "client": "client",
           "events": [
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": {
+                    "$$exists": false
+                  }
+                }
+              }
             },
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": {
+                    "$$exists": false
+                  }
+                }
+              }
             },
             {
-              "commandStartedEvent": {}
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
           ]
         }

--- a/data/command-monitoring/unified/redacted-commands.json
+++ b/data/command-monitoring/unified/redacted-commands.json
@@ -1,0 +1,340 @@
+{
+  "description": "redacted-commands",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "command-monitoring-tests"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "authenticate",
+            "command": {
+              "authenticate": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "saslStart",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslStart",
+            "command": {
+              "saslStart": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "saslContinue",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslContinue",
+            "command": {
+              "saslContinue": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "getnonce",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": "private"
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createUser",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "createUser",
+            "command": {
+              "createUser": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateUser",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "updateUser",
+            "command": {
+              "updateUser": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbgetnonce",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbgetnonce",
+            "command": {
+              "copydbgetnonce": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbsaslstart",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbsaslstart",
+            "command": {
+              "copydbsaslstart": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydb",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydb",
+            "command": {
+              "copydb": "private"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello with speculativeAuth",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": "private",
+              "speculativeAuthenticate": "foo"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": "private",
+              "speculativeAuthenticate": "foo"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": "private",
+              "speculativeAuthenticate": "foo"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {}
+            },
+            {
+              "commandStartedEvent": {}
+            },
+            {
+              "commandStartedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -29,11 +29,14 @@ tests:
         # in command monitoring.
         expectError:
           isError: true
-    expectEvents: &redacted-event
+    expectEvents:
       - client: *client
         events:
-          # Expect empty (redacted) event.
-          - commandStartedEvent: {}
+          - commandStartedEvent:
+              commandName: authenticate
+              # This only asserts that the command name has been redacted from the published command;
+              # however, it's unlikely that a driver would redact this but leave other, sensitive fields.
+              command: { authenticate: { $$exists: false } }
 
   - description: "saslStart"
     operations:
@@ -45,7 +48,12 @@ tests:
             saslStart: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: saslStart
+              command: { saslStart: { $$exists: false } }
 
   - description: "saslContinue"
     operations:
@@ -57,7 +65,12 @@ tests:
             saslContinue: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: saslContinue
+              command: { saslContinue: { $$exists: false } }
 
   - description: "getnonce"
     operations:
@@ -67,7 +80,12 @@ tests:
           commandName: getnonce
           command:
             getnonce: "private"
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: getnonce
+              command: { getnonce: { $$exists: false } }
 
   - description: "createUser"
     operations:
@@ -79,7 +97,12 @@ tests:
             createUser: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: createUser
+              command: { createUser: { $$exists: false } }
 
   - description: "updateUser"
     operations:
@@ -91,7 +114,12 @@ tests:
             updateUser: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: updateUser
+              command: { updateUser: { $$exists: false } }
 
   - description: "copydbgetnonce"
     operations:
@@ -103,7 +131,12 @@ tests:
             copydbgetnonce: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: copydbgetnonce
+              command: { copydbgetnonce: { $$exists: false } }
 
   - description: "copydbsaslstart"
     operations:
@@ -115,7 +148,12 @@ tests:
             copydbsaslstart: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: copydbsaslstart
+              command: { copydbsaslstart: { $$exists: false } }
 
   - description: "copydb"
     operations:
@@ -127,7 +165,12 @@ tests:
             copydb: "private"
         expectError:
           isError: true
-    expectEvents: *redacted-event
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: copydb
+              command: { copydb: { $$exists: false } }
 
   - description: "hello with speculativeAuth"
     operations:
@@ -161,6 +204,12 @@ tests:
     expectEvents:
       - client: *client
         events:
-          - commandStartedEvent: {}
-          - commandStartedEvent: {}
-          - commandStartedEvent: {}
+          - commandStartedEvent:
+              commandName: hello
+              command: { hello: { $$exists: false } }
+          - commandStartedEvent:
+              commandName: ismaster
+              command: { ismaster: { $$exists: false } }
+          - commandStartedEvent:
+              commandName: isMaster
+              command: { isMaster: { $$exists: false } }

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -172,7 +172,7 @@ tests:
               commandName: copydb
               command: { copydb: { $$exists: false } }
 
-  - description: "hello with speculativeAuth"
+  - description: "hello with speculative authenticate"
     operations:
       - name: runCommand
         object: *database
@@ -213,3 +213,36 @@ tests:
           - commandStartedEvent:
               commandName: isMaster
               command: { isMaster: { $$exists: false } }
+
+  - description: "hello without speculative authenticate is not redacted"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: hello
+          command:
+            hello: "public"
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: "public"
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: "public"
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: hello
+              command: { hello: "public" }
+          - commandStartedEvent:
+              commandName: ismaster
+              command: { ismaster: "public" }
+          - commandStartedEvent:
+              commandName: isMaster
+              command: { isMaster: "public" }

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -1,15 +1,17 @@
 description: "redacted-commands"
 
-schemaVersion: "1.0"
+schemaVersion: "1.5"
 
 runOnRequirements:
   - minServerVersion: "5.0"
+    auth: false
 
 createEntities:
   - client:
       id: &client client
       observeEvents:
         - commandStartedEvent
+      observeSensitiveCommands: true
   - database:
       id: &database database
       client: *client

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -1,0 +1,166 @@
+description: "redacted-commands"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "5.0"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName command-monitoring-tests
+
+tests:
+  - description: "authenticate"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: authenticate
+          command:
+            authenticate: "private"
+        # Malformed authentication commands will fail against the server, but we
+        # just want to assert that security-related commands are redacted
+        # in command monitoring.
+        expectError:
+          isError: true
+    expectEvents: &redacted-event
+      - client: *client
+        events:
+          # Expect empty (redacted) event.
+          - commandStartedEvent: {}
+
+  - description: "saslStart"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: saslStart
+          command:
+            saslStart: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "saslContinue"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: saslContinue
+          command:
+            saslContinue: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "getnonce"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: getnonce
+          command:
+            getnonce: "private"
+    expectEvents: *redacted-event
+
+  - description: "createUser"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: createUser
+          command:
+            createUser: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "updateUser"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: updateUser
+          command:
+            updateUser: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "copydbgetnonce"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: copydbgetnonce
+          command:
+            copydbgetnonce: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "copydbsaslstart"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: copydbsaslstart
+          command:
+            copydbsaslstart: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "copydb"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: copydb
+          command:
+            copydb: "private"
+        expectError:
+          isError: true
+    expectEvents: *redacted-event
+
+  - description: "hello with speculativeAuth"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: hello
+          command:
+            hello: "private"
+            speculativeAuthenticate: "foo"
+        expectError:
+          isError: true
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: "private"
+            speculativeAuthenticate: "foo"
+        expectError:
+          isError: true
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: "private"
+            speculativeAuthenticate: "foo"
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent: {}
+          - commandStartedEvent: {}
+          - commandStartedEvent: {}

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -36,6 +36,8 @@ tests:
               commandName: authenticate
               # This only asserts that the command name has been redacted from the published command;
               # however, it's unlikely that a driver would redact this but leave other, sensitive fields.
+              # We cannot simply assert that command is an empty document because it's at root-level, so
+              # additional fields in the actual document will be permitted
               command: { authenticate: { $$exists: false } }
 
   - description: "saslStart"

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -160,23 +160,23 @@ func (c *clientEntity) stopListeningForEvents() {
 }
 
 func (c *clientEntity) isIgnoredEvent(event *event.CommandStartedEvent) bool {
-	// Check if command is not in ignoredCommands.
-	if _, ok := c.ignoredCommands[event.CommandName]; !ok {
-		// Check if command is "hello" or legacy hello.
-		if event.CommandName == "hello" || strings.ToLower(event.CommandName) == "ismaster" {
-			_, err := event.Command.LookupErr("speculativeAuthenticate")
-			speculativeAuth := err == nil
-
-			// If observeSensitiveCommands is false (or unset) and hello command is with
-			// speculative authenticate, command should be ignored.
-			if (c.observeSensitiveCommands == nil || !*c.observeSensitiveCommands) &&
-				speculativeAuth {
-				return true
-			}
-		}
-		return false
+	// Check if command is in ignoredCommands.
+	if _, ok := c.ignoredCommands[event.CommandName]; ok {
+		return true
 	}
-	return true
+
+	if event.CommandName == "hello" || strings.ToLower(event.CommandName) == "ismaster" {
+		_, err := event.Command.LookupErr("speculativeAuthenticate")
+		speculativeAuth := err == nil
+
+		// If observeSensitiveCommands is false (or unset) and hello command is with
+		// speculative authenticate, command should be ignored.
+		if (c.observeSensitiveCommands == nil || !*c.observeSensitiveCommands) &&
+			speculativeAuth {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *clientEntity) startedEvents() []*event.CommandStartedEvent {

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -34,12 +34,13 @@ type entityOptions struct {
 	ID string `bson:"id"`
 
 	// Options for client entities.
-	URIOptions            bson.M                        `bson:"uriOptions"`
-	UseMultipleMongoses   *bool                         `bson:"useMultipleMongoses"`
-	ObserveEvents         []string                      `bson:"observeEvents"`
-	IgnoredCommands       []string                      `bson:"ignoreCommandMonitoringEvents"`
-	StoreEventsAsEntities []storeEventsAsEntitiesConfig `bson:"storeEventsAsEntities"`
-	ServerAPIOptions      *serverAPIOptions             `bson:"serverApi"`
+	URIOptions               bson.M                        `bson:"uriOptions"`
+	UseMultipleMongoses      *bool                         `bson:"useMultipleMongoses"`
+	ObserveEvents            []string                      `bson:"observeEvents"`
+	IgnoredCommands          []string                      `bson:"ignoreCommandMonitoringEvents"`
+	ObserveSensitiveCommands *bool                         `bson:"observeSensitiveCommands"`
+	StoreEventsAsEntities    []storeEventsAsEntitiesConfig `bson:"storeEventsAsEntities"`
+	ServerAPIOptions         *serverAPIOptions             `bson:"serverApi"`
 
 	// Options for database entities.
 	DatabaseName    string                 `bson:"databaseName"`

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -173,10 +173,8 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 				// there are not enough bytes to read a document from bson.RawValue{}.
 				// In the case of an empty Command, hardcode an empty bson.RawValue document.
 				if len(actual.Command) == 0 {
-					// This represents a null BSON value: first four bytes are length (7), and
-					// remaining bytes are the null value.
-					nullValue := []byte{7, 0, 0, 0, 10, 0, 0}
-					actualDoc = bson.RawValue{Type: bsontype.EmbeddedDocument, Value: nullValue}
+					emptyDoc := []byte{5, 0, 0, 0, 0}
+					actualDoc = bson.RawValue{Type: bsontype.EmbeddedDocument, Value: emptyDoc}
 				}
 
 				if err := verifyValuesMatch(ctx, expectedDoc, actualDoc, true); err != nil {

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -167,6 +167,18 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 			if expected.Command != nil {
 				expectedDoc := documentToRawValue(expected.Command)
 				actualDoc := documentToRawValue(actual.Command)
+
+				// If actual.Command is empty, as is the case with redacted commands,
+				// verifyValuesMatch will return an error from DocumentOK() because
+				// there are not enough bytes to read a document from bson.RawValue{}.
+				// In the case of an empty Command, hardcode an empty bson.RawValue document.
+				if len(actual.Command) == 0 {
+					// This represents a null BSON value: first four bytes are length (7), and
+					// remaining bytes are the null value.
+					nullValue := []byte{7, 0, 0, 0, 10, 0, 0}
+					actualDoc = bson.RawValue{Type: bsontype.EmbeddedDocument, Value: nullValue}
+				}
+
 				if err := verifyValuesMatch(ctx, expectedDoc, actualDoc, true); err != nil {
 					return newEventVerificationError(idx, client, "error comparing command documents: %v", err)
 				}

--- a/mongo/integration/unified/matches.go
+++ b/mongo/integration/unified/matches.go
@@ -55,7 +55,11 @@ func verifyValuesMatchInner(ctx context.Context, expected, actual bson.RawValue)
 
 		actualDoc, ok := actual.DocumentOK()
 		if !ok {
-			return newMatchingError(keyPath, "expected value to be a document but got a %s", actual.Type)
+			// If actual value isn't empty, return error.
+			if len(actual.Value) != 0 {
+				return newMatchingError(keyPath, "expected value to be a document but got a %s", actual.Type)
+			}
+			actualDoc = bson.Raw{}
 		}
 
 		// Perform element-wise comparisons.

--- a/mongo/integration/unified/matches.go
+++ b/mongo/integration/unified/matches.go
@@ -55,11 +55,7 @@ func verifyValuesMatchInner(ctx context.Context, expected, actual bson.RawValue)
 
 		actualDoc, ok := actual.DocumentOK()
 		if !ok {
-			// If actual value isn't empty, return error.
-			if len(actual.Value) != 0 {
-				return newMatchingError(keyPath, "expected value to be a document but got a %s", actual.Type)
-			}
-			actualDoc = bson.Raw{}
+			return newMatchingError(keyPath, "expected value to be a document but got a %s", actual.Type)
 		}
 
 		// Perform element-wise comparisons.

--- a/mongo/integration/unified/schema_version.go
+++ b/mongo/integration/unified/schema_version.go
@@ -16,7 +16,8 @@ import (
 
 var (
 	supportedSchemaVersions = map[int]string{
-		1: "1.3",
+		// We do not fully support the 1.5 schema, but we need 1.5 to test with observeSensitiveCommands.
+		1: "1.5",
 	}
 )
 

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -22,6 +22,7 @@ var (
 		"transactions/unified",
 		"load-balancers",
 		"collection-management",
+		"command-monitoring/unified",
 	}
 	failDirectories = []string{
 		"unified-test-format/valid-fail",

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1414,7 +1414,7 @@ func (op *Operation) redactCommand(cmd string, doc bsoncore.Document) bool {
 
 		return true
 	}
-	if strings.ToLower(cmd) != "ismaster" {
+	if strings.ToLower(cmd) != "ismaster" && cmd != "hello" {
 		return false
 	}
 


### PR DESCRIPTION
GODRIVER-2013

Adds tests to ensure that we are redacting security sensitive commands from command monitoring. Updates `redactCommand` to also redact `hello` when `speculativeAuthenticate` is present.