### PR TITLE
GODRIVER-2238 Skip TestCausalConsistencyExamples on MongoDB v4.0 for now.

### DIFF
--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -120,6 +120,12 @@ func TestCausalConsistencyExamples(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 
+	// TODO(GODRIVER-2238): Remove skip once failures on MongoDB v4.0 sharded clusters are fixed.
+	ver, err := getServerVersion(ctx, client)
+	if err != nil || testutil.CompareVersions(t, ver, "4.0") == 0 {
+		t.Skip("TODO(GODRIVER-2238): Skip until failures on MongoDB v4.0 sharded clusters are fixed")
+	}
+
 	err = documentation_examples.CausalConsistencyExamples(client)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
[GODRIVER-2238](https://jira.mongodb.org/browse/GODRIVER-2238)

Currently, `TestCausalConsistencyExamples` fails on most runs with MongoDB v4.0 sharded clusters. Skip the `TestCausalConsistencyExamples` test on MongoDB v4.0 CI variants for now until we can root cause the failures.