### PR TITLE
GODRIVER-1749 Check for ServerMarkedUnknownEvent in SDAM integration tests

### DIFF
--- a/mongo/integration/unified_runner_events_helper_test.go
+++ b/mongo/integration/unified_runner_events_helper_test.go
@@ -24,57 +24,89 @@ import (
 // pool events.
 
 var (
-	eventTypesMap = map[string]string{
+	poolEventTypesMap = map[string]string{
 		"PoolClearedEvent": event.PoolCleared,
 	}
 	defaultCallbackTimeout = 10 * time.Second
+	sdamEventCount         = make(map[string]int)
+	sdamEventCountLock     = sync.Mutex{}
 )
 
 // unifiedRunnerEventMonitor monitors connection pool-related events.
 type unifiedRunnerEventMonitor struct {
-	sync.Mutex
-	poolEventCount map[string]int
+	poolEventCountLock sync.Mutex
+	poolEventCount     map[string]int
+	sdamMonitor        *event.ServerMonitor
 }
 
 func newUnifiedRunnerEventMonitor() *unifiedRunnerEventMonitor {
+	// reset SDAM event count for each new unifiedRunnerEventMonitor.
+	sdamEventCountLock.Lock()
+	sdamEventCount = make(map[string]int)
+	sdamEventCountLock.Unlock()
+
 	return &unifiedRunnerEventMonitor{
 		poolEventCount: make(map[string]int),
+		sdamMonitor: &event.ServerMonitor{
+			ServerDescriptionChanged: handleServerDescriptionChanged,
+		},
 	}
 }
 
-// handlePoolEvent can be used as the event handler for an connection pool monitor.
+// handleServerDescriptionChanged can be used as the event handler for ServerDescriptionChanged
+// on a ServerMonitor.
+func handleServerDescriptionChanged(e *event.ServerDescriptionChangedEvent) {
+	sdamEventCountLock.Lock()
+	defer sdamEventCountLock.Unlock()
+
+	// Spec tests only ever handle ServerMarkedUnknown ServerDescriptionChangedEvents for the time being.
+	if e.NewDescription.Kind == description.Unknown {
+		sdamEventCount["ServerMarkedUnknownEvent"]++
+	}
+}
+
+// handlePoolEvent can be used as the event handler for a connection pool monitor.
 func (u *unifiedRunnerEventMonitor) handlePoolEvent(evt *event.PoolEvent) {
-	u.Lock()
-	defer u.Unlock()
+	u.poolEventCountLock.Lock()
+	defer u.poolEventCountLock.Unlock()
 
 	u.poolEventCount[evt.Type]++
 }
 
-// getCount returns the number of events of the given type, or 0 if no events were recorded.
-func (u *unifiedRunnerEventMonitor) getCount(eventType string) int {
-	u.Lock()
-	defer u.Unlock()
+// getPoolEventCount returns the number of pool events of the given type, or 0 if no events were recorded.
+func (u *unifiedRunnerEventMonitor) getPoolEventCount(eventType string) int {
+	u.poolEventCountLock.Lock()
+	defer u.poolEventCountLock.Unlock()
 
-	mappedType := eventTypesMap[eventType]
+	mappedType := poolEventTypesMap[eventType]
 	return u.poolEventCount[mappedType]
+}
+
+// getSDAMEventCount returns the number of SDAM events of the given type, or 0 if no events were recorded.
+func (u *unifiedRunnerEventMonitor) getSDAMEventCount(eventType string) int {
+	sdamEventCountLock.Lock()
+	defer sdamEventCountLock.Unlock()
+
+	return sdamEventCount[eventType]
 }
 
 func waitForEvent(mt *mtest.T, test *testCase, op *operation) {
 	eventType := op.Arguments.Lookup("event").StringValue()
-	if eventType == "ServerMarkedUnknownEvent" {
-		mt.Log("skipping waitForEvent assertion for event type ServerMarkedUnknownEvent")
-		return
-	}
-
 	expectedCount := int(op.Arguments.Lookup("count").Int32())
 
 	callback := func() {
 		for {
-			count := test.monitor.getCount(eventType)
+			var count int
+			// Spec tests only ever wait for ServerMarkedUnknown SDAM events for the time being.
+			if eventType == "ServerMarkedUnknownEvent" {
+				count = test.monitor.getSDAMEventCount(eventType)
+			} else {
+				count = test.monitor.getPoolEventCount(eventType)
+			}
+
 			if count >= expectedCount {
 				return
 			}
-
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
@@ -84,13 +116,15 @@ func waitForEvent(mt *mtest.T, test *testCase, op *operation) {
 
 func assertEventCount(mt *mtest.T, testCase *testCase, op *operation) {
 	eventType := op.Arguments.Lookup("event").StringValue()
-	if eventType == "ServerMarkedUnknownEvent" {
-		mt.Log("skipping waitForEvent assertion for event type ServerMarkedUnknownEvent")
-		return
-	}
-
 	expectedCount := int(op.Arguments.Lookup("count").Int32())
-	gotCount := testCase.monitor.getCount(eventType)
+
+	var gotCount int
+	// Spec tests only ever assert ServerMarkedUnknown SDAM events for the time being.
+	if eventType == "ServerMarkedUnknownEvent" {
+		gotCount = testCase.monitor.getSDAMEventCount(eventType)
+	} else {
+		gotCount = testCase.monitor.getPoolEventCount(eventType)
+	}
 	assert.Equal(mt, expectedCount, gotCount, "expected count %d for event %s, got %d", expectedCount, eventType,
 		gotCount)
 }

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -272,6 +272,7 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		testClientOpts.SetPoolMonitor(&event.PoolMonitor{
 			Event: test.monitor.handlePoolEvent,
 		})
+		testClientOpts.SetServerMonitor(test.monitor.sdamMonitor)
 		if testClientOpts.HeartbeatInterval == nil {
 			// If one isn't specified in the test, use a low heartbeat frequency so the Client will quickly recover when
 			// using failpoints that cause SDAM state changes.


### PR DESCRIPTION
GODRIVER-1749

Removes `ServerMarkedUnknownEvent` skips for SDAM integration tests. Actually handles, waits for, and asserts the count of [`ServerMarkedUnknownEvent`s](https://github.com/mongodb/specifications/blob/57d31cc6ccec53b31657d0807b6b24c51d3cb1af/source/server-discovery-and-monitoring/tests/README.rst#servermarkedunknownevent). 