### PR TITLE
GODRIVER-2092 Disallow positive srvMaxHosts with replicaSet or loadBalanced=true

### DIFF
--- a/data/initial-dns-seedlist-discovery/README.rst
+++ b/data/initial-dns-seedlist-discovery/README.rst
@@ -17,7 +17,7 @@ load-balanced sharded cluster with the mongos servers running on localhost ports
 27017 and 27018 (corresponding to the script in `drivers-evergreen-tools`_). The
 load balancers, shard servers, and config servers may run on any open ports.
 
-.. _`drivers-evergreen-tools`: ../../connection-string/connection-string-spec.rst
+.. _`drivers-evergreen-tools`: https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/run-load-balancer.sh
 
 The tests in the ``sharded`` directory MUST be executed against a sharded
 cluster with the mongos servers running on localhost ports 27017 and 27018.
@@ -98,7 +98,7 @@ These YAML and JSON files contain the following fields:
   hosts cannot be deterministically asserted.
 - ``options``: the parsed `URI options`_ as discovered from the
   `Connection String`_'s "Connection Options" component and SRV resolution
-  (e.g. TXT records, implicit ``ssl`` default).
+  (e.g. TXT records, implicit ``tls`` default).
 - ``parsed_options``: additional, parsed options from other `Connection String`_
   components. This is mainly used for asserting ``UserInfo`` (as ``user`` and
   ``password``) and ``Auth database`` (as ``auth_database``).
@@ -109,7 +109,7 @@ These YAML and JSON files contain the following fields:
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 .. _`URI options`: ../../uri-options/uri-options.rst
 
-For each file, create MongoClient initialized with the ``mongodb+srv``
+For each file, create a MongoClient initialized with the ``mongodb+srv``
 connection string.
 
 If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
@@ -123,11 +123,11 @@ size of that set matches ``numHosts``.
 
 If ``options`` is specified, drivers MUST verify each of the values under
 ``options`` match the MongoClient's parsed value for that option. There may be
-other options parsed by the Client as well, which a test does not verify.
+other options parsed by the MongoClient as well, which a test does not verify.
 
 If ``parsed_options`` is specified, drivers MUST verify that each of the values
 under ``parsed_options`` match the MongoClient's parsed value for that option.
-Support values include, but are not limited to, ``user`` and ``password``
+Supported values include, but are not limited to, ``user`` and ``password``
 (parsed from ``UserInfo``) and ``auth_database`` (parsed from
 ``Auth database``).
 

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)"
+}

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true"
+}

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -1,0 +1,10 @@
+# loadBalanced=true (TXT) is permitted because srvMaxHosts is non-positive
+uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost.test.build.10gen.cc:27017
+options:
+    loadBalanced: true
+    srvMaxHosts: 0
+    ssl: true

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "options": {
+    "loadBalanced": true,
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -1,0 +1,10 @@
+# loadBalanced=true is permitted because srvMaxHosts is non-positive
+uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost.test.build.10gen.cc:27017
+options:
+    loadBalanced: true
+    srvMaxHosts: 0
+    ssl: true

--- a/data/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -1,0 +1,21 @@
+{
+  "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "user": "b*b@f3tt=",
+    "password": "$4to@L8=MC",
+    "db": "mydb?"
+  },
+  "comment": "Encoded user, pass, and DB parse correctly"
+}

--- a/data/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
@@ -1,0 +1,15 @@
+uri: "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
+parsed_options:
+    user: "b*b@f3tt="
+    password: "$4to@L8=MC"
+    db: "mydb?"
+comment: Encoded user, pass, and DB parse correctly

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)"
+}

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option"
+}

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with replicaSet option

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=2",
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
   "numSeeds": 2,
   "seeds": [
     "localhost.test.build.10gen.cc:27017",
@@ -11,7 +11,6 @@
     "localhost:27019"
   ],
   "options": {
-    "replicaSet": "repl0",
     "srvMaxHosts": 2,
     "ssl": true
   }

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
@@ -1,6 +1,8 @@
 # When srvMaxHosts equals the number of SRV records, all hosts are added to the
 # seed list.
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=2"
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2"
 numSeeds: 2
 seeds:
     - localhost.test.build.10gen.cc:27017
