### PR TITLE
GODRIVER-2161 Add NewSingleResultFromDocument and NewCursorFromDocuments functions

### DIFF
--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -79,8 +79,9 @@ func NewCursorFromBytes(contents []byte, err error, registry *bsoncodec.Registry
 		err:      err,
 	}
 
-	// Initialize just the batchLength here so RemainingBatchLength will return an accurate result. The actual batch
-	// will be pulled up by the first Next/TryNext call.
+	// Initialize batch and batchLength here. The underlying batch cursor will be preloaded with the
+	// provided contents, and thus already has a batch before calls to Next/TryNext.
+	c.batch = c.bc.Batch()
 	c.batchLength = c.bc.Batch().DocumentCount()
 	return c
 }

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -67,6 +67,24 @@ func newEmptyCursor() *Cursor {
 	return &Cursor{bc: driver.NewEmptyBatchCursor()}
 }
 
+// NewCursorFromBytes creates a new Cursor pre-loaded with the provided contents, error and registry.
+func NewCursorFromBytes(contents []byte, err error, registry *bsoncodec.Registry) *Cursor {
+	if registry == nil {
+		registry = bson.DefaultRegistry
+	}
+
+	c := &Cursor{
+		bc:       driver.NewBatchCursorFromBytes(contents),
+		registry: registry,
+		err:      err,
+	}
+
+	// Initialize just the batchLength here so RemainingBatchLength will return an accurate result. The actual batch
+	// will be pulled up by the first Next/TryNext call.
+	c.batchLength = c.bc.Batch().DocumentCount()
+	return c
+}
+
 // ID returns the ID of this cursor, or 0 if the cursor has been closed or exhausted.
 func (c *Cursor) ID() int64 { return c.bc.ID() }
 

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -68,11 +68,11 @@ func newEmptyCursor() *Cursor {
 	return &Cursor{bc: driver.NewEmptyBatchCursor()}
 }
 
-// NewMockCursor creates a new Cursor pre-loaded with the provided documents, error and registry. If no registry is provided,
+// NewCursorFromDocuments creates a new Cursor pre-loaded with the provided documents, error and registry. If no registry is provided,
 // bson.DefaultRegistry will be used.
 //
