### PR TITLE
GODRIVER-517: Causal Consistency Examples for the Manual

### DIFF
--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -120,7 +120,7 @@ func TestCausalConsistencyExamples(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 
-	err = documentation_examples.CausalConsistencyExamples(t, client)
+	err = documentation_examples.CausalConsistencyExamples(client)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Writes usage examples for the causal consistency functionality available in version 3.6. Includes new test in examples_test.go that passes as expected. 