@@ -10,6 +12,5 @@ hosts:
     - localhost:27018
     - localhost:27019
 options:
-    replicaSet: repl0
     srvMaxHosts: 2
     ssl: true

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
@@ -1,6 +1,8 @@
 # When srvMaxHosts is greater than the number of SRV records, all hosts are
 # added to the seed list.
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=3"
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3"
 seeds:
     - localhost.test.build.10gen.cc:27017
     - localhost.test.build.10gen.cc:27018
@@ -9,6 +11,5 @@ hosts:
     - localhost:27018
     - localhost:27019
 options:
-    replicaSet: repl0
     srvMaxHosts: 3
     ssl: true

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1",
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
   "numSeeds": 1,
   "hosts": [
     "localhost:27017",
@@ -7,7 +7,6 @@
     "localhost:27019"
   ],
   "options": {
-    "replicaSet": "repl0",
     "srvMaxHosts": 1,
     "ssl": true
   }

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
@@ -2,13 +2,14 @@
 # hosts are added to the seed list. We cannot anticipate which hosts will be
 # selected, so this test uses numSeeds instead of seeds. Since this is a replica
 # set, all hosts should ultimately be discovered by SDAM.
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1"
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1"
 numSeeds: 1
 hosts:
     - localhost:27017
     - localhost:27018
     - localhost:27019
 options:
-    replicaSet: repl0
     srvMaxHosts: 1
     ssl: true

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
     "localhost.test.build.10gen.cc:27017",
     "localhost.test.build.10gen.cc:27018"
@@ -10,7 +10,9 @@
     "localhost:27019"
   ],
   "options": {
-    "srvMaxHosts": 3,
+    "authSource": "thisDB",
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
     "ssl": true
   }
 }

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -1,8 +1,7 @@
 {
   "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017",
-    "localhost.test.build.10gen.cc:27018"
+    "localhost.test.build.10gen.cc:27017"
   ],
   "hosts": [
     "localhost:27017",

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
@@ -4,7 +4,6 @@
 uri: "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0"
 seeds:
     - localhost.test.build.10gen.cc:27017
-    - localhost.test.build.10gen.cc:27018
 hosts:
     - localhost:27017
     - localhost:27018

--- a/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
+++ b/data/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
@@ -1,7 +1,7 @@
 # When srvMaxHosts is zero, all hosts are added to the seed list.
 #
-# replicaSet is permitted because srvMaxHosts is non-positive.
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0"
+# replicaSet (TXT) is permitted because srvMaxHosts is non-positive.
+uri: "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0"
 seeds:
     - localhost.test.build.10gen.cc:27017
     - localhost.test.build.10gen.cc:27018
@@ -10,6 +10,7 @@ hosts:
     - localhost:27018
     - localhost:27019
 options:
+    authSource: thisDB
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true

--- a/data/uri-options/README.rst
+++ b/data/uri-options/README.rst
@@ -21,10 +21,7 @@ array of test case objects, each of which have the following keys:
 
 - ``description``: A string describing the test.
 - ``uri``: A string containing the URI to be parsed.
-- ``valid``: A boolean indicating if the URI should be considered valid. 
-  This will always be true, as the Connection String spec tests the validity of the structure, but 
-  it's still included to make it easier to reuse the connection string spec test runners that 
-  drivers already have.
+- ``valid``: A boolean indicating if the URI should be considered valid.
 - ``warning``: A boolean indicating whether URI parsing should emit a warning.
 - ``hosts``: Included for compatibility with the Connection String spec tests. This will always be ``~``.
 - ``auth``: Included for compatibility with the Connection String spec tests. This will always be ``~``.

--- a/data/uri-options/srv-options.json
+++ b/data/uri-options/srv-options.json
@@ -102,7 +102,7 @@
     },
     {
       "description": "SRV URI with srvMaxHosts=0 and loadBalanced=true",
-      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true",
+      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true",
       "valid": true,
       "warning": false,
       "hosts": null,

--- a/data/uri-options/srv-options.json
+++ b/data/uri-options/srv-options.json
@@ -32,6 +32,24 @@
       }
     },
     {
+      "description": "SRV URI with negative integer for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
+      "valid": false,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with invalid type for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
+      "valid": false,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
       "description": "Non-SRV URI with srvMaxHosts",
       "uri": "mongodb://example.com/?srvMaxHosts=2",
       "valid": false,
@@ -39,6 +57,60 @@
       "hosts": null,
       "auth": null,
       "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo",
+      "valid": false,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=true",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true",
+      "valid": false,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=false",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": false,
+        "srvMaxHosts": 2
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&replicaSet=foo",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "replicaSet": "foo",
+        "srvMaxHosts": 0
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and loadBalanced=true",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": true,
+        "srvMaxHosts": 0
+      }
     }
   ]
 }

