### PR TITLE
GODRIVER-2156 Enable misspell linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - govet
     - ineffassign
     - makezero
-    # - misspell
+    - misspell
     - nakedret
     - prealloc
     - revive

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -43,7 +43,7 @@ type Unmarshaler interface {
 }
 
 // ValueUnmarshaler is an interface implemented by types that can unmarshal a
-// BSON value representaiton of themselves. The BSON bytes and type can be
+// BSON value representation of themselves. The BSON bytes and type can be
 // assumed to be valid. UnmarshalBSONValue must copy the BSON value bytes if it
 // wishes to retain the data after returning.
 type ValueUnmarshaler interface {

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -53,7 +53,7 @@ type DefaultValueDecoders struct{}
 // RegisterDefaultDecoders will register the decoder methods attached to DefaultValueDecoders with
 // the provided RegistryBuilder.
 //
-// There is no support for decoding map[string]interface{} becuase there is no decoder for
+// There is no support for decoding map[string]interface{} because there is no decoder for
 // interface{}, so users must either register this decoder themselves or use the
 // EmptyInterfaceDecoder available in the bson package.
 func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {

--- a/bson/bsoncodec/default_value_encoders_test.go
+++ b/bson/bsoncodec/default_value_encoders_test.go
@@ -1858,7 +1858,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 		got := dve.EmptyInterfaceEncodeValue(EncodeContext{Registry: NewRegistryBuilder().Build()}, llvrw, val)
 		want := ErrNoEncoder{Type: tInt64}
 		if !compareErrors(got, want) {
-			t.Errorf("Did not recieve expected error. got %v; want %v", got, want)
+			t.Errorf("Did not receive expected error. got %v; want %v", got, want)
 		}
 	})
 }

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -298,7 +298,7 @@ func (rb *RegistryBuilder) Build() *Registry {
 	return registry
 }
 
-// LookupEncoder inspects the registry for an encoder for the given type. The lookup precendence works as follows:
+// LookupEncoder inspects the registry for an encoder for the given type. The lookup precedence works as follows:
 //
 // 1. An encoder registered for the exact type. If the given type represents an interface, an encoder registered using
 // RegisterTypeEncoder for the interface will be selected.
@@ -376,7 +376,7 @@ func (r *Registry) lookupInterfaceEncoder(t reflect.Type, allowAddr bool) (Value
 	return nil, false
 }
 
-// LookupDecoder inspects the registry for an decoder for the given type. The lookup precendence works as follows:
+// LookupDecoder inspects the registry for an decoder for the given type. The lookup precedence works as follows:
 //
 // 1. A decoder registered for the exact type. If the given type represents an interface, a decoder registered using
 // RegisterTypeDecoder for the interface will be selected.

--- a/bson/bsonrw/extjson_parser.go
+++ b/bson/bsonrw/extjson_parser.go
@@ -423,7 +423,7 @@ func (ejp *extJSONParser) readValue(t bsontype.Type) (*extJSONValue, error) {
 				if ejp.canonical {
 					return nil, invalidJSONErrorForType("object", t)
 				}
-				return nil, invalidJSONErrorForType("ISO-8601 Internet Date/Time Format as decribed in RFC-3339", t)
+				return nil, invalidJSONErrorForType("ISO-8601 Internet Date/Time Format as described in RFC-3339", t)
 			}
 
 			ejp.advanceState()

