### PR TITLE
GODRIVER-1870 Remove insertedCount assertions on insertOne

### DIFF
--- a/data/crud/unified/insertMany-dots_and_dollars.json
+++ b/data/crud/unified/insertMany-dots_and_dollars.json
@@ -53,10 +53,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -162,10 +163,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -221,10 +223,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -284,10 +287,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }

--- a/data/crud/unified/insertMany-dots_and_dollars.yml
+++ b/data/crud/unified/insertMany-dots_and_dollars.yml
@@ -31,8 +31,8 @@ tests:
           documents:
             - &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedCount: 1
-          insertedIds: { $$unsetOrMatches: { 0: 1 } }
+          # InsertManyResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedIds: { $$unsetOrMatches: { 0: 1 } } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:

--- a/data/crud/unified/insertOne-dots_and_dollars.json
+++ b/data/crud/unified/insertOne-dots_and_dollars.json
@@ -63,7 +63,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -166,7 +165,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -221,7 +219,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -280,7 +277,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -390,7 +386,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": {
                 "a.b": 1
@@ -501,7 +496,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }

--- a/data/crud/unified/insertOne-dots_and_dollars.json
+++ b/data/crud/unified/insertOne-dots_and_dollars.json
@@ -63,8 +63,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -165,8 +167,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -219,8 +223,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -277,8 +283,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -386,9 +394,11 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": {
-                "a.b": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": {
+                  "a.b": 1
+                }
               }
             }
           }
@@ -496,8 +506,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -558,8 +570,10 @@
             }
           },
           "expectResult": {
-            "acknowledged": {
-              "$$unsetOrMatches": false
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              }
             }
           }
         }

--- a/data/crud/unified/insertOne-dots_and_dollars.yml
+++ b/data/crud/unified/insertOne-dots_and_dollars.yml
@@ -36,7 +36,8 @@ tests:
         arguments:
           document: &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedId: { $$unsetOrMatches: 1 }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:
@@ -155,7 +156,8 @@ tests:
         arguments:
           document: &dottedKeyInId { _id: { a.b: 1 } }
         expectResult:
-          insertedId: { $$unsetOrMatches: { a.b: 1 } }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: { a.b: 1 } } }
     expectEvents: &expectEventsDottedKeyInId
       - client: *client0
         events:
@@ -222,7 +224,8 @@ tests:
         arguments:
           document: *dollarPrefixedKeyInId
         expectResult:
-          acknowledged: { $$unsetOrMatches: false }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { acknowledged: { $$unsetOrMatches: false } }
     expectEvents:
       - client: *client0
         events:

--- a/data/crud/unified/insertOne-dots_and_dollars.yml
+++ b/data/crud/unified/insertOne-dots_and_dollars.yml
@@ -36,7 +36,6 @@ tests:
         arguments:
           document: &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedCount: 1
           insertedId: { $$unsetOrMatches: 1 }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
@@ -156,7 +155,6 @@ tests:
         arguments:
           document: &dottedKeyInId { _id: { a.b: 1 } }
         expectResult:
-          insertedCount: 1
           insertedId: { $$unsetOrMatches: { a.b: 1 } }
     expectEvents: &expectEventsDottedKeyInId
       - client: *client0

--- a/data/unified-test-format/valid-pass/poc-crud.json
+++ b/data/unified-test-format/valid-pass/poc-crud.json
@@ -242,12 +242,14 @@
           },
           "expectError": {
             "expectResult": {
-              "deletedCount": 0,
-              "insertedCount": 2,
-              "matchedCount": 0,
-              "modifiedCount": 0,
-              "upsertedCount": 0,
-              "upsertedIds": {}
+              "$$unsetOrMatches": {
+                "deletedCount": 0,
+                "insertedCount": 2,
+                "matchedCount": 0,
+                "modifiedCount": 0,
+                "upsertedCount": 0,
+                "upsertedIds": {}
+              }
             }
           }
         }

--- a/data/unified-test-format/valid-pass/poc-crud.yml
+++ b/data/unified-test-format/valid-pass/poc-crud.yml
@@ -101,16 +101,19 @@ tests:
           ordered: false
         expectError:
           expectResult:
-            deletedCount: 0
-            insertedCount: 2
-            # Since the map of insertedIds is generated before execution it
-            # could indicate inserts that did not actually succeed. We omit
-            # this field rather than expect drivers to provide an accurate
-            # map filtered by write errors.
-            matchedCount: 0
-            modifiedCount: 0
-            upsertedCount: 0
-            upsertedIds: { }
+            # insertMany throws BulkWriteException, which may optionally include
+            # an intermediary BulkWriteResult
+            $$unsetOrMatches:
+              deletedCount: 0
+              insertedCount: 2
+              # Since the map of insertedIds is generated before execution it
+              # could indicate inserts that did not actually succeed. We omit
+              # this field rather than expect drivers to provide an accurate
+              # map filtered by write errors.
+              matchedCount: 0
+              modifiedCount: 0
+              upsertedCount: 0
+              upsertedIds: { }
     outcome:
       - collectionName: *collection1Name
         databaseName: *database0Name

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -298,9 +298,6 @@
           },
           "expectResult": {
             "$$unsetOrMatches": {
-              "insertedCount": {
-                "$$unsetOrMatches": 2
-              },
               "insertedIds": {
                 "$$unsetOrMatches": {
                   "0": 3,

--- a/data/unified-test-format/valid-pass/poc-retryable-writes.yml
+++ b/data/unified-test-format/valid-pass/poc-retryable-writes.yml
@@ -141,9 +141,8 @@ tests:
             - { _id: 4, x: 44 }
           ordered: true
         expectResult:
-          $$unsetOrMatches:
-            insertedCount: { $$unsetOrMatches: 2 }
-            insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } }
+          # InsertManyResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } } }
     outcome:
       - collectionName: *collectionName
         databaseName: *databaseName

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -738,16 +738,12 @@ func executeInsertOne(ctx context.Context, operation *operation) (*operationResu
 	res, err := coll.InsertOne(ctx, document, opts)
 	raw := emptyCoreDocument
 	if res != nil {
-		idT, idData, err := bson.MarshalValue(res.InsertedID)
+		t, data, err := bson.MarshalValue(res.InsertedID)
 		if err != nil {
 			return nil, fmt.Errorf("error converting InsertedID field to BSON: %v", err)
 		}
-
-		// Some spec tests assert insertedCount for insertOne, so manually add insertedCount of 1.
-		countT, countData, _ := bson.MarshalValue(1)
 		raw = bsoncore.NewDocumentBuilder().
-			AppendValue("insertedId", bsoncore.Value{Type: idT, Data: idData}).
-			AppendValue("insertedCount", bsoncore.Value{Type: countT, Data: countData}).
+			AppendValue("insertedId", bsoncore.Value{Type: t, Data: data}).
 			Build()
 	}
 	return newDocumentResult(raw, err), nil


### PR DESCRIPTION
GODRIVER-1870

Assertions for `insertedCount` were recently removed from `insertOne-dots_and_dollars`, as "insertedCount" is not part of the specification for `insertOne`. Remove assertions from spec test and remove workaround for hardcoding `insertedCount` of 1 into `executeInsertOne` result.

Also remove assertions of `insertedCount` for `insertMany` since it's not a documented field in the CRUD spec and improve usages of `$$unsetOrMatches` (spec changes added in [DRIVERS-1828](https://jira.mongodb.org/browse/DRIVERS-1828)).