### PR TITLE
GODRIVER-2220 Ignore readpref for output aggs if any servers are pre-5.0

### DIFF
--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1204,6 +1204,8 @@ func (op Operation) getReadPrefBasedOnTransaction() (*readpref.ReadPref, error) 
 }
 
 func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bool) (bsoncore.Document, error) {
+	// TODO(GODRIVER-2231): Instead of checking if isOutputAggregate and desc.Server.WireVersion.Max < 13,
+	// somehow check if supplied readPreference was "overwritten" with primary in description.selectForReplicaSet.
 	if desc.Server.Kind == description.Standalone || (isOpQuery && desc.Server.Kind != description.Mongos) ||
 		op.Type == Write || (op.IsOutputAggregate && desc.Server.WireVersion.Max < 13) {
 		// Don't send read preference for:


### PR DESCRIPTION
GODRIVER-2220

Simplifies the logic for read preference application in server selection when the underlying operation is an `aggregate` with an output stage (`$out` or `$merge`). Previously, we attempted to use the read preference and only fell back to a primary if a pre-5.0 secondary was going to be selected. Now, we always disregard the read preference if there is any evidence of a pre-5.0 server in `candidates`. If there are either no candidates or all servers are 5.0+ (or load balanced, where we assume 5.0+), we utilize the read preference.