### PR TITLE
GODRIVER-2058 Document that File UploadDate is not configurable

### DIFF
--- a/mongo/gridfs/download_stream.go
+++ b/mongo/gridfs/download_stream.go
@@ -58,7 +58,8 @@ type File struct {
 	// ChunkSize is the maximum number of bytes for each chunk in this file.
 	ChunkSize int32
 
-	// UploadDate is the time this file was added to GridFS in UTC.
+	// UploadDate is the time this file was added to GridFS in UTC. This field is set by the driver and is not configurable.
+	// The Metadata field can be used to store a custom date.
 	UploadDate time.Time
 
 	// Name is the name of this file.


### PR DESCRIPTION
GODRIVER-2058

`UploadDate` is not configurable, and if a user wishes to store a custom date on a GridFS `File`, they'll have to use the `Metadata` field instead. Documents these facts.