### PR TITLE
GODRIVER-2215 Use git clone https:// instead of git://

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -125,7 +125,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec


### PR DESCRIPTION
GODRIVER-2215

Changes our call of `git clone` for the `drivers-evergreen-tools` repo to use `https://` instead of `git://` as the URL scheme. See new [GitHub changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective:).