### PR TITLE
Fix typo in mongo.go ensureNoDollarKey error message

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -190,7 +190,7 @@ func ensureDollarKey(doc bsoncore.Document) error {
 
 func ensureNoDollarKey(doc bsoncore.Document) error {
 	if elem, err := doc.IndexErr(0); err == nil && strings.HasPrefix(elem.Key(), "$") {
-		return errors.New("replacement document cannot contains keys beginning with '$")
+		return errors.New("replacement document cannot contain keys beginning with '$'")
 	}
 
 	return nil


### PR DESCRIPTION
We found this error was poorly formatted when upgrading from an old 1.1 version of the driver.