### PR TITLE
GODRIVER-2141 Implement RecursiveMap for primitive.D and A

### DIFF
--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -194,6 +194,24 @@ func (d D) Map() M {
 	return m
 }
 
+// RecursiveMap creates a map from the elements of the D, recursively creating
+// maps from embedded documents and arrays within D.
+func (d D) RecursiveMap() M {
+	m := make(M, len(d))
+	for _, e := range d {
+		key := e.Key
+		switch e := e.Value.(type) {
+		case D:
+			m[key] = e.RecursiveMap()
+		case A:
+			m[key] = e.RecursiveMap()
+		default:
+			m[key] = e
+		}
+	}
+	return m
+}
+
 // E represents a BSON element for a D. It is usually used inside a D.
 type E struct {
 	Key   string
@@ -215,3 +233,24 @@ type M map[string]interface{}
 //
 // 		bson.A{"bar", "world", 3.14159, bson.D{{"qux", 12345}}}
 type A []interface{}
+
+// RecursiveMap creates a map from the elements of the A, recursively creating
+// maps from embedded documents and arrays within A.
+func (a A) RecursiveMap() M {
+	m := make(M, len(a))
+
+	var index int
+	for _, v := range a {
+		key := fmt.Sprint(index)
+		switch v := v.(type) {
+		case D:
+			m[key] = v.RecursiveMap()
+		case A:
+			m[key] = v.RecursiveMap()
+		default:
+			m[key] = v
+		}
+		index += 1
+	}
+	return m
+}

--- a/bson/primitive/primitive_test.go
+++ b/bson/primitive/primitive_test.go
@@ -120,3 +120,59 @@ func TestDateTime(t *testing.T) {
 		})
 	})
 }
+
+func TestRecursiveMap(t *testing.T) {
+	testCases := []struct {
+		name string
+		d    D
+		m    M
+	}{
+		{
+			"basic",
+			D{
+				{"foo", "bar"},
+				{"baz", "qux"},
+			},
+			M{"foo": "bar", "baz": "qux"},
+		},
+		{
+			"embedded D",
+			D{
+				{"foo", D{
+					{"bar", "baz"},
+				}},
+				{"qux", "quux"},
+			},
+			M{"foo": M{"bar": "baz"}, "qux": "quux"},
+		},
+		{
+			"embedded A",
+			D{
+				{"foo", A{"bar", "baz"}},
+				{"qux", "quux"},
+			},
+			M{"foo": M{"0": "bar", "1": "baz"}, "qux": "quux"},
+		},
+		{
+			"embedded D in A",
+			D{
+				{"foo", A{"bar", D{
+					{"baz", "qux"},
+				}}},
+				{"quux", "quuz"},
+			},
+			M{"foo": M{"0": "bar", "1": M{"baz": "qux"}}, "quux": "quuz"},
+		},
+		{
+			"empty",
+			D{},
+			M{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.d.RecursiveMap()
+			assert.Equal(t, m, tc.m, "expected M %v, got %v", tc.m, m)
+		})
+	}
+}


### PR DESCRIPTION
GODRIVER-2141

Implements `RecursiveMap` for both `primitive.D` and `primitive.A`. This function is like `Map`, but it recursively creates `primitive.M` instances from embedded `D`s and `A`s within the initial `D` or `A`. Adds tests to verify `RecursiveMap`'s behavior.