### PR TITLE
GODRIVER-227 Sync Sharded server selection spec tests

### DIFF
--- a/data/server-selection/server_selection/Sharded/read/Nearest.json
+++ b/data/server-selection/server_selection/Sharded/read/Nearest.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Nearest",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/read/Nearest.yml
+++ b/data/server-selection/server_selection/Sharded/read/Nearest.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: Nearest
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/read/Primary.json
+++ b/data/server-selection/server_selection/Sharded/read/Primary.json
@@ -16,12 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
-    "tag_sets": [
-      {
-        "data_center": "nyc"
-      }
-    ]
+    "mode": "Primary"
   },
   "suitable_servers": [
     {

--- a/data/server-selection/server_selection/Sharded/read/Primary.yml
+++ b/data/server-selection/server_selection/Sharded/read/Primary.yml
@@ -11,9 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
-  tag_sets:
-  - data_center: nyc
+  mode: Primary
 suitable_servers:
 - *1
 - *2

--- a/data/server-selection/server_selection/Sharded/read/PrimaryPreferred.json
+++ b/data/server-selection/server_selection/Sharded/read/PrimaryPreferred.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "PrimaryPreferred",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/read/PrimaryPreferred.yml
+++ b/data/server-selection/server_selection/Sharded/read/PrimaryPreferred.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: PrimaryPreferred
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/read/Secondary.json
+++ b/data/server-selection/server_selection/Sharded/read/Secondary.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Secondary",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/read/Secondary.yml
+++ b/data/server-selection/server_selection/Sharded/read/Secondary.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: Secondary
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/write/Nearest.json
+++ b/data/server-selection/server_selection/Sharded/write/Nearest.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Nearest",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/write/Nearest.yml
+++ b/data/server-selection/server_selection/Sharded/write/Nearest.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: Nearest
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/write/Primary.json
+++ b/data/server-selection/server_selection/Sharded/write/Primary.json
@@ -14,14 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
-    "tag_sets": [
-      {
-        "data_center": "nyc"
-      }
-    ]
+    "mode": "Primary"
   },
   "suitable_servers": [
     {

--- a/data/server-selection/server_selection/Sharded/write/Primary.yml
+++ b/data/server-selection/server_selection/Sharded/write/Primary.yml
@@ -9,11 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
-  tag_sets:
-  - data_center: nyc
+  mode: Primary
 suitable_servers:
 - *1
 - *2

--- a/data/server-selection/server_selection/Sharded/write/PrimaryPreferred.json
+++ b/data/server-selection/server_selection/Sharded/write/PrimaryPreferred.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "PrimaryPreferred",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/write/PrimaryPreferred.yml
+++ b/data/server-selection/server_selection/Sharded/write/PrimaryPreferred.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: PrimaryPreferred
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/write/Secondary.json
+++ b/data/server-selection/server_selection/Sharded/write/Secondary.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Secondary",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/data/server-selection/server_selection/Sharded/write/Secondary.yml
+++ b/data/server-selection/server_selection/Sharded/write/Secondary.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: Secondary
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/data/server-selection/server_selection/Sharded/write/SecondaryPreferred.json
+++ b/data/server-selection/server_selection/Sharded/write/SecondaryPreferred.json
@@ -5,18 +5,12 @@
       {
         "address": "g:27017",
         "avg_rtt_ms": 5,
-        "type": "Mongos",
-        "tags": {
-          "data_center": "nyc"
-        }
+        "type": "Mongos"
       },
       {
         "address": "h:27017",
         "avg_rtt_ms": 35,
-        "type": "Mongos",
-        "tags": {
-          "data_center": "dc"
-        }
+        "type": "Mongos"
       }
     ]
   },
@@ -33,28 +27,19 @@
     {
       "address": "g:27017",
       "avg_rtt_ms": 5,
-      "type": "Mongos",
-      "tags": {
-        "data_center": "nyc"
-      }
+      "type": "Mongos"
     },
     {
       "address": "h:27017",
       "avg_rtt_ms": 35,
-      "type": "Mongos",
-      "tags": {
-        "data_center": "dc"
-      }
+      "type": "Mongos"
     }
   ],
   "in_latency_window": [
     {
       "address": "g:27017",
       "avg_rtt_ms": 5,
-      "type": "Mongos",
-      "tags": {
-        "data_center": "nyc"
-      }
+      "type": "Mongos"
     }
   ]
 }

--- a/data/server-selection/server_selection/Sharded/write/SecondaryPreferred.yml
+++ b/data/server-selection/server_selection/Sharded/write/SecondaryPreferred.yml
@@ -5,14 +5,10 @@ topology_description:
     address: g:27017
     avg_rtt_ms: 5
     type: Mongos
-    tags:
-      data_center: nyc
   - &2
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-    tags:
-      data_center: dc
 operation: write
 read_preference:
   mode: SecondaryPreferred


### PR DESCRIPTION
GODRIVER-227

We were missing a number of spec tests from [`server_selection/Sharded`](https://github.com/mongodb/specifications/tree/master/source/server-selection/tests/server_selection/Sharded). All new and modified tests seem to pass.