### PR TITLE
GODRIVER-2219 Make maxConnecting configurable via ClientOptions or URI options.

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -546,6 +546,13 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			topology.WithMinConnections(func(uint64) uint64 { return *opts.MinPoolSize }),
 		)
 	}
+	// MaxConnecting
+	if opts.MaxConnecting != nil {
+		serverOpts = append(
+			serverOpts,
+			topology.WithMaxConnecting(func(uint64) uint64 { return *opts.MaxConnecting }),
+		)
+	}
 	// PoolMonitor
 	if opts.PoolMonitor != nil {
 		serverOpts = append(

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -590,7 +590,7 @@ func (c *ClientOptions) SetMinPoolSize(u uint64) *ClientOptions {
 
 // SetMaxConnecting specifies the maximum number of connections a connection pool may establish simultaneously. This can
 // also be set through the "maxConnecting" URI option (e.g. "maxConnecting=2"). If this is 0, the default is used. The
-// defaults is 2. Values greater than 100 are not recommended.
+// default is 2. Values greater than 100 are not recommended.
 func (c *ClientOptions) SetMaxConnecting(u uint64) *ClientOptions {
 	c.MaxConnecting = &u
 	return c

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -109,6 +109,7 @@ type ClientOptions struct {
 	MaxConnIdleTime          *time.Duration
 	MaxPoolSize              *uint64
 	MinPoolSize              *uint64
+	MaxConnecting            *uint64
 	PoolMonitor              *event.PoolMonitor
 	Monitor                  *event.CommandMonitor
 	ServerMonitor            *event.ServerMonitor
@@ -310,6 +311,10 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 
 	if cs.MinPoolSizeSet {
 		c.MinPoolSize = &cs.MinPoolSize
+	}
+
+	if cs.MaxConnectingSet {
+		c.MaxConnecting = &cs.MaxConnecting
 	}
 
 	if cs.ReadConcernLevel != "" {
@@ -580,6 +585,14 @@ func (c *ClientOptions) SetMaxPoolSize(u uint64) *ClientOptions {
 // the minimum. This can also be set through the "minPoolSize" URI option (e.g. "minPoolSize=100"). The default is 0.
 func (c *ClientOptions) SetMinPoolSize(u uint64) *ClientOptions {
 	c.MinPoolSize = &u
+	return c
+}
+
+// SetMaxConnecting specifies the maximum number of connections a connection pool may establish simultaneously. This can
+// also be set through the "maxConnecting" URI option (e.g. "maxConnecting=2"). If this is 0, the default is used. The
+// defaults is 2. Values greater than 100 are not recommended.
+func (c *ClientOptions) SetMaxConnecting(u uint64) *ClientOptions {
+	c.MaxConnecting = &u
 	return c
 }
 
@@ -858,6 +871,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.MinPoolSize != nil {
 			c.MinPoolSize = opt.MinPoolSize
+		}
+		if opt.MaxConnecting != nil {
+			c.MaxConnecting = opt.MaxConnecting
 		}
 		if opt.PoolMonitor != nil {
 			c.PoolMonitor = opt.PoolMonitor

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -69,6 +69,7 @@ func TestClientOptions(t *testing.T) {
 			{"MaxConnIdleTime", (*ClientOptions).SetMaxConnIdleTime, 5 * time.Second, "MaxConnIdleTime", true},
 			{"MaxPoolSize", (*ClientOptions).SetMaxPoolSize, uint64(250), "MaxPoolSize", true},
 			{"MinPoolSize", (*ClientOptions).SetMinPoolSize, uint64(10), "MinPoolSize", true},
+			{"MaxConnecting", (*ClientOptions).SetMaxConnecting, uint64(10), "MaxConnecting", true},
 			{"PoolMonitor", (*ClientOptions).SetPoolMonitor, &event.PoolMonitor{}, "PoolMonitor", false},
 			{"Monitor", (*ClientOptions).SetMonitor, &event.CommandMonitor{}, "Monitor", false},
 			{"ReadConcern", (*ClientOptions).SetReadConcern, readconcern.Majority(), "ReadConcern", false},
@@ -337,6 +338,16 @@ func TestClientOptions(t *testing.T) {
 				"MaxPoolSize",
 				"mongodb://localhost/?maxPoolSize=256",
 				baseClient().SetMaxPoolSize(256),
+			},
+			{
+				"MinPoolSize",
+				"mongodb://localhost/?minPoolSize=256",
+				baseClient().SetMinPoolSize(256),
+			},
+			{
+				"MaxConnecting",
+				"mongodb://localhost/?maxConnecting=10",
+				baseClient().SetMaxConnecting(10),
 			},
 			{
 				"ReadConcern",

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -85,6 +85,8 @@ type ConnString struct {
 	MaxPoolSizeSet                     bool
 	MinPoolSize                        uint64
 	MinPoolSizeSet                     bool
+	MaxConnecting                      uint64
+	MaxConnectingSet                   bool
 	Password                           string
 	PasswordSet                        bool
 	ReadConcernLevel                   string
@@ -731,6 +733,13 @@ func (p *parser) addOption(pair string) error {
 		}
 		p.MinPoolSize = uint64(n)
 		p.MinPoolSizeSet = true
+	case "maxconnecting":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return fmt.Errorf("invalid value for %s: %s", key, value)
+		}
+		p.MaxConnecting = uint64(n)
+		p.MaxConnectingSet = true
 	case "readconcernlevel":
 		p.ReadConcernLevel = value
 	case "readpreference":

--- a/x/mongo/driver/connstring/connstring_test.go
+++ b/x/mongo/driver/connstring/connstring_test.go
@@ -319,6 +319,33 @@ func TestMinPoolSize(t *testing.T) {
 	}
 }
 
+func TestMaxConnecting(t *testing.T) {
+	tests := []struct {
+		s        string
+		expected uint64
+		err      bool
+	}{
+		{s: "maxConnecting=10", expected: 10},
+		{s: "maxConnecting=100", expected: 100},
+		{s: "maxConnecting=-2", err: true},
+		{s: "maxConnecting=gsdge", err: true},
+	}
+
+	for _, test := range tests {
+		s := fmt.Sprintf("mongodb://localhost/?%s", test.s)
+		t.Run(s, func(t *testing.T) {
+			cs, err := connstring.ParseAndValidate(s)
+			if test.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.True(t, cs.MaxConnectingSet)
+				require.Equal(t, test.expected, cs.MaxConnecting)
+			}
+		})
+	}
+}
+
 func TestReadPreference(t *testing.T) {
 	tests := []struct {
 		s        string

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -38,11 +38,12 @@ func (pe PoolError) Error() string { return string(pe) }
 
 // poolConfig contains all aspects of the pool that can be configured
 type poolConfig struct {
-	Address     address.Address
-	MinPoolSize uint64
-	MaxPoolSize uint64
-	MaxIdleTime time.Duration
-	PoolMonitor *event.PoolMonitor
+	Address       address.Address
+	MinPoolSize   uint64
+	MaxPoolSize   uint64
+	MaxConnecting uint64
+	MaxIdleTime   time.Duration
+	PoolMonitor   *event.PoolMonitor
 }
 
 type pool struct {
@@ -100,11 +101,16 @@ func newPool(config poolConfig, connOpts ...ConnectionOption) *pool {
 		connOpts = append(connOpts, WithIdleTimeout(func(_ time.Duration) time.Duration { return config.MaxIdleTime }))
 	}
 
+	var maxConnecting uint64 = 2
+	if config.MaxConnecting > 0 {
+		maxConnecting = config.MaxConnecting
+	}
+
 	pool := &pool{
 		address:          config.Address,
 		minSize:          config.MinPoolSize,
 		maxSize:          config.MaxPoolSize,
-		maxConnecting:    2,
+		maxConnecting:    maxConnecting,
 		monitor:          config.PoolMonitor,
 		connOpts:         connOpts,
 		generation:       newPoolGenerationMap(),

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -178,11 +178,12 @@ func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...Serv
 	s.rttMonitor = newRTTMonitor(rttCfg)
 
 	pc := poolConfig{
-		Address:     addr,
-		MinPoolSize: cfg.minConns,
-		MaxPoolSize: cfg.maxConns,
-		MaxIdleTime: cfg.connectionPoolMaxIdleTime,
-		PoolMonitor: cfg.poolMonitor,
+		Address:       addr,
+		MinPoolSize:   cfg.minConns,
+		MaxPoolSize:   cfg.maxConns,
+		MaxConnecting: cfg.maxConnecting,
+		MaxIdleTime:   cfg.connectionPoolMaxIdleTime,
+		PoolMonitor:   cfg.poolMonitor,
 	}
 
 	connectionOpts := copyConnectionOpts(cfg.connectionOpts)

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -27,6 +27,7 @@ type serverConfig struct {
 	heartbeatTimeout          time.Duration
 	maxConns                  uint64
 	minConns                  uint64
+	maxConnecting             uint64
 	poolMonitor               *event.PoolMonitor
 	serverMonitor             *event.ServerMonitor
 	connectionPoolMaxIdleTime time.Duration
@@ -120,6 +121,16 @@ func WithMaxConnections(fn func(uint64) uint64) ServerOption {
 func WithMinConnections(fn func(uint64) uint64) ServerOption {
 	return func(cfg *serverConfig) error {
 		cfg.minConns = fn(cfg.minConns)
+		return nil
+	}
+}
+
+// WithMaxConnecting configures the maximum number of connections a connection
+// pool may establish simultaneously. If maxConnecting is 0, the default value
+// of 2 is used.
+func WithMaxConnecting(fn func(uint64) uint64) ServerOption {
+	return func(cfg *serverConfig) error {
+		cfg.maxConnecting = fn(cfg.maxConnecting)
 		return nil
 	}
 }


### PR DESCRIPTION
[GODRIVER-2219](https://jira.mongodb.org/browse/GODRIVER-2219)

Add `ClientOptions.SetMaxConnecting` and support the `maxConnecting=<val>` URI option.