-// The documents parameter must be a slice of documents.
-func NewMockCursor(documents []interface{}, err error, registry *bsoncodec.Registry) (*Cursor, error) {
+// The documents parameter must be a slice of documents. The slice may be nil or empty, but all elements must be non-nil.
+func NewCursorFromDocuments(documents []interface{}, err error, registry *bsoncodec.Registry) (*Cursor, error) {
 	if registry == nil {
 		registry = bson.DefaultRegistry
 	}
@@ -81,6 +81,8 @@ func NewMockCursor(documents []interface{}, err error, registry *bsoncodec.Regis
 	var docsBytes []byte
 	for _, doc := range documents {
 		switch t := doc.(type) {
+		case nil:
+			return nil, ErrNilDocument
 		case bsonx.Doc:
 			doc = t.Copy()
 		case []byte:
@@ -95,7 +97,7 @@ func NewMockCursor(documents []interface{}, err error, registry *bsoncodec.Regis
 	}
 
 	c := &Cursor{
-		bc:       driver.NewMockBatchCursor(docsBytes),
+		bc:       driver.NewBatchCursorFromDocuments(docsBytes),
 		registry: registry,
 		err:      err,
 	}

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -181,7 +181,7 @@ func TestCursor(t *testing.T) {
 	})
 }
 
-func TestNewMockCursor(t *testing.T) {
+func TestNewCursorFromDocuments(t *testing.T) {
 	// Mock documents returned by Find in a Cursor.
 	t.Run("mock Find", func(t *testing.T) {
 		findResult := []interface{}{
@@ -189,8 +189,8 @@ func TestNewMockCursor(t *testing.T) {
 			bson.D{{"_id", 1}, {"baz", "qux"}},
 			bson.D{{"_id", 2}, {"quux", "quuz"}},
 		}
-		cur, err := NewMockCursor(findResult, nil, nil)
-		assert.Nil(t, err, "NewMockCursor error: %v", err)
+		cur, err := NewCursorFromDocuments(findResult, nil, nil)
+		assert.Nil(t, err, "NewCursorFromDocuments error: %v", err)
 
 		// Assert that decoded documents are as expected.
 		var i int
@@ -221,8 +221,8 @@ func TestNewMockCursor(t *testing.T) {
 	t.Run("mock Find with error", func(t *testing.T) {
 		mockErr := fmt.Errorf("mock error")
 		findResult := []interface{}{bson.D{{"_id", 0}, {"foo", "bar"}}}
-		cur, err := NewMockCursor(findResult, mockErr, nil)
-		assert.Nil(t, err, "NewMockCursor error: %v", err)
+		cur, err := NewCursorFromDocuments(findResult, mockErr, nil)
+		assert.Nil(t, err, "NewCursorFromDocuments error: %v", err)
 
 		// Assert that a call to Next will return false because of existing error.
 		next := cur.Next(context.Background())

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -8,6 +8,7 @@ package mongo
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -177,5 +178,59 @@ func TestCursor(t *testing.T) {
 			err = cursor.All(context.Background(), &docs)
 			assert.NotNil(t, err, "expected error, got: %v", err)
 		})
+	})
+}
+
+func TestNewMockCursor(t *testing.T) {
+	// Mock documents returned by Find in a Cursor.
+	t.Run("mock Find", func(t *testing.T) {
+		findResult := []interface{}{
+			bson.D{{"_id", 0}, {"foo", "bar"}},
+			bson.D{{"_id", 1}, {"baz", "qux"}},
+			bson.D{{"_id", 2}, {"quux", "quuz"}},
+		}
+		cur, err := NewMockCursor(findResult, nil, nil)
+		assert.Nil(t, err, "NewMockCursor error: %v", err)
+
+		// Assert that decoded documents are as expected.
+		var i int
+		for cur.Next(context.Background()) {
+			docBytes, err := bson.Marshal(findResult[i])
+			assert.Nil(t, err, "Marshal error: %v", err)
+			expectedDecoded := bson.Raw(docBytes)
+
+			var decoded bson.Raw
+			err = cur.Decode(&decoded)
+			assert.Nil(t, err, "Decode error: %v", err)
+			assert.Equal(t, expectedDecoded, decoded,
+				"expected decoded document %v of Cursor to be %v, got %v",
+				i, expectedDecoded, decoded)
+			i++
+		}
+		assert.Equal(t, 3, i, "expected 3 calls to cur.Next, got %v", i)
+
+		// Check for error on Cursor.
+		assert.Nil(t, cur.Err(), "Cursor error: %v", cur.Err())
+
+		// Assert that a call to cur.Close will not fail.
+		err = cur.Close(context.Background())
+		assert.Nil(t, err, "Close error: %v", err)
+	})
+
+	// Mock an error in a Cursor.
+	t.Run("mock Find with error", func(t *testing.T) {
+		mockErr := fmt.Errorf("mock error")
+		findResult := []interface{}{bson.D{{"_id", 0}, {"foo", "bar"}}}
+		cur, err := NewMockCursor(findResult, mockErr, nil)
+		assert.Nil(t, err, "NewMockCursor error: %v", err)
+
+		// Assert that a call to Next will return false because of existing error.
+		next := cur.Next(context.Background())
+		assert.False(t, next, "expected call to Next to return false, got true")
+
+		// Check for error on Cursor.
+		assert.NotNil(t, cur.Err(), "expected Cursor error, got nil")
+		assert.Equal(t, mockErr, cur.Err(), "expected Cursor error %v, got %v",
+			mockErr, cur.Err())
 	})
 }

--- a/mongo/integration/mock_find_test.go
+++ b/mongo/integration/mock_find_test.go
@@ -1,0 +1,132 @@
+// Copyright (C) MongoDB, Inc. 2021-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// finder is an object that implements FindOne and Find.
+type finder interface {
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) *mongo.SingleResult
+	Find(context.Context, interface{}, ...*options.FindOptions) (*mongo.Cursor, error)
+}
+
+// mockFinder implements finder.
+type mockFinder struct {
+	docs     []interface{}
+	err      error
+	registry *bsoncodec.Registry
+}
+
+// FindOne mocks a findOne operation using NewMockSingleResult.
+func (mf *mockFinder) FindOne(_ context.Context, _ interface{}, _ ...*options.FindOneOptions) *mongo.SingleResult {
+	res, err := mongo.NewMockSingleResult(mf.docs, mf.err, mf.registry)
+
+	// If there was an error in SingleResult creation, override the error of SingleResult.
+	if err != nil {
+		mf.err = err
+	}
+	return res
+}
+
+// Find mocks a find operation using NewMockCursor.
+func (mf *mockFinder) Find(context.Context, interface{}, ...*options.FindOptions) (*mongo.Cursor, error) {
+	return mongo.NewMockCursor(mf.docs, mf.err, mf.registry)
+}
+
+// ShopItem is an item with an associated ID and price.
+type ShopItem struct {
+	ID    int     `bson:"id"`
+	Price float64 `bson:"price"`
+}
+
+// getItem is an example function using the interface finder to test the mocking of SingleResult.
+func getItem(f finder, id int) (*ShopItem, error) {
+	res := f.FindOne(context.Background(), bson.D{{"id", id}})
+	var item ShopItem
+	err := res.Decode(&item)
+	return &item, err
+}
+
+// getItems is an example function using the interface finder to test the mocking of Cursor.
+func getItems(f finder) ([]ShopItem, error) {
+	cur, err := f.Find(context.Background(), bson.D{})
+	if err != nil {
+		return nil, err
+	}
+
+	var items []ShopItem
+	err = cur.All(context.Background(), &items)
+	return items, err
+}
+
+func TestMockFind(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+	defer mt.Close()
+
+	insertItems := []interface{}{
+		ShopItem{ID: 0, Price: 1.5},
+		ShopItem{ID: 1, Price: 5.7},
+		ShopItem{ID: 2, Price: 0.25},
+	}
+	insertItem := []interface{}{ShopItem{ID: 1, Price: 5.7}}
+
+	mt.Run("mongo.Collection can be passed as interface", func(mt *mtest.T) {
+		// Actually insert documents to collection.
+		_, err := mt.Coll.InsertMany(mtest.Background, insertItems)
+		assert.Nil(mt, err, "InsertMany error: %v", err)
+
+		// Assert that FindOne behaves as expected.
+		shopItem, err := getItem(mt.Coll, 1)
+		assert.Nil(mt, err, "getItem error: %v", err)
+		assert.Equal(mt, 1, shopItem.ID)
+		assert.Equal(mt, 5.7, shopItem.Price)
+
+		// Assert that Find behaves as expected.
+		shopItems, err := getItems(mt.Coll)
+		assert.Nil(mt, err, "getItems error: %v", err)
+		for i, shopItem := range shopItems {
+			expectedItem := insertItems[i].(ShopItem)
+			assert.Equal(mt, expectedItem.ID, shopItem.ID)
+			assert.Equal(mt, expectedItem.Price, shopItem.Price)
+		}
+	})
+
+	mt.Run("FindOne can be mocked", func(mt *mtest.T) {
+		// Mock a FindOne result with mockFinder.
+		mf := &mockFinder{docs: insertItem, err: nil, registry: nil}
+
+		// Assert that FindOne behaves as expected.
+		shopItem, err := getItem(mf, 1)
+		assert.Nil(mt, err, "getItem error: %v", err)
+		assert.Equal(mt, 1, shopItem.ID)
+		assert.Equal(mt, 5.7, shopItem.Price)
+	})
+
+	mt.Run("Find can be mocked", func(mt *mtest.T) {
+		// Mock a Find result with mockFinder.
+		mf := &mockFinder{docs: insertItems, err: nil, registry: nil}
+
+		// Assert that Find behaves as expected.
+		shopItems, err := getItems(mf)
+		assert.Nil(mt, err, "getItems error: %v", err)
+		for i, shopItem := range shopItems {
+			expectedItem := insertItems[i].(ShopItem)
+			assert.Equal(mt, expectedItem.ID, shopItem.ID)
+			assert.Equal(mt, expectedItem.Price, shopItem.Price)
+		}
+	})
+}

--- a/mongo/integration/mock_find_test.go
+++ b/mongo/integration/mock_find_test.go
@@ -31,9 +31,9 @@ type mockFinder struct {
 	registry *bsoncodec.Registry
 }
 
-// FindOne mocks a findOne operation using NewMockSingleResult.
+// FindOne mocks a findOne operation using NewSingleResultFromDocument.
 func (mf *mockFinder) FindOne(_ context.Context, _ interface{}, _ ...*options.FindOneOptions) *mongo.SingleResult {
-	res, err := mongo.NewMockSingleResult(mf.docs, mf.err, mf.registry)
+	res, err := mongo.NewSingleResultFromDocument(mf.docs[0], mf.err, mf.registry)
 
 	// If there was an error in SingleResult creation, override the error of SingleResult.
 	if err != nil {
@@ -42,9 +42,9 @@ func (mf *mockFinder) FindOne(_ context.Context, _ interface{}, _ ...*options.Fi
 	return res
 }
 
-// Find mocks a find operation using NewMockCursor.
+// Find mocks a find operation using NewCursorFromDocuments.
 func (mf *mockFinder) Find(context.Context, interface{}, ...*options.FindOptions) (*mongo.Cursor, error) {
-	return mongo.NewMockCursor(mf.docs, mf.err, mf.registry)
+	return mongo.NewCursorFromDocuments(mf.docs, mf.err, mf.registry)
 }
 
 // ShopItem is an item with an associated ID and price.

--- a/mongo/integration/mock_find_test.go
+++ b/mongo/integration/mock_find_test.go
@@ -33,13 +33,7 @@ type mockFinder struct {
 
 // FindOne mocks a findOne operation using NewSingleResultFromDocument.
 func (mf *mockFinder) FindOne(_ context.Context, _ interface{}, _ ...*options.FindOneOptions) *mongo.SingleResult {
-	res, err := mongo.NewSingleResultFromDocument(mf.docs[0], mf.err, mf.registry)
-
-	// If there was an error in SingleResult creation, override the error of SingleResult.
-	if err != nil {
-		mf.err = err
-	}
-	return res
+	return mongo.NewSingleResultFromDocument(mf.docs[0], mf.err, mf.registry)
 }
 
 // Find mocks a find operation using NewCursorFromDocuments.

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -93,11 +93,6 @@ func (sr *SingleResult) setRdrContents() error {
 	case sr.cur != nil:
 		defer sr.cur.Close(context.TODO())
 
-		// Set contents of rdr to cur.Current if non-nil. Otherwise, iterate underlying
-		// cursor.
-		if sr.rdr = sr.cur.Current; sr.rdr != nil {
-			return nil
-		}
 		if !sr.cur.Next(context.TODO()) {
 			if err := sr.cur.Err(); err != nil {
 				return err

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -28,18 +28,25 @@ type SingleResult struct {
 	reg *bsoncodec.Registry
 }
 
-// NewSingleResultFromBytes creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
-// the provided contents, error and registry.
-func NewSingleResultFromBytes(contents []byte, err error, registry *bsoncodec.Registry) *SingleResult {
+// NewMockSingleResult creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
+// the provided documents, error and registry. If no registry is provided, bson.DefaultRegistry will be used.
+//
+// The documents parameter must be a slice of documents.
+func NewMockSingleResult(documents []interface{}, err error, registry *bsoncodec.Registry) (*SingleResult, error) {
 	if registry == nil {
 		registry = bson.DefaultRegistry
 	}
 
+	cur, createErr := NewMockCursor(documents, err, registry)
+	if createErr != nil {
+		return nil, createErr
+	}
+
 	return &SingleResult{
-		cur: NewCursorFromBytes(contents, err, registry),
+		cur: cur,
 		err: err,
 		reg: registry,
-	}
+	}, nil
 }
 
 // Decode will unmarshal the document represented by this SingleResult into v. If there was an error from the operation

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -32,9 +32,9 @@ type SingleResult struct {
 // the provided document, error and registry. If no registry is provided, bson.DefaultRegistry will be used.
 //
 // The document parameter must be a non-nil document.
-func NewSingleResultFromDocument(document interface{}, err error, registry *bsoncodec.Registry) (*SingleResult, error) {
+func NewSingleResultFromDocument(document interface{}, err error, registry *bsoncodec.Registry) *SingleResult {
 	if document == nil {
-		return nil, ErrNilDocument
+		return &SingleResult{err: ErrNilDocument}
 	}
 	if registry == nil {
 		registry = bson.DefaultRegistry
@@ -42,14 +42,14 @@ func NewSingleResultFromDocument(document interface{}, err error, registry *bson
 
 	cur, createErr := NewCursorFromDocuments([]interface{}{document}, err, registry)
 	if createErr != nil {
-		return nil, createErr
+		return &SingleResult{err: createErr}
 	}
 
 	return &SingleResult{
 		cur: cur,
 		err: err,
 		reg: registry,
-	}, nil
+	}
 }
 
 // Decode will unmarshal the document represented by this SingleResult into v. If there was an error from the operation

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -29,7 +29,8 @@ type SingleResult struct {
 }
 
 // NewSingleResultFromDocument creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
-// the provided document, error and registry. If no registry is provided, bson.DefaultRegistry will be used.
+// the provided document, error and registry. If no registry is provided, bson.DefaultRegistry will be used. If an error distinct
+// from the one provided occurs during creation of the SingleResult, that error will be stored on the returned SingleResult.
 //
 // The document parameter must be a non-nil document.
 func NewSingleResultFromDocument(document interface{}, err error, registry *bsoncodec.Registry) *SingleResult {

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -28,16 +28,19 @@ type SingleResult struct {
 	reg *bsoncodec.Registry
 }
 
-// NewMockSingleResult creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
-// the provided documents, error and registry. If no registry is provided, bson.DefaultRegistry will be used.
+// NewSingleResultFromDocument creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
+// the provided document, error and registry. If no registry is provided, bson.DefaultRegistry will be used.
 //
-// The documents parameter must be a slice of documents.
-func NewMockSingleResult(documents []interface{}, err error, registry *bsoncodec.Registry) (*SingleResult, error) {
+// The document parameter must be a non-nil document.
+func NewSingleResultFromDocument(document interface{}, err error, registry *bsoncodec.Registry) (*SingleResult, error) {
+	if document == nil {
+		return nil, ErrNilDocument
+	}
 	if registry == nil {
 		registry = bson.DefaultRegistry
 	}
 
-	cur, createErr := NewMockCursor(documents, err, registry)
+	cur, createErr := NewCursorFromDocuments([]interface{}{document}, err, registry)
 	if createErr != nil {
 		return nil, createErr
 	}

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -12,7 +12,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 // ErrNoDocuments is returned by SingleResult methods when the operation that created the SingleResult did not return
@@ -29,19 +28,17 @@ type SingleResult struct {
 	reg *bsoncodec.Registry
 }
 
-// NewSingleResultFromBytes creates a SingleResult with an underlying Cursor pre-loaded with the provided contents.
-func NewSingleResultFromBytes(contents []byte) *SingleResult {
-	c := &Cursor{
-		bc:       driver.NewBatchCursorFromBytes(contents),
-		registry: bson.DefaultRegistry,
-		Current:  bson.Raw(contents),
+// NewSingleResultFromBytes creates a SingleResult with the provided error, registry, and an underlying Cursor pre-loaded with
+// the provided contents, error and registry.
+func NewSingleResultFromBytes(contents []byte, err error, registry *bsoncodec.Registry) *SingleResult {
+	if registry == nil {
+		registry = bson.DefaultRegistry
 	}
 
-	// Initialize just the batchLength here so RemainingBatchLength will return an accurate result.
-	c.batchLength = c.bc.Batch().DocumentCount()
 	return &SingleResult{
-		cur: c,
-		reg: bson.DefaultRegistry,
+		cur: NewCursorFromBytes(contents, err, registry),
+		err: err,
+		reg: registry,
 	}
 }
 

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -52,16 +52,16 @@ func TestSingleResult(t *testing.T) {
 	})
 }
 
-func TestNewSingleResultFromBytes(t *testing.T) {
+func TestNewMockSingleResult(t *testing.T) {
 	// Mock a document returned by FindOne in SingleResult.
-	t.Run("simple mock FindOne", func(t *testing.T) {
+	t.Run("mock FindOne", func(t *testing.T) {
 		findOneResult := bson.D{{"_id", 2}, {"foo", "bar"}}
-		findOneResultBytes, err := bson.Marshal(findOneResult)
-		assert.Nil(t, err, "Marshal error: %v", err)
-
-		res := NewSingleResultFromBytes(findOneResultBytes, nil, nil)
+		res, err := NewMockSingleResult([]interface{}{findOneResult}, nil, nil)
+		assert.Nil(t, err, "NewMockSingleResult error: %v", err)
 
 		// Assert that first, decoded document is as expected.
+		findOneResultBytes, err := bson.Marshal(findOneResult)
+		assert.Nil(t, err, "Marshal error: %v", err)
 		expectedDecoded := bson.Raw(findOneResultBytes)
 		decoded, err := res.DecodeBytes()
 		assert.Nil(t, err, "DecodeBytes error: %v", err)
@@ -74,7 +74,7 @@ func TestNewSingleResultFromBytes(t *testing.T) {
 			"expected RDR contents to be %v, got %v", expectedDecoded, res.rdr)
 
 		// Assert that a call to cur.Next will return false, as there was only one document in
-		// the contents passed to NewSingleResultFromBytes.
+		// the slice passed to NewMockSingleResult.
 		next := res.cur.Next(context.Background())
 		assert.False(t, next, "expected call to Next to return false, got true")
 
@@ -87,12 +87,13 @@ func TestNewSingleResultFromBytes(t *testing.T) {
 	})
 
 	// Mock an error in SingleResult.
-	t.Run("simple mock FindOne with error", func(t *testing.T) {
+	t.Run("mock FindOne with error", func(t *testing.T) {
 		mockErr := fmt.Errorf("mock error")
-		res := NewSingleResultFromBytes(nil, mockErr, nil)
+		res, err := NewMockSingleResult(nil, mockErr, nil)
+		assert.Nil(t, err, "NewMockSingleResult error: %v", err)
 
 		// Assert that decoding returns the mocked error.
-		_, err := res.DecodeBytes()
+		_, err = res.DecodeBytes()
 		assert.NotNil(t, err, "expected DecodeBytes error, got nil")
 		assert.Equal(t, mockErr, err, "expected error %v, got %v", mockErr, err)
 

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -56,8 +56,7 @@ func TestNewSingleResultFromDocument(t *testing.T) {
 	// Mock a document returned by FindOne in SingleResult.
 	t.Run("mock FindOne", func(t *testing.T) {
 		findOneResult := bson.D{{"_id", 2}, {"foo", "bar"}}
-		res, err := NewSingleResultFromDocument(findOneResult, nil, nil)
-		assert.Nil(t, err, "NewSingleResultFromDocument error: %v", err)
+		res := NewSingleResultFromDocument(findOneResult, nil, nil)
 
 		// Assert that first, decoded document is as expected.
 		findOneResultBytes, err := bson.Marshal(findOneResult)
@@ -89,11 +88,10 @@ func TestNewSingleResultFromDocument(t *testing.T) {
 	// Mock an error in SingleResult.
 	t.Run("mock FindOne with error", func(t *testing.T) {
 		mockErr := fmt.Errorf("mock error")
-		res, err := NewSingleResultFromDocument(bson.D{}, mockErr, nil)
-		assert.Nil(t, err, "NewSingleResultFromDocument error: %v", err)
+		res := NewSingleResultFromDocument(bson.D{}, mockErr, nil)
 
 		// Assert that decoding returns the mocked error.
-		_, err = res.DecodeBytes()
+		_, err := res.DecodeBytes()
 		assert.NotNil(t, err, "expected DecodeBytes error, got nil")
 		assert.Equal(t, mockErr, err, "expected error %v, got %v", mockErr, err)
 

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -57,7 +57,7 @@ func TestNewSingleResultFromBytes(t *testing.T) {
 	findOneResponseBytes, err := bson.Marshal(findOneResponse)
 	assert.Nil(t, err, "Marshal error: %v", err)
 
-	res := NewSingleResultFromBytes(findOneResponseBytes)
+	res := NewSingleResultFromBytes(findOneResponseBytes, nil, nil)
 
 	// Assert that decoded first batch is as expected.
 	expectedDecoded := bson.Raw(findOneResponseBytes)

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -52,12 +52,12 @@ func TestSingleResult(t *testing.T) {
 	})
 }
 
-func TestNewMockSingleResult(t *testing.T) {
+func TestNewSingleResultFromDocument(t *testing.T) {
 	// Mock a document returned by FindOne in SingleResult.
 	t.Run("mock FindOne", func(t *testing.T) {
 		findOneResult := bson.D{{"_id", 2}, {"foo", "bar"}}
-		res, err := NewMockSingleResult([]interface{}{findOneResult}, nil, nil)
-		assert.Nil(t, err, "NewMockSingleResult error: %v", err)
+		res, err := NewSingleResultFromDocument(findOneResult, nil, nil)
+		assert.Nil(t, err, "NewSingleResultFromDocument error: %v", err)
 
 		// Assert that first, decoded document is as expected.
 		findOneResultBytes, err := bson.Marshal(findOneResult)
@@ -74,7 +74,7 @@ func TestNewMockSingleResult(t *testing.T) {
 			"expected RDR contents to be %v, got %v", expectedDecoded, res.rdr)
 
 		// Assert that a call to cur.Next will return false, as there was only one document in
-		// the slice passed to NewMockSingleResult.
+		// the slice passed to NewSingleResultFromDocument.
 		next := res.cur.Next(context.Background())
 		assert.False(t, next, "expected call to Next to return false, got true")
 
@@ -89,8 +89,8 @@ func TestNewMockSingleResult(t *testing.T) {
 	// Mock an error in SingleResult.
 	t.Run("mock FindOne with error", func(t *testing.T) {
 		mockErr := fmt.Errorf("mock error")
-		res, err := NewMockSingleResult(nil, mockErr, nil)
-		assert.Nil(t, err, "NewMockSingleResult error: %v", err)
+		res, err := NewSingleResultFromDocument(bson.D{}, mockErr, nil)
+		assert.Nil(t, err, "NewSingleResultFromDocument error: %v", err)
 
 		// Assert that decoding returns the mocked error.
 		_, err = res.DecodeBytes()

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -187,7 +187,8 @@ func NewEmptyBatchCursor() *BatchCursor {
 // NewBatchCursorFromBytes returns a batch cursor with current batch set to the provided contents.
 func NewBatchCursorFromBytes(contents []byte) *BatchCursor {
 	return &BatchCursor{currentBatch: &bsoncore.DocumentSequence{
-		Data: contents,
+		Data:  contents,
+		Style: bsoncore.SequenceStyle,
 	}}
 }
 

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -184,9 +184,9 @@ func NewEmptyBatchCursor() *BatchCursor {
 	return &BatchCursor{currentBatch: new(bsoncore.DocumentSequence)}
 }
 
-// NewMockBatchCursor returns a batch cursor with current batch set to a sequence-style
+// NewBatchCursorFromDocuments returns a batch cursor with current batch set to a sequence-style
 // DocumentSequence containing the provided documents.
-func NewMockBatchCursor(documents []byte) *BatchCursor {
+func NewBatchCursorFromDocuments(documents []byte) *BatchCursor {
 	return &BatchCursor{currentBatch: &bsoncore.DocumentSequence{
 		Data:  documents,
 		Style: bsoncore.SequenceStyle,

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -184,6 +184,13 @@ func NewEmptyBatchCursor() *BatchCursor {
 	return &BatchCursor{currentBatch: new(bsoncore.DocumentSequence)}
 }
 
+// NewBatchCursorFromBytes returns a batch cursor with current batch set to the provided contents.
+func NewBatchCursorFromBytes(contents []byte) *BatchCursor {
+	return &BatchCursor{currentBatch: &bsoncore.DocumentSequence{
+		Data: contents,
+	}}
+}
+
 // ID returns the cursor ID for this batch cursor.
 func (bc *BatchCursor) ID() int64 {
 	return bc.id

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -187,10 +187,16 @@ func NewEmptyBatchCursor() *BatchCursor {
 // NewBatchCursorFromDocuments returns a batch cursor with current batch set to a sequence-style
 // DocumentSequence containing the provided documents.
 func NewBatchCursorFromDocuments(documents []byte) *BatchCursor {
-	return &BatchCursor{currentBatch: &bsoncore.DocumentSequence{
-		Data:  documents,
-		Style: bsoncore.SequenceStyle,
-	}}
+	return &BatchCursor{
+		currentBatch: &bsoncore.DocumentSequence{
+			Data:  documents,
+			Style: bsoncore.SequenceStyle,
+		},
+		// BatchCursors created with this function have no associated ID nor server, so no getMore
+		// calls will be made.
+		id:     0,
+		server: nil,
+	}
 }
 
 // ID returns the cursor ID for this batch cursor.

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -184,10 +184,11 @@ func NewEmptyBatchCursor() *BatchCursor {
 	return &BatchCursor{currentBatch: new(bsoncore.DocumentSequence)}
 }
 
-// NewBatchCursorFromBytes returns a batch cursor with current batch set to the provided contents.
-func NewBatchCursorFromBytes(contents []byte) *BatchCursor {
+// NewMockBatchCursor returns a batch cursor with current batch set to a sequence-style
+// DocumentSequence containing the provided documents.
+func NewMockBatchCursor(documents []byte) *BatchCursor {
 	return &BatchCursor{currentBatch: &bsoncore.DocumentSequence{
-		Data:  contents,
+		Data:  documents,
 		Style: bsoncore.SequenceStyle,
 	}}
 }


### PR DESCRIPTION
GODRIVER-2161

Adds a new `SingleResult` constructor `NewSingleResultFromDocument` that makes a `SingleResult` with an underlying `Cursor` pre-loaded with a singleton slice of documents (`[]interface{}{document}`) as the first batch. Adds a new `Cursor` construct `NewCursorFromDocuments` that makes a `Cursor` pre-loaded with a slice of documents (`[]interface{}`) as the first batch. These new functions can be used to mock server responses to read operations (e.g. `Find`, `FindOne`, `Aggregate`). Adds associated unit and integration tests.