### PR TITLE
GODRIVER-2136 Include LatencySelector in change stream server selector

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -104,11 +104,14 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 	}
 
 	cs := &ChangeStream{
-		client:        config.client,
-		registry:      config.registry,
-		streamType:    config.streamType,
-		options:       options.MergeChangeStreamOptions(opts...),
-		selector:      description.ReadPrefSelector(config.readPreference),
+		client:     config.client,
+		registry:   config.registry,
+		streamType: config.streamType,
+		options:    options.MergeChangeStreamOptions(opts...),
+		selector: description.CompositeSelector([]description.ServerSelector{
+			description.ReadPrefSelector(config.readPreference),
+			description.LatencySelector(config.client.localThreshold),
+		}),
 		cursorOptions: config.client.createBaseCursorOptions(),
 	}
 


### PR DESCRIPTION
GODRIVER-2136

Modifies the `selector` for new `ChangeStream` instances in `newChangeStream` to be a `CompositeSelector` of a `ReadPrefSelector` and a `LatencySelector`. This should make it so change stream server selection (both in creation and resumption) will respect the `Client`'s `LocalThreshold` value.