### PR TITLE
GODRIVER-2056 Fix uri merging on options.ClientOptions

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -873,7 +873,12 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		if opt.err != nil {
 			c.err = opt.err
 		}
-
+		if opt.uri != "" {
+			c.uri = opt.uri
+		}
+		if opt.cs != nil {
+			c.cs = opt.cs
+		}
 	}
 
 	return c

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -175,6 +175,16 @@ func TestClientOptions(t *testing.T) {
 				t.Errorf("Merged client options do not match. got %v; want %v", got.err.Error(), opt1.err.Error())
 			}
 		})
+
+		t.Run("MergeClientOptions/uri", func(t *testing.T) {
+			opt1, opt2 := Client(), Client()
+			opt1.uri = "Test URI"
+
+			got := MergeClientOptions(nil, opt1, opt2)
+			if got.uri != "Test URI" {
+				t.Errorf("Merged client options do not match. got %v; want %v", got.uri, opt1.uri)
+			}
+		})
 	})
 	t.Run("ApplyURI", func(t *testing.T) {
 		baseClient := func() *ClientOptions {


### PR DESCRIPTION
It seems that SRV polling is not spawned when using `opts.ApplyURI()` without (deprecated) deployment options.

That's because options.MergeClientOptions doesn't copy "uri" field. Then topology.New gets options with empty uri value, and polling is disabled.

```go
if t.cfg.uri != "" {
    t.pollingRequired = strings.HasPrefix(t.cfg.uri, "mongodb+srv://")
}
```

https://jira.mongodb.org/browse/GODRIVER-2057