### PR TITLE
GODRIVER-1867 Add new Details field on WriteError for server v5.0

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -376,12 +376,8 @@ func (coll *Collection) InsertMany(ctx context.Context, documents []interface{},
 	bwErrors := make([]BulkWriteError, 0, len(writeException.WriteErrors))
 	for _, we := range writeException.WriteErrors {
 		bwErrors = append(bwErrors, BulkWriteError{
-			WriteError{
-				Index:   we.Index,
-				Code:    we.Code,
-				Message: we.Message,
-			},
-			nil,
+			WriteError: we,
+			Request:    nil,
 		})
 	}
 

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -275,6 +275,7 @@ type WriteError struct {
 
 	Code    int
 	Message string
+	Details bson.Raw
 }
 
 func (we WriteError) Error() string { return we.Message }
@@ -299,7 +300,12 @@ func (we WriteErrors) Error() string {
 func writeErrorsFromDriverWriteErrors(errs driver.WriteErrors) WriteErrors {
 	wes := make(WriteErrors, 0, len(errs))
 	for _, err := range errs {
-		wes = append(wes, WriteError{Index: int(err.Index), Code: int(err.Code), Message: err.Message})
+		wes = append(wes, WriteError{
+			Index:   int(err.Index),
+			Code:    int(err.Code),
+			Message: err.Message,
+			Details: bson.Raw(err.Details),
+		})
 	}
 	return wes
 }

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -1,0 +1,58 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestErrorContains(t *testing.T) {
+	details, err := bson.Marshal(bson.D{{"details", bson.D{{"operatorName", "$jsonSchema"}}}})
+	require.Nil(t, err, "unexpected error marshaling BSON")
+
+	cases := []struct {
+		desc     string
+		err      error
+		contains []string
+	}{
+		{
+			desc: "WriteException error message should contain the WriteError Message and Details",
+			err: WriteException{
+				WriteErrors: WriteErrors{
+					{
+						Message: "test message",
+						Details: details,
+					},
+				},
+			},
+			contains: []string{"test message", `{"details": {"operatorName": "$jsonSchema"}}`},
+		},
+		{
+			desc: "BulkWriteException error message should contain the WriteError Message and Details",
+			err: BulkWriteException{
+				WriteErrors: []BulkWriteError{
+					{
+						WriteError: WriteError{
+							Message: "test message",
+							Details: details,
+						},
+					},
+				},
+			},
+			contains: []string{"test message", `{"details": {"operatorName": "$jsonSchema"}}`},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			for _, str := range tc.contains {
+				assert.Contains(t, tc.err.Error(), str)
+			}
+		})
+	}
+}

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -221,7 +221,7 @@ func TestWriteErrorsDetails(t *testing.T) {
 				assert.True(
 					mt,
 					sErr.HasErrorCode(121),
-					"expected mongo.WriteException to have error code 121 (DocumentValidationFailure)")
+					"expected mongo.ServerError to have error code 121 (DocumentValidationFailure)")
 
 				var details bson.Raw
 				if tc.expectBulkError {
@@ -229,30 +229,34 @@ func TestWriteErrorsDetails(t *testing.T) {
 					assert.True(
 						mt,
 						ok,
-						"expected error to be type mongo.BulkWriteException, got type = %T",
+						"expected error to be type mongo.BulkWriteException, got type %T (error %q)",
+						err,
 						err)
 					// Assert that there is one WriteError and that the Details field is populated.
 					assert.Equal(
 						mt,
 						1,
 						len(bwe.WriteErrors),
-						"expected exactly 1 write error, but got %d",
-						len(bwe.WriteErrors))
+						"expected exactly 1 write error, but got %d write errors (error %q)",
+						len(bwe.WriteErrors),
+						err)
 					details = bwe.WriteErrors[0].Details
 				} else {
 					we, ok := err.(mongo.WriteException)
 					assert.True(
 						mt,
 						ok,
-						"expected error to be type mongo.WriteException, got type = %T",
+						"expected error to be type mongo.WriteException, got type %T (error %q)",
+						err,
 						err)
 					// Assert that there is one WriteError and that the Details field is populated.
 					assert.Equal(
 						mt,
 						1,
 						len(we.WriteErrors),
-						"expected exactly 1 write error, but got %d",
-						len(we.WriteErrors))
+						"expected exactly 1 write error, but got %d write errors (error %q)",
+						len(we.WriteErrors),
+						err)
 					details = we.WriteErrors[0].Details
 				}
 

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -111,6 +112,237 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 		assert.True(mt, we.HasErrorLabel(label), "expected error to have label: %v", label)
 	})
 
