### PR TITLE
GODRIVER-2156 Enable gosimple linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
     - errcheck
     # - errorlint
     - goimports
-    # - gosimple
+    - gosimple
     - govet
     - ineffassign
     # - misspell

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -30,7 +30,7 @@ var errInvalidValue = errors.New("cannot encode invalid element")
 
 var sliceWriterPool = sync.Pool{
 	New: func() interface{} {
-		sw := make(bsonrw.SliceWriter, 0, 0)
+		sw := make(bsonrw.SliceWriter, 0)
 		return &sw
 	},
 }
@@ -333,14 +333,7 @@ func (dve DefaultValueEncoders) mapEncodeValue(ec EncodeContext, dw bsonrw.Docum
 			continue
 		}
 
-		if enc, ok := currEncoder.(ValueEncoder); ok {
-			err = enc.EncodeValue(ec, vw, currVal)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		err = encoder.EncodeValue(ec, vw, currVal)
+		err = currEncoder.EncodeValue(ec, vw, currVal)
 		if err != nil {
 			return err
 		}

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -126,14 +126,7 @@ func (mc *MapCodec) mapEncodeValue(ec EncodeContext, dw bsonrw.DocumentWriter, v
 			continue
 		}
 
-		if enc, ok := currEncoder.(ValueEncoder); ok {
-			err = enc.EncodeValue(ec, vw, currVal)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		err = encoder.EncodeValue(ec, vw, currVal)
+		err = currEncoder.EncodeValue(ec, vw, currVal)
 		if err != nil {
 			return err
 		}

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -368,7 +368,7 @@ func (r *Registry) lookupInterfaceEncoder(t reflect.Type, allowAddr bool) (Value
 			// in interfaceEncoders
 			defaultEnc, found := r.lookupInterfaceEncoder(t, false)
 			if !found {
-				defaultEnc, _ = r.kindEncoders[t.Kind()]
+				defaultEnc = r.kindEncoders[t.Kind()]
 			}
 			return newCondAddrEncoder(ienc.ve, defaultEnc), true
 		}
@@ -439,7 +439,7 @@ func (r *Registry) lookupInterfaceDecoder(t reflect.Type, allowAddr bool) (Value
 			// in interfaceDecoders
 			defaultDec, found := r.lookupInterfaceDecoder(t, false)
 			if !found {
-				defaultDec, _ = r.kindDecoders[t.Kind()]
+				defaultDec = r.kindDecoders[t.Kind()]
 			}
 			return newCondAddrDecoder(idec.vd, defaultDec), true
 		}

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -328,7 +328,7 @@ func TestRegistry(t *testing.T) {
 					t.Run("Decoder", func(t *testing.T) {
 						var wanterr error
 						if ene, ok := tc.wanterr.(ErrNoEncoder); ok {
-							wanterr = ErrNoDecoder{Type: ene.Type}
+							wanterr = ErrNoDecoder(ene)
 						} else {
 							wanterr = tc.wanterr
 						}

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -331,14 +331,7 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr bsonrw.ValueReader, val r
 			return newDecodeError(fd.name, ErrNoDecoder{Type: field.Elem().Type()})
 		}
 
-		if decoder, ok := fd.decoder.(ValueDecoder); ok {
-			err = decoder.DecodeValue(dctx, vr, field.Elem())
-			if err != nil {
-				return newDecodeError(fd.name, err)
-			}
-			continue
-		}
-		err = fd.decoder.DecodeValue(dctx, vr, field)
+		err = fd.decoder.DecodeValue(dctx, vr, field.Elem())
 		if err != nil {
 			return newDecodeError(fd.name, err)
 		}

--- a/bson/mgocompat/bson_test.go
+++ b/bson/mgocompat/bson_test.go
@@ -232,8 +232,7 @@ func TestUnmarshalNonNilInterface(t *testing.T) {
 	data, err := bson.MarshalWithRegistry(Registry, bson.M{"b": 2})
 	assert.Nil(t, err, "expected nil error, got: %v", err)
 	m := bson.M{"a": 1}
-	var i interface{}
-	i = m
+	var i interface{} = m
 	err = bson.UnmarshalWithRegistry(Registry, data, &i)
 	assert.Nil(t, err, "expected nil error, got: %v", err)
 	assert.True(t, reflect.DeepEqual(bson.M{"b": 2}, i), "expected: %v, got: %v", bson.M{"b": 2}, i)

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -135,9 +135,7 @@ Loop:
 // BigInt returns significand as big.Int and exponent, bi * 10 ^ exp.
 func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
 	high, low := d.GetBytes()
-	var posSign bool // positive sign
-
-	posSign = high>>63&1 == 0
+	posSign := high>>63&1 == 0 // positive sign
 
 	switch high >> 58 & (1<<5 - 1) {
 	case 0x1F:

--- a/mongo/integration/cmd_monitoring_helpers_test.go
+++ b/mongo/integration/cmd_monitoring_helpers_test.go
@@ -74,7 +74,7 @@ func compareValues(mt *mtest.T, key string, expected, actual bson.RawValue) erro
 			}
 			return nil
 		}
-		break // compare bytes for expected.Value and actual.Value outside of the switch
+		// Don't return. Compare bytes for expected.Value and actual.Value outside of the switch.
 	case bson.TypeEmbeddedDocument:
 		e := expected.Document()
 		if typeVal, err := e.LookupErr("$$type"); err == nil {

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -116,7 +116,6 @@ func parseOpQuery(wm []byte) (*SentMessage, error) {
 				Style: bsoncore.ArrayStyle,
 				Data:  elem.Value().Array(),
 			}
-			break
 		}
 		if docSequence != nil {
 			// There can only be one of these arrays in a well-formed command, so we exit the loop once one is found.

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -169,7 +169,7 @@ func Setup(setupOpts ...*SetupOptions) error {
 		// the shard is a standalone if the "/" character isn't present.
 		var foundStandalone bool
 		for _, shard := range shards {
-			if strings.Index(shard.Host, "/") == -1 {
+			if !strings.Contains(shard.Host, "/") {
 				foundStandalone = true
 				break
 			}

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -129,7 +129,6 @@ func runTestFile(t *testing.T, filepath string, expectValidFail bool, opts ...*O
 			if err != nil {
 				mt.Fatal(err)
 			}
-			return
 		})
 	}
 }

--- a/x/bsonx/bsoncore/bson_arraybuilder_test.go
+++ b/x/bsonx/bsoncore/bson_arraybuilder_test.go
@@ -195,8 +195,7 @@ func TestArrayBuilder(t *testing.T) {
 	})
 	t.Run("TestBuildInlineArray", func(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendInt32Element(nil, "0", int32(256)))
-		var expected Document
-		expected = BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docElement))
+		expected := Document(BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docElement)))
 		result := NewArrayBuilder().StartArray().AppendInt32(int32(256)).FinishArray().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
@@ -205,8 +204,7 @@ func TestArrayBuilder(t *testing.T) {
 	t.Run("TestBuildNestedInlineArray", func(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendDoubleElement(nil, "0", 3.14))
 		docInline := BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docElement))
-		var expected Document
-		expected = BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docInline))
+		expected := Document(BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", docInline)))
 		result := NewArrayBuilder().StartArray().StartArray().AppendDouble(3.14).FinishArray().FinishArray().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)

