### PR TITLE
GODRIVER-2189: Skip $out tests on serverless

### DIFF
--- a/data/crud/unified/aggregate-write-readPreference.json
+++ b/data/crud/unified/aggregate-write-readPreference.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-write-readPreference",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
@@ -90,7 +90,8 @@
       "description": "Aggregate with $out includes read preference for 5.0+ server",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0"
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -180,7 +181,8 @@
       "description": "Aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
-          "maxServerVersion": "4.4.99"
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/data/crud/unified/aggregate-write-readPreference.yml
+++ b/data/crud/unified/aggregate-write-readPreference.yml
@@ -1,6 +1,6 @@
 description: aggregate-write-readPreference
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   # 3.6+ non-standalone is needed to utilize $readPreference in OP_MSG
@@ -59,6 +59,7 @@ tests:
   - description: "Aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
       - minServerVersion: "5.0"
+        serverless: "forbid"
     operations:
       - object: *collection0
         name: aggregate
@@ -87,6 +88,7 @@ tests:
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
       - maxServerVersion: "4.4.99"
+        serverless: "forbid"
     operations:
       - object: *collection0
         name: aggregate

--- a/data/crud/unified/db-aggregate-write-readPreference.json
+++ b/data/crud/unified/db-aggregate-write-readPreference.json
@@ -64,7 +64,8 @@
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0"
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -157,7 +158,8 @@
       "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
-          "maxServerVersion": "4.4.99"
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/data/crud/unified/db-aggregate-write-readPreference.yml
+++ b/data/crud/unified/db-aggregate-write-readPreference.yml
@@ -52,6 +52,7 @@ tests:
   - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
       - minServerVersion: "5.0"
+        serverless: "forbid"
     operations:
       - object: *database0
         name: aggregate
@@ -81,6 +82,7 @@ tests:
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
       - maxServerVersion: "4.4.99"
+        serverless: "forbid"
     operations:
       - object: *database0
         name: aggregate


### PR DESCRIPTION
GODRIVER-2189.

Our `Serverless` task has been failing for a while because the tests modified in this PR used `$out` on a serverless instance, which resulted in `(AtlasError) $out is not allowed in this atlas tier`. Forbids serverless for these tests.