### PR TITLE
GODRIVER-2088 Versioned API strict migration example

### DIFF
--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -2806,15 +2806,14 @@ func VersionedAPIDeprecationErrorsExample() {
 // VersionedAPIStrictCountExample is an example of using CountDocuments instead of a traditional count
 // with a strict API version since the count command does not belong to API version 1.
 func VersionedAPIStrictCountExample(t *testing.T) {
-	ctx := context.Background()
 	uri := "mongodb://localhost:27017"
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
 
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(context.TODO(), clientOpts)
 	require.Nil(t, err, "Connect error: %v", err)
-	defer func() { _ = client.Disconnect(ctx) }()
+	defer func() { _ = client.Disconnect(context.TODO()) }()
 
 	// Start Versioned API Example 5
 
@@ -2829,13 +2828,13 @@ func VersionedAPIStrictCountExample(t *testing.T) {
 		bson.D{{"_id", 7}, {"item", "xyz"}, {"price", 5}, {"quantity", 10}, {"date", "2021-02-15T14:12:12Z"}},
 		bson.D{{"_id", 8}, {"item", "abc"}, {"price", 10}, {"quantity", 5}, {"date", "2021-03-16T20:20:13Z"}},
 	}
-	_, err = coll.InsertMany(ctx, docs)
+	_, err = coll.InsertMany(context.TODO(), docs)
 
 	// End Versioned API Example 5
-	defer func() { _ = coll.Drop(ctx) }()
+	defer func() { _ = coll.Drop(context.TODO()) }()
 	require.Nil(t, err, "InsertMany error: %v", err)
 
-	res := client.Database("db").RunCommand(ctx, bson.D{{"count", "sales"}})
+	res := client.Database("db").RunCommand(context.TODO(), bson.D{{"count", "sales"}})
 	require.NotNil(t, res.Err(), "expected RunCommand error, got nil")
 	expectedErr := "Provided apiStrict:true, but the command count is not in API Version 1"
 	require.True(t, strings.Contains(res.Err().Error(), expectedErr),
@@ -2849,7 +2848,7 @@ func VersionedAPIStrictCountExample(t *testing.T) {
 
 	// Start Versioned API Example 7
 
-	count, err := coll.CountDocuments(ctx, bson.D{})
+	count, err := coll.CountDocuments(context.TODO(), bson.D{})
 
 	// End Versioned API Example 7
 	require.Nil(t, err, "CountDocuments error: %v", err)

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -2863,10 +2863,9 @@ func VersionedAPIStrictCountExample(t *testing.T) {
 }
 
 // VersionedAPIExamples runs all versioned API examples.
-func VersionedAPIExamples(t *testing.T) {
+func VersionedAPIExamples() {
 	VersionedAPIExample()
 	VersionedAPIStrictExample()
 	VersionedAPINonStrictExample()
 	VersionedAPIDeprecationErrorsExample()
-	VersionedAPIStrictCountExample(t)
 }

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -34,20 +34,20 @@ func TestDocumentationExamples(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 
-	db := client.Database("documentation_examples")
-
-	documentation_examples.InsertExamples(t, db)
-	documentation_examples.QueryToplevelFieldsExamples(t, db)
-	documentation_examples.QueryEmbeddedDocumentsExamples(t, db)
-	documentation_examples.QueryArraysExamples(t, db)
-	documentation_examples.QueryArrayEmbeddedDocumentsExamples(t, db)
-	documentation_examples.QueryNullMissingFieldsExamples(t, db)
-	documentation_examples.ProjectionExamples(t, db)
-	documentation_examples.UpdateExamples(t, db)
-	documentation_examples.DeleteExamples(t, db)
-	documentation_examples.RunCommandExamples(t, db)
-	documentation_examples.IndexExamples(t, db)
-	documentation_examples.VersionedAPIExamples()
+	// db := client.Database("documentation_examples")
+	//
+	// documentation_examples.InsertExamples(t, db)
+	// documentation_examples.QueryToplevelFieldsExamples(t, db)
+	// documentation_examples.QueryEmbeddedDocumentsExamples(t, db)
+	// documentation_examples.QueryArraysExamples(t, db)
+	// documentation_examples.QueryArrayEmbeddedDocumentsExamples(t, db)
+	// documentation_examples.QueryNullMissingFieldsExamples(t, db)
+	// documentation_examples.ProjectionExamples(t, db)
+	// documentation_examples.UpdateExamples(t, db)
+	// documentation_examples.DeleteExamples(t, db)
+	// documentation_examples.RunCommandExamples(t, db)
+	// documentation_examples.IndexExamples(t, db)
+	documentation_examples.VersionedAPIExamples(t)
 }
 
 func TestAggregationExamples(t *testing.T) {

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -53,8 +53,9 @@ func TestDocumentationExamples(t *testing.T) {
 	// Because it uses RunCommand with an apiVersion, the strict count example can only be
 	// run on 5.0+ without auth.
 	ver, err := getServerVersion(ctx, client)
+	require.NoError(t, err, "getServerVersion error: %v", err)
 	auth := os.Getenv("AUTH") == "auth"
-	if err == nil && testutil.CompareVersions(t, ver, "5.0") >= 0 && !auth {
+	if testutil.CompareVersions(t, ver, "5.0") >= 0 && !auth {
 		documentation_examples.VersionedAPIStrictCountExample(t)
 	} else {
 		t.Log("skipping versioned API strict count example")

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -11,6 +11,7 @@ package documentation_examples_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -47,7 +48,17 @@ func TestDocumentationExamples(t *testing.T) {
 	documentation_examples.DeleteExamples(t, db)
 	documentation_examples.RunCommandExamples(t, db)
 	documentation_examples.IndexExamples(t, db)
-	documentation_examples.VersionedAPIExamples(t)
+	documentation_examples.VersionedAPIExamples()
+
+	// Because it uses RunCommand with an apiVersion, the strict count example can only be
+	// run on 5.0+ without auth.
+	ver, err := getServerVersion(ctx, client)
+	auth := os.Getenv("AUTH") == "auth"
+	if err == nil && testutil.CompareVersions(t, ver, "5.0") >= 0 && !auth {
+		documentation_examples.VersionedAPIStrictCountExample(t)
+	} else {
+		t.Log("skipping versioned API strict count example")
+	}
 }
 
 func TestAggregationExamples(t *testing.T) {

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -34,19 +34,19 @@ func TestDocumentationExamples(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 
-	// db := client.Database("documentation_examples")
-	//
-	// documentation_examples.InsertExamples(t, db)
-	// documentation_examples.QueryToplevelFieldsExamples(t, db)
-	// documentation_examples.QueryEmbeddedDocumentsExamples(t, db)
-	// documentation_examples.QueryArraysExamples(t, db)
-	// documentation_examples.QueryArrayEmbeddedDocumentsExamples(t, db)
-	// documentation_examples.QueryNullMissingFieldsExamples(t, db)
-	// documentation_examples.ProjectionExamples(t, db)
-	// documentation_examples.UpdateExamples(t, db)
-	// documentation_examples.DeleteExamples(t, db)
-	// documentation_examples.RunCommandExamples(t, db)
-	// documentation_examples.IndexExamples(t, db)
+	db := client.Database("documentation_examples")
+
+	documentation_examples.InsertExamples(t, db)
+	documentation_examples.QueryToplevelFieldsExamples(t, db)
+	documentation_examples.QueryEmbeddedDocumentsExamples(t, db)
+	documentation_examples.QueryArraysExamples(t, db)
+	documentation_examples.QueryArrayEmbeddedDocumentsExamples(t, db)
+	documentation_examples.QueryNullMissingFieldsExamples(t, db)
+	documentation_examples.ProjectionExamples(t, db)
+	documentation_examples.UpdateExamples(t, db)
+	documentation_examples.DeleteExamples(t, db)
+	documentation_examples.RunCommandExamples(t, db)
+	documentation_examples.IndexExamples(t, db)
 	documentation_examples.VersionedAPIExamples(t)
 }
 


### PR DESCRIPTION
GODRIVER-2088

Adds an example of migrating a command not available in strict API version 1 (`count`) to one that is (`CountDocuments`). 

This is an odd set of examples for Go, since we don't have an actual `count` helper. See [DRIVERS-1846](https://jira.mongodb.org/browse/DRIVERS-1846) for more information, but in short:

Example 5: Show inserting some documents to `db.sales`.
Example 6: Show the error returned in the Go driver from using our equivalent of `db.sales.count()`.
Example 7: Show an alternative to `db.sales.count()` that works with strict API version 1.
Example 8: Show the result of that alternative.