### PR TITLE
GODRIVER-2242 Update estimatedDocumentCount test for ADL

### DIFF
--- a/data/atlas-data-lake-testing/estimatedDocumentCount.json
+++ b/data/atlas-data-lake-testing/estimatedDocumentCount.json
@@ -15,8 +15,25 @@
         {
           "command_started_event": {
             "command": {
-              "count": "driverdata"
-            }
+              "aggregate": "driverdata",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "command_name": "aggregate",
+            "database_name": "test"
           }
         }
       ]

--- a/data/atlas-data-lake-testing/estimatedDocumentCount.yml
+++ b/data/atlas-data-lake-testing/estimatedDocumentCount.yml
@@ -13,4 +13,9 @@ tests:
       -
         command_started_event:
           command:
-            count: *collection_name
+            aggregate: *collection_name
+            pipeline:
+              - $collStats: { count: {} }
+              - $group: { _id: 1, n: { $sum: $count }}
+          command_name: aggregate
+          database_name: *database_name


### PR DESCRIPTION
GODRIVER-2242

Updates the `estimatedDocumentCount` test in `atlas-data-lake-testing` to expect an `aggregate` with `$collStats` instead of a `count` command, as ADL just bumped their max wire version to 13 (which has the new format for `estimatedDocumentCount`).