### PR TITLE
Replace Crypt struct with an interface

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -94,7 +94,7 @@ type changeStreamConfig struct {
 	streamType     StreamType
 	collectionName string
 	databaseName   string
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 }
 
 func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline interface{},

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -71,7 +71,7 @@ type Client struct {
 	keyVaultClientFLE *Client
 	keyVaultCollFLE   *Collection
 	mongocryptdFLE    *mcryptClient
-	cryptFLE          *driver.Crypt
+	cryptFLE          driver.Crypt
 	metadataClientFLE *Client
 	internalClientFLE *Client
 }
@@ -619,6 +619,8 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		if err := c.configureAutoEncryption(opts); err != nil {
 			return err
 		}
+	} else {
+		c.cryptFLE = opts.Crypt
 	}
 
 	// OCSP cache

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -22,7 +22,7 @@ import (
 
 // ClientEncryption is used to create data keys and explicitly encrypt and decrypt BSON values.
 type ClientEncryption struct {
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 	keyVaultClient *Client
 	keyVaultColl   *Collection
 }

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -99,6 +99,7 @@ type ClientOptions struct {
 	AutoEncryptionOptions    *AutoEncryptionOptions
 	ConnectTimeout           *time.Duration
 	Compressors              []string
+	Crypt                    driver.Crypt
 	Dialer                   ContextDialer
 	Direct                   *bool
 	DisableOCSPEndpointCheck *bool
@@ -460,6 +461,13 @@ func (c *ClientOptions) SetConnectTimeout(d time.Duration) *ClientOptions {
 	return c
 }
 
+// SetCrypt specifies a custom Crypt to be used to encrypt and decrypt documents. The default is no encryption.
+// Using SetAutoEncryptionOptions will override anything set here.
+func (c *ClientOptions) SetCrypt(cr driver.Crypt) *ClientOptions {
+	c.Crypt = cr
+	return c
+}
+
 // SetDialer specifies a custom ContextDialer to be used to create new connections to the server. The default is a
 // net.Dialer with the Timeout field set to ConnectTimeout. See https://golang.org/pkg/net/#Dialer for more information
 // about the net.Dialer type.
@@ -788,6 +796,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.ConnectTimeout != nil {
 			c.ConnectTimeout = opt.ConnectTimeout
+		}
+		if opt.Crypt != nil {
+			c.Crypt = opt.Crypt
 		}
 		if opt.HeartbeatInterval != nil {
 			c.HeartbeatInterval = opt.HeartbeatInterval

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -31,7 +31,7 @@ type BatchCursor struct {
 	firstBatch           bool
 	cmdMonitor           *event.CommandMonitor
 	postBatchResumeToken bsoncore.Document
-	crypt                *Crypt
+	crypt                Crypt
 	serverAPI            *ServerAPIOptions
 
 	// legacy server (< 3.2) fields
@@ -129,7 +129,7 @@ type CursorOptions struct {
 	MaxTimeMS      int64
 	Limit          int32
 	CommandMonitor *event.CommandMonitor
-	Crypt          *Crypt
+	Crypt          Crypt
 	ServerAPI      *ServerAPIOptions
 }
 

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -43,24 +43,41 @@ type CryptOptions struct {
 	BypassAutoEncryption bool
 }
 
-// Crypt consumes the libmongocrypt.MongoCrypt type to iterate the mongocrypt state machine and perform encryption
+type Crypt interface {
+	// Encrypt encrypts the given command.
+	Encrypt(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error)
+	// Decrypt decrypts the given command response.
+	Decrypt(ctx context.Context, cmdResponse bsoncore.Document) (bsoncore.Document, error)
+	// CreateDataKey creates a data key using the given KMS provider and options.
+	CreateDataKey(ctx context.Context, kmsProvider string, opts *options.DataKeyOptions) (bsoncore.Document, error)
+	// EncryptExplicit encrypts the given value with the given options.
+	EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *options.ExplicitEncryptionOptions) (byte, []byte, error)
+	// DecryptExplicit decrypts the given encrypted value.
+	DecryptExplicit(ctx context.Context, subtype byte, data []byte) (bsoncore.Value, error)
+	// Close cleans up any resources associated with the Crypt instance.
+	Close()
+	// BypassAutoEncryption returns true if auto-encryption should be bypassed.
+	BypassAutoEncryption() bool
+}
+
+// crypt consumes the libmongocrypt.MongoCrypt type to iterate the mongocrypt state machine and perform encryption
 // and decryption.
-type Crypt struct {
+type crypt struct {
 	mongoCrypt *mongocrypt.MongoCrypt
 	collInfoFn CollectionInfoFn
 	keyFn      KeyRetrieverFn
 	markFn     MarkCommandFn
 
-	BypassAutoEncryption bool
+	bypassAutoEncryption bool
 }
 
 // NewCrypt creates a new Crypt instance configured with the given AutoEncryptionOptions.
-func NewCrypt(opts *CryptOptions) (*Crypt, error) {
-	c := &Crypt{
+func NewCrypt(opts *CryptOptions) (Crypt, error) {
+	c := &crypt{
 		collInfoFn:           opts.CollInfoFn,
 		keyFn:                opts.KeyFn,
 		markFn:               opts.MarkFn,
-		BypassAutoEncryption: opts.BypassAutoEncryption,
+		bypassAutoEncryption: opts.BypassAutoEncryption,
 	}
 
 	mongocryptOpts := options.MongoCrypt().SetKmsProviders(opts.KmsProviders).SetLocalSchemaMap(opts.SchemaMap)
@@ -74,8 +91,8 @@ func NewCrypt(opts *CryptOptions) (*Crypt, error) {
 }
 
 // Encrypt encrypts the given command.
-func (c *Crypt) Encrypt(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
-	if c.BypassAutoEncryption {
+func (c *crypt) Encrypt(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
+	if c.bypassAutoEncryption {
 		return cmd, nil
 	}
 
@@ -89,7 +106,7 @@ func (c *Crypt) Encrypt(ctx context.Context, db string, cmd bsoncore.Document) (
 }
 
 // Decrypt decrypts the given command response.
-func (c *Crypt) Decrypt(ctx context.Context, cmdResponse bsoncore.Document) (bsoncore.Document, error) {
+func (c *crypt) Decrypt(ctx context.Context, cmdResponse bsoncore.Document) (bsoncore.Document, error) {
 	cryptCtx, err := c.mongoCrypt.CreateDecryptionContext(cmdResponse)
 	if err != nil {
 		return nil, err
@@ -100,7 +117,7 @@ func (c *Crypt) Decrypt(ctx context.Context, cmdResponse bsoncore.Document) (bso
 }
 
 // CreateDataKey creates a data key using the given KMS provider and options.
-func (c *Crypt) CreateDataKey(ctx context.Context, kmsProvider string, opts *options.DataKeyOptions) (bsoncore.Document, error) {
+func (c *crypt) CreateDataKey(ctx context.Context, kmsProvider string, opts *options.DataKeyOptions) (bsoncore.Document, error) {
 	cryptCtx, err := c.mongoCrypt.CreateDataKeyContext(kmsProvider, opts)
 	if err != nil {
 		return nil, err
@@ -111,7 +128,7 @@ func (c *Crypt) CreateDataKey(ctx context.Context, kmsProvider string, opts *opt
 }
 
 // EncryptExplicit encrypts the given value with the given options.
-func (c *Crypt) EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *options.ExplicitEncryptionOptions) (byte, []byte, error) {
+func (c *crypt) EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *options.ExplicitEncryptionOptions) (byte, []byte, error) {
 	idx, doc := bsoncore.AppendDocumentStart(nil)
 	doc = bsoncore.AppendValueElement(doc, "v", val)
 	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
@@ -132,7 +149,7 @@ func (c *Crypt) EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *o
 }
 
 // DecryptExplicit decrypts the given encrypted value.
-func (c *Crypt) DecryptExplicit(ctx context.Context, subtype byte, data []byte) (bsoncore.Value, error) {
+func (c *crypt) DecryptExplicit(ctx context.Context, subtype byte, data []byte) (bsoncore.Value, error) {
 	idx, doc := bsoncore.AppendDocumentStart(nil)
 	doc = bsoncore.AppendBinaryElement(doc, "v", subtype, data)
 	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
@@ -152,11 +169,15 @@ func (c *Crypt) DecryptExplicit(ctx context.Context, subtype byte, data []byte) 
 }
 
 // Close cleans up any resources associated with the Crypt instance.
-func (c *Crypt) Close() {
+func (c *crypt) Close() {
 	c.mongoCrypt.Close()
 }
 
-func (c *Crypt) executeStateMachine(ctx context.Context, cryptCtx *mongocrypt.Context, db string) (bsoncore.Document, error) {
+func (c *crypt) BypassAutoEncryption() bool {
+	return c.bypassAutoEncryption
+}
+
+func (c *crypt) executeStateMachine(ctx context.Context, cryptCtx *mongocrypt.Context, db string) (bsoncore.Document, error) {
 	var err error
 	for {
 		state := cryptCtx.State()
@@ -180,7 +201,7 @@ func (c *Crypt) executeStateMachine(ctx context.Context, cryptCtx *mongocrypt.Co
 	}
 }
 
-func (c *Crypt) collectionInfo(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
+func (c *crypt) collectionInfo(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
 	op, err := cryptCtx.NextOperation()
 	if err != nil {
 		return err
@@ -199,7 +220,7 @@ func (c *Crypt) collectionInfo(ctx context.Context, cryptCtx *mongocrypt.Context
 	return cryptCtx.CompleteOperation()
 }
 
-func (c *Crypt) markCommand(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
+func (c *crypt) markCommand(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
 	op, err := cryptCtx.NextOperation()
 	if err != nil {
 		return err
@@ -216,7 +237,7 @@ func (c *Crypt) markCommand(ctx context.Context, cryptCtx *mongocrypt.Context, d
 	return cryptCtx.CompleteOperation()
 }
 
-func (c *Crypt) retrieveKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
+func (c *crypt) retrieveKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
 	op, err := cryptCtx.NextOperation()
 	if err != nil {
 		return err
@@ -236,7 +257,7 @@ func (c *Crypt) retrieveKeys(ctx context.Context, cryptCtx *mongocrypt.Context) 
 	return cryptCtx.CompleteOperation()
 }
 
-func (c *Crypt) decryptKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
+func (c *crypt) decryptKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
 	for {
 		kmsCtx := cryptCtx.NextKmsContext()
 		if kmsCtx == nil {
@@ -251,7 +272,7 @@ func (c *Crypt) decryptKeys(ctx context.Context, cryptCtx *mongocrypt.Context) e
 	return cryptCtx.FinishKmsContexts()
 }
 
-func (c *Crypt) decryptKey(ctx context.Context, kmsCtx *mongocrypt.KmsContext) error {
+func (c *crypt) decryptKey(ctx context.Context, kmsCtx *mongocrypt.KmsContext) error {
 	host, err := kmsCtx.HostName()
 	if err != nil {
 		return err

--- a/x/mongo/driver/drivergen/drivergen.go
+++ b/x/mongo/driver/drivergen/drivergen.go
@@ -509,7 +509,7 @@ func (b Builtin) Type() string {
 	case Deployment:
 		t = "driver.Deployment"
 	case Crypt:
-		t = "*driver.Crypt"
+		t = "driver.Crypt"
 	}
 	return t
 }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -192,7 +192,7 @@ type Operation struct {
 	CommandMonitor *event.CommandMonitor
 
 	// Crypt specifies a Crypt object to use for automatic client side encryption and decryption.
-	Crypt *Crypt
+	Crypt Crypt
 
 	// ServerAPI specifies options used to configure the API version sent to the server.
 	ServerAPI *ServerAPIOptions
@@ -200,7 +200,7 @@ type Operation struct {
 
 // shouldEncrypt returns true if this operation should automatically be encrypted.
 func (op Operation) shouldEncrypt() bool {
-	return op.Crypt != nil && !op.Crypt.BypassAutoEncryption
+	return op.Crypt != nil && !op.Crypt.BypassAutoEncryption()
 }
 
 // selectServer handles performing server selection for an operation.

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -27,7 +27,7 @@ type AbortTransaction struct {
 	clock         *session.ClusterClock
 	collection    string
 	monitor       *event.CommandMonitor
-	crypt         *driver.Crypt
+	crypt         driver.Crypt
 	database      string
 	deployment    driver.Deployment
 	selector      description.ServerSelector
@@ -130,7 +130,7 @@ func (at *AbortTransaction) CommandMonitor(monitor *event.CommandMonitor) *Abort
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (at *AbortTransaction) Crypt(crypt *driver.Crypt) *AbortTransaction {
+func (at *AbortTransaction) Crypt(crypt driver.Crypt) *AbortTransaction {
 	if at == nil {
 		at = new(AbortTransaction)
 	}

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -44,7 +44,7 @@ type Aggregate struct {
 	retry                    *driver.RetryMode
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
-	crypt                    *driver.Crypt
+	crypt                    driver.Crypt
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 
@@ -352,7 +352,7 @@ func (a *Aggregate) Retry(retry driver.RetryMode) *Aggregate {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (a *Aggregate) Crypt(crypt *driver.Crypt) *Aggregate {
+func (a *Aggregate) Crypt(crypt driver.Crypt) *Aggregate {
 	if a == nil {
 		a = new(Aggregate)
 	}

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -30,7 +30,7 @@ type Command struct {
 	resultCursor   *driver.BatchCursor
 	srvr           driver.Server
 	desc           description.Server
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 	serverAPI      *driver.ServerAPIOptions
 	createCursor   bool
 	cursorOpts     driver.CursorOptions
@@ -185,7 +185,7 @@ func (c *Command) ServerSelector(selector description.ServerSelector) *Command {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (c *Command) Crypt(crypt *driver.Crypt) *Command {
+func (c *Command) Crypt(crypt driver.Crypt) *Command {
 	if c == nil {
 		c = new(Command)
 	}

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -27,7 +27,7 @@ type CommitTransaction struct {
 	session       *session.Client
 	clock         *session.ClusterClock
 	monitor       *event.CommandMonitor
-	crypt         *driver.Crypt
+	crypt         driver.Crypt
 	database      string
 	deployment    driver.Deployment
 	selector      description.ServerSelector
@@ -133,7 +133,7 @@ func (ct *CommitTransaction) CommandMonitor(monitor *event.CommandMonitor) *Comm
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (ct *CommitTransaction) Crypt(crypt *driver.Crypt) *CommitTransaction {
+func (ct *CommitTransaction) Crypt(crypt driver.Crypt) *CommitTransaction {
 	if ct == nil {
 		ct = new(CommitTransaction)
 	}

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -30,7 +30,7 @@ type Count struct {
 	clock          *session.ClusterClock
 	collection     string
 	monitor        *event.CommandMonitor
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readConcern    *readconcern.ReadConcern
@@ -238,7 +238,7 @@ func (c *Count) CommandMonitor(monitor *event.CommandMonitor) *Count {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (c *Count) Crypt(crypt *driver.Crypt) *Count {
+func (c *Count) Crypt(crypt driver.Crypt) *Count {
 	if c == nil {
 		c = new(Count)
 	}

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -37,7 +37,7 @@ type Create struct {
 	session             *session.Client
 	clock               *session.ClusterClock
 	monitor             *event.CommandMonitor
-	crypt               *driver.Crypt
+	crypt               driver.Crypt
 	database            string
 	deployment          driver.Deployment
 	selector            description.ServerSelector
@@ -281,7 +281,7 @@ func (c *Create) CommandMonitor(monitor *event.CommandMonitor) *Create {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (c *Create) Crypt(crypt *driver.Crypt) *Create {
+func (c *Create) Crypt(crypt driver.Crypt) *Create {
 	if c == nil {
 		c = new(Create)
 	}

--- a/x/mongo/driver/operation/createIndexes.go
+++ b/x/mongo/driver/operation/createIndexes.go
@@ -31,7 +31,7 @@ type CreateIndexes struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
-	crypt        *driver.Crypt
+	crypt        driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -208,7 +208,7 @@ func (ci *CreateIndexes) CommandMonitor(monitor *event.CommandMonitor) *CreateIn
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (ci *CreateIndexes) Crypt(crypt *driver.Crypt) *CreateIndexes {
+func (ci *CreateIndexes) Crypt(crypt driver.Crypt) *CreateIndexes {
 	if ci == nil {
 		ci = new(CreateIndexes)
 	}

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -29,7 +29,7 @@ type Delete struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
-	crypt        *driver.Crypt
+	crypt        driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -190,7 +190,7 @@ func (d *Delete) CommandMonitor(monitor *event.CommandMonitor) *Delete {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (d *Delete) Crypt(crypt *driver.Crypt) *Delete {
+func (d *Delete) Crypt(crypt driver.Crypt) *Delete {
 	if d == nil {
 		d = new(Delete)
 	}

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -31,7 +31,7 @@ type Distinct struct {
 	clock          *session.ClusterClock
 	collection     string
 	monitor        *event.CommandMonitor
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readConcern    *readconcern.ReadConcern
@@ -205,7 +205,7 @@ func (d *Distinct) CommandMonitor(monitor *event.CommandMonitor) *Distinct {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (d *Distinct) Crypt(crypt *driver.Crypt) *Distinct {
+func (d *Distinct) Crypt(crypt driver.Crypt) *Distinct {
 	if d == nil {
 		d = new(Distinct)
 	}

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -27,7 +27,7 @@ type DropCollection struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
-	crypt        *driver.Crypt
+	crypt        driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -150,7 +150,7 @@ func (dc *DropCollection) CommandMonitor(monitor *event.CommandMonitor) *DropCol
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (dc *DropCollection) Crypt(crypt *driver.Crypt) *DropCollection {
+func (dc *DropCollection) Crypt(crypt driver.Crypt) *DropCollection {
 	if dc == nil {
 		dc = new(DropCollection)
 	}

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -25,7 +25,7 @@ type DropDatabase struct {
 	session      *session.Client
 	clock        *session.ClusterClock
 	monitor      *event.CommandMonitor
-	crypt        *driver.Crypt
+	crypt        driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -96,7 +96,7 @@ func (dd *DropDatabase) CommandMonitor(monitor *event.CommandMonitor) *DropDatab
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (dd *DropDatabase) Crypt(crypt *driver.Crypt) *DropDatabase {
+func (dd *DropDatabase) Crypt(crypt driver.Crypt) *DropDatabase {
 	if dd == nil {
 		dd = new(DropDatabase)
 	}

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -29,7 +29,7 @@ type DropIndexes struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
-	crypt        *driver.Crypt
+	crypt        driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -173,7 +173,7 @@ func (di *DropIndexes) CommandMonitor(monitor *event.CommandMonitor) *DropIndexe
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (di *DropIndexes) Crypt(crypt *driver.Crypt) *DropIndexes {
+func (di *DropIndexes) Crypt(crypt driver.Crypt) *DropIndexes {
 	if di == nil {
 		di = new(DropIndexes)
 	}

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -25,7 +25,7 @@ type EndSessions struct {
 	session    *session.Client
 	clock      *session.ClusterClock
 	monitor    *event.CommandMonitor
-	crypt      *driver.Crypt
+	crypt      driver.Crypt
 	database   string
 	deployment driver.Deployment
 	selector   description.ServerSelector
@@ -113,7 +113,7 @@ func (es *EndSessions) CommandMonitor(monitor *event.CommandMonitor) *EndSession
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (es *EndSessions) Crypt(crypt *driver.Crypt) *EndSessions {
+func (es *EndSessions) Crypt(crypt driver.Crypt) *EndSessions {
 	if es == nil {
 		es = new(EndSessions)
 	}

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -50,7 +50,7 @@ type Find struct {
 	clock               *session.ClusterClock
 	collection          string
 	monitor             *event.CommandMonitor
-	crypt               *driver.Crypt
+	crypt               driver.Crypt
 	database            string
 	deployment          driver.Deployment
 	readConcern         *readconcern.ReadConcern
@@ -444,7 +444,7 @@ func (f *Find) CommandMonitor(monitor *event.CommandMonitor) *Find {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (f *Find) Crypt(crypt *driver.Crypt) *Find {
+func (f *Find) Crypt(crypt driver.Crypt) *Find {
 	if f == nil {
 		f = new(Find)
 	}

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -45,7 +45,7 @@ type FindAndModify struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
-	crypt                    *driver.Crypt
+	crypt                    driver.Crypt
 	hint                     bsoncore.Value
 	serverAPI                *driver.ServerAPIOptions
 
@@ -410,7 +410,7 @@ func (fam *FindAndModify) Retry(retry driver.RetryMode) *FindAndModify {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (fam *FindAndModify) Crypt(crypt *driver.Crypt) *FindAndModify {
+func (fam *FindAndModify) Crypt(crypt driver.Crypt) *FindAndModify {
 	if fam == nil {
 		fam = new(FindAndModify)
 	}

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -30,7 +30,7 @@ type Insert struct {
 	clock                    *session.ClusterClock
 	collection               string
 	monitor                  *event.CommandMonitor
-	crypt                    *driver.Crypt
+	crypt                    driver.Crypt
 	database                 string
 	deployment               driver.Deployment
 	selector                 description.ServerSelector
@@ -195,7 +195,7 @@ func (i *Insert) CommandMonitor(monitor *event.CommandMonitor) *Insert {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (i *Insert) Crypt(crypt *driver.Crypt) *Insert {
+func (i *Insert) Crypt(crypt driver.Crypt) *Insert {
 	if i == nil {
 		i = new(Insert)
 	}

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -35,7 +35,7 @@ type ListDatabases struct {
 	readPreference      *readpref.ReadPref
 	retry               *driver.RetryMode
 	selector            description.ServerSelector
-	crypt               *driver.Crypt
+	crypt               driver.Crypt
 	serverAPI           *driver.ServerAPIOptions
 
 	result ListDatabasesResult
@@ -307,7 +307,7 @@ func (ld *ListDatabases) Retry(retry driver.RetryMode) *ListDatabases {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (ld *ListDatabases) Crypt(crypt *driver.Crypt) *ListDatabases {
+func (ld *ListDatabases) Crypt(crypt driver.Crypt) *ListDatabases {
 	if ld == nil {
 		ld = new(ListDatabases)
 	}

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -27,7 +27,7 @@ type ListCollections struct {
 	session        *session.Client
 	clock          *session.ClusterClock
 	monitor        *event.CommandMonitor
-	crypt          *driver.Crypt
+	crypt          driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readPreference *readpref.ReadPref
@@ -159,7 +159,7 @@ func (lc *ListCollections) CommandMonitor(monitor *event.CommandMonitor) *ListCo
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (lc *ListCollections) Crypt(crypt *driver.Crypt) *ListCollections {
+func (lc *ListCollections) Crypt(crypt driver.Crypt) *ListCollections {
 	if lc == nil {
 		lc = new(ListCollections)
 	}

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -31,7 +31,7 @@ type ListIndexes struct {
 	deployment driver.Deployment
 	selector   description.ServerSelector
 	retry      *driver.RetryMode
-	crypt      *driver.Crypt
+	crypt      driver.Crypt
 	serverAPI  *driver.ServerAPIOptions
 
 	result driver.CursorResponse
@@ -205,7 +205,7 @@ func (li *ListIndexes) Retry(retry driver.RetryMode) *ListIndexes {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (li *ListIndexes) Crypt(crypt *driver.Crypt) *ListIndexes {
+func (li *ListIndexes) Crypt(crypt driver.Crypt) *ListIndexes {
 	if li == nil {
 		li = new(ListIndexes)
 	}

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -39,7 +39,7 @@ type Update struct {
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
 	result                   UpdateResult
-	crypt                    *driver.Crypt
+	crypt                    driver.Crypt
 	serverAPI                *driver.ServerAPIOptions
 }
 
@@ -346,7 +346,7 @@ func (u *Update) Retry(retry driver.RetryMode) *Update {
 }
 
 // Crypt sets the Crypt object to use for automatic encryption and decryption.
-func (u *Update) Crypt(crypt *driver.Crypt) *Update {
+func (u *Update) Crypt(crypt driver.Crypt) *Update {
 	if u == nil {
 		u = new(Update)
 	}


### PR DESCRIPTION
Uses an interface to represent the driver.Crypt for field-level encryption, so that users can provide their own implementation of FLE.

Auto encryption remains unaffected.