### PR TITLE
GODRIVER-2061 Test redaction of replies of security sensitive commands

### DIFF
--- a/data/command-monitoring/unified/redacted-commands.json
+++ b/data/command-monitoring/unified/redacted-commands.json
@@ -12,7 +12,8 @@
       "client": {
         "id": "client",
         "observeEvents": [
-          "commandStartedEvent"
+          "commandStartedEvent",
+          "commandSucceededEvent"
         ],
         "observeSensitiveCommands": true
       }
@@ -35,7 +36,10 @@
           "arguments": {
             "commandName": "authenticate",
             "command": {
-              "authenticate": "private"
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
             }
           },
           "expectError": {
@@ -52,6 +56,15 @@
                 "commandName": "authenticate",
                 "command": {
                   "authenticate": {
+                    "$$exists": false
+                  },
+                  "mechanism": {
+                    "$$exists": false
+                  },
+                  "user": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -70,7 +83,9 @@
           "arguments": {
             "commandName": "saslStart",
             "command": {
-              "saslStart": "private"
+              "saslStart": 1,
+              "payload": "definitely-invalid-payload",
+              "db": "admin"
             }
           },
           "expectError": {
@@ -87,6 +102,12 @@
                 "commandName": "saslStart",
                 "command": {
                   "saslStart": {
+                    "$$exists": false
+                  },
+                  "payload": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -105,7 +126,9 @@
           "arguments": {
             "commandName": "saslContinue",
             "command": {
-              "saslContinue": "private"
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "definitely-invalid-payload"
             }
           },
           "expectError": {
@@ -122,6 +145,12 @@
                 "commandName": "saslContinue",
                 "command": {
                   "saslContinue": {
+                    "$$exists": false
+                  },
+                  "conversationId": {
+                    "$$exists": false
+                  },
+                  "payload": {
                     "$$exists": false
                   }
                 }
@@ -140,7 +169,7 @@
           "arguments": {
             "commandName": "getnonce",
             "command": {
-              "getnonce": "private"
+              "getnonce": 1
             }
           }
         }
@@ -154,6 +183,19 @@
                 "commandName": "getnonce",
                 "command": {
                   "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "getnonce",
+                "reply": {
+                  "ok": {
+                    "$$exists": false
+                  },
+                  "nonce": {
                     "$$exists": false
                   }
                 }
@@ -172,7 +214,9 @@
           "arguments": {
             "commandName": "createUser",
             "command": {
-              "createUser": "private"
+              "createUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -189,6 +233,12 @@
                 "commandName": "createUser",
                 "command": {
                   "createUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -207,7 +257,9 @@
           "arguments": {
             "commandName": "updateUser",
             "command": {
-              "updateUser": "private"
+              "updateUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -224,6 +276,12 @@
                 "commandName": "updateUser",
                 "command": {
                   "updateUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -340,6 +398,11 @@
     },
     {
       "description": "hello with speculative authenticate",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -347,40 +410,11 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "private",
-              "speculativeAuthenticate": "foo"
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
             }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
           }
         }
       ],
@@ -394,15 +428,85 @@
                 "command": {
                   "hello": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculative authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
                   "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
                     "$$exists": false
                   }
                 }
@@ -414,6 +518,22 @@
                 "command": {
                   "isMaster": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
@@ -424,6 +544,11 @@
     },
     {
       "description": "hello without speculative authenticate is not redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -431,27 +556,7 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "public"
+              "hello": 1
             }
           }
         }
@@ -464,15 +569,67 @@
               "commandStartedEvent": {
                 "commandName": "hello",
                 "command": {
-                  "hello": "public"
+                  "hello": 1
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculative authenticate is not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
-                  "ismaster": "public"
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             },
@@ -480,7 +637,17 @@
               "commandStartedEvent": {
                 "commandName": "isMaster",
                 "command": {
-                  "isMaster": "public"
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             }

--- a/data/command-monitoring/unified/redacted-commands.yml
+++ b/data/command-monitoring/unified/redacted-commands.yml
@@ -11,6 +11,7 @@ createEntities:
       id: &client client
       observeEvents:
         - commandStartedEvent
+        - commandSucceededEvent
       observeSensitiveCommands: true
   - database:
       id: &database database
@@ -25,10 +26,12 @@ tests:
         arguments:
           commandName: authenticate
           command:
-            authenticate: "private"
-        # Malformed authentication commands will fail against the server, but we
-        # just want to assert that security-related commands are redacted
-        # in command monitoring.
+            authenticate: 1
+            mechanism: "MONGODB-X509"
+            user: "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
+            db: "$external"
+        # An authentication error is expected, but we want to check that the
+        # CommandStartedEvent is redacted
         expectError:
           isError: true
     expectEvents:
@@ -36,11 +39,14 @@ tests:
         events:
           - commandStartedEvent:
               commandName: authenticate
-              # This only asserts that the command name has been redacted from the published command;
-              # however, it's unlikely that a driver would redact this but leave other, sensitive fields.
-              # We cannot simply assert that command is an empty document because it's at root-level, so
-              # additional fields in the actual document will be permitted.
-              command: { authenticate: { $$exists: false } }
+              # We cannot simply assert that command is an empty document
+              # because it's at root-level, so we make a best effort to make
+              # sure sensitive fields are redacted.
+              command:
+                authenticate: { $$exists: false }
+                mechanism: { $$exists: false }
+                user: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslStart"
     operations:
@@ -49,7 +55,9 @@ tests:
         arguments:
           commandName: saslStart
           command:
-            saslStart: "private"
+            saslStart: 1
+            payload: "definitely-invalid-payload"
+            db: "admin"
         expectError:
           isError: true
     expectEvents:
@@ -57,7 +65,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslStart
-              command: { saslStart: { $$exists: false } }
+              command:
+                saslStart: { $$exists: false }
+                payload: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslContinue"
     operations:
@@ -66,7 +77,9 @@ tests:
         arguments:
           commandName: saslContinue
           command:
-            saslContinue: "private"
+            saslContinue: 1
+            conversationId: 0
+            payload: "definitely-invalid-payload"
         expectError:
           isError: true
     expectEvents:
@@ -74,7 +87,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslContinue
-              command: { saslContinue: { $$exists: false } }
+              command:
+                saslContinue: { $$exists: false }
+                conversationId: { $$exists: false }
+                payload: { $$exists: false }
 
   - description: "getnonce"
     operations:
@@ -83,13 +99,18 @@ tests:
         arguments:
           commandName: getnonce
           command:
-            getnonce: "private"
+            getnonce: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: getnonce
               command: { getnonce: { $$exists: false } }
+          - commandSucceededEvent:
+              commandName: getnonce
+              reply:
+                ok: { $$exists: false }
+                nonce: { $$exists: false }
 
   - description: "createUser"
     operations:
@@ -99,6 +120,10 @@ tests:
           commandName: createUser
           command:
             createUser: "private"
+            # Passing an object is prohibited and we want to trigger a command
+            # failure
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -106,7 +131,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: createUser
-              command: { createUser: { $$exists: false } }
+              command:
+                createUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "updateUser"
     operations:
@@ -116,6 +144,8 @@ tests:
           commandName: updateUser
           command:
             updateUser: "private"
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -123,7 +153,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: updateUser
-              command: { updateUser: { $$exists: false } }
+              command:
+                updateUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "copydbgetnonce"
     operations:
@@ -177,76 +210,131 @@ tests:
               command: { copydb: { $$exists: false } }
 
   - description: "hello with speculative authenticate"
+    runOnRequirements:
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
+            hello: 1
+            speculativeAuthenticate:
+              saslStart: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: { $$exists: false } }
+              command:
+                hello: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                # Even though authentication above fails and the reply does not
+                # contain sensitive information, we're expecting the reply to be
+                # redacted as well.
+                isWritablePrimary: { $$exists: false }
+                # This assertion will currently always hold true since we're
+                # not expecting successful authentication, in which case this
+                # field is missing anyways.
+                speculativeAuthenticate: { $$exists: false }
+
+  - description: "legacy hello with speculative authenticate"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: { $$exists: false } }
+              command:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: { $$exists: false } }
+              command:
+                isMaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
 
   - description: "hello without speculative authenticate is not redacted"
+    runOnRequirements:
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "public"
+            hello: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: "public" }
+              command:
+                hello: 1
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                isWritablePrimary: { $$exists: true }
+
+  - description: "legacy hello without speculative authenticate is not redacted"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: "public" }
+              command:
+                ismaster: 1
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: true }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: "public" }
+              command:
+                isMaster: 1
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: true }


### PR DESCRIPTION
GODRIVER-2061

Syncs the redacted commands spec tests. These tests have been updated to make a best effort at asserting that replies to security sensitive commands are redacted. The Go driver already has the correct behavior (reply redaction happens [here](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/operation.go#L1485-L1489)), so no code changes are necessary. 

Adds workaround for empty `Reply` fields in `verifyCommandEvents`; it is almost identical to the existing workaround for empty `Command` fields [here](https://github.com/mongodb/mongo-go-driver/blob/master/mongo/integration/unified/event_verification.go#L171-L178).