+}
+
+func TestWriteErrorsDetails(t *testing.T) {
+	clientOpts := options.Client().
+		SetRetryWrites(false).
+		SetWriteConcern(mtest.MajorityWc).
+		SetReadConcern(mtest.MajorityRc)
+	mtOpts := mtest.NewOptions().
+		ClientOptions(clientOpts).
+		MinServerVersion("5.0").
+		Topologies(mtest.ReplicaSet, mtest.Single).
+		CreateClient(false)
+
+	mt := mtest.New(t, mtOpts)
+	defer mt.Close()
+
+	mt.Run("JSON Schema validation", func(mt *mtest.T) {
+		// Create a JSON Schema validator document that requires properties "a" and "b". Use it in
+		// the collection creation options so that collections created for subtests have the JSON
+		// Schema validator applied.
+		validator := bson.D{{
+			Key: "validator",
+			Value: bson.M{
+				"$jsonSchema": bson.M{
+					"bsonType": "object",
+					"required": []string{"a", "b"},
+					"properties": bson.M{
+						"a": bson.M{"bsonType": "string"},
+						"b": bson.M{"bsonType": "int"},
+					},
+				},
+			},
+		}}
+		validatorOpts := mtest.NewOptions().CollectionCreateOptions(validator)
+
+		mt.RunOpts("InsertOne schema validation errors with details", validatorOpts, func(mt *mtest.T) {
+			// Try to insert a document that doesn't contain the required propertie.
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"nope", 1}})
+			assert.NotNil(mt, err, "expected an error, got nil")
+
+			we, ok := err.(mongo.WriteException)
+			assert.True(mt, ok, "expected mongo.WriteException, got %q (type = %T)", err, err)
+			assert.True(
+				mt,
+				we.HasErrorCode(121),
+				"expected mongo.WriteException to have error code 121 (DocumentValidationFailure)")
+
+			// Assert that there is one WriteError and that the Details field is populated.
+			assert.Equal(mt, 1, len(we.WriteErrors), "expected exactly 1 write error")
+			details := we.WriteErrors[0].Details
+			assert.True(
+				mt,
+				len(details) > 0,
+				"expected WriteError.Details to be populated, but is empty")
+
+			// Assert that the most recent CommandSucceededEvent was triggered by the InsertOne and
+			// contains the resulting write errors and that "writeErrors[0].errInfo" is the same as
+			// "WriteException.WriteErrors[0].Details".
+			evts := mt.GetAllSucceededEvents()
+			assert.True(
+				mt,
+				len(evts) >= 1,
+				"expected there to be at least 1 CommandSucceededEvent recorded")
+			evt := evts[len(evts)-1]
+			assert.Equal(
+				mt,
+				"insert",
+				evt.CommandName,
+				"expected the last CommandSucceededEvent to be for \"insert\", was %q",
+				evt.CommandName)
+			errInfo, ok := evt.Reply.Lookup("writeErrors", "0", "errInfo").DocumentOK()
+			assert.True(
+				mt,
+				ok,
+				"expected evt.Reply to contain writeErrors[0].errInfo but doesn't (evt.Reply = %v)",
+				evt.Reply)
+			assert.Equal(mt, details, errInfo, "want %v, got %v", details, errInfo)
+		})
+
+		mt.RunOpts("InsertMany schema validation errors with details", validatorOpts, func(mt *mtest.T) {
+			_, err := mt.Coll.InsertMany(
+				context.Background(),
+				[]interface{}{
+					bson.D{{"nope", 1}},
+					bson.D{{"nope", 2}},
+				})
+			assert.NotNil(mt, err, "expected an error, got nil")
+
+			bwe, ok := err.(mongo.BulkWriteException)
+			assert.True(mt, ok, "expected mongo.BulkWriteException, got %q (type = %T)", err, err)
+			assert.True(
+				mt,
+				bwe.HasErrorCode(121),
+				"expected mongo.BulkWriteException to have error code 121 (DocumentValidationFailure)")
+
+			// Assert that there is one WriteError and that the Details field is populated.
+			assert.Equal(mt, 1, len(bwe.WriteErrors), "expected exactly 1 write error")
+			details := bwe.WriteErrors[0].Details
+			assert.True(mt, len(details) > 0, "expected WriteError.Details to be populated, but is empty")
+
+			// Assert that the most recent CommandSucceededEvent was triggered by the InsertMany and
+			// contains the resulting write errors and that "writeErrors[0].errInfo" is the same as
+			// "WriteException.WriteErrors[0].Details".
+			evts := mt.GetAllSucceededEvents()
+			assert.True(
+				mt,
+				len(evts) >= 1,
+				"expected there to be at least 1 CommandSucceededEvent recorded")
+			evt := evts[len(evts)-1]
+			assert.Equal(
+				mt,
+				"insert",
+				evt.CommandName,
+				"expected the last CommandSucceededEvent to be for \"insert\", was %q",
+				evt.CommandName)
+			errInfo, ok := evt.Reply.Lookup("writeErrors", "0", "errInfo").DocumentOK()
+			assert.True(
+				mt,
+				ok,
+				"expected evt.Reply to contain writeErrors[0].errInfo but doesn't (evt.Reply = %v)",
+				evt.Reply)
+			assert.Equal(mt, details, errInfo, "want %v, got %v", details, errInfo)
+		})
+
+		mt.RunOpts("UpdateOne schema validation errors with details", validatorOpts, func(mt *mtest.T) {
+			// Insert two valid documents and then attempt to update them to be invalid.
+			_, err := mt.Coll.InsertMany(
+				context.Background(),
+				[]interface{}{
+					bson.D{{"a", "str1"}, {"b", 1}},
+					bson.D{{"a", "str2"}, {"b", 2}},
+				})
+			assert.Nil(mt, err, "unexpected error inserting valid documents: %s", err)
+
+			// Try to set "a" to be an int, which violates the string type requirement.
+			_, err = mt.Coll.UpdateOne(
+				context.Background(),
+				bson.D{},
+				bson.D{{"$set", bson.D{{"a", 1}}}})
+			assert.NotNil(mt, err, "expected an error, got nil")
+
+			we, ok := err.(mongo.WriteException)
+			assert.True(mt, ok, "expected mongo.WriteException, got %q (type = %T)", err, err)
+			assert.True(
+				mt,
+				we.HasErrorCode(121),
+				"expected mongo.WriteException to have error code 121 (DocumentValidationFailure)")
+
+			// Assert that there is one WriteError and that the Details field is populated.
+			assert.Equal(mt, 1, len(we.WriteErrors), "expected exactly 1 write error")
+			details := we.WriteErrors[0].Details
+			assert.True(mt, len(details) > 0, "expected WriteError.Details to be populated, but is empty")
+
+			// Assert that the most recent CommandSucceededEvent was triggered by the UpdateOne and
+			// contains the resulting write errors and that "writeErrors[0].errInfo" is the same as
+			// "WriteException.WriteErrors[0].Details".
+			evts := mt.GetAllSucceededEvents()
+			assert.True(
+				mt,
+				len(evts) >= 2,
+				"expected there to be at least 2 CommandSucceededEvent recorded")
+			evt := evts[len(evts)-1]
+			assert.Equal(
+				mt,
+				"update",
+				evt.CommandName,
+				"expected the last CommandSucceededEvent to be for \"update\", was %q",
+				evt.CommandName)
+			errInfo, ok := evt.Reply.Lookup("writeErrors", "0", "errInfo").DocumentOK()
+			assert.True(
+				mt,
+				ok,
+				"expected evt.Reply to contain writeErrors[0].errInfo but doesn't (evt.Reply = %v)",
+				evt.Reply)
+			assert.Equal(mt, details, errInfo, "want %v, got %v", details, errInfo)
+		})
+
+		mt.RunOpts("UpdateMany schema validation errors with details", validatorOpts, func(mt *mtest.T) {
+			// Insert two valid documents and then attempt to update them to be invalid.
+			_, err := mt.Coll.InsertMany(
+				context.Background(),
+				[]interface{}{
+					bson.D{{"a", "str1"}, {"b", 1}},
+					bson.D{{"a", "str2"}, {"b", 2}},
+				})
+			assert.Nil(mt, err, "unexpected error inserting valid documents: %s", err)
+
+			// Try to set "a" to be an int in all documents in the collection, which violates
+			// the string type requirement.
+			_, err = mt.Coll.UpdateMany(
+				context.Background(),
+				bson.D{},
+				bson.D{{"$set", bson.D{{"a", 1}}}})
+			assert.NotNil(mt, err, "expected an error, got nil")
+
+			we, ok := err.(mongo.WriteException)
+			assert.True(mt, ok, "expected mongo.WriteException, got %q (type = %T)", err, err)
+			assert.True(
+				mt,
+				we.HasErrorCode(121),
+				"expected mongo.WriteException to have error code 121 (DocumentValidationFailure)")
+
+			// Assert that there is one WriteError and that the Details field is populated.
+			assert.Equal(mt, 1, len(we.WriteErrors), "expected exactly 1 write error")
+			details := we.WriteErrors[0].Details
+			assert.True(mt, len(details) > 0, "expected WriteError.Details to be populated, but is empty")
+
+			// Assert that the most recent CommandSucceededEvent was triggered by the UpdateMany and
+			// contains the resulting write errors and that "writeErrors[0].errInfo" is the same as
+			// "WriteException.WriteErrors[0].Details".
+			evts := mt.GetAllSucceededEvents()
+			assert.True(
+				mt,
+				len(evts) >= 2,
+				"expected there to be at least 2 CommandSucceededEvent recorded")
+			evt := evts[len(evts)-1]
+			assert.Equal(
+				mt,
+				"update",
+				evt.CommandName,
+				"expected the last CommandSucceededEvent to be for \"update\", was %q",
+				evt.CommandName)
+			errInfo, ok := evt.Reply.Lookup("writeErrors", "0", "errInfo").DocumentOK()
+			assert.True(
+				mt,
+				ok,
+				"expected evt.Reply to contain writeErrors[0].errInfo but doesn't (evt.Reply = %v)",
+				evt.Reply)
+			assert.Equal(mt, details, errInfo, "want %v, got %v", details, errInfo)
+		})
+	})
 }
 
 func TestHintErrors(t *testing.T) {

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -160,7 +160,12 @@ func TestWriteErrorsDetails(t *testing.T) {
 				"expected mongo.WriteException to have error code 121 (DocumentValidationFailure)")
 
 			// Assert that there is one WriteError and that the Details field is populated.
-			assert.Equal(mt, 1, len(we.WriteErrors), "expected exactly 1 write error")
+			assert.Equal(
+				mt,
+				1,
+				len(we.WriteErrors),
+				"expected exactly 1 write error, but got %d",
+				len(we.WriteErrors))
 			details := we.WriteErrors[0].Details
 			assert.True(
 				mt,
@@ -192,12 +197,7 @@ func TestWriteErrorsDetails(t *testing.T) {
 		})
 
 		mt.RunOpts("InsertMany schema validation errors with details", validatorOpts, func(mt *mtest.T) {
-			_, err := mt.Coll.InsertMany(
-				context.Background(),
-				[]interface{}{
-					bson.D{{"nope", 1}},
-					bson.D{{"nope", 2}},
-				})
+			_, err := mt.Coll.InsertMany(context.Background(), []interface{}{bson.D{{"nope", 1}}})
 			assert.NotNil(mt, err, "expected an error, got nil")
 
 			bwe, ok := err.(mongo.BulkWriteException)
@@ -208,7 +208,12 @@ func TestWriteErrorsDetails(t *testing.T) {
 				"expected mongo.BulkWriteException to have error code 121 (DocumentValidationFailure)")
 
 			// Assert that there is one WriteError and that the Details field is populated.
-			assert.Equal(mt, 1, len(bwe.WriteErrors), "expected exactly 1 write error")
+			assert.Equal(
+				mt,
+				1,
+				len(bwe.WriteErrors),
+				"expected exactly 1 write error, but got %d",
+				len(bwe.WriteErrors))
 			details := bwe.WriteErrors[0].Details
 			assert.True(mt, len(details) > 0, "expected WriteError.Details to be populated, but is empty")
 

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -200,8 +200,8 @@ func TestErrors(t *testing.T) {
 				mongo.WriteException{
 					nil,
 					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "bar"},
-						mongo.WriteError{0, matchCode, "foo"},
+						mongo.WriteError{0, otherCode, "bar", nil},
+						mongo.WriteError{0, matchCode, "foo", nil},
 					},
 					[]string{"otherError"},
 				},
@@ -216,7 +216,7 @@ func TestErrors(t *testing.T) {
 				mongo.WriteException{
 					&mongo.WriteConcernError{"name", otherCode, "bar", nil},
 					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "baz"},
+						mongo.WriteError{0, otherCode, "baz", nil},
 					},
 					[]string{"otherError"},
 				},
@@ -231,7 +231,7 @@ func TestErrors(t *testing.T) {
 				mongo.WriteException{
 					&mongo.WriteConcernError{"name", matchCode, "bar", nil},
 					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "foo"},
+						mongo.WriteError{0, otherCode, "foo", nil},
 					},
 					[]string{"otherError"},
 				},
