### PR TITLE
GODRIVER-2243 Wrap write errors in IndexView.CreateMany

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -272,7 +272,8 @@ func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ..
 
 	err = op.Execute(ctx)
 	if err != nil {
-		return nil, replaceErrors(err)
+		_, err = processWriteError(err)
+		return nil, err
 	}
 
 	return names, nil


### PR DESCRIPTION
This was returning driver.ErrUnacknowledgedWrite when creating indexes with an unacknowledged WriteConcern.

Wrap the error using processWriteError so we can return mongo.ErrUnacknowledgedWrite.