### PR TITLE
GODRIVER-2064 Remove duplicate key mappings from Evg config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2047,7 +2047,6 @@ buildvariants:
       - name: ".test .enterprise-auth"
 
   - matrix_name: "aws-auth-test"
-    matrix_spec: { os-aws-auth: "*" }
     matrix_spec: { version: ["4.4", "5.0", "latest"], os-aws-auth: "*" }
     display_name: "MONGODB-AWS Auth ${version} ${os-aws-auth}"
     tasks:


### PR DESCRIPTION
GODRIVER-2064

The Evergreen team is now using YAML v3 which no longer supports duplicate key mappings (YAML v2 was last-definition-honored for duplicate keys). Removes the single duplicate key mapping of `matrix_spec` from our Evergreen config.