### PR TITLE
GODRIVER-2223 Fix data races caused by unsynchronized access to rand.Rand instances.

### DIFF
--- a/internal/randutil/randutil.go
+++ b/internal/randutil/randutil.go
@@ -1,0 +1,51 @@
+// Package randutil provides common random number utilities.
+package randutil
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// A LockedRand wraps a "math/rand".Rand and is safe to use from multiple goroutines.
+type LockedRand struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+// NewLockedRand returns a new LockedRand that uses random values from src to generate other random
+// values. It is safe to use from multiple goroutines.
+func NewLockedRand(src rand.Source) *LockedRand {
+	return &LockedRand{
+		r: rand.New(src),
+	}
+}
+
+// Read generates len(p) random bytes and writes them into p. It always returns len(p) and a nil
+// error.
+func (lr *LockedRand) Read(p []byte) (int, error) {
+	lr.mu.Lock()
+	n, err := lr.r.Read(p)
+	lr.mu.Unlock()
+	return n, err
+}
+
+// Intn returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n). It
+// panics if n <= 0.
+func (lr *LockedRand) Intn(n int) int {
+	lr.mu.Lock()
+	x := lr.r.Intn(n)
+	lr.mu.Unlock()
+	return x
+}
+
+// Shuffle pseudo-randomizes the order of elements. n is the number of elements. Shuffle panics if
+// n < 0. swap swaps the elements with indexes i and j.
+//
+// Note that Shuffle locks the LockedRand, so shuffling large collections may adversely affect other
+// concurrent calls. If many concurrent Shuffle and random value calls are required, consider using
+// the global "math/rand".Shuffle instead because it uses much more granular locking.
+func (lr *LockedRand) Shuffle(n int, swap func(i, j int)) {
+	lr.mu.Lock()
+	lr.r.Shuffle(n, swap)
+	lr.mu.Unlock()
+}

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -17,13 +17,14 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/internal"
+	"go.mongodb.org/mongo-driver/internal/randutil"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/dns"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
-// random is a package-global pseudo-random number source.
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+// random is a package-global pseudo-random number generator.
+var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
 
 // ParseAndValidate parses the provided URI into a ConnString object.
 // It check that all values are valid.

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -23,6 +23,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/internal/randutil"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -48,8 +49,8 @@ var ErrServerSelectionTimeout = errors.New("server selection timeout")
 // MonitorMode represents the way in which a server is monitored.
 type MonitorMode uint8
 
-// random is a package-global pseudo-random number source.
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+// random is a package-global pseudo-random number generator.
+var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
 
 // These constants are the available monitoring modes.
 const (

--- a/x/mongo/driver/uuid/uuid.go
+++ b/x/mongo/driver/uuid/uuid.go
@@ -10,13 +10,15 @@ import (
 	"io"
 	"math/rand"
 	"time"
+
+	"go.mongodb.org/mongo-driver/internal/randutil"
 )
 
 // UUID represents a UUID.
 type UUID [16]byte
 
-// random is a package-global pseudo-random number source.
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+// random is a package-global pseudo-random number generator.
+var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
 
 // New returns a random UUIDv4. It uses a "math/rand" pseudo-random number generator seeded with the
 // package initialization time.


### PR DESCRIPTION
The changes in https://github.com/mongodb/mongo-go-driver/pull/803 introduced a data race because `rand.Rand` is not goroutine safe. Add a new type `LockedRand` that synchronizes access to an underlying `rand.Rand` for frequently used pRNG functions and use `LockedRand` in place of a `rand.Rand` wherever it needs to be goroutine safe.