### PR TITLE
GODRIVER-2236 Fix atomic op alignment and run linters on multiple architectures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ EXAMPLES_TEST_PKGS = $(shell etc/list_test_pkgs.sh ./examples)
 PKGS = $(BSON_PKGS) $(EVENT_PKGS) $(MONGO_PKGS) $(UNSTABLE_PKGS) $(TAG_PKG) $(EXAMPLES_PKGS)
 TEST_PKGS = $(BSON_TEST_PKGS) $(EVENT_TEST_PKGS) $(MONGO_TEST_PKGS) $(UNSTABLE_TEST_PKGS) $(TAG_PKG) $(EXAMPLES_TEST_PKGS)
 ATLAS_URIS = "$(ATLAS_FREE)" "$(ATLAS_REPLSET)" "$(ATLAS_SHARD)" "$(ATLAS_TLS11)" "$(ATLAS_TLS12)" "$(ATLAS_FREE_SRV)" "$(ATLAS_REPLSET_SRV)" "$(ATLAS_SHARD_SRV)" "$(ATLAS_TLS11_SRV)" "$(ATLAS_TLS12_SRV)" "$(ATLAS_SERVERLESS)" "$(ATLAS_SERVERLESS_SRV)"
+GODISTS=linux/amd64 linux/386 linux/arm64 linux/arm linux/s390x
 
 TEST_TIMEOUT = 1800
 
@@ -59,7 +60,13 @@ fmt:
 
 .PHONY: lint
 lint:
-	golangci-lint run --config .golangci.yml ./...
+	for dist in $(GODISTS); do \
+		goos=$$(echo $$dist | cut -d/ -f 1) ; \
+		goarch=$$(echo $$dist | cut -d/ -f 2) ; \
+		command="GOOS=$$goos GOARCH=$$goarch golangci-lint run --config .golangci.yml ./..." ; \
+		echo $$command ; \
+		eval $$command ; \
+	done
 
 .PHONY: test
 test:

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -84,10 +84,13 @@ type WriteConcernErrorData struct {
 
 // T is a wrapper around testing.T.
 type T struct {
-	*testing.T
+	// connsCheckedOut is the net number of connections checked out during test execution.
+	// It must be accessed using the atomic package and should be at the beginning of the struct.
+	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// - suggested layout: https://go101.org/article/memory-layout.html
+	connsCheckedOut int64
 
-	_               *bool // 64-bit align connsCheckedOut on 64-bit and 32-bit platforms.
-	connsCheckedOut int64 // net number of connections checked out during test execution
+	*testing.T
 
 	// members for only this T instance
 	createClient      *bool

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -86,6 +86,9 @@ type WriteConcernErrorData struct {
 type T struct {
 	*testing.T
 
+	_               *bool // 64-bit align connsCheckedOut on 64-bit and 32-bit platforms.
+	connsCheckedOut int64 // net number of connections checked out during test execution
+
 	// members for only this T instance
 	createClient      *bool
 	createCollection  *bool
@@ -104,7 +107,6 @@ type T struct {
 	dataLake          *bool
 	ssl               *bool
 	collCreateOpts    bson.D
-	connsCheckedOut   int64 // net number of connections checked out during test execution
 	requireAPIVersion *bool
 
 	// options copied to sub-tests

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -82,9 +82,9 @@ func connectionStateString(state int64) string {
 
 // Server is a single server within a topology.
 type Server struct {
+	connectionstate int64
 	cfg             *serverConfig
 	address         address.Address
-	connectionstate int64
 
 	// connection related fields
 	pool *pool

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -82,9 +82,14 @@ func connectionStateString(state int64) string {
 
 // Server is a single server within a topology.
 type Server struct {
+	// connectionstate must be accessed using the atomic package and should be at the beginning of
+	// the struct.
+	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	// - suggested layout: https://go101.org/article/memory-layout.html
 	connectionstate int64
-	cfg             *serverConfig
-	address         address.Address
+
+	cfg     *serverConfig
+	address address.Address
 
 	// connection related fields
 	pool *pool


### PR DESCRIPTION
[GODRIVER-2236](https://jira.mongodb.org/browse/GODRIVER-2236)

Fix atomic operation struct field alignment panic noted in https://github.com/mongodb/mongo-go-driver/pull/723#issuecomment-971411194. Also run the linters on the Go distributions officially supported by the driver to prevent recurrence:
```
linux/amd64
linux/386
linux/arm64
linux/arm
linux/s390x
```