### PR TITLE
GODRIVER-1868 Support $out and $merge executing on secondaries

### DIFF
--- a/data/crud/unified/aggregate-write-readPreference.json
+++ b/data/crud/unified/aggregate-write-readPreference.json
@@ -1,0 +1,457 @@
+{
+  "description": "aggregate-write-readPreference",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0",
+        "collectionOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/aggregate-write-readPreference.yml
+++ b/data/crud/unified/aggregate-write-readPreference.yml
@@ -1,0 +1,149 @@
+description: aggregate-write-readPreference
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  # 3.6+ non-standalone is needed to utilize $readPreference in OP_MSG
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded, load-balanced ]
+
+_yamlAnchors:
+  readConcern: &readConcern
+    level: &readConcernLevel "local"
+  writeConcern: &writeConcern
+    w: &writeConcernW 1
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+      # Used to test that read and write concerns are still inherited
+      uriOptions:
+        readConcernLevel: *readConcernLevel
+        w: *writeConcernW
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name db0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+      collectionOptions:
+        readPreference: &readPreference
+          # secondaryPreferred is specified for compatibility with clusters that
+          # may not have a secondary (e.g. each shard is only a primary).
+          mode: secondaryPreferred
+          # maxStalenessSeconds is specified to ensure that drivers forward the
+          # read preference to mongos or a load balancer. That would not be the
+          # case with only secondaryPreferred.
+          maxStalenessSeconds: 600
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+  - collectionName: *collection1Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Aggregate with $out includes read preference for 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: &outPipeline
+            - { $match: { _id: { $gt: 1 } } }
+            - { $sort: { x: 1 } }
+            - { $out: *collection1Name }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *outPipeline
+                $readPreference: *readPreference
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: &outcome
+      - collectionName: *collection1Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+
+  - description: "Aggregate with $out omits read preference for pre-5.0 server"
+    runOnRequirements:
+      - maxServerVersion: "4.4.99"
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *outPipeline
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *outPipeline
+                $readPreference: { $$exists: false }
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome
+
+  - description: "Aggregate with $merge includes read preference for 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: &mergePipeline
+            - { $match: { _id: { $gt: 1 } } }
+            - { $sort: { x: 1 } }
+            - { $merge: { into: *collection1Name } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *mergePipeline
+                $readPreference: *readPreference
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome
+
+  - description: "Aggregate with $merge omits read preference for pre-5.0 server"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *mergePipeline
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *mergePipeline
+                $readPreference: { $$exists: false }
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome

--- a/data/crud/unified/db-aggregate-write-readPreference.json
+++ b/data/crud/unified/db-aggregate-write-readPreference.json
@@ -1,0 +1,445 @@
+{
+  "description": "db-aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0",
+        "databaseOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/db-aggregate-write-readPreference.json
+++ b/data/crud/unified/db-aggregate-write-readPreference.json
@@ -5,9 +5,7 @@
     {
       "minServerVersion": "3.6",
       "topologies": [
-        "replicaset",
-        "sharded",
-        "load-balanced"
+        "replicaset"
       ],
       "serverless": "forbid"
     }

--- a/data/crud/unified/db-aggregate-write-readPreference.yml
+++ b/data/crud/unified/db-aggregate-write-readPreference.yml
@@ -1,0 +1,144 @@
+description: db-aggregate-write-readPreference
+
+schemaVersion: '1.4'
+
+runOnRequirements:
+  # 3.6+ non-standalone is needed to utilize $readPreference in OP_MSG.
+  # Serverless does not support $listLocalSessions and $currentOp stages.
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded, load-balanced ]
+    serverless: forbid
+
+_yamlAnchors:
+  readConcern: &readConcern
+    level: &readConcernLevel "local"
+  writeConcern: &writeConcern
+    w: &writeConcernW 1
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+      # Used to test that read and write concerns are still inherited
+      uriOptions:
+        readConcernLevel: *readConcernLevel
+        w: *writeConcernW
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name db0
+      databaseOptions:
+        readPreference: &readPreference
+          # secondaryPreferred is specified for compatibility with clusters that
+          # may not have a secondary (e.g. each shard is only a primary).
+          mode: secondaryPreferred
+          # maxStalenessSeconds is specified to ensure that drivers forward the
+          # read preference to mongos or a load balancer. That would not be the
+          # case with only secondaryPreferred.
+          maxStalenessSeconds: 600
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *database0
+        name: aggregate
+        arguments:
+          pipeline: &outPipeline
+            - { $listLocalSessions: {} }
+            - { $limit: 1 }
+            - { $addFields: { _id: 1 } }
+            - { $project: { _id: 1 } }
+            - { $out: *collection0Name }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                pipeline: *outPipeline
+                $readPreference: *readPreference
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: &outcome
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+
+  - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
+    runOnRequirements:
+      - maxServerVersion: "4.4.99"
+    operations:
+      - object: *database0
+        name: aggregate
+        arguments:
+          pipeline: *outPipeline
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                pipeline: *outPipeline
+                $readPreference: { $$exists: false }
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome
+
+  - description: "Database-level aggregate with $merge includes read preference for 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *database0
+        name: aggregate
+        arguments:
+          pipeline: &mergePipeline
+            - { $listLocalSessions: {} }
+            - { $limit: 1 }
+            - { $addFields: { _id: 1 } }
+            - { $project: { _id: 1 } }
+            - { $merge: { into: *collection0Name } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                pipeline: *mergePipeline
+                $readPreference: *readPreference
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome
+
+  - description: "Database-level aggregate with $merge omits read preference for pre-5.0 server"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
+    operations:
+      - object: *database0
+        name: aggregate
+        arguments:
+          pipeline: *mergePipeline
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                pipeline: *mergePipeline
+                $readPreference: { $$exists: false }
+                readConcern: *readConcern
+                writeConcern: *writeConcern
+    outcome: *outcome

--- a/data/crud/unified/db-aggregate-write-readPreference.yml
+++ b/data/crud/unified/db-aggregate-write-readPreference.yml
@@ -4,9 +4,10 @@ schemaVersion: '1.4'
 
 runOnRequirements:
   # 3.6+ non-standalone is needed to utilize $readPreference in OP_MSG.
-  # Serverless does not support $listLocalSessions and $currentOp stages.
+  # Serverless does not support $listLocalSessions and $currentOp stages, and
+  # mongos does not allow combining them with $out or $merge.
   - minServerVersion: "3.6"
-    topologies: [ replicaset, sharded, load-balanced ]
+    topologies: [ replicaset ]
     serverless: forbid
 
 _yamlAnchors:

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -774,7 +774,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 
 	selector := makeReadPrefSelector(sess, a.readSelector, a.client.localThreshold)
 	if hasOutputStage {
-		selector = makeOutputSelector(sess, a.readPreference, a.client.localThreshold)
+		selector = makeOutputAggregateSelector(sess, a.readPreference, a.client.localThreshold)
 	}
 
 	ao := options.MergeAggregateOptions(a.opts...)
@@ -1677,14 +1677,14 @@ func makeReadPrefSelector(sess *session.Client, selector description.ServerSelec
 	return makePinnedSelector(sess, selector)
 }
 
-func makeOutputSelector(sess *session.Client, rp *readpref.ReadPref, localThreshold time.Duration) description.ServerSelectorFunc {
+func makeOutputAggregateSelector(sess *session.Client, rp *readpref.ReadPref, localThreshold time.Duration) description.ServerSelectorFunc {
 	if sess != nil && sess.TransactionRunning() {
 		// Use current transaction's read preference if available
 		rp = sess.CurrentRp
 	}
 
 	selector := description.CompositeSelector([]description.ServerSelector{
-		description.OutputSelector(rp),
+		description.OutputAggregateSelector(rp),
 		description.LatencySelector(localThreshold),
 	})
 	return makePinnedSelector(sess, selector)

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -784,6 +784,7 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 		Session(sess).
 		WriteConcern(wc).
 		ReadConcern(rc).
+		ReadPreference(a.readPreference).
 		CommandMonitor(a.client.monitor).
 		ServerSelector(selector).
 		ClusterClock(a.client.clock).
@@ -791,13 +792,8 @@ func aggregate(a aggregateParams) (*Cursor, error) {
 		Collection(a.col).
 		Deployment(a.client.deployment).
 		Crypt(a.client.cryptFLE).
-		ServerAPI(a.client.serverAPI)
-	if !hasOutputStage {
-		// Only pass the user-specified read preference if the aggregation doesn't have a $out or $merge stage.
-		// Otherwise, the read preference could be forwarded to a mongos, which would error if the aggregation were
-		// executed against a non-primary node.
-		op.ReadPreference(a.readPreference)
-	}
+		ServerAPI(a.client.serverAPI).
+		HasOutputStage(hasOutputStage)
 
 	if ao.AllowDiskUse != nil {
 		op.AllowDiskUse(*ao.AllowDiskUse)

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -133,9 +133,9 @@ func ReadPrefSelector(rp *readpref.ReadPref) ServerSelector {
 	return readPrefSelector(rp, false)
 }
 
-// OutputSelector selects servers based on the provided read preference given that the underlying operation is
+// OutputAggregateSelector selects servers based on the provided read preference given that the underlying operation is
 // aggregate with an output stage.
-func OutputSelector(rp *readpref.ReadPref) ServerSelector {
+func OutputAggregateSelector(rp *readpref.ReadPref) ServerSelector {
 	return readPrefSelector(rp, true)
 }
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1201,7 +1201,7 @@ func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bo
 		// 1. all standalones
 		// 2. non-mongos when using OP_QUERY
 		// 3. all writes
-		// 3. when operation is an aggregate with an output stage, and selected server's wire
+		// 4. when operation is an aggregate with an output stage, and selected server's wire
 		//    version is < 13
 		return nil, nil
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -202,6 +202,10 @@ type Operation struct {
 	// ServerAPI specifies options used to configure the API version sent to the server.
 	ServerAPI *ServerAPIOptions
 
+	// IsOutputAggregate specifies whether this operation is an aggregate with an output stage. If true,
+	// read preference will not be added to the command on wire versions < 13.
+	IsOutputAggregate bool
+
 	// cmdName is only set when serializing OP_MSG and is used internally in readWireMessage.
 	cmdName string
 }
@@ -831,7 +835,7 @@ func (op Operation) createQueryWireMessage(dst []byte, desc description.Selected
 	dst = wiremessage.AppendQueryNumberToReturn(dst, -1)
 
 	wrapper := int32(-1)
-	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, true)
+	rp, err := op.createReadPref(desc, true)
 	if err != nil {
 		return dst, info, err
 	}
@@ -929,7 +933,7 @@ func (op Operation) createMsgWireMessage(ctx context.Context, dst []byte, desc d
 	dst = op.addServerAPI(dst)
 
 	dst = bsoncore.AppendStringElement(dst, "$db", op.Database)
-	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, false)
+	rp, err := op.createReadPref(desc, false)
 	if err != nil {
 		return dst, info, err
 	}
@@ -1190,9 +1194,15 @@ func (op Operation) getReadPrefBasedOnTransaction() (*readpref.ReadPref, error) 
 	return op.ReadPreference, nil
 }
 
-func (op Operation) createReadPref(serverKind description.ServerKind, topologyKind description.TopologyKind, isOpQuery bool) (bsoncore.Document, error) {
-	if serverKind == description.Standalone || (isOpQuery && serverKind != description.Mongos) || op.Type == Write {
-		// Don't send read preference for non-mongos when using OP_QUERY or for all standalones
+func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bool) (bsoncore.Document, error) {
+	if desc.Server.Kind == description.Standalone || (isOpQuery && desc.Server.Kind != description.Mongos) ||
+		op.Type == Write || (op.IsOutputAggregate && desc.Server.WireVersion.Max < 13) {
+		// Don't send read preference for:
+		// 1. all standalones
+		// 2. non-mongos when using OP_QUERY
+		// 3. all writes
+		// 3. when operation is an aggregate with an output stage, and selected server's wire
+		//    version is < 13
 		return nil, nil
 	}
 
@@ -1203,7 +1213,7 @@ func (op Operation) createReadPref(serverKind description.ServerKind, topologyKi
 	}
 
 	if rp == nil {
-		if topologyKind == description.Single && serverKind != description.Mongos {
+		if desc.Kind == description.Single && desc.Server.Kind != description.Mongos {
 			doc = bsoncore.AppendStringElement(doc, "mode", "primaryPreferred")
 			doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
 			return doc, nil
@@ -1213,10 +1223,10 @@ func (op Operation) createReadPref(serverKind description.ServerKind, topologyKi
 
 	switch rp.Mode() {
 	case readpref.PrimaryMode:
-		if serverKind == description.Mongos {
+		if desc.Server.Kind == description.Mongos {
 			return nil, nil
 		}
-		if topologyKind == description.Single {
+		if desc.Kind == description.Single {
 			doc = bsoncore.AppendStringElement(doc, "mode", "primaryPreferred")
 			doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
 			return doc, nil
@@ -1226,7 +1236,7 @@ func (op Operation) createReadPref(serverKind description.ServerKind, topologyKi
 		doc = bsoncore.AppendStringElement(doc, "mode", "primaryPreferred")
 	case readpref.SecondaryPreferredMode:
 		_, ok := rp.MaxStaleness()
-		if serverKind == description.Mongos && isOpQuery && !ok && len(rp.TagSets()) == 0 && rp.HedgeEnabled() == nil {
+		if desc.Server.Kind == description.Mongos && isOpQuery && !ok && len(rp.TagSets()) == 0 && rp.HedgeEnabled() == nil {
 			return nil, nil
 		}
 		doc = bsoncore.AppendStringElement(doc, "mode", "secondaryPreferred")

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -47,6 +47,7 @@ type Aggregate struct {
 	crypt                    *driver.Crypt
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
+	hasOutputStage           bool
 
 	result driver.CursorResponse
 }
@@ -104,6 +105,7 @@ func (a *Aggregate) Execute(ctx context.Context) error {
 		Crypt:                          a.crypt,
 		MinimumWriteConcernWireVersion: 5,
 		ServerAPI:                      a.serverAPI,
+		IsOutputAggregate:              a.hasOutputStage,
 	}.Execute(ctx, nil)
 
 }
@@ -378,5 +380,16 @@ func (a *Aggregate) Let(let bsoncore.Document) *Aggregate {
 	}
 
 	a.let = let
+	return a
+}
+
+// HasOutputStage specifies whether the aggregate contains an output stage. Used in determining when to
+// append read preference at the operation level.
+func (a *Aggregate) HasOutputStage(hos bool) *Aggregate {
+	if a == nil {
+		a = new(Aggregate)
+	}
+
+	a.hasOutputStage = hos
 	return a
 }

--- a/x/mongo/driver/operation_legacy.go
+++ b/x/mongo/driver/operation_legacy.go
@@ -162,7 +162,7 @@ func (op Operation) createLegacyFindWireMessage(dst []byte, desc description.Sel
 	numToReturn = op.calculateNumberToReturn(limit, batchSize)
 
 	// add read preference if needed
-	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, true)
+	rp, err := op.createReadPref(desc, true)
 	if err != nil {
 		return dst, info, "", err
 	}
@@ -451,7 +451,7 @@ func (op Operation) createLegacyListCollectionsWiremessage(dst []byte, desc desc
 	if err != nil {
 		return dst, info, "", err
 	}
-	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, true)
+	rp, err := op.createReadPref(desc, true)
 	if err != nil {
 		return dst, info, "", err
 	}
@@ -607,7 +607,7 @@ func (op Operation) createLegacyListIndexesWiremessage(dst []byte, desc descript
 	filter = bsoncore.AppendStringElement(filter, "ns", op.getFullCollectionName(filterCollName))
 	filter, _ = bsoncore.AppendDocumentEnd(filter, fidx)
 
-	rp, err := op.createReadPref(desc.Server.Kind, desc.Kind, true)
+	rp, err := op.createReadPref(desc, true)
 	if err != nil {
 		return dst, info, "", err
 	}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -429,7 +429,8 @@ func TestOperation(t *testing.T) {
 		for _, tc := range testCases {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
-				got, err := Operation{ReadPreference: tc.rp}.createReadPref(tc.serverKind, tc.topoKind, tc.opQuery)
+				desc := description.SelectedServer{Kind: tc.topoKind, Server: description.Server{Kind: tc.serverKind}}
+				got, err := Operation{ReadPreference: tc.rp}.createReadPref(desc, tc.opQuery)
 				if err != nil {
 					t.Fatalf("error creating read pref: %v", err)
 				}


### PR DESCRIPTION
GODRIVER-1868

Allows non-primary read preferences (either inherited or explicit) for aggregates with `$out` and `$merge` stages on wire versions >= 13. Modifies server selection to remove secondaries with wire versions < 13 from the list of candidates when executing an aggregate with an output stage but fall back to primary in the case of no usable secondaries. Modifies `createReadPref` in `operation.go` to _not_ append read preference when executing an aggregate with an output stage against a server with wire version < 13.