### PR TITLE
GODRIVER-2107 Correctly ignore sensitive commands in unified test runner

### DIFF
--- a/data/unified-test-format/valid-pass/observeSensitiveCommands.json
+++ b/data/unified-test-format/valid-pass/observeSensitiveCommands.json
@@ -1,0 +1,691 @@
+{
+  "description": "observeSensitiveCommands",
+  "schemaVersion": "1.5",
+  "runOnRequirements": [
+    {
+      "auth": false
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ],
+        "observeSensitiveCommands": true
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ],
+        "observeSensitiveCommands": false
+      }
+    },
+    {
+      "client": {
+        "id": "client2",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "observeSensitiveCommands"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "observeSensitiveCommands"
+      }
+    },
+    {
+      "database": {
+        "id": "database2",
+        "client": "client2",
+        "databaseName": "observeSensitiveCommands"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "getnonce is observed with observeSensitiveCommands=true",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "getnonce",
+                "command": {
+                  "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "getnonce",
+                "reply": {
+                  "ok": {
+                    "$$exists": false
+                  },
+                  "nonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "getnonce is not observed with observeSensitiveCommands=false",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": []
+        }
+      ]
+    },
+    {
+      "description": "getnonce is not observed by default",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client2",
+          "events": []
+        }
+      ]
+    },
+    {
+      "description": "hello with speculativeAuthenticate",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client1",
+          "events": []
+        },
+        {
+          "client": "client2",
+          "events": []
+        }
+      ]
+    },
+    {
+      "description": "hello without speculativeAuthenticate is always observed",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client2",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "command": {
+                  "hello": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculativeAuthenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client1",
+          "events": []
+        },
+        {
+          "client": "client2",
+          "events": []
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculativeAuthenticate is always observed",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database1",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database2",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client2",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ismaster",
+                "command": {
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "isMaster",
+                "command": {
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/observeSensitiveCommands.yml
+++ b/data/unified-test-format/valid-pass/observeSensitiveCommands.yml
@@ -1,0 +1,249 @@
+description: "observeSensitiveCommands"
+
+schemaVersion: "1.5"
+
+runOnRequirements:
+  - auth: false
+
+createEntities:
+  - client:
+      id: &clientObserveSensitiveCommands client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+      observeSensitiveCommands: true
+  - client:
+      id: &clientDoNotObserveSensitiveCommands client1
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+      observeSensitiveCommands: false
+  - client:
+      id: &clientDoNotObserveSensitiveCommandsByDefault client2
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+  - database:
+      id: &databaseObserveSensitiveCommands database0
+      client: *clientObserveSensitiveCommands
+      databaseName: &databaseName observeSensitiveCommands
+  - database:
+      id: &databaseDoNotObserveSensitiveCommands database1
+      client: *clientDoNotObserveSensitiveCommands
+      databaseName: *databaseName
+  - database:
+      id: &databaseDoNotObserveSensitiveCommandsByDefault database2
+      client: *clientDoNotObserveSensitiveCommandsByDefault
+      databaseName: *databaseName
+
+tests:
+  - description: "getnonce is observed with observeSensitiveCommands=true"
+    operations:
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments:
+          commandName: getnonce
+          command: { getnonce: 1 }
+    expectEvents:
+      - client: *clientObserveSensitiveCommands
+        events:
+          - commandStartedEvent:
+              commandName: getnonce
+              command: { getnonce: { $$exists: false } }
+          - commandSucceededEvent:
+              commandName: getnonce
+              reply:
+                ok: { $$exists: false }
+                nonce: { $$exists: false }
+
+  - description: "getnonce is not observed with observeSensitiveCommands=false"
+    operations:
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments:
+          commandName: getnonce
+          command: { getnonce: 1 }
+    expectEvents:
+      - client: *clientDoNotObserveSensitiveCommands
+        events: []
+
+  - description: "getnonce is not observed by default"
+    operations:
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments:
+          commandName: getnonce
+          command: { getnonce: 1 }
+    expectEvents:
+      - client: *clientDoNotObserveSensitiveCommandsByDefault
+        events: []
+
+  - description: "hello with speculativeAuthenticate"
+    runOnRequirements:
+      - minServerVersion: "4.9"
+    operations:
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &helloArgs
+          commandName: hello
+          command:
+            hello: 1
+            speculativeAuthenticate: { saslStart: 1 }
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *helloArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *helloArgs
+    expectEvents:
+      - client: *clientObserveSensitiveCommands
+        events:
+          - commandStartedEvent:
+              commandName: hello
+              command:
+                # Assert that all fields in command are redacted
+                hello: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                # Assert that all fields in reply are redacted
+                isWritablePrimary: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+      - client: *clientDoNotObserveSensitiveCommands
+        events: []
+      - client: *clientDoNotObserveSensitiveCommandsByDefault
+        events: []
+
+  - description: "hello without speculativeAuthenticate is always observed"
+    runOnRequirements:
+      - minServerVersion: "4.9"
+    operations:
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &helloArgs
+          commandName: hello
+          command: { hello: 1 }
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *helloArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *helloArgs
+    expectEvents:
+      - client: *clientObserveSensitiveCommands
+        events: &helloEvents
+          - commandStartedEvent:
+              commandName: hello
+              command: { hello: 1 }
+          - commandSucceededEvent:
+              commandName: hello
+              reply: { isWritablePrimary: { $$exists: true } }
+      - client: *clientDoNotObserveSensitiveCommands
+        events: *helloEvents
+      - client: *clientDoNotObserveSensitiveCommandsByDefault
+        events: *helloEvents
+
+  - description: "legacy hello with speculativeAuthenticate"
+    operations:
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &ismasterArgs
+          commandName: ismaster
+          command:
+            ismaster: 1
+            speculativeAuthenticate: { saslStart: 1 }
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &isMasterArgs
+          commandName: isMaster
+          command:
+            isMaster: 1
+            speculativeAuthenticate: { saslStart: 1 }
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *ismasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *isMasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *ismasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *isMasterArgs
+    expectEvents:
+      - client: *clientObserveSensitiveCommands
+        events:
+          - commandStartedEvent:
+              commandName: ismaster
+              command:
+                # Assert that all fields in command are redacted
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                # Assert that all fields in reply are redacted
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandStartedEvent:
+              commandName: isMaster
+              command:
+                # Assert that all fields in command are redacted
+                isMaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                # Assert that all fields in reply are redacted
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+      - client: *clientDoNotObserveSensitiveCommands
+        events: []
+      - client: *clientDoNotObserveSensitiveCommandsByDefault
+        events: []
+
+  - description: "legacy hello without speculativeAuthenticate is always observed"
+    operations:
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &ismasterArgs
+          commandName: ismaster
+          command: { ismaster: 1 }
+      - name: runCommand
+        object: *databaseObserveSensitiveCommands
+        arguments: &isMasterArgs
+          commandName: isMaster
+          command: { isMaster: 1 }
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *ismasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommands
+        arguments: *isMasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *ismasterArgs
+      - name: runCommand
+        object: *databaseDoNotObserveSensitiveCommandsByDefault
+        arguments: *isMasterArgs
+    expectEvents:
+      - client: *clientObserveSensitiveCommands
+        events: &ismasterAndisMasterEvents
+          - commandStartedEvent:
+              commandName: ismaster
+              command: { ismaster: 1 }
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply: { ismaster: { $$exists: true } }
+          - commandStartedEvent:
+              commandName: isMaster
+              command: { isMaster: 1 }
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply: { ismaster: { $$exists: true } }
+      - client: *clientDoNotObserveSensitiveCommands
+        events: *ismasterAndisMasterEvents
+      - client: *clientDoNotObserveSensitiveCommandsByDefault
+        events: *ismasterAndisMasterEvents


### PR DESCRIPTION
GODRIVER-2107

Syncs spec tests for new [`observeSensitiveCommands`](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst) flag in the unified test format. Corrects logic in unified test runner event verification to ignore `hello`s and legacy hellos that had `speculativeAuthenticate` but have already been redacted. 

The previous behavior tried to check if `speculativeAuthenticate` was present in the `Command` or `Reply`, but if it were, `Command` or `Reply` would have been set to an empty `bson.Raw{}` [here](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/operation.go#L1476) in `operation.go`. See this [recent clarification](https://github.com/mongodb/specifications/commit/6847048c551431c8a328b9c1f0deeec158160d20#diff-f718c246f51e05b3731a7b03b176a0d4b0c381a9261810742d2677823f963f98R2787-R2791) in the spec.