### PR TITLE
GODRIVER-2119 implement methods required to use  as a map key

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -12,6 +12,7 @@ package primitive
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -33,6 +34,9 @@ var NilObjectID ObjectID
 
 var objectIDCounter = readRandomUint32()
 var processUnique = processUniqueBytes()
+
+var _ encoding.TextMarshaler = ObjectID{}
+var _ encoding.TextUnmarshaler = ObjectID{}
 
 // NewObjectID generates a new ObjectID.
 func NewObjectID() ObjectID {
@@ -103,7 +107,8 @@ func (id ObjectID) MarshalText() ([]byte, error) {
 // UnmarshalText populates the byte slice with the ObjectID. Implementing this allows us to use ObjectID
 // as a map key when unmarshalling JSON. See https://pkg.go.dev/encoding#TextUnmarshaler
 func (id ObjectID) UnmarshalText(b []byte) error {
-	return id.UnmarshalJSON(b)
+	id, err := ObjectIDFromHex(string(b))
+	return err
 }
 
 // MarshalJSON returns the ObjectID as a string

--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -99,6 +99,20 @@ func (id ObjectID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id.Hex())
 }
 
+// MarshalText returns the ObjectID as text
+// Implementing this allows us to use the ObjectID as a map key
+// when marshalling json.
+func (id ObjectID) MarshalText() ([]byte, error) {
+	return []byte(id.Hex()), nil
+}
+
+// UnmarshalText converts a text ObjectID into a byte string
+// Implementing this allows us to use the ObjectID as a map key
+// when marshalling json.
+func (id ObjectID) UnmarshalText(b []byte) error {
+	return id.UnmarshalJSON(b)
+}
+
 // UnmarshalJSON populates the byte slice with the ObjectID. If the byte slice is 24 bytes long, it
 // will be populated with the hex representation of the ObjectID. If the byte slice is twelve bytes
 // long, it will be populated with the BSON representation of the ObjectID. This method also accepts empty strings and

--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -94,23 +94,21 @@ func IsValidObjectID(s string) bool {
 	return err == nil
 }
 
-// MarshalJSON returns the ObjectID as a string
-func (id ObjectID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(id.Hex())
-}
-
-// MarshalText returns the ObjectID as text
-// Implementing this allows us to use the ObjectID as a map key
-// when marshalling json.
+// MarshalText returns the ObjectID as UTF-8-encoded text. Implementing this allows us to use ObjectID
+// as a map key when marshalling JSON. See https://pkg.go.dev/encoding#TextMarshaler
 func (id ObjectID) MarshalText() ([]byte, error) {
 	return []byte(id.Hex()), nil
 }
 
-// UnmarshalText converts a text ObjectID into a byte string
-// Implementing this allows us to use the ObjectID as a map key
-// when marshalling json.
+// UnmarshalText populates the byte slice with the ObjectID. Implementing this allows us to use ObjectID
+// as a map key when unmarshalling JSON. See https://pkg.go.dev/encoding#TextUnmarshaler
 func (id ObjectID) UnmarshalText(b []byte) error {
 	return id.UnmarshalJSON(b)
+}
+
+// MarshalJSON returns the ObjectID as a string
+func (id ObjectID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.Hex())
 }
 
 // UnmarshalJSON populates the byte slice with the ObjectID. If the byte slice is 24 bytes long, it

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -172,6 +172,37 @@ func TestCounterOverflow(t *testing.T) {
 	require.Equal(t, uint32(0), objectIDCounter)
 }
 
+func TestObjectID_MarshalJSONMap(t *testing.T) {
+	type mapOID struct {
+		Map map[ObjectID]string
+	}
+
+	oid := NewObjectID()
+	expectedJson := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
+	data := mapOID{
+		Map: map[ObjectID]string{oid: "foo"},
+	}
+
+	out, err := json.Marshal(&data)
+	require.NoError(t, err)
+	require.Equal(t, expectedJson, out)
+}
+
+func TestObjectID_UnmarshalJSONMap(t *testing.T) {
+	type mapOID struct {
+		Map map[ObjectID]string
+	}
+	oid := NewObjectID()
+	mapOIDJson := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
+	expectedData := mapOID{
+		Map: map[ObjectID]string{oid: "foo"},
+	}
+
+	data := mapOID{}
+	err := json.Unmarshal(mapOIDJson, &data)
+	require.NoError(t, err)
+	require.Equal(t, expectedData, data)
+}
 func TestObjectID_UnmarshalJSON(t *testing.T) {
 	oid := NewObjectID()
 

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -178,14 +178,14 @@ func TestObjectID_MarshalJSONMap(t *testing.T) {
 	}
 
 	oid := NewObjectID()
-	expectedJson := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
+	expectedJSON := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
 	data := mapOID{
 		Map: map[ObjectID]string{oid: "foo"},
 	}
 
 	out, err := json.Marshal(&data)
 	require.NoError(t, err)
-	require.Equal(t, expectedJson, out)
+	require.Equal(t, expectedJSON, out)
 }
 
 func TestObjectID_UnmarshalJSONMap(t *testing.T) {
@@ -193,16 +193,17 @@ func TestObjectID_UnmarshalJSONMap(t *testing.T) {
 		Map map[ObjectID]string
 	}
 	oid := NewObjectID()
-	mapOIDJson := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
+	mapOIDJSON := []byte(fmt.Sprintf(`{"Map":{%q:"foo"}}`, oid.Hex()))
 	expectedData := mapOID{
 		Map: map[ObjectID]string{oid: "foo"},
 	}
 
 	data := mapOID{}
-	err := json.Unmarshal(mapOIDJson, &data)
+	err := json.Unmarshal(mapOIDJSON, &data)
 	require.NoError(t, err)
 	require.Equal(t, expectedData, data)
 }
+
 func TestObjectID_UnmarshalJSON(t *testing.T) {
 	oid := NewObjectID()
 


### PR DESCRIPTION
[GODRIVER-2119](https://jira.mongodb.org/browse/GODRIVER-2119)

Implements the [TextMarshaler](https://cs.opensource.google/go/go/+/go1.16.7:src/encoding/encoding.go;l=36) and [TextUnmarshaler](https://cs.opensource.google/go/go/+/go1.16.7:src/encoding/encoding.go;l=46) methods on `primitive.ObjectID` to allow it to be used as a map key. 