@@ -259,8 +259,8 @@ func TestErrors(t *testing.T) {
 				mongo.BulkWriteException{
 					nil,
 					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, matchCode, "foo"}, &mongo.InsertOneModel{}},
-						{mongo.WriteError{0, otherCode, "bar"}, &mongo.InsertOneModel{}},
+						{mongo.WriteError{0, matchCode, "foo", nil}, &mongo.InsertOneModel{}},
+						{mongo.WriteError{0, otherCode, "bar", nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -275,7 +275,7 @@ func TestErrors(t *testing.T) {
 				mongo.BulkWriteException{
 					&mongo.WriteConcernError{"name", otherCode, "bar", nil},
 					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, otherCode, "baz"}, &mongo.InsertOneModel{}},
+						{mongo.WriteError{0, otherCode, "baz", nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -290,7 +290,7 @@ func TestErrors(t *testing.T) {
 				mongo.BulkWriteException{
 					&mongo.WriteConcernError{"name", matchCode, "bar", nil},
 					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, otherCode, "foo"}, &mongo.InsertOneModel{}},
+						{mongo.WriteError{0, otherCode, "foo", nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -337,7 +337,7 @@ func TestErrors(t *testing.T) {
 					mongo.WriteException{
 						&mongo.WriteConcernError{"name", 11001, "bar", nil},
 						mongo.WriteErrors{
-							mongo.WriteError{0, 100, "baz"},
+							mongo.WriteError{0, 100, "baz", nil},
 						},
 						nil,
 					},
@@ -348,7 +348,7 @@ func TestErrors(t *testing.T) {
 					mongo.WriteException{
 						&mongo.WriteConcernError{"name", 100, "bar", nil},
 						mongo.WriteErrors{
-							mongo.WriteError{0, 12582, "baz"},
+							mongo.WriteError{0, 12582, "baz", nil},
 						},
 						nil,
 					},
@@ -359,7 +359,7 @@ func TestErrors(t *testing.T) {
 					mongo.WriteException{
 						&mongo.WriteConcernError{"name", 16460, "bar", nil},
 						mongo.WriteErrors{
-							mongo.WriteError{0, 100, "blah  E11000 blah"},
+							mongo.WriteError{0, 100, "blah E11000 blah", nil},
 						},
 						nil,
 					},
@@ -370,7 +370,7 @@ func TestErrors(t *testing.T) {
 					mongo.BulkWriteException{
 						&mongo.WriteConcernError{"name", 100, "bar", nil},
 						[]mongo.BulkWriteError{
-							{mongo.WriteError{0, 16460, "blah  E11000 blah"}, &mongo.InsertOneModel{}},
+							{mongo.WriteError{0, 16460, "blah E11000 blah", nil}, &mongo.InsertOneModel{}},
 						},
 						[]string{"otherError"},
 					},
@@ -381,7 +381,7 @@ func TestErrors(t *testing.T) {
 					mongo.BulkWriteException{
 						&mongo.WriteConcernError{"name", 100, "bar", nil},
 						[]mongo.BulkWriteError{
-							{mongo.WriteError{0, 110, "blah"}, &mongo.InsertOneModel{}},
+							{mongo.WriteError{0, 110, "blah", nil}, &mongo.InsertOneModel{}},
 						},
 						[]string{"otherError"},
 					},

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -262,6 +262,8 @@ func (t *T) ClearMockResponses() {
 
 // GetStartedEvent returns the most recent CommandStartedEvent, or nil if one is not present.
 // This can only be called once per event.
+// TODO(GODRIVER-2075): GetStartedEvent documents that it returns the most recent event, but
+// actually returns the first event. Update either the documentation or implementation.
 func (t *T) GetStartedEvent() *event.CommandStartedEvent {
 	if len(t.started) == 0 {
 		return nil
@@ -273,6 +275,8 @@ func (t *T) GetStartedEvent() *event.CommandStartedEvent {
 
 // GetSucceededEvent returns the most recent CommandSucceededEvent, or nil if one is not present.
 // This can only be called once per event.
+// TODO(GODRIVER-2075): GetSucceededEvent documents that it returns the most recent event, but
+// actually returns the first event. Update either the documentation or implementation.
 func (t *T) GetSucceededEvent() *event.CommandSucceededEvent {
 	if len(t.succeeded) == 0 {
 		return nil
@@ -284,6 +288,8 @@ func (t *T) GetSucceededEvent() *event.CommandSucceededEvent {
 
 // GetFailedEvent returns the most recent CommandFailedEvent, or nil if one is not present.
 // This can only be called once per event.
+// TODO(GODRIVER-2075): GetFailedEvent documents that it returns the most recent event, but actually
+// returns the first event. Update either the documentation or implementation.
 func (t *T) GetFailedEvent() *event.CommandFailedEvent {
 	if len(t.failed) == 0 {
 		return nil

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -187,6 +187,7 @@ type WriteError struct {
 	Index   int64
 	Code    int64
 	Message string
+	Details bsoncore.Document
 }
 
 func (we WriteError) Error() string { return we.Message }
@@ -410,6 +411,10 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 				}
 				if msg, exists := doc.Lookup("errmsg").StringValueOK(); exists {
 					we.Message = msg
+				}
+				if info, exists := doc.Lookup("errInfo").DocumentOK(); exists {
+					we.Details = make([]byte, len(info))
+					copy(we.Details, info)
 				}
 				wcError.WriteErrors = append(wcError.WriteErrors, we)
 			}


### PR DESCRIPTION
Add the new `Details` field to the `WriteError` type and set it from the `"errInfo"` property on the server error response. Test that it is populated when there is a JSON Schema validation error.

[GODRIVER-1867](https://jira.mongodb.org/browse/GODRIVER-1867)