--- a/data/uri-options/srv-options.yml
+++ b/data/uri-options/srv-options.yml
@@ -22,6 +22,20 @@ tests:
       auth: ~
       options:
           srvMaxHosts: 2
+    - description: "SRV URI with negative integer for srvMaxHosts"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
+      valid: false
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with invalid type for srvMaxHosts"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
+      valid: false
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
     - description: "Non-SRV URI with srvMaxHosts"
       uri: "mongodb://example.com/?srvMaxHosts=2"
       valid: false
@@ -29,3 +43,47 @@ tests:
       hosts: ~
       auth: ~
       options: {}
+    # Note: Testing URI validation for srvMaxHosts conflicting with either
+    # loadBalanced=true or # replicaSet specified via TXT records is covered by
+    # the Initial DNS Seedlist Discovery test suite.
+    - description: "SRV URI with positive srvMaxHosts and replicaSet"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo"
+      valid: false
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with positive srvMaxHosts and loadBalanced=true"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true"
+      valid: false
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with positive srvMaxHosts and loadBalanced=false"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          loadBalanced: false
+          srvMaxHosts: 2
+    - description: "SRV URI with srvMaxHosts=0 and replicaSet"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&replicaSet=foo"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          replicaSet: foo
+          srvMaxHosts: 0
+    - description: "SRV URI with srvMaxHosts=0 and loadBalanced=true"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          loadBalanced: true
+          srvMaxHosts: 0

--- a/data/uri-options/srv-options.yml
+++ b/data/uri-options/srv-options.yml
@@ -79,7 +79,7 @@ tests:
           replicaSet: foo
           srvMaxHosts: 0
     - description: "SRV URI with srvMaxHosts=0 and loadBalanced=true"
-      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true"
+      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true"
       valid: true
       warning: false
       hosts: ~

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -295,6 +295,17 @@ func (p *parser) parse(original string) error {
 		}
 	}
 
+	// A positive "srvMaxHosts" value is not allowed with "loadbalanced=true" or
+	// "replSetName".
+	if p.SRVMaxHosts > 0 {
+		if p.ReplicaSet != "" {
+			return fmt.Errorf("cannot specify positive srvMaxHosts with replicaSet")
+		}
+		if p.LoadBalanced {
+			return fmt.Errorf("cannot specify positive srvMaxHosts with loadBalanced=true")
+		}
+	}
+
 	// do SRV lookup if "mongodb+srv://"
 	if p.Scheme == SchemeMongoDBSRV {
 		parsedHosts, err = p.dnsResolver.ParseHosts(hosts, p.SRVServiceName, true)


### PR DESCRIPTION
GODRIVER-2092

Followup to [original PR](https://github.com/mongodb/mongo-go-driver/pull/764) that added support for the `srvMaxHosts` URI option. Errors when `srvMaxHosts` is specified and is a positive number with `replicaSet` or `loadBalanced=true` in the connection string or TXT record. If `replicaSet` is specified or the configuration is load-balanced, a positive `srvMaxHosts` value does not make sense, so we should error (this according to [recent spec changes](https://github.com/mongodb/specifications/pull/1069/files/68a3e6bdf9e1912eefaf3657a236b5eba29bc700..f409dcd75f6c1eca6fe709eba2c2abaa550b748a)).