### PR TITLE
GODRIVER-2080 Document that StartSession does not error on disconnected client

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -271,6 +271,9 @@ func (c *Client) Ping(ctx context.Context, rp *readpref.ReadPref) error {
 
 // StartSession starts a new session configured with the given options.
 //
+// StartSession does not actually communicate with the server and will not necessarily error if the client is
+// disconnected.
+//
 // If the DefaultReadConcern, DefaultWriteConcern, or DefaultReadPreference options are not set, the client's read
 // concern, write concern, or read preference will be used, respectively.
 func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) {

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -271,7 +271,7 @@ func (c *Client) Ping(ctx context.Context, rp *readpref.ReadPref) error {
 
 // StartSession starts a new session configured with the given options.
 //
-// StartSession does not actually communicate with the server and will not necessarily error if the client is
+// StartSession does not actually communicate with the server and will not error if the client is
 // disconnected.
 //
 // If the DefaultReadConcern, DefaultWriteConcern, or DefaultReadPreference options are not set, the client's read


### PR DESCRIPTION
GODRIVER-2080

Users may expect that `client.StartSession` will always error when `client` is disconnected from the server (e.g. `client.Disconnect` has been called). `StartSession` will only return `ErrClientDisconnected` if `sessionPool` is empty. Documents this behavior.