### PR TITLE
GODRIVER-2159 Bump maxWireVersion to 14

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(2, 13)
+	SupportedWireVersions = description.NewVersionRange(2, 14)
 )
 
 const (


### PR DESCRIPTION
GODRIVER-2159

Bumps supported max wire version to 14 to support running against the upcoming MongoDB 5.1.