### PR TITLE
GODRIVER-2065 Don't send the operation if the Context deadline is before (now + minimum RTT).

### DIFF
--- a/internal/testutil/assert/assert.go
+++ b/internal/testutil/assert/assert.go
@@ -81,8 +81,7 @@ func NotNil(t testing.TB, obj interface{}, msg string, args ...interface{}) {
 	}
 }
 
-// Soon runs the provided callback for a maximum of timeoutMS milliseconds. It returns the callback error
-// if the callback returned and ErrCallbackTimedOut if the timeout expired.
+// Soon runs the provided callback for a maximum of timeoutMS milliseconds.
 func Soon(t testing.TB, callback func(), timeout time.Duration) {
 	t.Helper()
 

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -36,9 +36,8 @@ func (c *changeStreamDeployment) Connection(context.Context) (driver.Connection,
 	return c.conn, nil
 }
 
-// MinRTT always returns 0. It implements the driver.Server interface.
 func (c *changeStreamDeployment) MinRTT() time.Duration {
-	return 0
+	return c.server.MinRTT()
 }
 
 func (c *changeStreamDeployment) ProcessError(err error, conn driver.Connection) driver.ProcessErrorResult {

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -8,6 +8,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -33,6 +34,11 @@ func (c *changeStreamDeployment) Kind() description.TopologyKind {
 
 func (c *changeStreamDeployment) Connection(context.Context) (driver.Connection, error) {
 	return c.conn, nil
+}
+
+// MinRTT always returns 0. It implements the driver.Server interface.
+func (c *changeStreamDeployment) MinRTT() time.Duration {
+	return 0
 }
 
 func (c *changeStreamDeployment) ProcessError(err error, conn driver.Connection) driver.ProcessErrorResult {

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -8,6 +8,7 @@ package mtest
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -131,6 +132,11 @@ func (md *mockDeployment) Kind() description.TopologyKind {
 // Connection implements the driver.Server interface.
 func (md *mockDeployment) Connection(context.Context) (driver.Connection, error) {
 	return md.conn, nil
+}
+
+// MinRTT always returns 0. It implements the driver.Server interface.
+func (md *mockDeployment) MinRTT() time.Duration {
+	return 0
 }
 
 // Connect is a no-op method which implements the driver.Connector interface.

--- a/mongo/integration/mtest/proxy_dialer.go
+++ b/mongo/integration/mtest/proxy_dialer.go
@@ -131,10 +131,8 @@ func (p *proxyDialer) Messages() []*ProxyMessage {
 	p.Lock()
 	defer p.Unlock()
 
-	copiedMessages := make([]*ProxyMessage, 0, len(p.messages))
-	for _, msg := range p.messages {
-		copiedMessages = append(copiedMessages, msg)
-	}
+	copiedMessages := make([]*ProxyMessage, len(p.messages))
+	copy(copiedMessages, p.messages)
 	return copiedMessages
 }
 

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -121,7 +122,7 @@ func TestSessions(t *testing.T) {
 	clusterTimeHandshakeOpts := options.Client().
 		SetHosts(hosts[:1]). // Prevent handshakes to other hosts from updating the cluster time.
 		SetDirect(true).
-		SetHeartbeatInterval(50 * time.Second) // Prevent extra heartbeats from updating the cluster time.
+		SetHeartbeatInterval(1 * time.Hour) // Prevent extra heartbeats from updating the cluster time.
 	clusterTimeHandshakeMtOpts := mtest.NewOptions().
 		ClientType(mtest.Proxy).
 		ClientOptions(clusterTimeHandshakeOpts).
@@ -130,22 +131,33 @@ func TestSessions(t *testing.T) {
 	mt.RunOpts("cluster time is updated from handshakes", clusterTimeHandshakeMtOpts, func(mt *mtest.T) {
 		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)
-		msgPairs := mt.GetProxiedMessages()
-		assert.True(mt, len(msgPairs) > 2, "expected more than two messages, got %d", len(msgPairs))
 
-		for idx, pair := range mt.GetProxiedMessages() {
-			// Get the $clusterTime value sent to the server. The first three messages are the handshakes for the
-			// heartbeat, RTT, and application connections. These should not contain $clusterTime because they happen on
-			// connections that don't know the server's wire version and therefore don't know if the server supports
-			// $clusterTime.
-			_, err = pair.Sent.Command.LookupErr("$clusterTime")
-			if idx <= 2 {
-				assert.NotNil(mt, err, "expected no $clusterTime field in command %s", pair.Sent.Command)
-				continue
+		// Assert that all sent commands (including handshake commands) include a "$clusterTime" in
+		// the command document.
+		for _, pair := range mt.GetProxiedMessages() {
+			_, err := pair.Sent.Command.LookupErr("$clusterTime")
+			hasClusterTime := err == nil
+
+			switch pair.CommandName {
+			// If the command is either legacy hello or "hello" (used as the first message in any
+			// handshake or the checks from the heartbeat or RTT monitors), expect that there is no
+			// "$clusterTime" because the connection doesn't know the server's wire version yet so
+			// it doesn't know if the connection supports "$clusterTime".
+			case internal.LegacyHello, "hello":
+				assert.False(
+					mt,
+					hasClusterTime,
+					"expected no $clusterTime field in command %s",
+					pair.Sent.Command)
+			// If the command is anything else (including other handshake commands), assert that the
+			// command includes "$clusterTime".
+			default:
+				assert.True(
+					mt,
+					hasClusterTime,
+					"expected $clusterTime field in in Ping command %s",
+					pair.Sent.Command)
 			}
-
-			// All messages after the first two should contain $clusterTime.
-			assert.Nil(mt, err, "expected $clusterTime field in command %s", pair.Sent.Command)
 		}
 	})
 

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -122,7 +122,7 @@ func TestSessions(t *testing.T) {
 	clusterTimeHandshakeOpts := options.Client().
 		SetHosts(hosts[:1]). // Prevent handshakes to other hosts from updating the cluster time.
 		SetDirect(true).
-		SetHeartbeatInterval(1 * time.Hour) // Prevent extra heartbeats from updating the cluster time.
+		SetHeartbeatInterval(50 * time.Second) // Prevent extra heartbeats from updating the cluster time.
 	clusterTimeHandshakeMtOpts := mtest.NewOptions().
 		ClientType(mtest.Proxy).
 		ClientOptions(clusterTimeHandshakeOpts).

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/event"
@@ -424,6 +425,11 @@ func (lbcd *loadBalancedCursorDeployment) Kind() description.TopologyKind {
 
 func (lbcd *loadBalancedCursorDeployment) Connection(_ context.Context) (Connection, error) {
 	return lbcd.conn, nil
+}
+
+// MinRTT always returns 0. It implements the driver.Server interface.
+func (lbcd *loadBalancedCursorDeployment) MinRTT() time.Duration {
+	return 0
 }
 
 func (lbcd *loadBalancedCursorDeployment) ProcessError(err error, conn Connection) ProcessErrorResult {

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -2,6 +2,7 @@ package driver // import "go.mongodb.org/mongo-driver/x/mongo/driver"
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
@@ -43,6 +44,9 @@ type Subscriber interface {
 // retrieving and returning of connections.
 type Server interface {
 	Connection(context.Context) (Connection, error)
+
+	// MinRTT returns the minimum round-trip time to the server observed over the window period.
+	MinRTT() time.Duration
 }
 
 // Connection represents a connection to a MongoDB server.
@@ -192,6 +196,11 @@ func (ssd SingleConnectionDeployment) Kind() description.TopologyKind { return d
 // Connection implements the Server interface. It always returns the embedded connection.
 func (ssd SingleConnectionDeployment) Connection(context.Context) (Connection, error) {
 	return ssd.C, nil
+}
+
+// MinRTT always returns 0. It implements the driver.Server interface.
+func (ssd SingleConnectionDeployment) MinRTT() time.Duration {
+	return 0
 }
 
 // TODO(GODRIVER-617): We can likely use 1 type for both the Type and the RetryMode by using

--- a/x/mongo/driver/drivertest/channel_netconn.go
+++ b/x/mongo/driver/drivertest/channel_netconn.go
@@ -76,11 +76,12 @@ func (c *ChannelNetConn) SetWriteDeadline(_ time.Time) error {
 
 // GetWrittenMessage gets the last wire message written to the connection
 func (c *ChannelNetConn) GetWrittenMessage() []byte {
-	var wm []byte
 	select {
-	case wm = <-c.Written:
+	case wm := <-c.Written:
+		return wm
+	default:
+		return nil
 	}
-	return wm
 }
 
 // AddResponse adds a response to the connection.

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -51,7 +51,6 @@ type connection struct {
 	readTimeout          time.Duration
 	writeTimeout         time.Duration
 	desc                 description.Server
-	helloRTT             time.Duration
 	compressor           wiremessage.CompressorID
 	zliblevel            int
 	zstdLevel            int
@@ -216,7 +215,6 @@ func (c *connection) connect(ctx context.Context) {
 	}
 
 	var handshakeInfo driver.HandshakeInformation
-	handshakeStartTime := time.Now()
 	handshakeConn := initConnection{c}
 	handshakeInfo, err = handshaker.GetHandshakeInformation(handshakeCtx, c.addr, handshakeConn)
 	if err == nil {
@@ -224,7 +222,6 @@ func (c *connection) connect(ctx context.Context) {
 		// fields in handshakeInfo are tracked by the handshaker if necessary.
 		c.desc = handshakeInfo.Description
 		c.serverConnectionID = handshakeInfo.ServerConnectionID
-		c.helloRTT = time.Since(handshakeStartTime)
 
 		// If the application has indicated that the cluster is load balanced, ensure the server has included serviceId
 		// in its handshake response to signal that it knows it's behind an LB as well.

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -51,6 +51,7 @@ type connection struct {
 	readTimeout          time.Duration
 	writeTimeout         time.Duration
 	desc                 description.Server
+	helloRTT             time.Duration
 	compressor           wiremessage.CompressorID
 	zliblevel            int
 	zstdLevel            int
@@ -215,6 +216,7 @@ func (c *connection) connect(ctx context.Context) {
 	}
 
 	var handshakeInfo driver.HandshakeInformation
+	handshakeStartTime := time.Now()
 	handshakeConn := initConnection{c}
 	handshakeInfo, err = handshaker.GetHandshakeInformation(handshakeCtx, c.addr, handshakeConn)
 	if err == nil {
@@ -222,6 +224,7 @@ func (c *connection) connect(ctx context.Context) {
 		// fields in handshakeInfo are tracked by the handshaker if necessary.
 		c.desc = handshakeInfo.Description
 		c.serverConnectionID = handshakeInfo.ServerConnectionID
+		c.helloRTT = time.Since(handshakeStartTime)
 
 		// If the application has indicated that the cluster is load balanced, ensure the server has included serviceId
 		// in its handshake response to signal that it knows it's behind an LB as well.

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -129,7 +129,7 @@ func (r *rttMonitor) runHello(conn *connection) *connection {
 	return conn
 }
 
-// reset sets the average RTT to 0. This should only be called from the server monitor when an error
+// reset sets the average and min RTT to 0. This should only be called from the server monitor when an error
 // occurs during a server check. Errors in the RTT monitor should not reset the RTTs.
 func (r *rttMonitor) reset() {
 	r.mu.Lock()

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -1,0 +1,212 @@
+package topology
+
+import (
+	"context"
+	"math"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
+)
+
+func makeHelloReply() []byte {
+	didx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendInt32Element(doc, "ok", 1)
+	doc, _ = bsoncore.AppendDocumentEnd(doc, didx)
+	return drivertest.MakeReply(doc)
+}
+
+func TestRTTMonitor(t *testing.T) {
+	t.Run("creates the correct size samples slice", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			desc           string
+			interval       time.Duration
+			wantSamplesLen int
+		}{
+			{
+				desc:           "default",
+				interval:       10 * time.Second,
+				wantSamplesLen: 30,
+			},
+			{
+				desc:           "min",
+				interval:       10 * time.Minute,
+				wantSamplesLen: 5,
+			},
+			{
+				desc:           "max",
+				interval:       1 * time.Millisecond,
+				wantSamplesLen: 500,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.desc, func(t *testing.T) {
+				rtt := newRTTMonitor(&rttConfig{
+					interval:     tc.interval,
+					minRTTWindow: 5 * time.Minute,
+				})
+				assert.Equal(t, tc.wantSamplesLen, len(rtt.samples), "expected samples length to match")
+			})
+		}
+	})
+
+	t.Run("can connect and disconnect repeatedly", func(t *testing.T) {
+		t.Parallel()
+
+		dialer := DialerFunc(func(_ context.Context, _, _ string) (net.Conn, error) {
+			reply := makeHelloReply()
+			return newSlowConn(10*time.Millisecond, reply[:4], reply[4:]), nil
+		})
+		rtt := newRTTMonitor(&rttConfig{
+			interval: 10 * time.Second,
+			createConnectionFn: func() (*connection, error) {
+				return newConnection("", WithDialer(func(Dialer) Dialer {
+					return dialer
+				}))
+			},
+			createOperationFn: func(conn driver.Connection) *operation.Hello {
+				return operation.NewHello().Deployment(driver.SingleConnectionDeployment{C: conn})
+			},
+		})
+		for i := 0; i < 100; i++ {
+			rtt.connect()
+			rtt.disconnect()
+		}
+	})
+
+	t.Run("works", func(t *testing.T) {
+		t.Parallel()
+
+		dialer := DialerFunc(func(_ context.Context, _, _ string) (net.Conn, error) {
+			reply := makeHelloReply()
+			return newSlowConn(10*time.Millisecond, reply[:4], reply[4:]), nil
+		})
+		rtt := newRTTMonitor(&rttConfig{
+			interval: 10 * time.Millisecond,
+			createConnectionFn: func() (*connection, error) {
+				return newConnection("", WithDialer(func(Dialer) Dialer {
+					return dialer
+				}))
+			},
+			createOperationFn: func(conn driver.Connection) *operation.Hello {
+				return operation.NewHello().Deployment(driver.SingleConnectionDeployment{C: conn})
+			},
+		})
+		rtt.connect()
+		defer rtt.disconnect()
+
+		// Wait up to a second for the avg and min RTTs to be greater than 0.
+		start := time.Now()
+		for time.Since(start) < 1*time.Second {
+			if rtt.getRTT() > 0 && rtt.getMinRTT() > 0 {
+				break
+			}
+		}
+
+		assert.Greater(t, rtt.getMinRTT().Nanoseconds(), int64(0), "expected getMinRTT() to return a positive duration")
+		assert.Greater(t, rtt.getRTT().Nanoseconds(), int64(0), "expected getRTT() to return a positive duration")
+	})
+}
+
+var _ net.Conn = &slowConn{}
+
+// slowConn is a net.Conn that returns a response after sleeping for a specified time.
+type slowConn struct {
+	duration  time.Duration
+	responses [][]byte
+	offset    int
+}
+
+func newSlowConn(duration time.Duration, responses ...[]byte) *slowConn {
+	return &slowConn{
+		duration:  duration,
+		responses: responses,
+	}
+}
+
+func (c *slowConn) Read(b []byte) (int, error) {
+	time.Sleep(c.duration)
+	response := c.responses[c.offset]
+	c.offset = (c.offset + 1) % len(c.responses)
+
+	return copy(b, response), nil
+}
+
+func (c *slowConn) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+func (c *slowConn) Close() error                       { return nil }
+func (c *slowConn) LocalAddr() net.Addr                { return nil }
+func (c *slowConn) RemoteAddr() net.Addr               { return nil }
+func (c *slowConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *slowConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *slowConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func TestMin(t *testing.T) {
+	cases := []struct {
+		desc       string
+		samples    []time.Duration
+		minSamples int
+		want       time.Duration
+	}{
+		{
+			desc:       "Should return the min for minSamples = 0",
+			samples:    []time.Duration{1, 0, 0, 0},
+			minSamples: 0,
+			want:       1,
+		},
+		{
+			desc:       "Should return 0 for fewer than minSamples samples",
+			samples:    []time.Duration{1, 0, 0, 0},
+			minSamples: 2,
+			want:       0,
+		},
+		{
+			desc:       "Should return 0 for empty samples slice",
+			samples:    []time.Duration{},
+			minSamples: 0,
+			want:       0,
+		},
+		{
+			desc:       "Should return 0 for no valid samples",
+			samples:    []time.Duration{0, 0, 0},
+			minSamples: 0,
+			want:       0,
+		},
+		{
+			desc:       "Should return max int64 if all samples are max int64",
+			samples:    []time.Duration{math.MaxInt64, math.MaxInt64, math.MaxInt64},
+			minSamples: 0,
+			want:       math.MaxInt64,
+		},
+		{
+			desc:       "Should return the minimum if there are enough samples",
+			samples:    []time.Duration{1 * time.Second, 100 * time.Millisecond, 150 * time.Millisecond, 0, 0, 0},
+			minSamples: 3,
+			want:       100 * time.Millisecond,
+		},
+		{
+			desc:       "Should return 0 if there are are not enough samples",
+			samples:    []time.Duration{1 * time.Second, 100 * time.Millisecond, 0, 0, 0, 0},
+			minSamples: 3,
+			want:       0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := min(tc.samples, tc.minSamples)
+			assert.Equal(t, tc.want, got, "TODO")
+		})
+	}
+}

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -46,8 +46,8 @@ func (c *slowConn) Read(b []byte) (int, error) {
 }
 
 func (c *slowConn) Write(b []byte) (int, error) {
-	c.reader.Seek(0, io.SeekStart)
-	return len(b), nil
+	_, err := c.reader.Seek(0, io.SeekStart)
+	return len(b), err
 }
 
 func (c *slowConn) Close() error                       { return nil }

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -795,10 +795,7 @@ func (s *Server) String() string {
 		str += fmt.Sprintf(", Tag sets: %s", desc.Tags)
 	}
 	if connState == connected {
-		str += fmt.Sprintf(", Average RTT: %s", desc.AverageRTT)
-	}
-	if connState == connected {
-		str += fmt.Sprintf(", Min RTT: %s", s.MinRTT())
+		str += fmt.Sprintf(", Average RTT: %s, Min RTT: %s", desc.AverageRTT, s.MinRTT())
 	}
 	if desc.LastError != nil {
 		str += fmt.Sprintf(", Last error: %s", desc.LastError)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -679,6 +679,8 @@ func (s *Server) check() (description.Server, error) {
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
 		if err == nil {
+			// Use the description from the connection handshake as the value for this check.
+			s.rttMonitor.addSample(s.conn.helloRTT)
 			descPtr = &s.conn.desc
 		}
 	}

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -43,7 +43,9 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 				err = json.Unmarshal(content, &test)
 				assert.Nil(t, err, "Unmarshal error: %v", err)
 
-				var monitor rttMonitor
+				monitor := newRTTMonitor(&rttConfig{
+					interval: 10 * time.Second,
+				})
 				if test.AvgRttMs != "NULL" {
 					// If not "NULL", then must be a number, so typecast to float64
 					monitor.addSample(time.Duration(test.AvgRttMs.(float64) * float64(time.Millisecond)))

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -32,13 +32,6 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
-func makeHelloReply() []byte {
-	didx, doc := bsoncore.AppendDocumentStart(nil)
-	doc = bsoncore.AppendInt32Element(doc, "ok", 1)
-	doc, _ = bsoncore.AppendDocumentEnd(doc, didx)
-	return drivertest.MakeReply(doc)
-}
-
 type channelNetConnDialer struct{}
 
 func (cncd *channelNetConnDialer) DialContext(_ context.Context, _, _ string) (net.Conn, error) {


### PR DESCRIPTION
[GODRIVER-2065](https://jira.mongodb.org/browse/GODRIVER-2065)

If an operation times out during the network round trip, the driver closes the in-use connection. Minimize the number of closed connections by trying to predict which operations are likely to time out during the network round trip using the minimum measured RTT value for the last 5 minutes.

Changes:
* Add `rttMonitor.getMinRTT()` that returns the minimum RTT measured for the last window (default 5 minutes). If there are fewer than the minimum number of samples (default 5), return 0 to prevent calculating minimum on too few values.
* Refactor `rttMonitor.start()` to manage creating and closing its own connection to avoid synchronization logic around a shared `*connection`.
* Add `MinRTT() time.Duration` to the `driver.Server` interface so that callers can get the minimum RTT for a given server.
* Add `rtt_monitor_test.go` to test the `rttMonitor` type.