### PR TITLE
GODRIVER-2037 Don't clear the connection pool on client-side connect timeout errors.

### DIFF
--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -60,6 +60,7 @@ func (tpm *testPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*ev
 		for _, filter := range filters {
 			if !filter(evt) {
 				keep = false
+				break
 			}
 		}
 		if keep {
@@ -68,6 +69,15 @@ func (tpm *testPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*ev
 	}
 
 	return filtered
+}
+
+// IsPoolCleared returns true if there are any events of type "event.PoolCleared" in the events
+// recorded by the testPoolMonitor.
+func (tpm *testPoolMonitor) IsPoolCleared() bool {
+	poolClearedEvents := tpm.Events(func(evt *event.PoolEvent) bool {
+		return evt.Type == event.PoolCleared
+	})
+	return len(poolClearedEvents) > 0
 }
 
 var poolChan = make(chan *event.PoolEvent, 100)

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -49,12 +49,13 @@ func TestSDAMErrorHandling(t *testing.T) {
 	mt.RunOpts("before handshake completes", baseMtOpts().Auth(true).MinServerVersion("4.4"), func(mt *mtest.T) {
 		mt.RunOpts("network errors", noClientOpts, func(mt *mtest.T) {
 			mt.Run("pool not cleared on operation-scoped network timeout", func(mt *mtest.T) {
-				// Assert that the pool is cleared when a connection created by an application operation thread
-				// encounters a network timeout during handshaking. Unlike the non-timeout test below, we only test
-				// connections created in the foreground for timeouts because connections created by the pool
-				// maintenance routine can't be timed out using a context.
+				// Assert that the pool is not cleared when a connection created by an application
+				// operation thread encounters an operation timeout during handshaking. Unlike the
+				// non-timeout test below, we only test connections created in the foreground for
+				// timeouts because connections created by the pool maintenance routine can't be
+				// timed out using a context.
 
-				appName := "authNetworkTimeoutTest"
+				appName := "authOperationTimeoutTest"
 				// Set failpoint on saslContinue instead of saslStart because saslStart isn't done when using
 				// speculative auth.
 				mt.SetFailPoint(mtest.FailPoint{
@@ -91,12 +92,11 @@ func TestSDAMErrorHandling(t *testing.T) {
 			})
 
 			mt.Run("pool cleared on non-operation-scoped network timeout", func(mt *mtest.T) {
-				// Assert that the pool is cleared when a connection created by an application operation thread
-				// encounters a network timeout during handshaking. Unlike the non-timeout test below, we only test
-				// connections created in the foreground for timeouts because connections created by the pool
-				// maintenance routine can't be timed out using a context.
+				// Assert that the pool is cleared when a connection created by an application
+				// operation thread encounters a timeout caused by connectTimeoutMS during
+				// handshaking.
 
-				appName := "authNetworkTimeoutTest"
+				appName := "authConnectTimeoutTest"
 				// Set failpoint on saslContinue instead of saslStart because saslStart isn't done when using
 				// speculative auth.
 				mt.SetFailPoint(mtest.FailPoint{

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -101,7 +101,7 @@ func newConnection(addr address.Address, opts ...ConnectionOption) (*connection,
 	return c, nil
 }
 
-func (c *connection) processInitializationError(err error) {
+func (c *connection) processInitializationError(err, ctxErr error) {
 	atomic.StoreInt32(&c.connected, disconnected)
 	if c.nc != nil {
 		_ = c.nc.Close()
@@ -109,7 +109,7 @@ func (c *connection) processInitializationError(err error) {
 
 	c.connectErr = ConnectionError{Wrapped: err, init: true}
 	if c.config.errorHandlingCallback != nil {
-		c.config.errorHandlingCallback(c.connectErr, c.generation, c.desc.ServiceID)
+		c.config.errorHandlingCallback(c.connectErr, ctxErr, c.generation, c.desc.ServiceID)
 	}
 }
 
@@ -184,7 +184,7 @@ func (c *connection) connect(ctx context.Context) {
 	var tempNc net.Conn
 	tempNc, err = c.config.dialer.DialContext(dialCtx, c.addr.Network(), c.addr.String())
 	if err != nil {
-		c.processInitializationError(err)
+		c.processInitializationError(err, ctx.Err())
 		return
 	}
 	c.nc = tempNc
@@ -200,7 +200,7 @@ func (c *connection) connect(ctx context.Context) {
 		}
 		tlsNc, err := configureTLS(dialCtx, c.config.tlsConnectionSource, c.nc, c.addr, tlsConfig, ocspOpts)
 		if err != nil {
-			c.processInitializationError(err)
+			c.processInitializationError(err, ctx.Err())
 			return
 		}
 		c.nc = tlsNc
@@ -252,7 +252,7 @@ func (c *connection) connect(ctx context.Context) {
 
 	// We have a failed handshake here
 	if err != nil {
-		c.processInitializationError(err)
+		c.processInitializationError(err, ctx.Err())
 		return
 	}
 

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -101,7 +101,7 @@ func newConnection(addr address.Address, opts ...ConnectionOption) (*connection,
 	return c, nil
 }
 
-func (c *connection) processInitializationError(err error, opCtx context.Context) {
+func (c *connection) processInitializationError(opCtx context.Context, err error) {
 	atomic.StoreInt32(&c.connected, disconnected)
 	if c.nc != nil {
 		_ = c.nc.Close()
@@ -109,7 +109,7 @@ func (c *connection) processInitializationError(err error, opCtx context.Context
 
 	c.connectErr = ConnectionError{Wrapped: err, init: true}
 	if c.config.errorHandlingCallback != nil {
-		c.config.errorHandlingCallback(c.connectErr, opCtx, c.generation, c.desc.ServiceID)
+		c.config.errorHandlingCallback(opCtx, c.connectErr, c.generation, c.desc.ServiceID)
 	}
 }
 
@@ -184,7 +184,7 @@ func (c *connection) connect(ctx context.Context) {
 	var tempNc net.Conn
 	tempNc, err = c.config.dialer.DialContext(dialCtx, c.addr.Network(), c.addr.String())
 	if err != nil {
-		c.processInitializationError(err, ctx)
+		c.processInitializationError(ctx, err)
 		return
 	}
 	c.nc = tempNc
@@ -200,7 +200,7 @@ func (c *connection) connect(ctx context.Context) {
 		}
 		tlsNc, err := configureTLS(dialCtx, c.config.tlsConnectionSource, c.nc, c.addr, tlsConfig, ocspOpts)
 		if err != nil {
-			c.processInitializationError(err, ctx)
+			c.processInitializationError(ctx, err)
 			return
 		}
 		c.nc = tlsNc
@@ -252,7 +252,7 @@ func (c *connection) connect(ctx context.Context) {
 
 	// We have a failed handshake here
 	if err != nil {
-		c.processInitializationError(err, ctx)
+		c.processInitializationError(ctx, err)
 		return
 	}
 

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -55,7 +55,7 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(err error, opCtx context.Context, startGenNum uint64, svcID *primitive.ObjectID)
+	errorHandlingCallback    func(opCtx context.Context, err error, startGenNum uint64, svcID *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
@@ -92,7 +92,7 @@ func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) C
 	}
 }
 
-func withErrorHandlingCallback(fn func(err error, opCtx context.Context, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
+func withErrorHandlingCallback(fn func(opCtx context.Context, err error, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.errorHandlingCallback = fn
 		return nil

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -55,7 +55,7 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(err, ctxErr error, startGenNum uint64, svcID *primitive.ObjectID)
+	errorHandlingCallback    func(err error, opCtx context.Context, startGenNum uint64, svcID *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
@@ -92,7 +92,7 @@ func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) C
 	}
 }
 
-func withErrorHandlingCallback(fn func(err, ctxErr error, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
+func withErrorHandlingCallback(fn func(err error, opCtx context.Context, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.errorHandlingCallback = fn
 		return nil

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -55,7 +55,7 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(error, uint64, *primitive.ObjectID)
+	errorHandlingCallback    func(error, error, uint64, *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
@@ -92,7 +92,7 @@ func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) C
 	}
 }
 
-func withErrorHandlingCallback(fn func(error, uint64, *primitive.ObjectID)) ConnectionOption {
+func withErrorHandlingCallback(fn func(error, error, uint64, *primitive.ObjectID)) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.errorHandlingCallback = fn
 		return nil

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -55,7 +55,7 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(error, error, uint64, *primitive.ObjectID)
+	errorHandlingCallback    func(err, ctxErr error, startGenNum uint64, svcID *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
@@ -92,7 +92,7 @@ func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) C
 	}
 }
 
-func withErrorHandlingCallback(fn func(error, error, uint64, *primitive.ObjectID)) ConnectionOption {
+func withErrorHandlingCallback(fn func(err, ctxErr error, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.errorHandlingCallback = fn
 		return nil

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -129,7 +129,7 @@ func TestConnection(t *testing.T) {
 							return &net.TCPConn{}, nil
 						})
 					}),
-					withErrorHandlingCallback(func(err error, _ context.Context, _ uint64, _ *primitive.ObjectID) {
+					withErrorHandlingCallback(func(_ context.Context, err error, _ uint64, _ *primitive.ObjectID) {
 						got = err
 					}),
 				)

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -129,7 +129,7 @@ func TestConnection(t *testing.T) {
 							return &net.TCPConn{}, nil
 						})
 					}),
-					withErrorHandlingCallback(func(err error, _ uint64, _ *primitive.ObjectID) {
+					withErrorHandlingCallback(func(err, ctxErr error, _ uint64, _ *primitive.ObjectID) {
 						got = err
 					}),
 				)

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -129,7 +129,7 @@ func TestConnection(t *testing.T) {
 							return &net.TCPConn{}, nil
 						})
 					}),
-					withErrorHandlingCallback(func(err, ctxErr error, _ uint64, _ *primitive.ObjectID) {
+					withErrorHandlingCallback(func(err, _ error, _ uint64, _ *primitive.ObjectID) {
 						got = err
 					}),
 				)

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -129,7 +129,7 @@ func TestConnection(t *testing.T) {
 							return &net.TCPConn{}, nil
 						})
 					}),
-					withErrorHandlingCallback(func(err, _ error, _ uint64, _ *primitive.ObjectID) {
+					withErrorHandlingCallback(func(err error, _ context.Context, _ uint64, _ *primitive.ObjectID) {
 						got = err
 					}),
 				)

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -343,7 +343,7 @@ func applyErrors(t *testing.T, topo *Topology, errors []applicationError) {
 
 		switch appErr.When {
 		case "beforeHandshakeCompletes":
-			server.ProcessHandshakeError(currError, generation, nil)
+			server.ProcessHandshakeError(currError, nil, generation, nil)
 		case "afterHandshakeCompletes":
 			_ = server.ProcessError(currError, &conn)
 		default:

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -343,7 +343,7 @@ func applyErrors(t *testing.T, topo *Topology, errors []applicationError) {
 
 		switch appErr.When {
 		case "beforeHandshakeCompletes":
-			server.ProcessHandshakeError(currError, nil, generation, nil)
+			server.ProcessHandshakeError(nil, currError, generation, nil)
 		case "afterHandshakeCompletes":
 			_ = server.ProcessError(currError, &conn)
 		default:

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -272,10 +272,11 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 	return &Connection{connection: connImpl}, nil
 }
 
-// ProcessHandshakeError implements SDAM error handling for errors that occur before a connection finishes handshaking.
-// ctxErr is any error caused by the context passed to Server.Connection() and is used to determine whether or not an
-// operation-scoped context deadline or cancellation was the cause of the handshake error.
-func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
+// ProcessHandshakeError implements SDAM error handling for errors that occur before a connection
+// finishes handshaking. opCtx is the context passed to Server.Connection() and is used to determine
+// whether or not an operation-scoped context deadline or cancellation was the cause of the
+// handshake error.
+func (s *Server) ProcessHandshakeError(err error, opCtx context.Context, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
 	// Ignore the error if the server is behind a load balancer but the service ID is unknown. This indicates that the
 	// error happened when dialing the connection or during the MongoDB handshake, so we don't know the service ID to
 	// use for clearing the pool.
@@ -292,7 +293,29 @@ func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumb
 		return
 	}
 
-	isTimeoutOrCanceled := func(err error) bool {
+	isCtxTimeoutOrCanceled := func(ctx context.Context) bool {
+		if ctx == nil {
+			return false
+		}
+
+		if ctx.Err() != nil {
+			return true
+		}
+
+		// In some networking functions, the deadline from the context is used to determine timeouts
+		// instead of the ctx.Done() chan closure. In that case, there can be a race condition
+		// between the networking functing returning an error and ctx.Err() returning an an error
+		// (i.e. the networking function returns an error caused by the context deadline, but
+		// ctx.Err() returns nil). If the operation-scoped context deadline was exceeded, assume
+		// operation-scoped context timeout caused the error.
+		if deadline, ok := ctx.Deadline(); ok && time.Now().After(deadline) {
+			return true
+		}
+
+		return false
+	}
+
+	isErrTimeoutOrCanceled := func(err error) bool {
 		for err != nil {
 			// Check for errors that implement the "net.Error" interface and self-report as timeout
 			// errors. Includes some "*net.OpError" errors and "context.DeadlineExceeded".
@@ -322,7 +345,7 @@ func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumb
 	// still clear the pool.
 	// TODO(GODRIVER-2038): Remove this condition when connections are no longer created with an
 	// operation-scoped timeout.
-	if ctxErr != nil && isTimeoutOrCanceled(wrappedConnErr) {
+	if isCtxTimeoutOrCanceled(opCtx) && isErrTimeoutOrCanceled(wrappedConnErr) {
 		return
 	}
 

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -294,10 +294,8 @@ func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumb
 
 	isTimeout := func(err error) bool {
 		for err != nil {
-			if netErr, ok := err.(net.Error); ok {
-				if netErr.Timeout() {
-					return true
-				}
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				return true
 			}
 			// Handle the case where an error has been replaced by "net.errCanceled", which isn't
 			// exported and can't be compared directly. In this case, just compare the error message.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -275,8 +275,8 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 // ProcessHandshakeError implements SDAM error handling for errors that occur before a connection
 // finishes handshaking. opCtx is the context passed to Server.Connection() and is used to determine
 // whether or not an operation-scoped context deadline or cancellation was the cause of the
-// handshake error.
-func (s *Server) ProcessHandshakeError(err error, opCtx context.Context, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
+// handshake error; it is not used for timeout or cancellation of ProcessHandshakeError.
+func (s *Server) ProcessHandshakeError(opCtx context.Context, err error, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
 	// Ignore the error if the server is behind a load balancer but the service ID is unknown. This indicates that the
 	// error happened when dialing the connection or during the MongoDB handshake, so we don't know the service ID to
 	// use for clearing the pool.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -273,7 +273,7 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 }
 
 // ProcessHandshakeError implements SDAM error handling for errors that occur before a connection finishes handshaking.
-// ctxErr is any error caused by the context passed to Server#Connection() and is used to determine whether or not an
+// ctxErr is any error caused by the context passed to Server.Connection() and is used to determine whether or not an
 // operation-scoped context deadline or cancellation was the cause of the handshake error.
 func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumber uint64, serviceID *primitive.ObjectID) {
 	// Ignore the error if the server is behind a load balancer but the service ID is unknown. This indicates that the
@@ -292,29 +292,37 @@ func (s *Server) ProcessHandshakeError(err, ctxErr error, startingGenerationNumb
 		return
 	}
 
-	isTimeout := func(err error) bool {
+	isTimeoutOrCanceled := func(err error) bool {
 		for err != nil {
+			// Check for errors that implement the "net.Error" interface and self-report as timeout
+			// errors. Includes some "*net.OpError" errors and "context.DeadlineExceeded".
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				return true
 			}
-			// Handle the case where an error has been replaced by "net.errCanceled", which isn't
-			// exported and can't be compared directly. In this case, just compare the error message.
-			if err.Error() == "operation was canceled" {
+			// Check for context cancellation. Also handle the case where the cancellation error has
+			// been replaced by "net.errCanceled" (which isn't exported and can't be compared
+			// directly) by checking the error message.
+			if err == context.Canceled || err.Error() == "operation was canceled" {
 				return true
 			}
-			if wrapper, ok := err.(interface{ Unwrap() error }); ok {
-				err = wrapper.Unwrap()
-			} else {
+
+			wrapper, ok := err.(interface{ Unwrap() error })
+			if !ok {
 				break
 			}
+			err = wrapper.Unwrap()
 		}
 
 		return false
 	}
 
-	// Ignore errors that indicate a client-side timeout occurred when using an operation-scoped
-	// deadline (i.e. not using connectTimeoutMS as the connection timeout).
-	if (ctxErr == context.DeadlineExceeded || ctxErr == context.Canceled) && isTimeout(wrappedConnErr) {
+	// Ignore errors that indicate a client-side timeout occurred when the context passed into an
+	// operation timed out or was canceled (i.e. errors caused by an operation-scoped timeout).
+	// Timeouts caused by reaching connectTimeoutMS or other non-operation-scoped timeouts should
+	// still clear the pool.
+	// TODO(GODRIVER-2038): Remove this condition when connections are no longer created with an
+	// operation-scoped timeout.
+	if ctxErr != nil && isTimeoutOrCanceled(wrappedConnErr) {
 		return
 	}
 

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -243,9 +243,10 @@ func TestServerConnectionTimeout(t *testing.T) {
 				assert.Nil(t, err, "expected no error but got %s", err)
 			}
 
-			// Close the events channel and expect that no more events are sent on the channel. Then
-			// wait for the events channel loop to return before inspecting the events slice.
-			server.Disconnect(context.Background())
+			// Disconnect the server then close the events channel and expect that no more events
+			// are sent on the channel. Then wait for the events channel loop to return before
+			// inspecting the events slice.
+			_ = server.Disconnect(context.Background())
 			close(eventsCh)
 			eventsWg.Wait()
 			require.NotEmpty(t, events, "expected more than 0 connection pool monitor events")
@@ -267,6 +268,10 @@ func TestServerConnectionTimeout(t *testing.T) {
 				poolCleared)
 		})
 	}
+}
+
+func TestServerConnectionCancellation(t *testing.T) {
+	// TODO: Write test.
 }
 
 func TestServer(t *testing.T) {

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -54,6 +54,8 @@ func (cncd *channelNetConnDialer) DialContext(_ context.Context, _, _ string) (n
 	return cnc, nil
 }
 
+// TestServerConnectionTimeout tests how different timeout errors are handled during connection
+// creation and server handshake.
 func TestServerConnectionTimeout(t *testing.T) {
 	testCases := []struct {
 		desc              string
@@ -177,6 +179,8 @@ func TestServerConnectionTimeout(t *testing.T) {
 			// Start a goroutine that pulls events from the events channel and inserts them into the
 			// events slice. Use a sync.WaitGroup to allow the test code to block until the events
 			// channel loop exits, guaranteeing that all events were copied from the channel.
+			// TODO(GODRIVER-2068): Consider using the "testPoolMonitor" from the "mongo/integration"
+			// package. Requires moving "testPoolMonitor" into a test utilities package.
 			events := make([]*event.PoolEvent, 0)
 			eventsCh := make(chan *event.PoolEvent)
 			var eventsWg sync.WaitGroup
@@ -270,10 +274,14 @@ func TestServerConnectionTimeout(t *testing.T) {
 	}
 }
 
+// TestServerConnectionCancellation tests how context cancellation errors are handled during
+// connection creation.
 func TestServerConnectionCancellation(t *testing.T) {
 	// Start a goroutine that pulls events from the events channel and inserts them into the
 	// events slice. Use a sync.WaitGroup to allow the test code to block until the events
 	// channel loop exits, guaranteeing that all events were copied from the channel.
+	// TODO(GODRIVER-2068): Consider using the "testPoolMonitor" from the "mongo/integration"
+	// package. Requires moving "testPoolMonitor" into a test utilities package.
 	events := make([]*event.PoolEvent, 0)
 	eventsCh := make(chan *event.PoolEvent)
 	var eventsWg sync.WaitGroup

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -309,7 +309,6 @@ func TestServerConnectionCancellation(t *testing.T) {
 		// Disable monitoring to prevent unrelated failures from the RTT monitor and
 		// heartbeats from unexpectedly clearing the connection pool.
 		withMonitoringDisabled(func(bool) bool { return true }),
-		// Use the standard auth.Handshaker
 		WithConnectionOptions(func(opts ...ConnectionOption) []ConnectionOption {
 			return append(opts, WithDialer(func(Dialer) Dialer {
 				var d net.Dialer
@@ -337,7 +336,7 @@ func TestServerConnectionCancellation(t *testing.T) {
 	require.NotEmpty(t, events, "expected more than 0 connection pool monitor events")
 
 	// Look for any "ConnectionPoolCleared" events in the events slice so we can assert that
-	// the Server connection pool was or wasn't cleared, depending on the test expectations.
+	// the Server connection pool wasn't cleared.
 	poolCleared := false
 	for _, evt := range events {
 		if evt.Type == event.PoolCleared {


### PR DESCRIPTION
Update `topology.Server#ProcessHandshakeError` to not clear the server connection pool on client-side timeout errors that occur while creating a connection in-line with an operation. This is intended as a patch to prevent clearing the connection pool on specific identified conditions that currently cause the driver to clear the server connection pool unnecessarily and is not intended to handle a comprehensive set of errors that could occur during handshake.
Note that the changes here are likely irrelevant once all connections are established in the background with the `connectTimeoutMS` deadline ([GODRIVER-2038](https://jira.mongodb.org/browse/GODRIVER-2038)).

Possible cases:
1. `server.Connection(context.Background())`
Get a connection to `server` using `connectTimeoutMS`. The `server` connection pool will be cleared on timeout during handshake. This case is used for connections created by the `MinPoolSize` maintenance goroutine and by operations that use `context.Background()` for the timeout.
2. `server.Connection(context.WithTimeout(..., 1*time.Second))`
Get a connection to `server` using a timeout specified on an operation lower than `connectTimeoutMS`. The `server` connection pool will not be cleared on timeout during handshake. This case is used for connections created by operations that use `context.WithTimeout()` for timeouts shorter than the `connectTimeoutMS`.
3. `server.Connection(context.WithTimeout(..., 10*time.Minute))`
Get a connection to `server` using a timeout specified on an operation higher than `connectTimeoutMS`. The `server` connection pool will be cleared on timeout during handshake. This case is used for connections created by operations that use `context.WithTimeout()` for timeouts longer than `connectTimeoutMS`.
4. `server.Connection(context.WithCancel(...))`
Get a connection to `server` using a cancellation specified on an operation. The `server` connection pool will not be cleared on timeout during handshake. This case is used for connections created by operations that use `context.WithCancel()` for cancellation.

[GODRIVER-2037](https://jira.mongodb.org/browse/GODRIVER-2037)