### PR TITLE
GODRIVER-2114 Fix failing KMS TLS tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -125,7 +125,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone -b activateVenvTypos git@github.com:benjirewis/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec
@@ -825,7 +825,7 @@ functions:
           cat setup.js
           mongo --nodb setup.js aws_e2e_ecs.js
 
-  start-kms-mock-server:
+  start-kms-mock-servers:
     - command: shell.exec
       type: test
       params:
@@ -834,13 +834,9 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          cat <<EOF > kms_setup.json
-          {
-              "kms_ca_file": "${KMS_CA_FILE}",
-              "kms_cert_file": "${KMS_CERT_FILE}"
-          }
-          EOF
-          mongo --nodb mock_kms.js
+          . ./activate_venv.sh
+          python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
 
   run-kms-tls-test:
     - command: shell.exec
@@ -849,7 +845,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          export KMS_TLS_TESTCASE="${KMS_TLS_TESTCASE}"
+          export TEST_KMS_TLS=true
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -1709,7 +1705,7 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
 
-  - name: "test-kms-tls-invalid-cert"
+  - name: "test-kms-tls"
     tags: ["kms-tls"]
     commands:
       - func: bootstrap-mongo-orchestration
@@ -1717,32 +1713,9 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
-      - func: start-kms-mock-server
-        vars:
-          KMS_CA_FILE: "ca.pem"
-          KMS_CERT_FILE: "expired.pem"
+      - func: start-kms-mock-servers
       - func: run-kms-tls-test
         vars:
-          KMS_TLS_TESTCASE: "INVALID_CERT"
-          TOPOLOGY: "server"
-          AUTH: "noauth"
-          SSL: "nossl"
-
-  - name: "test-kms-tls-invalid-hostname"
-    tags: ["kms-tls"]
-    commands:
-      - func: bootstrap-mongo-orchestration
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "noauth"
-          SSL: "nossl"
-      - func: start-kms-mock-server
-        vars:
-          KMS_CA_FILE: "ca.pem"
-          KMS_CERT_FILE: "wrong-host.pem"
-      - func: run-kms-tls-test
-        vars:
-          KMS_TLS_TESTCASE: "INVALID_HOSTNAME"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -827,21 +827,18 @@ functions:
 
   start-kms-mock-server:
     - command: shell.exec
-      type: test
       params:
-        working_dir: src
-        background: true
         script: |
           ${PREPARE_SHELL}
-          set -o xtrace
-          echo "Logging a mock KMS server!"
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          if [ ! -z ${FIRST_RUN} ]; then
-            unset FIRST_RUN
-            . ./activate_venv.sh
-          fi
-          python -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT}
+          . ./activate_venv.sh
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port 8000
 
   run-kms-tls-test:
     - command: shell.exec
@@ -850,8 +847,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          export TEST_KMS_TLS=true
-          ps aux
+          export KMS_TLS_TESTCASE="${KMS_TLS_TESTCASE}"
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -1711,7 +1707,7 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
 
-  - name: "test-kms-tls"
+  - name: "test-kms-tls-invalid-cert"
     tags: ["kms-tls"]
     commands:
       - func: bootstrap-mongo-orchestration
@@ -1721,15 +1717,28 @@ tasks:
           SSL: "nossl"
       - func: start-kms-mock-server
         vars:
-          FIRST_RUN: true
-          CERT_FILE: expired.pem
-          PORT: 9000
-      - func: start-kms-mock-server
-        vars:
-          CERT_FILE: wrong-host.pem
-          PORT: 9001
+          CERT_FILE: "expired.pem"
       - func: run-kms-tls-test
         vars:
+          KMS_TLS_TESTCASE: "INVALID_CERT"
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+
+  - name: "test-kms-tls-invalid-hostname"
+    tags: ["kms-tls"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: start-kms-mock-server
+        vars:
+          CERT_FILE: "wrong-host.pem"
+      - func: run-kms-tls-test
+        vars:
+          KMS_TLS_TESTCASE: "INVALID_HOSTNAME"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -125,7 +125,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone -b activateVenvTypos git@github.com:benjirewis/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec
@@ -825,7 +825,7 @@ functions:
           cat setup.js
           mongo --nodb setup.js aws_e2e_ecs.js
 
-  start-kms-mock-servers:
+  start-kms-mock-server:
     - command: shell.exec
       type: test
       params:
@@ -833,10 +833,15 @@ functions:
         background: true
         script: |
           ${PREPARE_SHELL}
+          set -o xtrace
+          echo "Logging a mock KMS server!"
+
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          . ./activate_venv.sh
-          python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
-            python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
+          if [ ! -z ${FIRST_RUN} ]; then
+            unset FIRST_RUN
+            . ./activate_venv.sh
+          fi
+          python -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT}
 
   run-kms-tls-test:
     - command: shell.exec
@@ -846,6 +851,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           export TEST_KMS_TLS=true
+          ps aux
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -1713,7 +1719,15 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
-      - func: start-kms-mock-servers
+      - func: start-kms-mock-server
+        vars:
+          FIRST_RUN: true
+          CERT_FILE: expired.pem
+          PORT: 9000
+      - func: start-kms-mock-server
+        vars:
+          CERT_FILE: wrong-host.pem
+          PORT: 9001
       - func: run-kms-tls-test
         vars:
           TOPOLOGY: "server"

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1037,7 +1037,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 
-	// These tests only run when KMS mock servers are running on localhost:8000 and 8001.
+	// These tests only run when KMS mock servers are running on localhost:9000 and 9001.
 	mt.RunOpts("kms tls tests", noClientOpts, func(mt *mtest.T) {
 		testKmsTls := os.Getenv("TEST_KMS_TLS")
 		if testKmsTls == "" || testKmsTls == "false" {
@@ -1051,12 +1051,12 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}{
 			{
 				"invalid certificate",
-				8000,
+				9000,
 				"expired",
 			},
 			{
 				"invalid hostname",
-				8001,
+				9001,
 				"SANs",
 			},
 		}

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1037,44 +1037,48 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 
-	// These tests only run when KMS mock servers are running on localhost:9000 and 9001.
+	// These tests only run when a KMS mock server is running on localhost:8000.
 	mt.RunOpts("kms tls tests", noClientOpts, func(mt *mtest.T) {
-		testKmsTls := os.Getenv("TEST_KMS_TLS")
-		if testKmsTls == "" || testKmsTls == "false" {
-			mt.Skipf("Skipping test as TEST_KMS_TLS is unset or false")
+		kmsTlsTestcase := os.Getenv("KMS_TLS_TESTCASE")
+		if kmsTlsTestcase == "" {
+			mt.Skipf("Skipping test as KMS_TLS_TESTCASE is not set")
 		}
 
 		testcases := []struct {
 			name       string
-			kmsPort    int
+			envValue   string
 			errMessage string
 		}{
 			{
 				"invalid certificate",
-				9000,
+				"INVALID_CERT",
 				"expired",
 			},
 			{
 				"invalid hostname",
-				9001,
+				"INVALID_HOSTNAME",
 				"SANs",
 			},
 		}
 
 		for _, tc := range testcases {
 			mt.Run(tc.name, func(mt *mtest.T) {
+				// Only run test if correct KMS mock server is running.
+				if kmsTlsTestcase != tc.envValue {
+					mt.Skipf("Skipping test as KMS_TLS_TESTCASE is set to %q, expected %v", kmsTlsTestcase, tc.envValue)
+				}
+
 				ceo := options.ClientEncryption().
 					SetKmsProviders(fullKmsProvidersMap).
 					SetKeyVaultNamespace(kvNamespace)
 				cpt := setup(mt, nil, nil, ceo)
 				defer cpt.teardown(mt)
 
-				endpoint := fmt.Sprintf("127.0.0.1:%v", tc.kmsPort)
 				_, err := cpt.clientEnc.CreateDataKey(context.Background(), "aws", options.DataKey().SetMasterKey(
 					bson.D{
 						{"region", "us-east-1"},
 						{"key", "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"},
-						{"endpoint", endpoint},
+						{"endpoint", "127.0.0.1:8000"},
 					},
 				))
 				assert.NotNil(mt, err, "expected CreateDataKey error, got nil")


### PR DESCRIPTION
Uses the new `kms_http_server.py` instead of the now-removed, trivial `mock_kms.js`.