### PR TITLE
Feature - Transaction state in session

### DIFF
--- a/mongo/session.go
+++ b/mongo/session.go
@@ -121,6 +121,7 @@ type Session interface {
 	OperationTime() *primitive.Timestamp
 	Client() *Client
 	ID() bson.Raw
+	TransactionState() session.TransactionState
 
 	// Functions to modify mutable session properties.
 	AdvanceClusterTime(bson.Raw) error
@@ -165,6 +166,11 @@ func (s *sessionImpl) EndSession(ctx context.Context) {
 		_ = s.AbortTransaction(ctx)
 	}
 	s.clientSession.EndSession()
+}
+
+// TransactionState implements the Session interface.
+func (s *sessionImpl) TransactionState() session.TransactionState {
+	return s.clientSession.TransactionState
 }
 
 // WithTransaction implements the Session interface.


### PR DESCRIPTION
Now the only possible way to check if transaction in progress (for Session interface) is to call StartTransaction, AbortTransaction or CommitTransaction method and handle errors. It is unacceptable for obvious reasons. I've added TransactionState method to Session interface. 

Use case: choosing read preference for collection method call depending on transaction status.