### PR TITLE
GODRIVER-2133 Error on semantic single documents as aggregate pipelines

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -219,10 +219,6 @@ func transformAggregatePipeline(registry *bsoncodec.Registry, pipeline interface
 		}
 
 		return pipelineDoc, hasOutputStage, nil
-	case bson.D, bson.Raw, bsoncore.Document:
-		// Explicitly forbid pipeline types that are semantically single documents
-		// but are implemented as slices.
-		return nil, false, fmt.Errorf("can only transform types that are semantically arrays of documents, got %T", t)
 	default:
 		val := reflect.ValueOf(t)
 		if !val.IsValid() || (val.Kind() != reflect.Slice && val.Kind() != reflect.Array) {
@@ -232,6 +228,17 @@ func transformAggregatePipeline(registry *bsoncodec.Registry, pipeline interface
 		aidx, arr := bsoncore.AppendArrayStart(nil)
 		var hasOutputStage bool
 		valLen := val.Len()
+
+		// Explicitly forbid non-empty pipelines that are semantically single documents
+		// and are implemented as slices.
+		switch t := pipeline.(type) {
+		case bson.D, bson.Raw, bsoncore.Document:
+			if valLen > 0 {
+				return nil, false,
+					fmt.Errorf("%T is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead", t)
+			}
+		}
+
 		for idx := 0; idx < valLen; idx++ {
 			doc, err := transformBsoncoreDocument(registry, val.Index(idx).Interface(), true, fmt.Sprintf("pipeline stage :%v", idx))
 			if err != nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -219,6 +219,10 @@ func transformAggregatePipeline(registry *bsoncodec.Registry, pipeline interface
 		}
 
 		return pipelineDoc, hasOutputStage, nil
+	case bson.D, bson.Raw, bsoncore.Document:
+		// Explicitly forbid pipeline types that are semantically single documents
+		// but are implemented as slices.
+		return nil, false, fmt.Errorf("can only transform types that are semantically arrays of documents, got %T", t)
 	default:
 		val := reflect.ValueOf(t)
 		if !val.IsValid() || (val.Kind() != reflect.Slice && val.Kind() != reflect.Array) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -374,6 +374,20 @@ func TestMongoHelpers(t *testing.T) {
 				false,
 				nil,
 			},
+			{
+				"semantic single document/empty bson.Raw",
+				bson.Raw{},
+				bson.A{},
+				false,
+				nil,
+			},
+			{
+				"semantic single document/empty bsoncore.Document",
+				bsoncore.Document{},
+				bson.A{},
+				false,
+				nil,
+			},
 		}
 
 		for _, tc := range testCases {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -342,6 +342,27 @@ func TestMongoHelpers(t *testing.T) {
 				true,
 				nil,
 			},
+			{
+				"semantic single document/primitive.D",
+				bson.D{},
+				nil,
+				false,
+				errors.New("can only transform types that are semantically arrays of documents, got primitive.D"),
+			},
+			{
+				"semantic single document/bson.Raw",
+				bson.Raw{},
+				nil,
+				false,
+				errors.New("can only transform types that are semantically arrays of documents, got bson.Raw"),
+			},
+			{
+				"semantic single document/bsoncore.Document",
+				bsoncore.Document{},
+				nil,
+				false,
+				errors.New("can only transform types that are semantically arrays of documents, got bsoncore.Document"),
+			},
 		}
 
 		for _, tc := range testCases {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -343,7 +343,7 @@ func TestMongoHelpers(t *testing.T) {
 				nil,
 			},
 			{
-				"semantic single document/primitive.D",
+				"semantic single document/bson.D",
 				bson.D{},
 				nil,
 				false,

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -126,8 +126,9 @@ func TestMongoHelpers(t *testing.T) {
 		arr, _ = bsoncore.AppendDocumentEnd(arr, dindex)
 		arr, _ = bsoncore.AppendArrayEnd(arr, index)
 
-		docBytes, err := bson.Marshal(bson.D{{"x", 1}})
-		assert.Nil(t, err, "Marshal error: %v", err)
+		index, doc := bsoncore.AppendDocumentStart(nil)
+		doc = bsoncore.AppendInt32Element(doc, "x", 1)
+		doc, _ = bsoncore.AppendDocumentEnd(doc, index)
 
 		testCases := []struct {
 			name           string
@@ -354,14 +355,14 @@ func TestMongoHelpers(t *testing.T) {
 			},
 			{
 				"semantic single document/bson.Raw",
-				bson.Raw(docBytes),
+				bson.Raw(doc),
 				nil,
 				false,
 				errors.New("bson.Raw is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead"),
 			},
 			{
 				"semantic single document/bsoncore.Document",
-				bsoncore.Document(docBytes),
+				bsoncore.Document(doc),
 				nil,
 				false,
 				errors.New("bsoncore.Document is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead"),

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -126,6 +126,9 @@ func TestMongoHelpers(t *testing.T) {
 		arr, _ = bsoncore.AppendDocumentEnd(arr, dindex)
 		arr, _ = bsoncore.AppendArrayEnd(arr, index)
 
+		docBytes, err := bson.Marshal(bson.D{{"x", 1}})
+		assert.Nil(t, err, "Marshal error: %v", err)
+
 		testCases := []struct {
 			name           string
 			pipeline       interface{}
@@ -344,24 +347,31 @@ func TestMongoHelpers(t *testing.T) {
 			},
 			{
 				"semantic single document/bson.D",
-				bson.D{},
+				bson.D{{"x", 1}},
 				nil,
 				false,
-				errors.New("can only transform types that are semantically arrays of documents, got primitive.D"),
+				errors.New("primitive.D is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead"),
 			},
 			{
 				"semantic single document/bson.Raw",
-				bson.Raw{},
+				bson.Raw(docBytes),
 				nil,
 				false,
-				errors.New("can only transform types that are semantically arrays of documents, got bson.Raw"),
+				errors.New("bson.Raw is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead"),
 			},
 			{
 				"semantic single document/bsoncore.Document",
-				bsoncore.Document{},
+				bsoncore.Document(docBytes),
 				nil,
 				false,
-				errors.New("can only transform types that are semantically arrays of documents, got bsoncore.Document"),
+				errors.New("bsoncore.Document is not an allowed pipeline type as it represents a single document. Use bson.A or mongo.Pipeline instead"),
+			},
+			{
+				"semantic single document/empty bson.D",
+				bson.D{},
+				bson.A{},
+				false,
+				nil,
 			},
 		}
 


### PR DESCRIPTION
GODRIVER-2133

Modifies `transformAggregatePipeline` to error if the provided `pipeline` is a non-empty semantically a single document (`bson.D`, `bson.Raw`, `bsoncore.Document`) but is implemented as a slice. This will stop users from passing something like `bson.D{{"x", 1}}` as a pipeline since it is not strictly speaking an array of documents and give them an informative error message.