### PR TITLE
GODRIVER-2085 Add serverConnectionId to command monitoring events

### DIFF
--- a/data/command-monitoring/unified/pre-42-server-connection-id.json
+++ b/data/command-monitoring/unified/pre-42-server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/command-monitoring/unified/pre-42-server-connection-id.yml
+++ b/data/command-monitoring/unified/pre-42-server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "pre-42-server-connection-id"
+
+schemaVersion: "1.6"
+
+runOnRequirements:
+  - maxServerVersion: "4.0.99"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events do not include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: false
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: false

--- a/data/command-monitoring/unified/server-connection-id.json
+++ b/data/command-monitoring/unified/server-connection-id.json
@@ -1,6 +1,6 @@
 {
   "description": "server-connection-id",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.6",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2"

--- a/data/command-monitoring/unified/server-connection-id.json
+++ b/data/command-monitoring/unified/server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/command-monitoring/unified/server-connection-id.yml
+++ b/data/command-monitoring/unified/server-connection-id.yml
@@ -1,6 +1,6 @@
 description: "server-connection-id"
 
-schemaVersion: "1.0"
+schemaVersion: "1.6"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/data/command-monitoring/unified/server-connection-id.yml
+++ b/data/command-monitoring/unified/server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "server-connection-id"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: true
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: true

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -24,7 +24,7 @@ type CommandStartedEvent struct {
 	ConnectionID string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
-	ServerConnectionID *uint32
+	ServerConnectionID *int32
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID
@@ -38,7 +38,7 @@ type CommandFinishedEvent struct {
 	ConnectionID  string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
-	ServerConnectionID *uint32
+	ServerConnectionID *int32
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -22,6 +22,9 @@ type CommandStartedEvent struct {
 	CommandName  string
 	RequestID    int64
 	ConnectionID string
+	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
+	// this value (e.g. on MDB < 4.2), it is unset.
+	ServerConnectionID *uint64
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID
@@ -33,6 +36,9 @@ type CommandFinishedEvent struct {
 	CommandName   string
 	RequestID     int64
 	ConnectionID  string
+	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
+	// this value (e.g. on MDB < 4.2), it is unset.
+	ServerConnectionID *uint64
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -24,7 +24,7 @@ type CommandStartedEvent struct {
 	ConnectionID string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
-	ServerConnectionID *uint64
+	ServerConnectionID *uint32
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID
@@ -38,7 +38,7 @@ type CommandFinishedEvent struct {
 	ConnectionID  string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
-	ServerConnectionID *uint64
+	ServerConnectionID *uint32
 	// ServiceID contains the ID of the server to which the command was sent if it is running behind a load balancer.
 	// Otherwise, it is unset.
 	ServiceID *primitive.ObjectID

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -35,7 +35,7 @@ type Server struct {
 	AverageRTT            time.Duration
 	AverageRTTSet         bool
 	Compression           []string // compression methods returned by server
-	ConnectionID          *uint64
+	ConnectionID          *uint32
 	CanonicalAddr         address.Address
 	ElectionID            primitive.ObjectID
 	HeartbeatInterval     time.Duration
@@ -96,13 +96,13 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				return desc
 			}
 		case "connectionId":
-			i64, ok := element.Value().AsInt64OK()
+			i32, ok := element.Value().AsInt32OK()
 			if !ok {
 				desc.LastError = fmt.Errorf("expected 'connectionId' to be an integer but it's a BSON %s", element.Value().Type)
 				return desc
 			}
-			ui64 := uint64(i64)
-			desc.ConnectionID = &ui64
+			ui32 := uint32(i32)
+			desc.ConnectionID = &ui32
 		case "electionId":
 			desc.ElectionID, ok = element.Value().ObjectIDOK()
 			if !ok {

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	AverageRTT            time.Duration
 	AverageRTTSet         bool
 	Compression           []string // compression methods returned by server
+	ConnectionID          *uint64
 	CanonicalAddr         address.Address
 	ElectionID            primitive.ObjectID
 	HeartbeatInterval     time.Duration
@@ -94,6 +95,14 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				desc.LastError = err
 				return desc
 			}
+		case "connectionId":
+			i64, ok := element.Value().AsInt64OK()
+			if !ok {
+				desc.LastError = fmt.Errorf("expected 'connectionId' to be an integer but it's a BSON %s", element.Value().Type)
+				return desc
+			}
+			ui64 := uint64(i64)
+			desc.ConnectionID = &ui64
 		case "electionId":
 			desc.ElectionID, ok = element.Value().ObjectIDOK()
 			if !ok {

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -35,7 +35,6 @@ type Server struct {
 	AverageRTT            time.Duration
 	AverageRTTSet         bool
 	Compression           []string // compression methods returned by server
-	ConnectionID          *uint32
 	CanonicalAddr         address.Address
 	ElectionID            primitive.ObjectID
 	HeartbeatInterval     time.Duration
@@ -95,14 +94,6 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				desc.LastError = err
 				return desc
 			}
-		case "connectionId":
-			i32, ok := element.Value().AsInt32OK()
-			if !ok {
-				desc.LastError = fmt.Errorf("expected 'connectionId' to be an integer but it's a BSON %s", element.Value().Type)
-				return desc
-			}
-			ui32 := uint32(i32)
-			desc.ConnectionID = &ui32
 		case "electionId":
 			desc.ElectionID, ok = element.Value().ObjectIDOK()
 			if !ok {

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -88,6 +88,12 @@ func (*connection) ID() string {
 	return "<mock_connection>"
 }
 
+// ServerConnectionID returns a fixed identifier for the server connection.
+func (*connection) ServerConnectionID() *uint32 {
+	serverConnectionID := uint32(42)
+	return &serverConnectionID
+}
+
 // Address returns a fixed address for the connection.
 func (*connection) Address() address.Address {
 	return serverAddress

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -89,8 +89,8 @@ func (*connection) ID() string {
 }
 
 // ServerConnectionID returns a fixed identifier for the server connection.
-func (*connection) ServerConnectionID() *uint32 {
-	serverConnectionID := uint32(42)
+func (*connection) ServerConnectionID() *int32 {
+	serverConnectionID := int32(42)
 	return &serverConnectionID
 }
 

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -366,7 +366,7 @@ func verifyServiceID(expectServiceID bool, serviceID *primitive.ObjectID) error 
 	return nil
 }
 
-func verifyServerConnectionID(expectedHasSCID bool, scid *uint32) error {
+func verifyServerConnectionID(expectedHasSCID bool, scid *int32) error {
 	if actualHasSCID := scid != nil; expectedHasSCID != actualHasSCID {
 		if expectedHasSCID {
 			return fmt.Errorf("expected event to have server connection ID, event has none")

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -373,6 +373,9 @@ func verifyServerConnectionID(expectedHasSCID bool, scid *uint32) error {
 		}
 		return fmt.Errorf("expected event to have no server connection ID, got %d", *scid)
 	}
+	if expectedHasSCID && *scid <= 0 {
+		return fmt.Errorf("expected event to have a positive server connection ID, got %d", *scid)
+	}
 	return nil
 }
 

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -366,7 +366,7 @@ func verifyServiceID(expectServiceID bool, serviceID *primitive.ObjectID) error 
 	return nil
 }
 
-func verifyServerConnectionID(expectedHasSCID bool, scid *uint64) error {
+func verifyServerConnectionID(expectedHasSCID bool, scid *uint32) error {
 	if actualHasSCID := scid != nil; expectedHasSCID != actualHasSCID {
 		if expectedHasSCID {
 			return fmt.Errorf("expected event to have server connection ID, event has none")

--- a/mongo/integration/unified/schema_version.go
+++ b/mongo/integration/unified/schema_version.go
@@ -16,8 +16,7 @@ import (
 
 var (
 	supportedSchemaVersions = map[int]string{
-		// We do not fully support the 1.5 schema, but we need 1.5 to test with observeSensitiveCommands.
-		1: "1.5",
+		1: "1.6",
 	}
 )
 

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -52,6 +52,7 @@ type Connection interface {
 	Description() description.Server
 	Close() error
 	ID() string
+	ServerConnectionID() *uint32
 	Address() address.Address
 	Stale() bool
 }
@@ -137,11 +138,14 @@ type ErrorProcessor interface {
 }
 
 // HandshakeInformation contains information extracted from a MongoDB connection handshake. This is a helper type that
-// augments description.Server by also tracking authentication-related fields. We use this type rather than adding
-// these fields to description.Server to avoid retaining sensitive information in a user-facing type.
+// augments description.Server by also tracking server connection ID and authentication-related fields. We use this type
+// rather than adding authentication-related fields to description.Server to avoid retaining sensitive information in a
+// user-facing type. The server connection ID is stored in this type because unlike description.Server, all handshakes are
+// correlated with a single network connection.
 type HandshakeInformation struct {
 	Description             description.Server
 	SpeculativeAuthenticate bsoncore.Document
+	ServerConnectionID      *uint32
 	SaslSupportedMechs      []string
 }
 

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -52,7 +52,7 @@ type Connection interface {
 	Description() description.Server
 	Close() error
 	ID() string
-	ServerConnectionID() *uint32
+	ServerConnectionID() *int32
 	Address() address.Address
 	Stale() bool
 }
@@ -145,7 +145,7 @@ type ErrorProcessor interface {
 type HandshakeInformation struct {
 	Description             description.Server
 	SpeculativeAuthenticate bsoncore.Document
-	ServerConnectionID      *uint32
+	ServerConnectionID      *int32
 	SaslSupportedMechs      []string
 }
 

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -62,8 +62,8 @@ func (c *ChannelConn) ID() string {
 }
 
 // ServerConnectionID implements the driver.Connection interface.
-func (c *ChannelConn) ServerConnectionID() *uint32 {
-	serverConnectionID := uint32(42)
+func (c *ChannelConn) ServerConnectionID() *int32 {
+	serverConnectionID := int32(42)
 	return &serverConnectionID
 }
 

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -61,6 +61,12 @@ func (c *ChannelConn) ID() string {
 	return "faked"
 }
 
+// ServerConnectionID implements the driver.Connection interface.
+func (c *ChannelConn) ServerConnectionID() *uint32 {
+	serverConnectionID := uint32(42)
+	return &serverConnectionID
+}
+
 // Address implements the driver.Connection interface.
 func (c *ChannelConn) Address() address.Address { return address.Address("0.0.0.0") }
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -73,7 +73,7 @@ type startedInformation struct {
 	cmdName                  string
 	documentSequenceIncluded bool
 	connID                   string
-	serverConnID             *uint64
+	serverConnID             *uint32
 	redacted                 bool
 	serviceID                *primitive.ObjectID
 }
@@ -85,7 +85,7 @@ type finishedInformation struct {
 	response     bsoncore.Document
 	cmdErr       error
 	connID       string
-	serverConnID *uint64
+	serverConnID *uint32
 	startTime    time.Time
 	redacted     bool
 	serviceID    *primitive.ObjectID

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -401,7 +401,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		op.cmdName = startedInfo.cmdName
 		startedInfo.redacted = op.redactCommand(startedInfo.cmdName, startedInfo.cmd)
 		startedInfo.serviceID = conn.Description().ServiceID
-		startedInfo.serverConnID = desc.ConnectionID
+		startedInfo.serverConnID = conn.ServerConnectionID()
 		op.publishStartedEvent(ctx, startedInfo)
 
 		// get the moreToCome flag information before we compress

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -73,7 +73,7 @@ type startedInformation struct {
 	cmdName                  string
 	documentSequenceIncluded bool
 	connID                   string
-	serverConnID             *uint32
+	serverConnID             *int32
 	redacted                 bool
 	serviceID                *primitive.ObjectID
 }
@@ -85,7 +85,7 @@ type finishedInformation struct {
 	response     bsoncore.Document
 	cmdErr       error
 	connID       string
-	serverConnID *uint32
+	serverConnID *int32
 	startTime    time.Time
 	redacted     bool
 	serviceID    *primitive.ObjectID

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -274,6 +274,10 @@ func (h *Hello) GetHandshakeInformation(ctx context.Context, _ address.Address, 
 	if speculativeAuthenticate, ok := h.res.Lookup("speculativeAuthenticate").DocumentOK(); ok {
 		info.SpeculativeAuthenticate = speculativeAuthenticate
 	}
+	if serverConnectionID, ok := h.res.Lookup("connectionId").AsInt32OK(); ok {
+		ui32 := uint32(serverConnectionID)
+		info.ServerConnectionID = &ui32
+	}
 	// Cast to bson.Raw to lookup saslSupportedMechs to avoid converting from bsoncore.Value to bson.RawValue for the
 	// StringSliceFromRawValue call.
 	if saslSupportedMechs, lookupErr := bson.Raw(h.res).LookupErr("saslSupportedMechs"); lookupErr == nil {

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -274,9 +274,8 @@ func (h *Hello) GetHandshakeInformation(ctx context.Context, _ address.Address, 
 	if speculativeAuthenticate, ok := h.res.Lookup("speculativeAuthenticate").DocumentOK(); ok {
 		info.SpeculativeAuthenticate = speculativeAuthenticate
 	}
-	if serverConnectionID, ok := h.res.Lookup("connectionId").AsInt32OK(); ok {
-		ui32 := uint32(serverConnectionID)
-		info.ServerConnectionID = &ui32
+	if serverConnectionID, ok := h.res.Lookup("connectionId").Int32OK(); ok {
+		info.ServerConnectionID = &serverConnectionID
 	}
 	// Cast to bson.Raw to lookup saslSupportedMechs to avoid converting from bsoncore.Value to bson.RawValue for the
 	// StringSliceFromRawValue call.

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -638,20 +638,22 @@ type mockConnection struct {
 	pReadDst []byte
 
 	// returns
-	rWriteErr  error
-	rReadWM    []byte
-	rReadErr   error
-	rDesc      description.Server
-	rCloseErr  error
-	rID        string
-	rAddr      address.Address
-	rCanStream bool
-	rStreaming bool
+	rWriteErr     error
+	rReadWM       []byte
+	rReadErr      error
+	rDesc         description.Server
+	rCloseErr     error
+	rID           string
+	rServerConnID *uint32
+	rAddr         address.Address
+	rCanStream    bool
+	rStreaming    bool
 }
 
 func (m *mockConnection) Description() description.Server { return m.rDesc }
 func (m *mockConnection) Close() error                    { return m.rCloseErr }
 func (m *mockConnection) ID() string                      { return m.rID }
+func (m *mockConnection) ServerConnectionID() *uint32     { return m.rServerConnID }
 func (m *mockConnection) Address() address.Address        { return m.rAddr }
 func (m *mockConnection) SupportsStreaming() bool         { return m.rCanStream }
 func (m *mockConnection) CurrentlyStreaming() bool        { return m.rStreaming }

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -644,7 +644,7 @@ type mockConnection struct {
 	rDesc         description.Server
 	rCloseErr     error
 	rID           string
-	rServerConnID *uint32
+	rServerConnID *int32
 	rAddr         address.Address
 	rCanStream    bool
 	rStreaming    bool
@@ -653,7 +653,7 @@ type mockConnection struct {
 func (m *mockConnection) Description() description.Server { return m.rDesc }
 func (m *mockConnection) Close() error                    { return m.rCloseErr }
 func (m *mockConnection) ID() string                      { return m.rID }
-func (m *mockConnection) ServerConnectionID() *uint32     { return m.rServerConnID }
+func (m *mockConnection) ServerConnectionID() *int32      { return m.rServerConnID }
 func (m *mockConnection) Address() address.Address        { return m.rAddr }
 func (m *mockConnection) SupportsStreaming() bool         { return m.rCanStream }
 func (m *mockConnection) CurrentlyStreaming() bool        { return m.rStreaming }

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -95,7 +95,7 @@ type LoadBalancedTransactionConnection interface {
 	Description() description.Server
 	Close() error
 	ID() string
-	ServerConnectionID() *uint32
+	ServerConnectionID() *int32
 	Address() address.Address
 	Stale() bool
 

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -95,6 +95,7 @@ type LoadBalancedTransactionConnection interface {
 	Description() description.Server
 	Close() error
 	ID() string
+	ServerConnectionID() *uint32
 	Address() address.Address
 	Stale() bool
 

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -62,6 +62,7 @@ type connection struct {
 	currentlyStreaming   bool
 	connectContextMutex  sync.Mutex
 	cancellationListener cancellationListener
+	serverConnectionID   *uint32 // the server's ID for this client's connection
 
 	// pool related fields
 	pool         *pool
@@ -227,11 +228,13 @@ func (c *connection) connect(ctx context.Context) {
 	handshakeConn := initConnection{c}
 	handshakeInfo, err = handshaker.GetHandshakeInformation(handshakeCtx, c.addr, handshakeConn)
 	if err == nil {
-		// We only need to retain the Description field as the connection's description. The authentication-related
-		// fields in handshakeInfo are tracked by the handshaker if necessary.
+		// We only need to retain the Description field and the server connection ID. The authentication-related
+		// fields in handshakeInfo are tracked by the handshaker if necessary. We also lock the description mutex
+		// before setting the server description.
 		c.descMu.Lock()
 		c.desc = handshakeInfo.Description
 		c.descMu.Unlock()
+		c.serverConnectionID = handshakeInfo.ServerConnectionID
 		c.helloRTT = time.Since(handshakeStartTime)
 
 		// If the application has indicated that the cluster is load balanced, ensure the server has included serviceId
@@ -562,6 +565,10 @@ func (c *connection) setSocketTimeout(timeout time.Duration) {
 
 func (c *connection) ID() string {
 	return c.id
+}
+
+func (c *connection) ServerConnectionID() *uint32 {
+	return c.serverConnectionID
 }
 
 // initConnection is an adapter used during connection initialization. It has the minimum

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -62,7 +62,7 @@ type connection struct {
 	currentlyStreaming   bool
 	connectContextMutex  sync.Mutex
 	cancellationListener cancellationListener
-	serverConnectionID   *uint32 // the server's ID for this client's connection
+	serverConnectionID   *int32 // the server's ID for this client's connection
 
 	// pool related fields
 	pool         *pool
@@ -567,7 +567,7 @@ func (c *connection) ID() string {
 	return c.id
 }
 
-func (c *connection) ServerConnectionID() *uint32 {
+func (c *connection) ServerConnectionID() *int32 {
 	return c.serverConnectionID
 }
 


### PR DESCRIPTION
GODRIVER-2085

Adds a `ServerConnectionID` field to `CommandStartedEvent`, `CommandSucceededEvent` and `CommandFailedEvent` to track the `serverConnectionId` returned in the server's `hello` or legacy hello response (on 4.2+). Syncs command monitoring spec tests. Bumps supported schema version of the unified test runner to 1.6.