### PR TITLE
GODRIVER-2195 Do not expect readConcern with write stage on pre 4.2

### DIFF
--- a/data/crud/unified/aggregate-write-readPreference.json
+++ b/data/crud/unified/aggregate-write-readPreference.json
@@ -181,6 +181,7 @@
       "description": "Aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
+          "minServerVersion": "4.2",
           "maxServerVersion": "4.4.99",
           "serverless": "forbid"
         }

--- a/data/crud/unified/aggregate-write-readPreference.yml
+++ b/data/crud/unified/aggregate-write-readPreference.yml
@@ -87,7 +87,11 @@ tests:
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
-      - maxServerVersion: "4.4.99"
+        # MongoDB 4.2 introduced support for read concerns and write stages.
+        # Pre-4.2 servers may allow a "local" read concern anyway, but some
+        # drivers may avoid inheriting a client-level read concern for pre-4.2.
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
         serverless: "forbid"
     operations:
       - object: *collection0

--- a/data/crud/unified/db-aggregate-write-readPreference.json
+++ b/data/crud/unified/db-aggregate-write-readPreference.json
@@ -158,6 +158,7 @@
       "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
+          "minServerVersion": "4.2",
           "maxServerVersion": "4.4.99",
           "serverless": "forbid"
         }

--- a/data/crud/unified/db-aggregate-write-readPreference.yml
+++ b/data/crud/unified/db-aggregate-write-readPreference.yml
@@ -81,7 +81,11 @@ tests:
 
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
-      - maxServerVersion: "4.4.99"
+      # MongoDB 4.2 introduced support for read concerns and write stages.
+      # Pre-4.2 servers may allow a "local" read concern anyway, but some
+      # drivers may avoid inheriting a client-level read concern for pre-4.2.
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
         serverless: "forbid"
     operations:
       - object: *database0


### PR DESCRIPTION
GODRIVER-2195

Syncs spec tests for `aggregate`s with write stages (e.g. `$out` and `$merge`) to avoid testing against pre-4.2 servers when read concern is specified. MongoDB 4.2 introduced support for read concern and write stages, so we should not run the modified tests on servers above that version.