### PR TITLE
GODRIVER-2190 Support authorizedCollections option for ListCollections

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -382,6 +382,9 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		cursorOpts.BatchSize = *lco.BatchSize
 		op = op.BatchSize(*lco.BatchSize)
 	}
+	if lco.AuthorizedCollections != nil {
+		op = op.AuthorizedCollections(*lco.AuthorizedCollections)
+	}
 
 	retry := driver.RetryNone
 	if db.client.retryReads {

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -249,19 +249,10 @@ func TestDatabase(t *testing.T) {
 			assert.Nil(mt, err, "expected command %s to contain key 'batchSize'", evt.Command)
 		})
 		mt.RunOpts("authorizedCollections", mtest.NewOptions().MinServerVersion("4.0"), func(mt *mtest.T) {
-			// Create two new collections so there will be three total.
-			createCollections(mt, 2)
-
 			mt.ClearEvents()
 			lcOpts := options.ListCollections().SetAuthorizedCollections(true)
-			cur, err := mt.DB.ListCollections(mtest.Background, bson.D{}, lcOpts)
+			_, err := mt.DB.ListCollections(mtest.Background, bson.D{}, lcOpts)
 			assert.Nil(mt, err, "ListCollections error: %v", err)
-
-			var numColls int
-			for cur.Next(mtest.Background) {
-				numColls++
-			}
-			assert.Equal(mt, 3, numColls, "expected 3 collections to be returned, got %v", numColls)
 
 			evt := mt.GetStartedEvent()
 			assert.Equal(mt, "listCollections", evt.CommandName,

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -14,8 +14,8 @@ type ListCollectionsOptions struct {
 	// The maximum number of documents to be included in each batch returned by the server.
 	BatchSize *int32
 
-	// If true, limits the documents returned to only contain collections the user is authorized to use. The default value
-	// is false.
+	// If true, and NameOnly is true, limits the documents returned to only contain collections the user is authorized to use. The default value
+	// is false. This option is only valid for MongoDB server versions >= 4.0. Server versions < 4.0 ignore this option.
 	AuthorizedCollections *bool
 }
 
@@ -36,7 +36,8 @@ func (lc *ListCollectionsOptions) SetBatchSize(size int32) *ListCollectionsOptio
 	return lc
 }
 
-// SetAuthorizedCollections sets the value for the AuthorizedCollections field.
+// SetAuthorizedCollections sets the value for the AuthorizedCollections field. This option is only valid for MongoDB server versions >= 4.0. Server
+// versions < 4.0 ignore this option.
 func (lc *ListCollectionsOptions) SetAuthorizedCollections(b bool) *ListCollectionsOptions {
 	lc.AuthorizedCollections = &b
 	return lc

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -13,6 +13,10 @@ type ListCollectionsOptions struct {
 
 	// The maximum number of documents to be included in each batch returned by the server.
 	BatchSize *int32
+
+	// If true, limits the documents returned to only contain collections the user is authorized to use. The default value
+	// is false.
+	AuthorizedCollections *bool
 }
 
 // ListCollections creates a new ListCollectionsOptions instance.
@@ -32,6 +36,12 @@ func (lc *ListCollectionsOptions) SetBatchSize(size int32) *ListCollectionsOptio
 	return lc
 }
 
+// SetAuthorizedCollections sets the value for the AuthorizedCollections field.
+func (lc *ListCollectionsOptions) SetAuthorizedCollections(b bool) *ListCollectionsOptions {
+	lc.AuthorizedCollections = &b
+	return lc
+}
+
 // MergeListCollectionsOptions combines the given ListCollectionsOptions instances into a single *ListCollectionsOptions
 // in a last-one-wins fashion.
 func MergeListCollectionsOptions(opts ...*ListCollectionsOptions) *ListCollectionsOptions {
@@ -45,6 +55,9 @@ func MergeListCollectionsOptions(opts ...*ListCollectionsOptions) *ListCollectio
 		}
 		if opt.BatchSize != nil {
 			lc.BatchSize = opt.BatchSize
+		}
+		if opt.AuthorizedCollections != nil {
+			lc.AuthorizedCollections = opt.AuthorizedCollections
 		}
 	}
 

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -20,20 +20,21 @@ import (
 
 // ListCollections performs a listCollections operation.
 type ListCollections struct {
-	filter         bsoncore.Document
-	nameOnly       *bool
-	session        *session.Client
-	clock          *session.ClusterClock
-	monitor        *event.CommandMonitor
-	crypt          driver.Crypt
-	database       string
-	deployment     driver.Deployment
-	readPreference *readpref.ReadPref
-	selector       description.ServerSelector
-	retry          *driver.RetryMode
-	result         driver.CursorResponse
-	batchSize      *int32
-	serverAPI      *driver.ServerAPIOptions
+	filter                bsoncore.Document
+	nameOnly              *bool
+	authorizedCollections *bool
+	session               *session.Client
+	clock                 *session.ClusterClock
+	monitor               *event.CommandMonitor
+	crypt                 driver.Crypt
+	database              string
+	deployment            driver.Deployment
+	readPreference        *readpref.ReadPref
+	selector              description.ServerSelector
+	retry                 *driver.RetryMode
+	result                driver.CursorResponse
+	batchSize             *int32
+	serverAPI             *driver.ServerAPIOptions
 }
 
 // NewListCollections constructs and returns a new ListCollections.
@@ -89,7 +90,6 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 }
 
 func (lc *ListCollections) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
-
 	dst = bsoncore.AppendInt32Element(dst, "listCollections", 1)
 	if lc.filter != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "filter", lc.filter)
@@ -97,6 +97,10 @@ func (lc *ListCollections) command(dst []byte, desc description.SelectedServer) 
 	if lc.nameOnly != nil {
 		dst = bsoncore.AppendBooleanElement(dst, "nameOnly", *lc.nameOnly)
 	}
+	if lc.authorizedCollections != nil {
+		dst = bsoncore.AppendBooleanElement(dst, "authorizedCollections", *lc.authorizedCollections)
+	}
+
 	cursorDoc := bsoncore.NewDocumentBuilder()
 	if lc.batchSize != nil {
 		cursorDoc.AppendInt32("batchSize", *lc.batchSize)
@@ -123,6 +127,17 @@ func (lc *ListCollections) NameOnly(nameOnly bool) *ListCollections {
 	}
 
 	lc.nameOnly = &nameOnly
+	return lc
+}
+
+// AuthorizedCollections specifies whether to only return collections the user
+// is authorized to use.
+func (lc *ListCollections) AuthorizedCollections(authorizedCollections bool) *ListCollections {
+	if lc == nil {
+		lc = new(ListCollections)
+	}
+
+	lc.authorizedCollections = &authorizedCollections
 	return lc
 }
 


### PR DESCRIPTION
GODRIVER-2190

Adds support for the `authorizedCollections` option in `ListCollectionsOptions`. Adds a small unit test to ensure `authorizedCollections` is passed correctly in a `listCollections` command.