### PR TITLE
Fix data race in cancellation listener

### DIFF
--- a/internal/cancellation_listener_test.go
+++ b/internal/cancellation_listener_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancellationListenerDataRace makes sure that there is no data race
+// when cancellation listener is used concurrently.
+func TestCancellationListenerDataRace(t *testing.T) {
+	l := NewCancellationListener()
+	ctx := context.Background()
+	go l.Listen(ctx, func() {})
+	go l.Listen(ctx, func() {})
+	require.False(t, l.StopListening())
+}


### PR DESCRIPTION
The cancellation listener introduced in https://github.com/mongodb/mongo-go-driver/pull/473 has a data race issue where its internal `aborted` field is not protected by a mutex.

This leads to a data race issue between `x/mongo/driver/topology.Connection` ReadWireMessage/WriteWireMessage methods - since they both launch `go c.cancellationListener.Listen(ctx, c.cancellationListenerCallback)` which modify the internal field:

https://github.com/mongodb/mongo-go-driver/blob/v1.5.3/x/mongo/driver/topology/connection.go#L340
https://github.com/mongodb/mongo-go-driver/blob/v1.5.3/x/mongo/driver/topology/connection.go#L405

The issue was discovered by running `go test` with -race flag on a library that uses this MongoDB driver.