### PR TITLE
GODRIVER-2156 Enable nakedret linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - govet
     - ineffassign
     # - misspell
-    # - nakedret
+    - nakedret
     - revive
     - staticcheck
     # - structcheck

--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -133,7 +133,7 @@ Loop:
 }
 
 // BigInt returns significand as big.Int and exponent, bi * 10 ^ exp.
-func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
+func (d Decimal128) BigInt() (*big.Int, int, error) {
 	high, low := d.GetBytes()
 	var posSign bool // positive sign
 
@@ -149,6 +149,7 @@ func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
 		return nil, 0, ErrParseNegInf
 	}
 
+	var exp int
 	if high>>61&3 == 3 {
 		// Bits: 1*sign 2*ignored 14*exponent 111*significand.
 		// Implicit 0b100 prefix in significand.
@@ -171,7 +172,7 @@ func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
 		return new(big.Int), 0, nil
 	}
 
-	bi = big.NewInt(0)
+	bi := big.NewInt(0)
 	const host32bit = ^uint(0)>>32 == 0
 	if host32bit {
 		bi.SetBits([]big.Word{big.Word(low), big.Word(low >> 32), big.Word(high), big.Word(high >> 32)})
@@ -182,7 +183,7 @@ func (d Decimal128) BigInt() (bi *big.Int, exp int, err error) {
 	if !posSign {
 		return bi.Neg(bi), exp, nil
 	}
-	return
+	return bi, exp, nil
 }
 
 // IsNaN returns whether d is NaN.


### PR DESCRIPTION
Enable the `nakedret` linter and remove suggested naked returns.