### PR TITLE
GODRIVER-2247 Add missing comments to exported functions/types

### DIFF
--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -225,10 +225,13 @@ func MarshalExtJSONAppendWithContext(ec bsoncodec.EncodeContext, dst []byte, val
 	return *sw, nil
 }
 
+// IndentExtJSON will prefix and indent the provided extended JSON src and append it to dst.
 func IndentExtJSON(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 	return json.Indent(dst, src, prefix, indent)
 }
 
+// MarshalExtJSONIndent returns the extended JSON encoding of val with each line with prefixed
+// and indented.
 func MarshalExtJSONIndent(val interface{}, canonical, escapeHTML bool, prefix, indent string) ([]byte, error) {
 	marshaled, err := MarshalExtJSON(val, canonical, escapeHTML)
 	if err != nil {

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -21,7 +21,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
-// Performs an aggregate operation
+// Aggregate represents an aggregate operation.
 type Aggregate struct {
 	allowDiskUse             *bool
 	batchSize                *int32
@@ -67,6 +67,8 @@ func (a *Aggregate) Result(opts driver.CursorOptions) (*driver.BatchCursor, erro
 	return driver.NewBatchCursor(a.result, clientSession, clock, opts)
 }
 
+// ResultCursorResponse returns the underlying CursorResponse result of executing this
+// operation.
 func (a *Aggregate) ResultCursorResponse() driver.CursorResponse {
 	return a.result
 }

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -20,7 +20,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
-// Performs a count operation
+// Count represents a count operation.
 type Count struct {
 	maxTimeMS      *int64
 	query          bsoncore.Document
@@ -39,6 +39,7 @@ type Count struct {
 	serverAPI      *driver.ServerAPIOptions
 }
 
+// CountResult represents a count result returned by the server.
 type CountResult struct {
 	// The number of documents found
 	N int64

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -18,7 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
-// Create a create operation
+// Create represents a create operation.
 type Create struct {
 	capped              *bool
 	collation           bsoncore.Document
@@ -127,7 +127,7 @@ func (c *Create) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	return dst, nil
 }
 
-// Specifies if the collection is capped.
+// Capped specifies if the collection is capped.
 func (c *Create) Capped(capped bool) *Create {
 	if c == nil {
 		c = new(Create)
@@ -147,7 +147,7 @@ func (c *Create) Collation(collation bsoncore.Document) *Create {
 	return c
 }
 
-// Specifies the name of the collection to create.
+// CollectionName specifies the name of the collection to create.
 func (c *Create) CollectionName(collectionName string) *Create {
 	if c == nil {
 		c = new(Create)
@@ -157,7 +157,7 @@ func (c *Create) CollectionName(collectionName string) *Create {
 	return c
 }
 
-// Specifies a default configuration for indexes on the collection.
+// IndexOptionDefaults specifies a default configuration for indexes on the collection.
 func (c *Create) IndexOptionDefaults(indexOptionDefaults bsoncore.Document) *Create {
 	if c == nil {
 		c = new(Create)
@@ -167,7 +167,7 @@ func (c *Create) IndexOptionDefaults(indexOptionDefaults bsoncore.Document) *Cre
 	return c
 }
 
-// Specifies the maximum number of documents allowed in a capped collection.
+// Max specifies the maximum number of documents allowed in a capped collection.
 func (c *Create) Max(max int64) *Create {
 	if c == nil {
 		c = new(Create)
@@ -177,7 +177,7 @@ func (c *Create) Max(max int64) *Create {
 	return c
 }
 
-// Specifies the agggregtion pipeline to be run against the source to create the view.
+// Pipeline specifies the agggregtion pipeline to be run against the source to create the view.
 func (c *Create) Pipeline(pipeline bsoncore.Document) *Create {
 	if c == nil {
 		c = new(Create)
@@ -187,7 +187,7 @@ func (c *Create) Pipeline(pipeline bsoncore.Document) *Create {
 	return c
 }
 
-// Specifies the maximum size in bytes for a capped collection.
+// Size specifies the maximum size in bytes for a capped collection.
 func (c *Create) Size(size int64) *Create {
 	if c == nil {
 		c = new(Create)
@@ -197,7 +197,7 @@ func (c *Create) Size(size int64) *Create {
 	return c
 }
 
-// Specifies the storage engine to use for the index.
+// StorageEngine specifies the storage engine to use for the index.
 func (c *Create) StorageEngine(storageEngine bsoncore.Document) *Create {
 	if c == nil {
 		c = new(Create)
@@ -207,7 +207,7 @@ func (c *Create) StorageEngine(storageEngine bsoncore.Document) *Create {
 	return c
 }
 
-// Specifies what should happen if a document being inserted does not pass validation.
+// ValidationAction specifies what should happen if a document being inserted does not pass validation.
 func (c *Create) ValidationAction(validationAction string) *Create {
 	if c == nil {
 		c = new(Create)
@@ -217,7 +217,8 @@ func (c *Create) ValidationAction(validationAction string) *Create {
 	return c
 }
 
-// Specifies how strictly the server applies validation rules to existing documents in the collection during update operations.
+// ValidationLevel specifies how strictly the server applies validation rules to existing documents in the collection
+// during update operations.
 func (c *Create) ValidationLevel(validationLevel string) *Create {
 	if c == nil {
 		c = new(Create)
@@ -227,7 +228,7 @@ func (c *Create) ValidationLevel(validationLevel string) *Create {
 	return c
 }
 
-// Specifies validation rules for the collection.
+// Validator specifies validation rules for the collection.
 func (c *Create) Validator(validator bsoncore.Document) *Create {
 	if c == nil {
 		c = new(Create)
@@ -237,7 +238,7 @@ func (c *Create) Validator(validator bsoncore.Document) *Create {
 	return c
 }
 
-// Specifies the name of the source collection or view on which the view will be created.
+// ViewOn specifies the name of the source collection or view on which the view will be created.
 func (c *Create) ViewOn(viewOn string) *Create {
 	if c == nil {
 		c = new(Create)

--- a/x/mongo/driver/operation/createIndexes.go
+++ b/x/mongo/driver/operation/createIndexes.go
@@ -38,6 +38,7 @@ type CreateIndexes struct {
 	serverAPI    *driver.ServerAPIOptions
 }
 
+// CreateIndexesResult represents a createIndexes result returned by the server.
 type CreateIndexesResult struct {
 	// If the collection was created automatically.
 	CreatedCollectionAutomatically bool
@@ -133,9 +134,9 @@ func (ci *CreateIndexes) command(dst []byte, desc description.SelectedServer) ([
 	return dst, nil
 }
 
-// The number of data-bearing members of a replica set, including the primary, that must complete the index builds
-// successfully before the primary marks the indexes as ready. This should either be a string or int32 value.
-//
+// CommitQuorum specifies the number of data-bearing members of a replica set, including the primary, that must
+// complete the index builds successfully before the primary marks the indexes as ready. This should either be a
+// string or int32 value.
 func (ci *CreateIndexes) CommitQuorum(commitQuorum bsoncore.Value) *CreateIndexes {
 	if ci == nil {
 		ci = new(CreateIndexes)
@@ -145,7 +146,7 @@ func (ci *CreateIndexes) CommitQuorum(commitQuorum bsoncore.Value) *CreateIndexe
 	return ci
 }
 
-// An array containing index specification documents for the indexes being created.
+// Indexes specifies an array containing index specification documents for the indexes being created.
 func (ci *CreateIndexes) Indexes(indexes bsoncore.Document) *CreateIndexes {
 	if ci == nil {
 		ci = new(CreateIndexes)

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -38,6 +38,7 @@ type Delete struct {
 	serverAPI    *driver.ServerAPIOptions
 }
 
+// DeleteResult represents a delete result returned by the server.
 type DeleteResult struct {
 	// Number of documents successfully deleted.
 	N int32

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -40,6 +40,7 @@ type Distinct struct {
 	serverAPI      *driver.ServerAPIOptions
 }
 
+// DistinctResult represents a distinct result returned by the server.
 type DistinctResult struct {
 	// The distinct values for the field.
 	Values bsoncore.Value

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -34,6 +34,7 @@ type DropCollection struct {
 	serverAPI    *driver.ServerAPIOptions
 }
 
+// DropCollectionResult represents a dropCollection result returned by the server.
 type DropCollectionResult struct {
 	// The number of indexes in the dropped collection.
 	NIndexesWas int32

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -36,6 +36,7 @@ type DropIndexes struct {
 	serverAPI    *driver.ServerAPIOptions
 }
 
+// DropIndexesResult represents a dropIndexes result returned by the server.
 type DropIndexesResult struct {
 	// Number of indexes that existed before the drop was executed.
 	NIndexesWas int32

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -70,7 +70,7 @@ func (es *EndSessions) command(dst []byte, desc description.SelectedServer) ([]b
 	return dst, nil
 }
 
-// sessionIDs specify the sessions to be expired.
+// SessionIDs specifies the sessions to be expired.
 func (es *EndSessions) SessionIDs(sessionIDs bsoncore.Document) *EndSessions {
 	if es == nil {
 		es = new(EndSessions)

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -321,7 +321,7 @@ func (f *Find) OplogReplay(oplogReplay bool) *Find {
 	return f
 }
 
-// Project limits the fields returned for all documents.
+// Projection limits the fields returned for all documents.
 func (f *Find) Projection(projection bsoncore.Document) *Find {
 	if f == nil {
 		f = new(Find)

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -50,6 +50,7 @@ type FindAndModify struct {
 	result FindAndModifyResult
 }
 
+// LastErrorObject represents information about updates and upserts returned by the server.
 type LastErrorObject struct {
 	// True if an update modified an existing document
 	UpdatedExisting bool
@@ -57,6 +58,7 @@ type LastErrorObject struct {
 	Upserted interface{}
 }
 
+// FindAndModifyResult represents a findAndModify result returned by the server.
 type FindAndModifyResult struct {
 	// Either the old or modified document, depending on the value of the new parameter.
 	Value bsoncore.Document

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -38,6 +38,7 @@ type Insert struct {
 	serverAPI                *driver.ServerAPIOptions
 }
 
+// InsertResult represents an insert result returned by the server.
 type InsertResult struct {
 	// Number of documents successfully inserted.
 	N int32

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -39,6 +39,7 @@ type ListDatabases struct {
 	result ListDatabasesResult
 }
 
+// ListDatabasesResult represents a listDatabases result returned by the server.
 type ListDatabasesResult struct {
 	// An array of documents, one document for each database
 	Databases []databaseRecord


### PR DESCRIPTION
GODRIVER-2247

Adds missing (and fixes malformed) comments of exported functions/types across the repo. `golint` was complaining on older branches.