### PR TITLE
GODRIVER-2109 Prevent a data race between connecting and checking out a connection from the resourcePool.

### DIFF
--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -456,6 +457,13 @@ func TestClient(t *testing.T) {
 
 		mode := modeVal.StringValue()
 		assert.Equal(mt, mode, "primaryPreferred", "expected read preference mode primaryPreferred, got %v", mode)
+	})
+
+	// Test that using a client with minPoolSize set doesn't cause a data race.
+	mtOpts = mtest.NewOptions().ClientOptions(options.Client().SetMinPoolSize(5))
+	mt.RunOpts("minPoolSize", mtOpts, func(mt *mtest.T) {
+		err := mt.Client.Ping(context.Background(), readpref.Primary())
+		assert.Nil(t, err, "unexpected error calling Ping: %v", err)
 	})
 }
 

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -131,7 +131,7 @@ func (p *pool) connectionInitFunc() interface{} {
 		return nil
 	}
 
-	go c.connect(context.Background())
+	c.connect(context.Background())
 
 	return c
 }


### PR DESCRIPTION
[GODRIVER-2109](https://jira.mongodb.org/browse/GODRIVER-2109)

There is currently a data race on the field `connection.desc` between setting it at [connection.go#L231](https://github.com/mongodb/mongo-go-driver/blob/e142bb3bb6c3c05f3feedefc6c5e87ee096c7422/x/mongo/driver/topology/connection.go#L231) and reading it at [pool.go#L199](https://github.com/mongodb/mongo-go-driver/blob/e142bb3bb6c3c05f3feedefc6c5e87ee096c7422/x/mongo/driver/topology/pool.go#L199) and [pool.go#L535](https://github.com/mongodb/mongo-go-driver/blob/e142bb3bb6c3c05f3feedefc6c5e87ee096c7422/x/mongo/driver/topology/pool.go#L535). The data race occurs when the `resourcePool.Maintain()` function adds connections to satisfy `minPoolSize` (only when `minPoolSize > 0`). The unconnected connections are added to the `resourcePool` and then connected in a separate goroutine, which results in concurrent access to the `connection.desc` field when another goroutine attempts to get the connection from the `resourcePool`.

Changes:
* Update `resourcePool.Maintain()` and `pool.connectionInitFunc()` to wait for a connection to finish connecting before making it available to check out from the `resourcePool`.
* Add a test that triggers the data race when run with the data race detector enabled.