### PR TITLE
GODRIVER-2237: Run KMS KMIP spec and prose tests in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -835,7 +835,37 @@ functions:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port 8000
+          ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT}
+
+  start-kms-mock-server-require-client-cert:
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          . ./activate_venv.sh
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT} --require_client_cert
+
+  start-kmip-mock-server:
+     - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          . ./activate_venv.sh
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          cd ${DRIVERS_TOOLS}/.evergreen/csfle
+          ./kmstlsvenv/bin/python3 -u kms_kmip_server.py --port 5698
 
   run-kms-tls-test:
     - command: shell.exec
@@ -860,6 +890,34 @@ functions:
           AZURE_CLIENT_SECRET="${cse_azure_client_secret}" \
           GCP_EMAIL="${cse_gcp_email}" \
           GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
+          make evg-test-kms \
+          PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+
+  run-kmip-tests:
+  - command: shell.exec
+      type: test
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+
+          export GOFLAGS=-mod=vendor
+          AUTH="${AUTH}" \
+          SSL="${SSL}" \
+          MONGODB_URI="${MONGODB_URI}" \
+          TOPOLOGY="${TOPOLOGY}" \
+          MONGO_GO_DRIVER_COMPRESSOR=${MONGO_GO_DRIVER_COMPRESSOR} \
+          BUILD_TAGS="-tags cse" \
+          AWS_ACCESS_KEY_ID="${cse_aws_access_key_id}" \
+          AWS_SECRET_ACCESS_KEY="${cse_aws_secret_access_key}" \
+          AZURE_TENANT_ID="${cse_azure_tenant_id}" \
+          AZURE_CLIENT_ID="${cse_azure_client_id}" \
+          AZURE_CLIENT_SECRET="${cse_azure_client_secret}" \
+          GCP_EMAIL="${cse_gcp_email}" \
+          GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
+          CSFLE_TLS_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+          CSFLE_TLS_CERTIFICATE_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
           make evg-test-kms \
           PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH
@@ -1693,6 +1751,7 @@ tasks:
       - func: start-kms-mock-server
         vars:
           CERT_FILE: "expired.pem"
+          PORT: 8000
       - func: run-kms-tls-test
         vars:
           KMS_TLS_TESTCASE: "INVALID_CERT"
@@ -1711,9 +1770,37 @@ tasks:
       - func: start-kms-mock-server
         vars:
           CERT_FILE: "wrong-host.pem"
+          PORT: 8000
       - func: run-kms-tls-test
         vars:
           KMS_TLS_TESTCASE: "INVALID_HOSTNAME"
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+
+    - name: "test-kms-kmip"
+    tags: ["kms-kmip"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: start-kms-mock-server
+        vars:
+          CERT_FILE: "expired.pem"
+          PORT: 8000
+      - func: start-kms-mock-server
+        vars:
+          CERT_FILE: "wrong-host.pem"
+          PORT: 8001
+      - func: start-kms-mock-server-require-client-cert
+        vars:
+          CERT_FILE: "server.pem"
+          PORT: 8002
+      - func: start-kms-kmip-server
+      - func: run-kmip-tests
+        vars:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
@@ -2075,3 +2162,9 @@ buildvariants:
     display_name: "Serverless ${os-ssl-40}"
     tasks:
       - "serverless_task_group"
+
+  - matrix_name: "kms-kmip-test"
+    matrix_spec: { version: ["latest"], os-ssl-40: ["ubuntu1804-64-go-1-16"] }
+    display_name: "KMS KMIP ${os-ssl-40}"
+    tasks:
+      - name: ".kms-kmip"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -903,7 +903,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          export KMS_MOCK_SERVERS_RUNNING="${KMS_MOCK_SERVERS_RUNNING}"
+          KMS_MOCK_SERVERS_RUNNING="true"
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -1804,7 +1804,6 @@ tasks:
       - func: start-kms-kmip-server
       - func: run-kmip-tests
         vars:
-          KMS_MOCK_SERVERS_RUNNING: "true"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -920,7 +920,7 @@ functions:
           GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
           CSFLE_TLS_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
           CSFLE_TLS_CERTIFICATE_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
-          make evg-test-kms \
+          make evg-test-kmip \
           PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -903,7 +903,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          KMS_MOCK_SERVERS_RUNNING="true"
+          export KMS_MOCK_SERVERS_RUNNING="true"
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -853,13 +853,14 @@ functions:
           ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT} --require_client_cert
 
   start-kms-kmip-server:
-     - command: shell.exec
+    - command: shell.exec
       params:
         script: |
           ${PREPARE_SHELL}
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
           . ./activate_venv.sh
+          # TODO: Stabilize this pip install with a non-forked version of PyKMIP in https://jira.mongodb.org/browse/GODRIVER-2239
           pip install git+https://github.com/kevinAlbs/PyKMIP.git@expand_tls12_ciphers
     - command: shell.exec
       params:
