### PR TITLE
Fix panic on ARM, 386, and 32-bit MIPS by aligne fileds used by atomic package

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -39,6 +39,11 @@ var (
 func nextConnectionID() uint64 { return atomic.AddUint64(&globalConnectionID, 1) }
 
 type connection struct {
+	// connected must be accessed using the atomic package and should be at the begin of struct.
+	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// - suggested layout: https://go101.org/article/memory-layout.html
+	connected int64
+
 	id                   string
 	nc                   net.Conn // When nil, the connection is closed.
 	addr                 address.Address
@@ -51,7 +56,6 @@ type connection struct {
 	compressor           wiremessage.CompressorID
 	zliblevel            int
 	zstdLevel            int
-	connected            int32 // must be accessed using the sync/atomic package
 	connectDone          chan struct{}
 	connectErr           error
 	config               *connectionConfig
@@ -96,13 +100,13 @@ func newConnection(addr address.Address, opts ...ConnectionOption) (*connection,
 	if !c.config.loadBalanced {
 		c.setGenerationNumber()
 	}
-	atomic.StoreInt32(&c.connected, initialized)
+	atomic.StoreInt64(&c.connected, initialized)
 
 	return c, nil
 }
 
 func (c *connection) processInitializationError(opCtx context.Context, err error) {
-	atomic.StoreInt32(&c.connected, disconnected)
+	atomic.StoreInt64(&c.connected, disconnected)
 	if c.nc != nil {
 		_ = c.nc.Close()
 	}
@@ -137,7 +141,7 @@ func (c *connection) hasGenerationNumber() bool {
 // connect handles the I/O for a connection. It will dial, configure TLS, and perform
 // initialization handshakes.
 func (c *connection) connect(ctx context.Context) {
-	if !atomic.CompareAndSwapInt32(&c.connected, initialized, connected) {
+	if !atomic.CompareAndSwapInt64(&c.connected, initialized, connected) {
 		return
 	}
 	defer close(c.connectDone)
@@ -342,7 +346,7 @@ func (c *connection) cancellationListenerCallback() {
 
 func (c *connection) writeWireMessage(ctx context.Context, wm []byte) error {
 	var err error
-	if atomic.LoadInt32(&c.connected) != connected {
+	if atomic.LoadInt64(&c.connected) != connected {
 		return ConnectionError{ConnectionID: c.id, message: "connection is closed"}
 	}
 	select {
@@ -399,7 +403,7 @@ func (c *connection) write(ctx context.Context, wm []byte) (err error) {
 
 // readWireMessage reads a wiremessage from the connection. The dst parameter will be overwritten.
 func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
-	if atomic.LoadInt32(&c.connected) != connected {
+	if atomic.LoadInt64(&c.connected) != connected {
 		return dst, ConnectionError{ConnectionID: c.id, message: "connection is closed"}
 	}
 
@@ -502,7 +506,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 
 func (c *connection) close() error {
 	// Overwrite the connection state as the first step so only the first close call will execute.
-	if !atomic.CompareAndSwapInt32(&c.connected, connected, disconnected) {
+	if !atomic.CompareAndSwapInt64(&c.connected, connected, disconnected) {
 		return nil
 	}
 
@@ -515,7 +519,7 @@ func (c *connection) close() error {
 }
 
 func (c *connection) closed() bool {
-	return atomic.LoadInt32(&c.connected) == disconnected
+	return atomic.LoadInt64(&c.connected) == disconnected
 }
 
 func (c *connection) idleTimeoutExpired() bool {

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -39,7 +39,7 @@ var (
 func nextConnectionID() uint64 { return atomic.AddUint64(&globalConnectionID, 1) }
 
 type connection struct {
-	// connected must be accessed using the atomic package and should be at the begin of struct.
+	// connected must be accessed using the atomic package and should be at the beginning of the struct.
 	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	// - suggested layout: https://go101.org/article/memory-layout.html
 	connected int64

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -81,7 +81,7 @@ func TestConnection(t *testing.T) {
 				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 					t.Errorf("errors do not match. got %v; want %v", got, want)
 				}
-				connState := atomic.LoadInt32(&conn.connected)
+				connState := atomic.LoadInt64(&conn.connected)
 				assert.Equal(t, disconnected, connState, "expected connection state %v, got %v", disconnected, connState)
 			})
 			t.Run("handshaker error", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestConnection(t *testing.T) {
 				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 					t.Errorf("errors do not match. got %v; want %v", got, want)
 				}
-				connState := atomic.LoadInt32(&conn.connected)
+				connState := atomic.LoadInt64(&conn.connected)
 				assert.Equal(t, disconnected, connState, "expected connection state %v, got %v", disconnected, connState)
 			})
 			t.Run("calls error callback", func(t *testing.T) {
@@ -753,7 +753,7 @@ func TestConnection(t *testing.T) {
 				conn.connect(context.Background())
 				err = conn.wait()
 				assert.NotNil(t, err, "expected handshake error from wait, got nil")
-				connState := atomic.LoadInt32(&conn.connected)
+				connState := atomic.LoadInt64(&conn.connected)
 				assert.Equal(t, disconnected, connState, "expected connection state %v, got %v", disconnected, connState)
 
 				err = conn.close()

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -58,15 +58,10 @@ type checkOutResult struct {
 
 // pool is a wrapper of resource pool that follows the CMAP spec for connection pools
 type pool struct {
-	address    address.Address
-	opts       []ConnectionOption
-	conns      *resourcePool // pool for non-checked out connections
-	generation *poolGenerationMap
-	monitor    *event.PoolMonitor
-
-	// Must be accessed using the atomic package.
-	connected                    int32
-	_alignment64bits            int32 // details of atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// connected,nextid must be accessed using the atomic package and should be at the begin of struct.
+	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// - suggested layout: https://go101.org/article/memory-layout.html
+	connected                    int64
 	pinnedCursorConnections      uint64
 	pinnedTransactionConnections uint64
 
@@ -74,6 +69,12 @@ type pool struct {
 	opened map[uint64]*connection // opened holds all of the currently open connections.
 	sem    *semaphore.Weighted
 	sync.Mutex
+
+	address    address.Address
+	opts       []ConnectionOption
+	conns      *resourcePool // pool for non-checked out connections
+	generation *poolGenerationMap
+	monitor    *event.PoolMonitor
 }
 
 // connectionExpiredFunc checks if a given connection is stale and should be removed from the resource pool
@@ -88,7 +89,7 @@ func connectionExpiredFunc(v interface{}) bool {
 	}
 
 	switch {
-	case atomic.LoadInt32(&c.pool.connected) != connected:
+	case atomic.LoadInt64(&c.pool.connected) != connected:
 		c.expireReason = event.ReasonPoolClosed
 	case c.closed():
 		// A connection would only be closed if it encountered a network error during an operation and closed itself.
@@ -202,7 +203,7 @@ func (p *pool) stale(c *connection) bool {
 
 // connect puts the pool into the connected state, allowing it to be used and will allow items to begin being processed from the wait queue
 func (p *pool) connect() error {
-	if !atomic.CompareAndSwapInt32(&p.connected, disconnected, connected) {
+	if !atomic.CompareAndSwapInt64(&p.connected, disconnected, connected) {
 		return ErrPoolConnected
 	}
 	p.generation.connect()
@@ -212,7 +213,7 @@ func (p *pool) connect() error {
 
 // disconnect disconnects the pool and closes all connections including those both in and out of the pool
 func (p *pool) disconnect(ctx context.Context) error {
-	if !atomic.CompareAndSwapInt32(&p.connected, connected, disconnecting) {
+	if !atomic.CompareAndSwapInt64(&p.connected, connected, disconnecting) {
 		return ErrPoolDisconnected
 	}
 
@@ -261,7 +262,7 @@ func (p *pool) disconnect(ctx context.Context) error {
 		_ = p.removeConnection(pc, event.ReasonPoolClosed)
 		_ = p.closeConnection(pc) // We don't care about errors while closing the connection.
 	}
-	atomic.StoreInt32(&p.connected, disconnected)
+	atomic.StoreInt64(&p.connected, disconnected)
 	p.conns.clearTotal()
 
 	if p.monitor != nil {
@@ -295,7 +296,7 @@ func (p *pool) makeNewConnection() (*connection, string, error) {
 		})
 	}
 
-	if atomic.LoadInt32(&p.connected) != connected {
+	if atomic.LoadInt64(&p.connected) != connected {
 		// Manually publish a ConnectionClosed event here because the connection reference hasn't been stored and we
 		// need to ensure each ConnectionCreated event has a corresponding ConnectionClosed event.
 		if p.monitor != nil {
@@ -342,7 +343,7 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 		ctx = context.Background()
 	}
 
-	if atomic.LoadInt32(&p.connected) != connected {
+	if atomic.LoadInt64(&p.connected) != connected {
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
 				Type:    event.GetFailed,
@@ -374,7 +375,7 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 	// This loop is so that we don't end up with more than maxPoolSize connections if p.conns.Maintain runs between
 	// calling p.conns.Get() and making the new connection
 	for {
-		if atomic.LoadInt32(&p.connected) != connected {
+		if atomic.LoadInt64(&p.connected) != connected {
 			if p.monitor != nil {
 				p.monitor.Event(&event.PoolEvent{
 					Type:    event.GetFailed,
@@ -389,7 +390,7 @@ func (p *pool) get(ctx context.Context) (*connection, error) {
 		connVal := p.conns.Get()
 		if c, ok := connVal.(*connection); ok && connVal != nil {
 			// call connect if not connected
-			if atomic.LoadInt32(&c.connected) == initialized {
+			if atomic.LoadInt64(&c.connected) == initialized {
 				c.connect(ctx)
 			}
 
@@ -493,12 +494,12 @@ func (p *pool) closeConnection(c *connection) error {
 		return ErrWrongPool
 	}
 
-	if atomic.LoadInt32(&c.connected) == connected {
+	if atomic.LoadInt64(&c.connected) == connected {
 		c.closeConnectContext()
 		_ = c.wait() // Make sure that the connection has finished connecting
 	}
 
-	if !atomic.CompareAndSwapInt32(&c.connected, connected, disconnected) {
+	if !atomic.CompareAndSwapInt64(&c.connected, connected, disconnected) {
 		return nil // We're closing an already closed connection
 	}
 

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -66,6 +66,7 @@ type pool struct {
 
 	// Must be accessed using the atomic package.
 	connected                    int32
+	_alignment_64bits            int32 // details of atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	pinnedCursorConnections      uint64
 	pinnedTransactionConnections uint64
 

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -66,7 +66,7 @@ type pool struct {
 
 	// Must be accessed using the atomic package.
 	connected                    int32
-	_alignment_64bits            int32 // details of atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	_alignment64bits            int32 // details of atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	pinnedCursorConnections      uint64
 	pinnedTransactionConnections uint64
 

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -58,7 +58,7 @@ type checkOutResult struct {
 
 // pool is a wrapper of resource pool that follows the CMAP spec for connection pools
 type pool struct {
-	// connected,nextid must be accessed using the atomic package and should be at the begin of struct.
+	// These fields must be accessed using the atomic package and should be at the beginning of the struct.
 	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	// - suggested layout: https://go101.org/article/memory-layout.html
 	connected                    int64

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -24,8 +24,10 @@ type generationStats struct {
 // load balancer, there is only one service ID: primitive.NilObjectID. For load-balanced deployments, each server behind
 // the load balancer will have a unique service ID.
 type poolGenerationMap struct {
-	// state must be accessed using the atomic package.
-	state         int32
+	// state must be accessed using the atomic package and should be at the begin of struct.
+	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// - suggested layout: https://go101.org/article/memory-layout.html
+	state         int64
 	generationMap map[primitive.ObjectID]*generationStats
 
 	sync.Mutex
@@ -40,11 +42,11 @@ func newPoolGenerationMap() *poolGenerationMap {
 }
 
 func (p *poolGenerationMap) connect() {
-	atomic.StoreInt32(&p.state, connected)
+	atomic.StoreInt64(&p.state, connected)
 }
 
 func (p *poolGenerationMap) disconnect() {
-	atomic.StoreInt32(&p.state, disconnected)
+	atomic.StoreInt64(&p.state, disconnected)
 }
 
 // addConnection increments the connection count for the generation associated with the given service ID and returns the
@@ -100,7 +102,7 @@ func (p *poolGenerationMap) clear(serviceIDPtr *primitive.ObjectID) {
 
 func (p *poolGenerationMap) stale(serviceIDPtr *primitive.ObjectID, knownGeneration uint64) bool {
 	// If the map has been disconnected, all connections should be considered stale to ensure that they're closed.
-	if atomic.LoadInt32(&p.state) == disconnected {
+	if atomic.LoadInt64(&p.state) == disconnected {
 		return true
 	}
 

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -24,7 +24,7 @@ type generationStats struct {
 // load balancer, there is only one service ID: primitive.NilObjectID. For load-balanced deployments, each server behind
 // the load balancer will have a unique service ID.
 type poolGenerationMap struct {
-	// state must be accessed using the atomic package and should be at the begin of struct.
+	// state must be accessed using the atomic package and should be at the beginning of the struct.
 	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	// - suggested layout: https://go101.org/article/memory-layout.html
 	state         int64

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -193,7 +193,7 @@ func TestPool(t *testing.T) {
 				t.Errorf("Should have closed 1 connections, but didn't. got %d; want %d", d.lenclosed(), 1)
 			}
 			close(cleanup)
-			state := atomic.LoadInt32(&p.connected)
+			state := atomic.LoadInt64(&p.connected)
 			if state != disconnected {
 				t.Errorf("Should have set the connection state on return. got %d; want %d", state, disconnected)
 			}
@@ -250,10 +250,10 @@ func TestPool(t *testing.T) {
 	})
 	t.Run("connect", func(t *testing.T) {
 		t.Run("can reconnect a disconnected pool", func(t *testing.T) {
-			assertGenerationMapState := func(t *testing.T, p *pool, expectedState int32) {
+			assertGenerationMapState := func(t *testing.T, p *pool, expectedState int64) {
 				t.Helper()
 
-				actualState := atomic.LoadInt32(&p.generation.state)
+				actualState := atomic.LoadInt64(&p.generation.state)
 				assert.Equal(t, expectedState, actualState, "expected generation map state %d, got %d", expectedState, actualState)
 			}
 
@@ -296,7 +296,7 @@ func TestPool(t *testing.T) {
 				t.Errorf("Pool should have 0 total connections. got %d; want %d", p.conns.totalSize, 0)
 			}
 			close(cleanup)
-			state := atomic.LoadInt32(&p.connected)
+			state := atomic.LoadInt64(&p.connected)
 			if state != disconnected {
 				t.Errorf("Should have set the connection state on return. got %d; want %d", state, disconnected)
 			}

--- a/x/mongo/driver/topology/topology_errors_test.go
+++ b/x/mongo/driver/topology/topology_errors_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build go1.13
 // +build go1.13
 
 package topology
@@ -30,7 +31,7 @@ func TestTopologyErrors(t *testing.T) {
 			noerr(t, err)
 
 			topo.cfg.cs.HeartbeatInterval = time.Minute
-			atomic.StoreInt32(&topo.connectionstate, connected)
+			atomic.StoreInt64(&topo.connectionstate, connected)
 			desc := description.Topology{
 				Servers: []description.Server{},
 			}

--- a/x/mongo/driver/topology/topology_errors_test.go
+++ b/x/mongo/driver/topology/topology_errors_test.go
@@ -4,7 +4,6 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-//go:build go1.13
 // +build go1.13
 
 package topology

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -104,7 +104,7 @@ func TestServerSelection(t *testing.T) {
 			SupportedWireVersions.Max,
 		)
 		desc.CompatibilityErr = want
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
 		assert.Equal(t, err, want, "expected %v, got %v", want, err)
@@ -129,7 +129,7 @@ func TestServerSelection(t *testing.T) {
 			MinSupportedMongoDBVersion,
 		)
 		desc.CompatibilityErr = want
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
 		assert.Equal(t, err, want, "expected %v, got %v", want, err)
@@ -282,7 +282,7 @@ func TestServerSelection(t *testing.T) {
 	t.Run("findServer returns topology kind", func(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 		srvr, err := ConnectServer(address.Address("one"), topo.updateCallback, topo.id)
 		noerr(t, err)
 		topo.servers[address.Address("one")] = srvr
@@ -302,7 +302,7 @@ func TestServerSelection(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 
 		addr1 := address.Address("one")
 		addr2 := address.Address("two")
@@ -337,7 +337,7 @@ func TestServerSelection(t *testing.T) {
 		// send a not primary error to the server forcing an update
 		serv, err := topo.FindServer(desc.Servers[0])
 		noerr(t, err)
-		atomic.StoreInt32(&serv.connectionstate, connected)
+		atomic.StoreInt64(&serv.connectionstate, connected)
 		_ = serv.ProcessError(driver.Error{Message: internal.LegacyNotPrimary}, initConnection{})
 
 		resp := make(chan []description.Server)
@@ -369,7 +369,7 @@ func TestServerSelection(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 
 		primaryAddr := address.Address("one")
 		desc := description.Topology{
@@ -399,7 +399,7 @@ func TestServerSelection(t *testing.T) {
 		noerr(t, err)
 
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt32(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.connectionstate, connected)
 		desc := description.Topology{
 			Servers: []description.Server{},
 		}


### PR DESCRIPTION
When I tried to use my program on ARM I got panic:
```
(...)
panic: unaligned 64-bit atomic operation [recovered]
        panic: unaligned 64-bit atomic operation

goroutine 1 [running]:
github.com/alecthomas/kong.catch(0x2cb1f58)
        /home/sr/go/pkg/mod/github.com/alecthomas/kong@v0.2.18-0.20210713035501-d1a818b5a1a8/kong.go:407 +0xa8
panic(0x6b9540, 0x8b0528)
        /usr/lib/go/src/runtime/panic.go:965 +0x174
runtime/internal/atomic.panicUnaligned()
        /usr/lib/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Xadd64(0x2c77b14, 0x1, 0x0, 0x7, 0xc)
        /usr/lib/go/src/runtime/internal/atomic/asm_arm.s:233 +0x14
go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*pool).makeNewConnection(0x2c77ae0, 0x2d62c01, 0x0, 0x1, 0x0, 0x0)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/topology/pool.go:287 +0x94
go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*pool).get(0x2c77ae0, 0x8bc73c, 0x2cf99c0, 0x0, 0x0, 0x2cc8988)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/topology/pool.go:440 +0x3b0
go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*Server).Connection(0x2d96f30, 0x8bc73c, 0x2cf99c0, 0x0, 0x0, 0x0, 0x0)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/topology/server.go:268 +0x5c
go.mongodb.org/mongo-driver/x/mongo/driver.Operation.getServerAndConnection(0x2dae628, 0x752d82, 0xb, 0x8ba99c, 0x2d87580, 0x2dae630, 0x8b84d4, 0x2db3680, 0x0, 0x0, ...)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/operation.go:246 +0x94
go.mongodb.org/mongo-driver/x/mongo/driver.Operation.Execute(0x2dae628, 0x752d82, 0xb, 0x8ba99c, 0x2d87580, 0x2dae630, 0x8b84d4, 0x2db3680, 0x0, 0x0, ...)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/operation.go:301 +0x80
go.mongodb.org/mongo-driver/x/mongo/driver/operation.(*Insert).Execute(0x2d9aea0, 0x8bc73c, 0x2cf99c0, 0x2dae620, 0x9f3c141e)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/x/mongo/driver/operation/insert.go:109 +0x1a4
go.mongodb.org/mongo-driver/mongo.(*Collection).insert(0x2d83440, 0x8bc73c, 0x2cf99c0, 0x2cb1bf4, 0x1, 0x1, 0x2cb1be8, 0x1, 0x1, 0x0, ...)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/mongo/collection.go:297 +0x54c
go.mongodb.org/mongo-driver/mongo.(*Collection).InsertOne(0x2d83440, 0x8bc73c, 0x2cf99c0, 0x690128, 0x2d9ae40, 0x0, 0x0, 0x0, 0xc0425a05, 0x82bfeb58, ...)
        /home/sr/go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.1/mongo/collection.go:336 +0xd4
 (...)
```

The atomic package has a [bug section](https://pkg.go.dev/sync/atomic#pkg-note-BUG) with this note:
> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 

I have tested it with my program after change (on arm target) and it worked. 