### PR TITLE
fix: compare object id directly

### DIFF
--- a/bson/bsonrw/value_reader_test.go
+++ b/bson/bsonrw/value_reader_test.go
@@ -459,7 +459,7 @@ func TestValueReader(t *testing.T) {
 				if ns != tc.ns {
 					t.Errorf("Incorrect namespace returned. got %v; want %v", ns, tc.ns)
 				}
-				if !bytes.Equal(oid[:], tc.oid[:]) {
+				if oid != tc.oid {
 					t.Errorf("ObjectIDs did not match. got %v; want %v", oid, tc.oid)
 				}
 			})
@@ -1049,7 +1049,7 @@ func TestValueReader(t *testing.T) {
 				if !errequal(t, err, tc.err) {
 					t.Errorf("Returned errors do not match. got %v; want %v", err, tc.err)
 				}
-				if !bytes.Equal(oid[:], tc.oid[:]) {
+				if oid != tc.oid {
 					t.Errorf("ObjectIDs did not match. got %v; want %v", oid, tc.oid)
 				}
 			})

--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -10,7 +10,6 @@
 package primitive
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding"
 	"encoding/binary"
@@ -71,7 +70,7 @@ func (id ObjectID) String() string {
 
 // IsZero returns true if id is the empty ObjectID.
 func (id ObjectID) IsZero() bool {
-	return bytes.Equal(id[:], NilObjectID[:])
+	return id == NilObjectID
 }
 
 // ObjectIDFromHex creates a new ObjectID from a hex string. It returns an error if the hex string is not a
@@ -87,7 +86,7 @@ func ObjectIDFromHex(s string) (ObjectID, error) {
 	}
 
 	var oid [12]byte
-	copy(oid[:], b[:])
+	copy(oid[:], b)
 
 	return oid, nil
 }

--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -111,7 +111,7 @@ func (d DBPointer) String() string {
 
 // Equal compares d to d2 and returns true if they are equal.
 func (d DBPointer) Equal(d2 DBPointer) bool {
-	return d.DB == d2.DB && bytes.Equal(d.Pointer[:], d2.Pointer[:])
+	return d == d2
 }
 
 // IsZero returns if d is the empty DBPointer.

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -239,7 +239,7 @@ func (f *fsm) updateRSFromPrimary(s description.Server) {
 		return
 	}
 
-	if s.SetVersion != 0 && !bytes.Equal(s.ElectionID[:], primitive.NilObjectID[:]) {
+	if s.SetVersion != 0 && !s.ElectionID.IsZero() {
 		if f.maxSetVersion > s.SetVersion || bytes.Compare(f.maxElectionID[:], s.ElectionID[:]) == 1 {
 			f.replaceServer(description.Server{
 				Addr:      s.Addr,

--- a/x/mongo/driver/uuid/uuid.go
+++ b/x/mongo/driver/uuid/uuid.go
@@ -7,7 +7,6 @@
 package uuid // import "go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 
 import (
-	"bytes"
 	"crypto/rand"
 	"io"
 )
@@ -33,5 +32,5 @@ func New() (UUID, error) {
 
 // Equal returns true if two UUIDs are equal.
 func Equal(a, b UUID) bool {
-	return bytes.Equal([]byte(a[:]), []byte(b[:]))
+	return a == b
 }


### PR DESCRIPTION
ObjectID is an array typed `[12]byte`, so it can be compared with another one directly.

I don't know why we convert two ObjectID to slices and compare them with `bytes.Equal`, I believe it is unnecessary.