@@ -896,7 +897,7 @@ functions:
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
   run-kmip-tests:
-  - command: shell.exec
+    - command: shell.exec
       type: test
       params:
         working_dir: src/go.mongodb.org/mongo-driver
@@ -1779,7 +1780,7 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
 
-    - name: "test-kms-kmip"
+  - name: "test-kms-kmip"
     tags: ["kms-kmip"]
     commands:
       - func: bootstrap-mongo-orchestration

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -852,7 +852,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
           ./kmstlsvenv/bin/python3 -u kms_http_server.py -v --ca_file ../x509gen/ca.pem --cert_file ../x509gen/${CERT_FILE} --port ${PORT} --require_client_cert
 
-  start-kmip-mock-server:
+  start-kms-kmip-server:
      - command: shell.exec
       params:
         script: |
@@ -860,6 +860,7 @@ functions:
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
           . ./activate_venv.sh
+          pip install git+https://github.com/kevinAlbs/PyKMIP.git@expand_tls12_ciphers
     - command: shell.exec
       params:
         background: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -903,6 +903,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
+          export KMS_MOCK_SERVERS_RUNNING="${KMS_MOCK_SERVERS_RUNNING}"
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -1803,6 +1804,7 @@ tasks:
       - func: start-kms-kmip-server
       - func: run-kmip-tests
         vars:
+          KMS_MOCK_SERVERS_RUNNING: "true"
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,14 @@ evg-test-load-balancers:
 evg-test-kms:
 	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/kms_tls_tests >> test.suite
 
+.PHONY: evg-test-kmip
+evg-test-kmip:
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionSpec/kmipKMS >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/data_key_and_double_encryption >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/corpus >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/custom_endpoint >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse/kms_tls_options_test >> test.suite
+
 .PHONY: evg-test-serverless
 evg-test-serverless:
 	go test $(BUILD_TAGS) ./mongo/integration -run TestCrudSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1177,6 +1177,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 	// These tests only run when 3 KMS HTTP servers and 1 KMS KMIP server are running. See specification for port numbers and necessary arguments:
 	// https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#kms-tls-options-tests
 	mt.RunOpts("kms tls options tests", noClientOpts, func(mt *mtest.T) {
+		if os.Getenv("KMS_MOCK_SERVERS_RUNNING") == "" {
+			mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+		}
 		validKmsProviders := map[string]map[string]interface{}{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -140,6 +140,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 		for _, tc := range testCases {
 			mt.Run(tc.provider, func(mt *mtest.T) {
+				if tc.provider == "kmip" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+					mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+				}
 				var startedEvents []*event.CommandStartedEvent
 				monitor := &event.CommandMonitor{
 					Started: func(_ context.Context, evt *event.CommandStartedEvent) {
@@ -398,6 +401,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			"expected error '%v' to contain substring '%v'", errStr, viewErrSubstr)
 	})
 	mt.RunOpts("corpus", noClientOpts, func(mt *mtest.T) {
+		if "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+			mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+		}
 		corpusSchema := readJSONFile(mt, "corpus-schema.json")
 		localSchemaMap := map[string]interface{}{
 			"db.coll": corpusSchema,
@@ -772,6 +778,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
+				if strings.Contains(tc.name, "kmip") && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+					mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+				}
 				cpt := setup(mt, nil, defaultKvClientOptions, validClientEncryptionOptions)
 				defer cpt.teardown(mt)
 
@@ -1332,6 +1341,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
+				if tc.name =="kmip" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+					mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+				}
 				// call CreateDataKey with CEO no TLS with each provider and corresponding master key
 				cpt := setup(mt, nil, defaultKvClientOptions, validClientEncryptionOptionsWithoutClientCert)
 				defer cpt.teardown(mt)

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1344,7 +1344,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
-				if tc.name =="kmip" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+				if tc.name == "kmip" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
 					mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
 				}
 				// call CreateDataKey with CEO no TLS with each provider and corresponding master key

--- a/mongo/integration/client_side_encryption_spec_test.go
+++ b/mongo/integration/client_side_encryption_spec_test.go
@@ -9,6 +9,7 @@
 package integration
 
 import (
+	"os"
 	"path"
 	"testing"
 )
@@ -52,6 +53,9 @@ func TestClientSideEncryptionSpec(t *testing.T) {
 
 	for _, fileName := range jsonFilesInDir(t, path.Join(dataPath, encryptionSpecName)) {
 		t.Run(fileName, func(t *testing.T) {
+			if fileName == "kmipKMS.json" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
+				t.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
+			}
 			runSpecTestFile(t, encryptionSpecName, fileName)
 		})
 	}


### PR DESCRIPTION
[GODRIVER-2237](https://jira.mongodb.org/browse/GODRIVER-2237)

Configures an Evergreen build variant to test the KMS KMIP spec and prose tests. Passes according to [this patch](https://spruce.mongodb.com/version/6196d83161837d799a22ece1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).