### PR TITLE
GODRIVER-1826 Add prose-style tests for the maxConnecting CMAP spec tests

### DIFF
--- a/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "maxConnecting is enforced",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster",
+        "hello"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 1
+    },
+    {
+      "name": "wait",
+      "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCheckOutStarted",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
@@ -1,0 +1,79 @@
+version: 1
+style: integration
+description: maxConnecting is enforced
+runOn:
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 50 }
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  waitQueueTimeoutMS: 5000
+operations:
+  - name: ready
+  # start 3 threads
+  - name: start
+    target: thread1
+  - name: start
+    target: thread2
+  - name: start
+    target: thread3
+  # start creating a Connection. This will take a while
+  # due to the fail point.
+  - name: checkOut
+    thread: thread1
+  # wait for thread1 to actually start creating a Connection
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 1
+  # wait some more time to ensure thread1 has begun establishing a Connection
+  - name: wait
+    ms: 100
+  # start 2 check out requests. Only one thread should
+  # start creating a Connection and the other one should be
+  # waiting for pendingConnectionCount to be less than maxConnecting,
+  # only starting once thread1 finishes creating its Connection.
+  - name: checkOut
+    thread: thread2
+  - name: checkOut
+    thread: thread3
+  # wait until all Connections have been created.
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 3
+events:
+  # thread1 creates its connection
+  - type: ConnectionCreated
+    address: 42
+    connectionId: 1
+  # either thread2 or thread3 creates its connection
+  # the other thread is stuck waiting for maxConnecting to come down
+  - type: ConnectionCreated
+    address: 42
+  # thread1 finishes establishing its connection, freeing
+  # up the blocked thread to start establishing
+  - type: ConnectionReady
+    address: 42
+    connectionId: 1
+  - type: ConnectionCreated
+    address: 42
+  # the remaining two Connections finish establishing
+  - type: ConnectionReady
+    address: 42
+  - type: ConnectionReady
+    address: 42
+ignore:
+  - ConnectionCheckOutStarted
+  - ConnectionCheckedIn
+  - ConnectionCheckedOut
+  - ConnectionClosed
+  - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "waiting on maxConnecting is limited by WaitQueueTimeoutMS",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster",
+        "hello"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 50
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 2
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "waitForThread",
+      "target": "thread3"
+    }
+  ],
+  "error": {
+    "type": "WaitQueueTimeoutError",
+    "message": "Timed out while checking out a connection from connection pool"
+  },
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "timeout",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
@@ -1,0 +1,69 @@
+version: 1
+style: integration
+description: waiting on maxConnecting is limited by WaitQueueTimeoutMS
+runOn:
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 50 }
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  # Drivers that limit connection establishment by waitQueueTimeoutMS may skip
+  # this test. While waitQueueTimeoutMS is technically not supposed to limit establishment time,
+  # it will soon be deprecated, so it is easier for those drivers to just skip this test.
+  waitQueueTimeoutMS: 50
+operations:
+  - name: ready
+  # start creating two connections simultaneously.
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: start
+    target: thread2
+  - name: checkOut
+    thread: thread2
+  # wait for other two threads to start establishing
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 2
+  # start a third thread that will be blocked waiting for
+  # one of the other two to finish
+  - name: start
+    target: thread3
+  - name: checkOut
+    thread: thread3
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  # rejoin thread3, should experience error
+  - name: waitForThread
+    target: thread3
+error:
+  type: WaitQueueTimeoutError
+  message: Timed out while checking out a connection from connection pool
+events:
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: timeout
+    address: 42
+ignore:
+  - ConnectionCreated
+  - ConnectionCheckedIn
+  - ConnectionCheckedOut
+  - ConnectionClosed
+  - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/data/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
@@ -1,0 +1,124 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "threads blocked by maxConnecting check out returned connections",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster",
+        "hello"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut",
+      "label": "conn0"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
+    },
+    {
+      "name": "wait",
+      "ms": 100
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn0"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 4
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolReady",
+    "ConnectionClosed",
+    "ConnectionReady",
+    "ConnectionPoolCreated",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
@@ -1,0 +1,86 @@
+version: 1
+style: integration
+description: threads blocked by maxConnecting check out returned connections
+runOn:
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 50 }
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  waitQueueTimeoutMS: 5000
+operations:
+  - name: ready
+  # check out a connection and hold on to it.
+  - name: checkOut
+    label: conn0
+  # then start three threads that all attempt to check out. Two threads
+  # will fill maxConnecting, and the other should be waiting either for
+  # the other two to finish or for the main thread to check its connection
+  # back in.
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: start
+    target: thread2
+  - name: checkOut
+    thread: thread2
+  - name: start
+    target: thread3
+  - name: checkOut
+    thread: thread3
+  # wait for all three to start checking out and a little longer
+  # for the establishments to begin.
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
+    count: 4
+  - name: wait
+    ms: 100
+  # check original connection back in, so the thread that isn't
+  # currently establishing will become unblocked. Then wait for
+  # all threads to complete.
+  - name: checkIn
+    connection: conn0
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 4
+events:
+  # main thread checking out a Connection and holding it
+  - type: ConnectionCreated
+    address: 42
+    connectionId: 1
+  - type: ConnectionCheckedOut
+    address: 42
+  # two threads creating their Connections
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  # main thread checking its Connection back in
+  - type: ConnectionCheckedIn
+    connectionId: 1
+    address: 42
+  # remaining thread checking out the returned Connection
+  - type: ConnectionCheckedOut
+    connectionId: 1
+    address: 42
+  # first two threads finishing Connection establishment
+  - type: ConnectionCheckedOut
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+ignore:
+  - ConnectionPoolReady
+  - ConnectionClosed
+  - ConnectionReady
+  - ConnectionPoolCreated
+  - ConnectionCheckOutStarted

