### PR TITLE
GODRIVER-2086 Allow custom SRV service names with URI option srvServiceName

### DIFF
--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
+  "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
   "seeds": [
     "localhost.test.build.10gen.cc:27017",
     "localhost.test.build.10gen.cc:27018"

--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "srvServiceName": "customname"
+  }
+}

--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -1,7 +1,8 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
   ],
   "hosts": [
     "localhost:27017",

--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
+uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
 seeds:
     - localhost.test.build.10gen.cc:27017
     - localhost.test.build.10gen.cc:27018

--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -1,0 +1,10 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true
+    srvServiceName: "customname"

--- a/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -1,6 +1,7 @@
-uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
 seeds:
     - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
 hosts:
     - localhost:27017
     - localhost:27018

--- a/data/uri-options/srv-service-name-option.json
+++ b/data/uri-options/srv-service-name-option.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "SRV URI with custom srvServiceName",
-      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
+      "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
       "valid": true,
       "warning": false,
       "hosts": null,

--- a/data/uri-options/srv-service-name-option.json
+++ b/data/uri-options/srv-service-name-option.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "description": "SRV URI with custom srvServiceName",
+      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "srvServiceName": "customname"
+      }
+    },
+    {
+      "description": "Non-SRV URI with custom srvServiceName",
+      "uri": "mongodb://example.com/?srvServiceName=customname",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/data/uri-options/srv-service-name-option.json
+++ b/data/uri-options/srv-service-name-option.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "SRV URI with custom srvServiceName",
-      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -15,7 +15,7 @@
       "description": "Non-SRV URI with custom srvServiceName",
       "uri": "mongodb://example.com/?srvServiceName=customname",
       "valid": false,
-      "warning": null,
+      "warning": true,
       "hosts": null,
       "auth": null,
       "options": {}

--- a/data/uri-options/srv-service-name-option.yml
+++ b/data/uri-options/srv-service-name-option.yml
@@ -1,6 +1,6 @@
 tests:
     - description: "SRV URI with custom srvServiceName"
-      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
+      uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
       valid: true
       warning: false
       hosts: ~

--- a/data/uri-options/srv-service-name-option.yml
+++ b/data/uri-options/srv-service-name-option.yml
@@ -1,0 +1,16 @@
+tests:
+    - description: "SRV URI with custom srvServiceName"
+      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          srvServiceName: "customname"
+    - description: "Non-SRV URI with custom srvServiceName"
+      uri: "mongodb://example.com/?srvServiceName=customname"
+      valid: false
+      warning: ~
+      hosts: ~
+      auth: ~
+      options: {}

--- a/data/uri-options/srv-service-name-option.yml
+++ b/data/uri-options/srv-service-name-option.yml
@@ -1,6 +1,6 @@
 tests:
     - description: "SRV URI with custom srvServiceName"
-      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
       valid: true
       warning: false
       hosts: ~
@@ -10,7 +10,7 @@ tests:
     - description: "Non-SRV URI with custom srvServiceName"
       uri: "mongodb://example.com/?srvServiceName=customname"
       valid: false
-      warning: ~
+      warning: true
       hosts: ~
       auth: ~
       options: {}

--- a/internal/testutil/helpers/helpers.go
+++ b/internal/testutil/helpers/helpers.go
@@ -150,6 +150,8 @@ func VerifyConnStringOptions(t *testing.T, cs connstring.ConnString, options map
 			require.Equal(t, value, cs.RetryWrites)
 		case "serverselectiontimeoutms":
 			require.Equal(t, value, float64(cs.ServerSelectionTimeout/time.Millisecond))
+		case "srvservicename":
+			require.Equal(t, value, cs.SRVServiceName)
 		case "ssl", "tls":
 			require.Equal(t, value, cs.SSL)
 		case "sockettimeoutms":

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -375,10 +375,16 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 	// ClusterClock
 	c.clock = new(session.ClusterClock)
 
-	// Pass down URI so topology can determine whether or not SRV polling is required
-	topologyOpts = append(topologyOpts, topology.WithURI(func(uri string) string {
-		return opts.GetURI()
-	}))
+	// Pass down URI and SRV service name so topology can poll SRV records correctly
+	topologyOpts = append(topologyOpts,
+		topology.WithURI(func(uri string) string { return opts.GetURI() }),
+		topology.WithSRVServiceName(func(srvName string) string {
+			if opts.SRVServiceName != nil {
+				return *opts.SRVServiceName
+			}
+			return ""
+		}),
+	)
 
 	// AppName
 	var appName string

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -675,9 +675,9 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 
 	// Deployment
 	if opts.Deployment != nil {
-		// topology options: WithSeedlist and WithURI
+		// topology options: WithSeedlist, WithURI and WithSRVServiceName
 		// server options: WithClock and WithConnectionOptions
-		if len(serverOpts) > 2 || len(topologyOpts) > 2 {
+		if len(serverOpts) > 2 || len(topologyOpts) > 3 {
 			return errors.New("cannot specify topology or server options with a deployment")
 		}
 		c.deployment = opts.Deployment

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -135,6 +135,9 @@ func verifyConnstringOptions(mt *mtest.T, expected bson.Raw, cs connstring.ConnS
 			lb := opt.Boolean()
 			assert.True(mt, cs.LoadBalancedSet, "expected cs.LoadBalancedSet set to be true, got false")
 			assert.Equal(mt, lb, cs.LoadBalanced, "expected cs.LoadBalanced to be %v, got %v", lb, cs.LoadBalanced)
+		case "srvServiceName":
+			srvName := opt.StringValue()
+			assert.Equal(mt, srvName, cs.SRVServiceName, "expected cs.SRVServiceName to be %q, got %q", srvName, cs.SRVServiceName)
 		default:
 			mt.Fatalf("unrecognized connstring option %v", key)
 		}

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -121,6 +121,7 @@ type ClientOptions struct {
 	ServerAPIOptions         *ServerAPIOptions
 	ServerSelectionTimeout   *time.Duration
 	SocketTimeout            *time.Duration
+	SRVServiceName           *string
 	TLSConfig                *tls.Config
 	WriteConcern             *writeconcern.WriteConcern
 	ZlibLevel                *int
@@ -336,6 +337,10 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 
 	if cs.SocketTimeoutSet {
 		c.SocketTimeout = &cs.SocketTimeout
+	}
+
+	if cs.SRVServiceName != "" {
+		c.SRVServiceName = &cs.SRVServiceName
 	}
 
 	if cs.SSL {
@@ -760,6 +765,13 @@ func (c *ClientOptions) SetServerAPIOptions(opts *ServerAPIOptions) *ClientOptio
 	return c
 }
 
+// SetSRVServiceName specifies a custom SRV service name to use in SRV polling. To use a custom SRV service name
+// in SRV discovery, this function must be called before ApplyURI.
+func (c *ClientOptions) SetSRVServiceName(srvName string) *ClientOptions {
+	c.SRVServiceName = &srvName
+	return c
+}
+
 // MergeClientOptions combines the given *ClientOptions into a single *ClientOptions in a last one wins fashion.
 // The specified options are merged with the existing options on the client, with the specified options taking
 // precedence.
@@ -848,6 +860,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.SocketTimeout != nil {
 			c.SocketTimeout = opt.SocketTimeout
+		}
+		if opt.SRVServiceName != nil {
+			c.SRVServiceName = opt.SRVServiceName
 		}
 		if opt.TLSConfig != nil {
 			c.TLSConfig = opt.TLSConfig

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -766,7 +766,8 @@ func (c *ClientOptions) SetServerAPIOptions(opts *ServerAPIOptions) *ClientOptio
 }
 
 // SetSRVServiceName specifies a custom SRV service name to use in SRV polling. To use a custom SRV service name
-// in SRV discovery, this function must be called before ApplyURI.
+// in SRV discovery, this function must be called before ApplyURI. This can also be set through the "srvServiceName"
+// URI option.
 func (c *ClientOptions) SetSRVServiceName(srvName string) *ClientOptions {
 	c.SRVServiceName = &srvName
 	return c

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -776,6 +776,14 @@ func (p *parser) addOption(pair string) error {
 		if p.Scheme != SchemeMongoDBSRV {
 			return fmt.Errorf("cannot specify srvServiceName on non-SRV URI")
 		}
+
+		// srvServiceName must be between 1 and 62 characters according to
+		// our specification. Empty service names are not valid, and the service
+		// name (including prepended underscore) should not exceed the 63 character
+		// limit for DNS query subdomains.
+		if len(value) < 1 || len(value) > 62 {
+			return fmt.Errorf("srvServiceName value must be between 1 and 62 characters")
+		}
 		p.SRVServiceName = value
 	case "ssl", "tls":
 		switch value {

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -768,20 +768,21 @@ func (t *Topology) publishTopologyClosedEvent() {
 	}
 }
 
-// extracts the srvServiceName option from a URI if it exists
+// extracts the last occurrence of the srvServiceName option from a URI if it exists.
 func extractSrvServiceName(uri string) string {
 	parsedURI := strings.Split(uri, "?")
 	if len(parsedURI) != 2 {
 		return ""
 	}
 
+	var srvName string
 	connectionArgs := strings.Split(parsedURI[1], "&")
 	for _, pair := range connectionArgs {
 		parsedPair := strings.Split(pair, "=")
 		if len(parsedPair) == 2 && parsedPair[0] == "srvServiceName" {
-			return parsedPair[1]
+			srvName = parsedPair[1]
 		}
 	}
 
-	return ""
+	return srvName
 }

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -527,8 +527,7 @@ func (t *Topology) pollSRVRecords() {
 			break
 		}
 
-		srvName := extractSrvServiceName(uri)
-		parsedHosts, err := t.dnsResolver.ParseHosts(hosts, srvName, false)
+		parsedHosts, err := t.dnsResolver.ParseHosts(hosts, t.cfg.srvServiceName, false)
 		// DNS problem or no verified hosts returned
 		if err != nil || len(parsedHosts) == 0 {
 			if !t.pollHeartbeatTime.Load().(bool) {
@@ -766,23 +765,4 @@ func (t *Topology) publishTopologyClosedEvent() {
 	if t.cfg.serverMonitor != nil && t.cfg.serverMonitor.TopologyClosed != nil {
 		t.cfg.serverMonitor.TopologyClosed(topologyClosed)
 	}
-}
-
-// extracts the last occurrence of the srvServiceName option from a URI if it exists.
-func extractSrvServiceName(uri string) string {
-	parsedURI := strings.Split(uri, "?")
-	if len(parsedURI) != 2 {
-		return ""
-	}
-
-	var srvName string
-	connectionArgs := strings.Split(parsedURI[1], "&")
-	for _, pair := range connectionArgs {
-		parsedPair := strings.Split(pair, "=")
-		if len(parsedPair) == 2 && parsedPair[0] == "srvServiceName" {
-			srvName = parsedPair[1]
-		}
-	}
-
-	return srvName
 }

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -527,7 +527,8 @@ func (t *Topology) pollSRVRecords() {
 			break
 		}
 
-		parsedHosts, err := t.dnsResolver.ParseHosts(hosts, false)
+		// TODO: Don't use t.cfg.cs!!
+		parsedHosts, err := t.dnsResolver.ParseHosts(hosts, t.cfg.cs.SRVServiceName, false)
 		// DNS problem or no verified hosts returned
 		if err != nil || len(parsedHosts) == 0 {
 			if !t.pollHeartbeatTime.Load().(bool) {

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -36,6 +36,7 @@ type config struct {
 	uri                    string
 	serverSelectionTimeout time.Duration
 	serverMonitor          *event.ServerMonitor
+	srvServiceName         string
 	loadBalanced           bool
 }
 
@@ -304,6 +305,22 @@ func WithURI(fn func(string) string) Option {
 	}
 }
 
+// WithLoadBalanced specifies whether or not the cluster is behind a load balancer.
+func WithLoadBalanced(fn func(bool) bool) Option {
+	return func(cfg *config) error {
+		cfg.loadBalanced = fn(cfg.loadBalanced)
+		return nil
+	}
+}
+
+// WithSRVServiceName specifies the SRV service name that was used to create the topology.
+func WithSRVServiceName(fn func(string) string) Option {
+	return func(cfg *config) error {
+		cfg.srvServiceName = fn(cfg.srvServiceName)
+		return nil
+	}
+}
+
 // addCACertFromFile adds a root CA certificate to the configuration given a path
 // to the containing file.
 func addCACertFromFile(cfg *tls.Config, file string) error {
@@ -421,12 +438,4 @@ func addClientCertFromFile(cfg *tls.Config, clientFile, keyPasswd string) (strin
 	}
 
 	return x509CertSubject(crt), nil
-}
-
-// WithLoadBalanced specifies whether or not the cluster is behind a load balancer.
-func WithLoadBalanced(fn func(bool) bool) Option {
-	return func(cfg *config) error {
-		cfg.loadBalanced = fn(cfg.loadBalanced)
-		return nil
-	}
 }


### PR DESCRIPTION
GODRIVER-2086

Introduces a new URI option, `srvServiceName`, that can be used to specify a custom SRV service name for SRV discovery and polling. Adds new field to `ConnString`, updates test runners, and syncs spec tests.