--- a/bson/bsonrw/value_writer.go
+++ b/bson/bsonrw/value_writer.go
@@ -529,7 +529,7 @@ func (vw *valueWriter) WriteDocumentEnd() error {
 	vw.pop()
 
 	if vw.stack[vw.frame].mode == mCodeWithScope {
-		// We ignore the error here because of the gaurantee of writeLength.
+		// We ignore the error here because of the guarantee of writeLength.
 		// See the docs for writeLength for more info.
 		_ = vw.writeLength()
 		vw.pop()

--- a/bson/mgocompat/bson_test.go
+++ b/bson/mgocompat/bson_test.go
@@ -957,7 +957,7 @@ func TestUnmarshalSetterErrors(t *testing.T) {
 	assert.Nil(t, m["def"], "expected value to be nil, got: %v", m["def"])
 	assert.Nil(t, m["ghi"], "expected value to be nil, got: %v", m["ghi"])
 
-	assert.Equal(t, "1", m["abc"].Received, "expected m[\"abc\"].recieved to be: %v, got: %v", "1", m["abc"].Received)
+	assert.Equal(t, "1", m["abc"].Received, "expected m[\"abc\"].Received to be: %v, got: %v", "1", m["abc"].Received)
 }
 
 func TestDMap(t *testing.T) {

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -23,7 +23,7 @@ type Unmarshaler interface {
 }
 
 // ValueUnmarshaler is an interface implemented by types that can unmarshal a
-// BSON value representaiton of themselves. The BSON bytes and type can be
+// BSON value representation of themselves. The BSON bytes and type can be
 // assumed to be valid. UnmarshalBSONValue must copy the BSON value bytes if it
 // wishes to retain the data after returning.
 type ValueUnmarshaler interface {

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -140,7 +140,7 @@ func TestUnmarshalExtJSONWithContext(t *testing.T) {
 			want:  &fooString{Foo: "�"},
 		},
 		{
-			name:  "Low surrogate value with no preceeding high surrogate value",
+			name:  "Low surrogate value with no preceding high surrogate value",
 			sType: reflect.TypeOf(fooString{}),
 			data:  []byte(`{"foo":"abc \uDd1e 123"}`),
 			want:  &fooString{Foo: "abc � 123"},

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -836,7 +836,7 @@ func (c *Client) Database(name string, opts ...*options.DatabaseOptions) *Databa
 // databases are included in the result. It cannot be nil. An empty document (e.g. bson.D{}) should be used to include
 // all databases.
 //
-// The opts paramter can be used to specify options for this operation (see the options.ListDatabasesOptions documentation).
+// The opts parameter can be used to specify options for this operation (see the options.ListDatabasesOptions documentation).
 //
 // For more information about the command, see https://docs.mongodb.com/manual/reference/command/listDatabases/.
 func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...*options.ListDatabasesOptions) (ListDatabasesResult, error) {

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -874,7 +874,7 @@ func ExampleCursor_TryNext() {
 		}
 
 		// If TryNext returns false, the next document is not yet available, the
-		// cursor was exhausted and was closed, or an error occured. TryNext
+		// cursor was exhausted and was closed, or an error occurred. TryNext
 		// should only be called again for the empty batch case.
 		if err := cursor.Err(); err != nil {
 			log.Fatal(err)

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -143,7 +143,7 @@ func readPrefSelector(rp *readpref.ReadPref, isOutputAggregate bool) ServerSelec
 	return ServerSelectorFunc(func(t Topology, candidates []Server) ([]Server, error) {
 		if t.Kind == LoadBalanced {
 			// In LoadBalanced mode, there should only be one server in the topology and it must be selected. We check
-			// this before checking MaxStaleness support becuase there's no monitoring in this mode, so the candidate
+			// this before checking MaxStaleness support because there's no monitoring in this mode, so the candidate
 			// server wouldn't have a wire version set, which would result in an error.
 			return candidates, nil
 		}

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -554,7 +554,7 @@ func (b *Bucket) createIndexes(ctx context.Context) error {
 
 	_, err = docRes.DecodeBytes()
 	if err != mongo.ErrNoDocuments {
-		// nil, or error that occured during the FindOne operation
+		// nil, or error that occurred during the FindOne operation
 		return err
 	}
 

--- a/mongo/integration/causal_consistency_test.go
+++ b/mongo/integration/causal_consistency_test.go
@@ -147,7 +147,7 @@ func TestCausalConsistency_Supported(t *testing.T) {
 		checkOperationTime(mt, evt.Command, false)
 	})
 	mt.Run("default read concern", func(mt *mtest.T) {
-		// when using the deafult server read concern, the readConcern parameter in the command sent to the server should
+		// when using the default server read concern, the readConcern parameter in the command sent to the server should
 		// not include a level field
 
 		sess, err := mt.Client.StartSession()

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1701,7 +1701,7 @@ func TestCollection(t *testing.T) {
 				deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(bson.D{}))
 			}
 
-			// Seed mock responses. Both insert and delete respones look like {ok: 1, n: <inserted/deleted count>}.
+			// Seed mock responses. Both insert and delete responses look like {ok: 1, n: <inserted/deleted count>}.
 			// This loop only creates one set of responses, but the sets for insert and delete should be equivalent,
 			// so we can duplicate the generated set before calling mt.AddMockResponses().
 			var responses []bson.D

--- a/mongo/integration/cursor_test.go
+++ b/mongo/integration/cursor_test.go
@@ -133,7 +133,7 @@ func TestCursor(t *testing.T) {
 		})
 		mt.RunOpts("first batch is empty", mtest.NewOptions().ClientType(mtest.Mock), func(mt *mtest.T) {
 			// Test that the cursor reports the correct value for RemainingBatchLength if the first batch is empty.
-			// Using a mock deployment simplifies this test becuase the server won't create a valid cursor if the
+			// Using a mock deployment simplifies this test because the server won't create a valid cursor if the
 			// collection is empty when the find is run.
 
 			cursorID := int64(50)

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -114,7 +114,7 @@ func TestDatabase(t *testing.T) {
 			writeExcept, ok := gotErr.(mongo.WriteException)
 			assert.True(mt, ok, "expected WriteCommandError, got %T", gotErr)
 			assert.NotNil(mt, writeExcept.WriteConcernError, "expected WriteConcernError to be non-nil")
-			assert.Equal(mt, writeExcept.WriteConcernError.Code, 100, "expeced error code 100, got %v", writeExcept.WriteConcernError.Code)
+			assert.Equal(mt, writeExcept.WriteConcernError.Code, 100, "expected error code 100, got %v", writeExcept.WriteConcernError.Code)
 		})
 		mt.Run("multi key map command", func(mt *mtest.T) {
 			err := mt.DB.RunCommand(mtest.Background, bson.M{"insert": "test", "documents": bson.A{bson.D{{"a", 1}}}}).Err()

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -191,7 +191,7 @@ func setSSLSettings(mt *mtest.T, cs *connstring.ConnString, test seedlistTest) {
 
 	// Skip SSL tests if the server is running without SSL.
 	if testCaseExpectsSSL && !envSSL {
-		mt.Skip("skipping test that expectes ssl in a non-ssl environment")
+		mt.Skip("skipping test that expects ssl in a non-ssl environment")
 	}
 
 	// If SSL tests are running, set the CA file.

--- a/mongo/options/mongooptions.go
+++ b/mongo/options/mongooptions.go
@@ -22,7 +22,7 @@ type Collation struct {
 	Locale          string `bson:",omitempty"` // The locale
 	CaseLevel       bool   `bson:",omitempty"` // The case level
 	CaseFirst       string `bson:",omitempty"` // The case ordering
-	Strength        int    `bson:",omitempty"` // The number of comparision levels to use
+	Strength        int    `bson:",omitempty"` // The number of comparison levels to use
 	NumericOrdering bool   `bson:",omitempty"` // Whether to order numbers based on numerical order and not collation order
 	Alternate       string `bson:",omitempty"` // Whether spaces and punctuation are considered base characters
 	MaxVariable     string `bson:",omitempty"` // Which characters are affected by alternate: "shifted"

--- a/x/bsonx/bsoncore/bson_documentbuilder.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder.go
@@ -45,7 +45,7 @@ func (db *DocumentBuilder) AppendInt32(key string, i32 int32) *DocumentBuilder {
 	return db
 }
 
-// AppendDocument will append a bson embeded document element using key
+// AppendDocument will append a bson embedded document element using key
 // and doc to DocumentBuilder.doc
 func (db *DocumentBuilder) AppendDocument(key string, doc []byte) *DocumentBuilder {
 	db.doc = AppendDocumentElement(db.doc, key, doc)

--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -15,7 +15,7 @@
 // enough bytes. This library attempts to do no validation, it will only return
 // false if there are not enough bytes for an item to be read. For example, the
 // ReadDocument function checks the length, if that length is larger than the
-// number of bytes availble, it will return false, if there are enough bytes, it
+// number of bytes available, it will return false, if there are enough bytes, it
 // will return those bytes and true. It is the consumers responsibility to
 // validate those bytes.
 //
@@ -69,7 +69,7 @@ func AppendHeader(dst []byte, t bsontype.Type, key string) []byte {
 // was read.
 
 // ReadType will return the first byte of the provided []byte as a type. If
-// there is no availble byte, false is returned.
+// there is no available byte, false is returned.
 func ReadType(src []byte) (bsontype.Type, []byte, bool) {
 	if len(src) < 1 {
 		return 0, src, false
@@ -231,7 +231,7 @@ func AppendDocumentEnd(dst []byte, index int32) ([]byte, error) {
 // AppendDocument will append doc to dst and return the extended buffer.
 func AppendDocument(dst []byte, doc []byte) []byte { return append(dst, doc...) }
 
-// AppendDocumentElement will append a BSON embeded document element using key
+// AppendDocumentElement will append a BSON embedded document element using key
 // and doc to dst and return the extended buffer.
 func AppendDocumentElement(dst []byte, key string, doc []byte) []byte {
 	return AppendDocument(AppendHeader(dst, bsontype.EmbeddedDocument, key), doc)

--- a/x/bsonx/document_test.go
+++ b/x/bsonx/document_test.go
@@ -282,7 +282,7 @@ func TestDocument(t *testing.T) {
 				rets = fn.Call(params)
 			}
 			if len(rets) != len(tc.rets) {
-				t.Fatalf("mismatched number of returns. recieved %d; expected %d", len(rets), len(tc.rets))
+				t.Fatalf("mismatched number of returns. received %d; expected %d", len(rets), len(tc.rets))
 			}
 			for idx := range rets {
 				got, want := rets[idx].Interface(), tc.rets[idx]

--- a/x/bsonx/mdocument_test.go
+++ b/x/bsonx/mdocument_test.go
@@ -210,7 +210,7 @@ func TestMDoc(t *testing.T) {
 				rets = fn.Call(params)
 			}
 			if len(rets) != len(tc.rets) {
-				t.Fatalf("mismatched number of returns. recieved %d; expected %d", len(rets), len(tc.rets))
+				t.Fatalf("mismatched number of returns. received %d; expected %d", len(rets), len(tc.rets))
 			}
 			for idx := range rets {
 				got, want := rets[idx].Interface(), tc.rets[idx]

--- a/x/mongo/driver/auth/auth_test.go
+++ b/x/mongo/driver/auth/auth_test.go
@@ -21,14 +21,14 @@ func TestCreateAuthenticator(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
-		auther Authenticator
+		auth   Authenticator
 	}{
-		{name: "", auther: &DefaultAuthenticator{}},
-		{name: "SCRAM-SHA-1", auther: &ScramAuthenticator{}},
-		{name: "SCRAM-SHA-256", auther: &ScramAuthenticator{}},
-		{name: "MONGODB-CR", auther: &MongoDBCRAuthenticator{}},
-		{name: "PLAIN", auther: &PlainAuthenticator{}},
-		{name: "MONGODB-X509", auther: &MongoDBX509Authenticator{}},
+		{name: "", auth: &DefaultAuthenticator{}},
+		{name: "SCRAM-SHA-1", auth: &ScramAuthenticator{}},
+		{name: "SCRAM-SHA-256", auth: &ScramAuthenticator{}},
+		{name: "MONGODB-CR", auth: &MongoDBCRAuthenticator{}},
+		{name: "PLAIN", auth: &PlainAuthenticator{}},
+		{name: "MONGODB-X509", auth: &MongoDBX509Authenticator{}},
 	}
 
 	for _, test := range tests {
@@ -41,7 +41,7 @@ func TestCreateAuthenticator(t *testing.T) {
 
 			a, err := CreateAuthenticator(test.name, cred)
 			require.NoError(t, err)
-			require.IsType(t, test.auther, a)
+			require.IsType(t, test.auth, a)
 		})
 	}
 }

--- a/x/mongo/driver/connstring/connstring_spec_test.go
+++ b/x/mongo/driver/connstring/connstring_spec_test.go
@@ -119,7 +119,7 @@ func runTest(t *testing.T, filename string, test testCase, warningsError bool) {
 		cs, err := connstring.ParseAndValidate(test.URI)
 		// Since we don't have warnings in Go, we return warnings as errors.
 		//
-		// This is a bit unfortuante, but since we do raise warnings as errors with the newer
+		// This is a bit unfortunate, but since we do raise warnings as errors with the newer
 		// URI options, but don't with some of the older things, we do a switch on the filename
 		// here. We are trying to not break existing user applications that have unrecognized
 		// options.

--- a/x/mongo/driver/ocsp/ocsp.go
+++ b/x/mongo/driver/ocsp/ocsp.go
@@ -261,7 +261,7 @@ func contactResponders(ctx context.Context, cfg config) (*ResponseDetails, error
 			//
 			// 2. If any other errors occurred, including the defaultRequestTimeout expiring, or the response has a
 			// non-200 status code, suppress the error because we want to ignore this responder and wait for a different
-			// one to responsd.
+			// one to respond.
 			httpResponse, err := http.DefaultClient.Do(request)
 			if err != nil {
 				urlErr, ok := err.(*url.Error)

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -40,7 +40,7 @@ var ErrAbortTwice = errors.New("cannot call abortTransaction twice")
 // ErrCommitAfterAbort is returned if commit is called after an abort.
 var ErrCommitAfterAbort = errors.New("cannot call commitTransaction after calling abortTransaction")
 
-// ErrUnackWCUnsupported is returned if an unacknowledged write concern is supported for a transaciton.
+// ErrUnackWCUnsupported is returned if an unacknowledged write concern is supported for a transaction.
 var ErrUnackWCUnsupported = errors.New("transactions do not support unacknowledged write concerns")
 
 // ErrSnapshotTransaction is returned if an transaction is started on a snapshot session.
@@ -364,7 +364,7 @@ func (c *Client) TransactionRunning() bool {
 	return c != nil && (c.TransactionState == Starting || c.TransactionState == InProgress)
 }
 
-// TransactionCommitted returns true of the client session just committed a transaciton.
+// TransactionCommitted returns true of the client session just committed a transaction.
 func (c *Client) TransactionCommitted() bool {
 	return c.TransactionState == Committed
 }

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -126,7 +126,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 	for _, op := range test.Operations {
 		if tempErr := runOperation(t, op, testInfo, s, test.PoolOptions.WaitQueueTimeoutMS); tempErr != nil {
 			if err != nil {
-				t.Fatalf("recieved multiple errors in primary thread: %v and %v", err, tempErr)
+				t.Fatalf("received multiple errors in primary thread: %v and %v", err, tempErr)
 			}
 			err = tempErr
 		}
@@ -171,7 +171,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 				}
 			}
 			if !erroredCorrectly {
-				t.Fatalf("error differed from expected error, expected: %v, actual errors recieved: %v", test.Error.Message, errs)
+				t.Fatalf("error differed from expected error, expected: %v, actual errors received: %v", test.Error.Message, errs)
 			}
 		}
 	}
@@ -196,22 +196,22 @@ func checkEvents(t *testing.T, expectedEvents []cmapEvent, actualEvents chan *ev
 			if validEvent.Type == "ConnectionCheckOutFailed" {
 				reason = ": " + validEvent.Reason
 			}
-			t.Fatalf("unexpected event occured: expected: %v, actual: %v%v", expectedEvent.EventType, validEvent.Type, reason)
+			t.Fatalf("unexpected event occurred: expected: %v, actual: %v%v", expectedEvent.EventType, validEvent.Type, reason)
 		}
 
 		if expectedEvent.Address != nil {
 
 			if expectedEvent.Address == float64(42) { // can be any address
 				if validEvent.Address == "" {
-					t.Fatalf("expected address in event, instead recieved none in %v", expectedEvent.EventType)
+					t.Fatalf("expected address in event, instead received none in %v", expectedEvent.EventType)
 				}
 			} else { // must be specific address
 				addr, ok := expectedEvent.Address.(string)
 				if !ok {
-					t.Fatalf("recieved non string address: %v", expectedEvent.Address)
+					t.Fatalf("received non string address: %v", expectedEvent.Address)
 				}
 				if addr != validEvent.Address {
-					t.Fatalf("recieved unexpected address: %v, expected: %v", validEvent.Address, expectedEvent.Address)
+					t.Fatalf("received unexpected address: %v, expected: %v", validEvent.Address, expectedEvent.Address)
 				}
 			}
 		}
@@ -264,7 +264,7 @@ EventsLeft:
 				continue EventsLeft
 			}
 		}
-		t.Fatalf("extra event occured: %v", event.Type)
+		t.Fatalf("extra event occurred: %v", event.Type)
 	}
 }
 
@@ -273,7 +273,7 @@ func nextValidEvent(t *testing.T, events chan *event.PoolEvent, ignoreEvents []s
 NextEvent:
 	for {
 		if len(events) == 0 {
-			t.Fatalf("unable to get next event. too few events occured")
+			t.Fatalf("unable to get next event. too few events occurred")
 		}
 
 		event := <-events

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -995,7 +995,7 @@ func TestConnection(t *testing.T) {
 // nc.continueChan <- struct{}{}
 //
 // By default, the read/write methods will error after they can read from continueChan to simulate a connection being
-// closed after context cancellation. This type also supports skipping to allow a number of successfull read/write calls
+// closed after context cancellation. This type also supports skipping to allow a number of successful read/write calls
 // before one fails.
 type cancellationTestNetConn struct {
 	net.Conn

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -11,7 +11,7 @@ type ConnectionError struct {
 	ConnectionID string
 	Wrapped      error
 
-	// init will be set to true if this error occured during connection initialization or
+	// init will be set to true if this error occurred during connection initialization or
 	// during a connection handshake.
 	init    bool
 	message string
@@ -21,7 +21,7 @@ type ConnectionError struct {
 func (e ConnectionError) Error() string {
 	message := e.message
 	if e.init {
-		fullMsg := "error occured during connection handshake"
+		fullMsg := "error occurred during connection handshake"
 		if message != "" {
 			fullMsg = fmt.Sprintf("%s: %s", fullMsg, message)
 		}

--- a/x/mongo/driver/topology/topology_errors_test.go
+++ b/x/mongo/driver/topology/topology_errors_test.go
@@ -55,7 +55,7 @@ func TestTopologyErrors(t *testing.T) {
 				_, serverSelectionErr = topo.selectServerFromSubscription(ctx, subCh, state)
 			}
 			assert.Soon(t, callback, 150*time.Millisecond)
-			assert.True(t, errors.Is(serverSelectionErr, context.DeadlineExceeded), "expected %v, recieved %v",
+			assert.True(t, errors.Is(serverSelectionErr, context.DeadlineExceeded), "expected %v, received %v",
 				context.DeadlineExceeded, serverSelectionErr)
 		})
 	})

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -391,7 +391,7 @@ func ReadMsgSectionRawDocumentSequence(src []byte) (identifier string, data []by
 		return "", nil, rem, false
 	}
 
-	// After these assignments, rem will be the data containing the identifer string + the document sequence bytes and
+	// After these assignments, rem will be the data containing the identifier string + the document sequence bytes and
 	// rest will be the rest of the wire message after this document sequence.
 	rem, rest := rem[:length-4], rem[length-4:]
 


### PR DESCRIPTION
Enable the `misspell` linter and fix identified misspellings.