--- a/mongo/integration/cmap_spec_test.go
+++ b/mongo/integration/cmap_spec_test.go
@@ -48,7 +48,8 @@ func TestCMAPSpec(t *testing.T) {
 		tpm := newTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
-			SetMaxPoolSize(10))
+			SetMaxPoolSize(10).
+			SetMaxConnecting(2))
 
 		events := make(chan *event.PoolEvent, 20)
 		tpm.Subscribe(events)
@@ -141,7 +142,8 @@ func TestCMAPSpec(t *testing.T) {
 		tpm := newTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
-			SetMaxPoolSize(10))
+			SetMaxPoolSize(10).
+			SetMaxConnecting(2))
 
 		events := make(chan *event.PoolEvent, 20)
 		tpm.Subscribe(events)
@@ -236,7 +238,8 @@ func TestCMAPSpec(t *testing.T) {
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
 			SetMaxPoolSize(10).
-			SetMinPoolSize(3))
+			SetMinPoolSize(3).
+			SetMaxConnecting(2))
 
 		events := make(chan *event.PoolEvent, 20)
 		tpm.Subscribe(events)

--- a/mongo/integration/cmap_spec_test.go
+++ b/mongo/integration/cmap_spec_test.go
@@ -1,0 +1,382 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/internal"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+)
+
+func TestCMAPSpec(t *testing.T) {
+	mtOpts := mtest.NewOptions().
+		CreateClient(false).
+		MinServerVersion("4.4.0")
+	mt := mtest.New(t, mtOpts)
+	defer mt.Close()
+
+	// Test that maxConnecting is enforced.
+	// Based on CMAP spec test
+	// "connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json"
+	mt.Run("pool-checkout-maxConnecting-is-enforced.json", func(mt *mtest.T) {
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 50,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"hello", internal.LegacyHello},
+				CloseConnection: false,
+				BlockConnection: true,
+				BlockTimeMS:     750,
+			},
+		})
+
+		tpm := newTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetPoolMonitor(tpm.PoolMonitor).
+			SetMaxPoolSize(10))
+
+		events := make(chan *event.PoolEvent, 20)
+		tpm.Subscribe(events)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+			assert.NoErrorf(mt, err, "InsertOne error")
+		}()
+
+		count := 1
+		for evt := range events {
+			if evt.Type == "ConnectionCreated" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+				assert.NoErrorf(mt, err, "InsertOne error")
+			}()
+		}
+
+		count = 3
+		for evt := range events {
+			if evt.Type == "ConnectionReady" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		wg.Wait()
+
+		want := []*event.PoolEvent{
+			{
+				Type:         "ConnectionCreated",
+				ConnectionID: 1,
+			},
+			{Type: "ConnectionCreated"},
+			{
+				Type:         "ConnectionReady",
+				ConnectionID: 1,
+			},
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionReady"},
+			{Type: "ConnectionReady"},
+		}
+		ignore := []string{
+			"ConnectionCheckOutStarted",
+			"ConnectionCheckedIn",
+			"ConnectionCheckedOut",
+			"ConnectionClosed",
+			"ConnectionPoolCreated",
+			"ConnectionPoolReady",
+		}
+		assertEvents(mt, want, ignore, tpm.Events())
+	})
+
+	// Test that waiting on maxConnecting is limited by WaitQueueTimeoutMS.
+	// Based on CMAP spec test
+	// "connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json"
+	mt.Run("pool-checkout-maxConnecting-timeout.json", func(mt *mtest.T) {
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 50,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"hello", internal.LegacyHello},
+				CloseConnection: false,
+				BlockConnection: true,
+				BlockTimeMS:     750,
+			},
+		})
+
+		tpm := newTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetPoolMonitor(tpm.PoolMonitor).
+			SetMaxPoolSize(10))
+
+		events := make(chan *event.PoolEvent, 20)
+		tpm.Subscribe(events)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+				assert.NoErrorf(mt, err, "InsertOne error")
+			}()
+		}
+
+		count := 2
+		for evt := range events {
+			if evt.Type == "ConnectionCreated" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			_, err := mt.Coll.InsertOne(ctx, bson.D{{"key", "value"}})
+			assert.IsTypef(
+				mt,
+				topology.WaitQueueTimeoutError{},
+				err,
+				"expected InsertOne error to be a WaitQueueTimeoutError")
+		}()
+
+		count = 1
+		for evt := range events {
+			if evt.Type == "ConnectionCheckOutFailed" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		wg.Wait()
+
+		want := []*event.PoolEvent{
+			{Type: "ConnectionCheckOutStarted"},
+			{Type: "ConnectionCheckOutStarted"},
+			{Type: "ConnectionCheckOutStarted"},
+			{
+				Type:   "ConnectionCheckOutFailed",
+				Reason: "timeout",
+			},
+		}
+		ignore := []string{
+			"ConnectionCreated",
+			"ConnectionCheckedIn",
+			"ConnectionCheckedOut",
+			"ConnectionClosed",
+			"ConnectionPoolCreated",
+			"ConnectionPoolReady",
+		}
+		assertEvents(mt, want, ignore, tpm.Events())
+	})
+
+	// Test that threads blocked by maxConnecting check out returned connections.
+	// Based on CMAP spec test
+	// "connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json"
+	// Note that the sequence of operations is modified from the original CMAP spec test to be able
+	// to use the exported APIs.
+	mt.Run("pool-checkout-returned-connection-maxConnecting.json", func(mt *mtest.T) {
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 50,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"hello", internal.LegacyHello, "insert"},
+				CloseConnection: false,
+				BlockConnection: true,
+				BlockTimeMS:     750,
+			},
+		})
+
+		tpm := newTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetPoolMonitor(tpm.PoolMonitor).
+			SetMaxPoolSize(10).
+			SetMinPoolSize(3))
+
+		events := make(chan *event.PoolEvent, 20)
+		tpm.Subscribe(events)
+
+		// Wait until 3 connections are ready in the pool. We need all 3 inserts to start at about
+		// the same time, so we don't want maxConnecting to impact when connections are available
+		// for these first 3 inserts.
+		count := 3
+		for evt := range events {
+			if evt.Type == "ConnectionReady" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		// Start 3 inserts that should take about 750ms to complete. Each will check their
+		// connection back into the pool when the operation completes.
+		var wg sync.WaitGroup
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+				assert.NoErrorf(mt, err, "InsertOne error")
+			}()
+		}
+
+		// Wait for all 3 connection check-outs to complete so we know the insert operation just
+		// started.
+		count = 3
+		for evt := range events {
+			if evt.Type == "ConnectionCheckedOut" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		// Wait for about half of the 750ms operation delay, then start 2 new insert operations.
+		// That should allow 2 new connections to start establishing. Expect that those 2 new
+		// connections won't complete before the 3 previously started inserts check their
+		// connections back into the pool.
+		time.Sleep(300 * time.Millisecond)
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+				assert.NoErrorf(mt, err, "InsertOne error")
+			}()
+		}
+
+		// Wait for 2 connection created events so we know that the next operation should block on
+		// maxConnecting for about 750ms before it can start creating a new connection.
+		count = 2
+		for evt := range events {
+			if evt.Type == "ConnectionCreated" {
+				count--
+			}
+			if count <= 0 {
+				break
+			}
+		}
+
+		// Start one more insert operation that should try to check out a connection, find an empty
+		// pool, and block on maxConnecting waiting to create a new connection. One of the first 3
+		// insert operations should complete before the number of connections being created is less
+		// than maxConnecting. This last insert should take one of those connections instead of
+		// creating a new one.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"key", "value"}})
+			assert.NoErrorf(mt, err, "InsertOne error")
+		}()
+
+		wg.Wait()
+
+		// Assert that there are 6 connections checked out and 5 created.
+		want := []*event.PoolEvent{
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionCheckedOut"},
+			{Type: "ConnectionCheckedOut"},
+			{Type: "ConnectionCheckedOut"},
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionCreated"},
+			{Type: "ConnectionCheckedOut"},
+			{Type: "ConnectionCheckedOut"},
+			{Type: "ConnectionCheckedOut"},
+		}
+		ignore := []string{
+			"ConnectionPoolReady",
+			"ConnectionClosed",
+			"ConnectionReady",
+			"ConnectionPoolCreated",
+			"ConnectionCheckOutStarted",
+			"ConnectionCheckedIn",
+		}
+		assertEvents(mt, want, ignore, tpm.Events())
+	})
+}
+
+// assertEvents asserts that the events slice contains events equivalent to the events in
+// wantEvents, ignoring any event types in ignoreEventTypes.
+func assertEvents(mt *mtest.T, wantEvents []*event.PoolEvent, ignoreEventTypes []string, events []*event.PoolEvent) {
+	ignore := make(map[string]bool, len(ignoreEventTypes))
+	for _, typ := range ignoreEventTypes {
+		ignore[typ] = true
+	}
+
+	offset := 0
+	for i, evt := range events {
+		if ignore[evt.Type] {
+			continue
+		}
+		if offset >= len(wantEvents) {
+			break
+		}
+
+		wantEvent := wantEvents[offset]
+		assert.Equalf(mt, wantEvent.Type, evt.Type, "event %d: expected event types to match", i)
+		assert.NotEmpty(mt, evt.Address, "event %d: expected event address to not be empty", i)
+		if len(wantEvent.Reason) > 0 {
+			assert.Equalf(mt, wantEvent.Reason, evt.Reason, "event %d: expected event reasons to match", i)
+		}
+		if wantEvent.ConnectionID > 0 {
+			assert.Equalf(mt, wantEvent.ConnectionID, evt.ConnectionID, "event %d: expected event connection IDs to match", i)
+		}
+		offset++
+	}
+
+	if offset != len(wantEvents) {
+		mt.Errorf("missing expected events: %v", wantEvents[offset:])
+	}
+}

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology
 
 import (
@@ -39,6 +45,7 @@ type cmapTestFile struct {
 	Description string                   `json:"description"`
 	SkipReason  string                   `json:"skipReason"`
 	PoolOptions poolOptions              `json:"poolOptions"`
+	FailPoint   json.RawMessage          `json:"failPoint"`
 	Operations  []map[string]interface{} `json:"operations"`
 	Error       *cmapTestError           `json:"error"`
 	Events      []cmapEvent              `json:"events"`
@@ -87,6 +94,14 @@ func runCMAPTest(t *testing.T, testFileName string) {
 
 	if test.SkipReason != "" {
 		t.Skip(test.SkipReason)
+	}
+
+	// CMAP spec integration tests that require server failpoints are not currently supported. The
+	// only practical way to manage server failpoints is using a "mongo.Client", but importing the
+	// "mongo" package here creates an import cycle.
+	// TODO(GODRIVER-2257): Run CMAP spec integration tests in the "mongo/integration" package.
+	if len(test.FailPoint) > 0 {
+		t.Skip("failpoints are not currently supported in the CMAP spec test runner")
 	}
 
 	testInfo := &testInfo{

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -100,8 +100,13 @@ func runCMAPTest(t *testing.T, testFileName string) {
 	// only practical way to manage server failpoints is using a "mongo.Client", but importing the
 	// "mongo" package here creates an import cycle.
 	// TODO(GODRIVER-2257): Run CMAP spec integration tests in the "mongo/integration" package.
-	if len(test.FailPoint) > 0 {
-		t.Skip("failpoints are not currently supported in the CMAP spec test runner")
+	prohibited := map[string]bool{
+		"waiting on maxConnecting is limited by WaitQueueTimeoutMS":       true,
+		"maxConnecting is enforced":                                       true,
+		"threads blocked by maxConnecting check out returned connections": true,
+	}
+	if prohibited[test.Description] {
+		t.Skip("failpoints are not currently supported in the CMAP spec test runner. See GODRIVER-2257.")
 	}
 
 	testInfo := &testInfo{


### PR DESCRIPTION
[GODRIVER-1826](https://jira.mongodb.org/browse/GODRIVER-1826)

Changes:
* Sync the `maxConnecting` CMAP spec tests.
* Skip any CMAP spec tests that require failpoints because the CMAP spec test runner can't currently support those.
* Add prose-style test in the `mongo/integration` package for any synced CMAP spec test that requires failpoints.