### PR TITLE
GODRIVER-2076 Update documentation for time-series collections

### DIFF
--- a/mongo/options/createcollectionoptions.go
+++ b/mongo/options/createcollectionoptions.go
@@ -110,10 +110,20 @@ type CreateCollectionOptions struct {
 	// collection.
 	Validator interface{}
 
-	// Value indicating after how many seconds old time-series data should be deleted.
+	// Value indicating after how many seconds old time-series data should be deleted. See
+	// https://docs.mongodb.com/manual/reference/command/create/ for supported options, and
+	// https://docs.mongodb.com/manual/core/timeseries-collections/ for more information on time-series
+	// collections.
+	//
+	// This option is only valid for MongoDB versions >= 5.0
 	ExpireAfterSeconds *int64
 
-	// Options for specifying a time-series collection.
+	// Options for specifying a time-series collection. See
+	// https://docs.mongodb.com/manual/reference/command/create/ for supported options, and
+	// https://docs.mongodb.com/manual/core/timeseries-collections/ for more information on time-series
+	// collections.
+	//
+	// This option is only valid for MongoDB versions >= 5.0
 	TimeSeriesOptions *TimeSeriesOptions
 }
 


### PR DESCRIPTION
GODRIVER-2076

Updates documentation for `CreateCollectionOptions#ExpireAfterSeconds` and `CreateCollectionOptions#TimeSeriesOptions`. Includes link to [new server documentation](https://docs.mongodb.com/manual/core/timeseries-collections/), and specifies that options can only be used on 5.0+.