--- a/x/bsonx/bsoncore/bson_documentbuilder_test.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder_test.go
@@ -197,8 +197,7 @@ func TestDocumentBuilder(t *testing.T) {
 	})
 	t.Run("TestBuildInlineDocument", func(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendInt32Element(nil, "x", int32(256)))
-		var expected Document
-		expected = BuildDocumentFromElements(nil, AppendDocumentElement(nil, "y", docElement))
+		expected := Document(BuildDocumentFromElements(nil, AppendDocumentElement(nil, "y", docElement)))
 		result := NewDocumentBuilder().StartDocument("y").AppendInt32("x", int32(256)).FinishDocument().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)
@@ -207,8 +206,7 @@ func TestDocumentBuilder(t *testing.T) {
 	t.Run("TestBuildNestedInlineDocument", func(t *testing.T) {
 		docElement := BuildDocumentFromElements(nil, AppendDoubleElement(nil, "x", 3.14))
 		docInline := BuildDocumentFromElements(nil, AppendDocumentElement(nil, "y", docElement))
-		var expected Document
-		expected = BuildDocumentFromElements(nil, AppendDocumentElement(nil, "z", docInline))
+		expected := Document(BuildDocumentFromElements(nil, AppendDocumentElement(nil, "z", docInline)))
 		result := NewDocumentBuilder().StartDocument("z").StartDocument("y").AppendDouble("x", 3.14).FinishDocument().FinishDocument().Build()
 		if !bytes.Equal(result, expected) {
 			t.Errorf("Documents do not match. got %v; want %v", result, expected)

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -873,7 +873,7 @@ func TestBuild(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("BuildDocument", func(t *testing.T) {
-				elems := make([]byte, 0, 0)
+				elems := make([]byte, 0)
 				for _, elem := range tc.elems {
 					elems = append(elems, elem...)
 				}

--- a/x/bsonx/document.go
+++ b/x/bsonx/document.go
@@ -264,7 +264,7 @@ func (d Doc) Equal(id IDoc) bool {
 			}
 		}
 	case MDoc:
-		unique := make(map[string]struct{}, 0)
+		unique := make(map[string]struct{})
 		for _, elem := range d {
 			unique[elem.Key] = struct{}{}
 			val, ok := tt[elem.Key]

--- a/x/bsonx/mdocument.go
+++ b/x/bsonx/mdocument.go
@@ -21,7 +21,7 @@ type MDoc map[string]Val
 // ReadMDoc will create a Doc using the provided slice of bytes. If the
 // slice of bytes is not a valid BSON document, this method will return an error.
 func ReadMDoc(b []byte) (MDoc, error) {
-	doc := make(MDoc, 0)
+	doc := make(MDoc)
 	err := doc.UnmarshalBSON(b)
 	if err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (d MDoc) Equal(id IDoc) bool {
 			}
 		}
 	case Doc:
-		unique := make(map[string]struct{}, 0)
+		unique := make(map[string]struct{})
 		for _, elem := range tt {
 			unique[elem.Key] = struct{}{}
 			val, ok := d[elem.Key]

--- a/x/bsonx/value.go
+++ b/x/bsonx/value.go
@@ -470,16 +470,12 @@ func (v Val) Undefined() {
 	if v.t != bsontype.Undefined {
 		panic(ElementTypeError{"bson.Value.Undefined", v.t})
 	}
-	return
 }
 
 // UndefinedOK is the same as Undefined, except it returns a boolean instead of
 // panicking.
 func (v Val) UndefinedOK() bool {
-	if v.t != bsontype.Undefined {
-		return false
-	}
-	return true
+	return v.t == bsontype.Undefined
 }
 
 // ObjectID returns the BSON ObjectID the Value represents. It panics if the value is a BSON type
@@ -566,7 +562,6 @@ func (v Val) Null() {
 	if v.t != bsontype.Null && v.t != bsontype.Type(0) {
 		panic(ElementTypeError{"bson.Value.Null", v.t})
 	}
-	return
 }
 
 // NullOK is the same as Null, except it returns a boolean instead of
@@ -762,16 +757,12 @@ func (v Val) MinKey() {
 	if v.t != bsontype.MinKey {
 		panic(ElementTypeError{"bson.Value.MinKey", v.t})
 	}
-	return
 }
 
 // MinKeyOK is the same as MinKey, except it returns a boolean instead of
 // panicking.
 func (v Val) MinKeyOK() bool {
-	if v.t != bsontype.MinKey {
-		return false
-	}
-	return true
+	return v.t == bsontype.MinKey
 }
 
 // MaxKey returns the BSON maxkey the Value represents. It panics if the value is a BSON type
@@ -780,16 +771,12 @@ func (v Val) MaxKey() {
 	if v.t != bsontype.MaxKey {
 		panic(ElementTypeError{"bson.Value.MaxKey", v.t})
 	}
-	return
 }
 
 // MaxKeyOK is the same as MaxKey, except it returns a boolean instead of
 // panicking.
 func (v Val) MaxKeyOK() bool {
-	if v.t != bsontype.MaxKey {
-		return false
-	}
-	return true
+	return v.t == bsontype.MaxKey
 }
 
 // Equal compares v to v2 and returns true if they are equal. Unknown BSON types are

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -74,7 +74,7 @@ func (e ResponseError) Error() string {
 	if e.Wrapped != nil {
 		return fmt.Sprintf("%s: %s", e.Message, e.Wrapped)
 	}
-	return fmt.Sprintf("%s", e.Message)
+	return e.Message
 }
 
 // WriteCommandError is an error for a write command.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1516,7 +1516,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 	var durationNanos int64
 	var emptyTime time.Time
 	if info.startTime != emptyTime {
-		durationNanos = time.Now().Sub(info.startTime).Nanoseconds()
+		durationNanos = time.Since(info.startTime).Nanoseconds()
 	}
 
 	finished := event.CommandFinishedEvent{

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -346,8 +346,6 @@ func (c *Client) EndSession() {
 
 	c.Terminated = true
 	c.pool.ReturnSession(c.Server)
-
-	return
 }
 
 // TransactionInProgress returns true if the client session is in an active transaction.

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -361,7 +361,7 @@ func loadCert(data []byte) ([]byte, error) {
 	var certBlock *pem.Block
 
 	for certBlock == nil {
-		if data == nil || len(data) == 0 {
+		if len(data) == 0 {
 			return nil, errors.New(".pem file must have both a CERTIFICATE and an RSA PRIVATE KEY section")
 		}
 


### PR DESCRIPTION
Enable the `gosimple` linter and make suggested simplifications.