### PR TITLE
GODRIVER-2252 Don't call UnmarshalBSON for pointer values if the BSON field value is empty.

### DIFF
--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
@@ -30,10 +31,7 @@ func TestBasicDecode(t *testing.T) {
 			noerr(t, err)
 			err = decoder.DecodeValue(bsoncodec.DecodeContext{Registry: reg}, vr, got)
 			noerr(t, err)
-
-			if !reflect.DeepEqual(got.Addr().Interface(), tc.want) {
-				t.Errorf("Results do not match. got %+v; want %+v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got.Addr().Interface(), "Results do not match.")
 		})
 	}
 }
@@ -44,20 +42,11 @@ func TestDecoderv2(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				got := reflect.New(tc.sType).Interface()
 				vr := bsonrw.NewBSONDocumentReader(tc.data)
-				var reg *bsoncodec.Registry
-				if tc.reg != nil {
-					reg = tc.reg
-				} else {
-					reg = DefaultRegistry
-				}
-				dec, err := NewDecoderWithContext(bsoncodec.DecodeContext{Registry: reg}, vr)
+				dec, err := NewDecoderWithContext(bsoncodec.DecodeContext{Registry: DefaultRegistry}, vr)
 				noerr(t, err)
 				err = dec.Decode(got)
 				noerr(t, err)
-
-				if !reflect.DeepEqual(got, tc.want) {
-					t.Errorf("Results do not match. got %+v; want %+v", got, tc.want)
-				}
+				assert.Equal(t, tc.want, got, "Results do not match.")
 			})
 		}
 		t.Run("lookup error", func(t *testing.T) {
@@ -70,9 +59,7 @@ func TestDecoderv2(t *testing.T) {
 			noerr(t, err)
 			want := bsoncodec.ErrNoDecoder{Type: reflect.TypeOf(cdeih)}
 			got := dec.Decode(&cdeih)
-			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
-				t.Errorf("Received unexpected error. got %v; want %v", got, want)
-			}
+			assert.Equal(t, want, got, "Received unexpected error.")
 		})
 		t.Run("Unmarshaler", func(t *testing.T) {
 			testCases := []struct {
@@ -160,6 +147,7 @@ func TestDecoderv2(t *testing.T) {
 			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 				t.Errorf("Was expecting error but got different error. got %v; want %v", got, want)
 			}
+
 		})
 		t.Run("success", func(t *testing.T) {
 			got, err := NewDecoderWithContext(bsoncodec.DecodeContext{}, bsonrw.NewBSONDocumentReader([]byte{}))
@@ -191,9 +179,7 @@ func TestDecoderv2(t *testing.T) {
 		err = dec.Decode(&got)
 		noerr(t, err)
 		want := foo{Item: "canvas", Qty: 4, Bonus: 2}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("Results do not match. got %+v; want %+v", got, want)
-		}
+		assert.Equal(t, want, got, "Results do not match.")
 	})
 	t.Run("Reset", func(t *testing.T) {
 		vr1, vr2 := bsonrw.NewBSONDocumentReader([]byte{}), bsonrw.NewBSONDocumentReader([]byte{})

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBasicDecode(t *testing.T) {
-	for _, tc := range unmarshalingTestCases {
+	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			got := reflect.New(tc.sType).Elem()
 			vr := bsonrw.NewBSONDocumentReader(tc.data)
@@ -38,7 +38,7 @@ func TestBasicDecode(t *testing.T) {
 
 func TestDecoderv2(t *testing.T) {
 	t.Run("Decode", func(t *testing.T) {
-		for _, tc := range unmarshalingTestCases {
+		for _, tc := range unmarshalingTestCases() {
 			t.Run(tc.name, func(t *testing.T) {
 				got := reflect.New(tc.sType).Interface()
 				vr := bsonrw.NewBSONDocumentReader(tc.data)
@@ -147,7 +147,6 @@ func TestDecoderv2(t *testing.T) {
 			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 				t.Errorf("Was expecting error but got different error. got %v; want %v", got, want)
 			}
-
 		})
 		t.Run("success", func(t *testing.T) {
 			got, err := NewDecoderWithContext(bsoncodec.DecodeContext{}, bsonrw.NewBSONDocumentReader([]byte{}))

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
-	for _, tc := range unmarshalingTestCases {
+	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			got := reflect.New(tc.sType).Interface()
 			err := Unmarshal(tc.data, got)
@@ -28,7 +28,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshalWithRegistry(t *testing.T) {
-	for _, tc := range unmarshalingTestCases {
+	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			got := reflect.New(tc.sType).Interface()
 			err := UnmarshalWithRegistry(DefaultRegistry, tc.data, got)
@@ -39,7 +39,7 @@ func TestUnmarshalWithRegistry(t *testing.T) {
 }
 
 func TestUnmarshalWithContext(t *testing.T) {
-	for _, tc := range unmarshalingTestCases {
+	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			dc := bsoncodec.DecodeContext{Registry: DefaultRegistry}
 			got := reflect.New(tc.sType).Interface()

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -10,25 +10,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
-	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestUnmarshal(t *testing.T) {
 	for _, tc := range unmarshalingTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.reg != nil {
-				t.Skip() // test requires custom registry
-			}
 			got := reflect.New(tc.sType).Interface()
 			err := Unmarshal(tc.data, got)
 			noerr(t, err)
-			if !cmp.Equal(got, tc.want) {
-				t.Errorf("Did not unmarshal as expected. got %v; want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
 		})
 	}
 }
@@ -36,18 +30,10 @@ func TestUnmarshal(t *testing.T) {
 func TestUnmarshalWithRegistry(t *testing.T) {
 	for _, tc := range unmarshalingTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var reg *bsoncodec.Registry
-			if tc.reg != nil {
-				reg = tc.reg
-			} else {
-				reg = DefaultRegistry
-			}
 			got := reflect.New(tc.sType).Interface()
-			err := UnmarshalWithRegistry(reg, tc.data, got)
+			err := UnmarshalWithRegistry(DefaultRegistry, tc.data, got)
 			noerr(t, err)
-			if !cmp.Equal(got, tc.want) {
-				t.Errorf("Did not unmarshal as expected. got %v; want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
 		})
 	}
 }
@@ -55,19 +41,11 @@ func TestUnmarshalWithRegistry(t *testing.T) {
 func TestUnmarshalWithContext(t *testing.T) {
 	for _, tc := range unmarshalingTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var reg *bsoncodec.Registry
-			if tc.reg != nil {
-				reg = tc.reg
-			} else {
-				reg = DefaultRegistry
-			}
-			dc := bsoncodec.DecodeContext{Registry: reg}
+			dc := bsoncodec.DecodeContext{Registry: DefaultRegistry}
 			got := reflect.New(tc.sType).Interface()
 			err := UnmarshalWithContext(dc, tc.data, got)
 			noerr(t, err)
-			if !cmp.Equal(got, tc.want) {
-				t.Errorf("Did not unmarshal as expected. got %v; want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
 		})
 	}
 }
@@ -80,9 +58,7 @@ func TestUnmarshalExtJSONWithRegistry(t *testing.T) {
 		err := UnmarshalExtJSONWithRegistry(DefaultRegistry, data, true, &got)
 		noerr(t, err)
 		want := teststruct{1}
-		if !cmp.Equal(got, want) {
-			t.Errorf("Did not unmarshal as expected. got %v; want %v", got, want)
-		}
+		assert.Equal(t, want, got, "Did not unmarshal as expected.")
 	})
 
 	t.Run("UnmarshalExtJSONInvalidInput", func(t *testing.T) {
@@ -165,9 +141,7 @@ func TestUnmarshalExtJSONWithContext(t *testing.T) {
 			dc := bsoncodec.DecodeContext{Registry: DefaultRegistry}
 			err := UnmarshalExtJSONWithContext(dc, tc.data, true, got)
 			noerr(t, err)
-			if !cmp.Equal(got, tc.want) {
-				t.Errorf("Did not unmarshal as expected. got %+v; want %+v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
 		})
 	}
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -9,72 +9,164 @@ package bson
 import (
 	"reflect"
 
-	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
 type unmarshalingTestCase struct {
 	name  string
-	reg   *bsoncodec.Registry
 	sType reflect.Type
 	want  interface{}
 	data  []byte
 }
 
-var unmarshalingTestCases = []unmarshalingTestCase{
+var unmarshalingTestCases = func() []unmarshalingTestCase {
+	var zeroMyStruct myStruct
 	{
-		"small struct",
-		nil,
-		reflect.TypeOf(struct {
-			Foo bool
-		}{}),
-		&struct {
-			Foo bool
-		}{Foo: true},
-		docToBytes(D{{"foo", true}}),
-	},
+		i := myInt64(0)
+		m := myMap{}
+		b := myBytes{}
+		s := myString("")
+		zeroMyStruct = myStruct{I: &i, M: &m, B: &b, S: &s}
+	}
+
+	var valMyStruct myStruct
 	{
-		"nested document",
-		nil,
-		reflect.TypeOf(struct {
-			Foo struct {
-				Bar bool
-			}
-		}{}),
-		&struct {
-			Foo struct {
-				Bar bool
-			}
-		}{
-			Foo: struct {
-				Bar bool
-			}{Bar: true},
+		i := myInt64(5)
+		m := myMap{"key": "value"}
+		b := myBytes{0x00, 0x01}
+		s := myString("test")
+		valMyStruct = myStruct{I: &i, M: &m, B: &b, S: &s}
+	}
+
+	return []unmarshalingTestCase{
+		{
+			name: "small struct",
+			sType: reflect.TypeOf(struct {
+				Foo bool
+			}{}),
+			want: &struct {
+				Foo bool
+			}{Foo: true},
+			data: docToBytes(D{{"foo", true}}),
 		},
-		docToBytes(D{{"foo", D{{"bar", true}}}}),
-	},
-	{
-		"simple array",
-		nil,
-		reflect.TypeOf(struct {
-			Foo []bool
-		}{}),
-		&struct {
-			Foo []bool
-		}{
-			Foo: []bool{true},
+		{
+			name: "nested document",
+			sType: reflect.TypeOf(struct {
+				Foo struct {
+					Bar bool
+				}
+			}{}),
+			want: &struct {
+				Foo struct {
+					Bar bool
+				}
+			}{
+				Foo: struct {
+					Bar bool
+				}{Bar: true},
+			},
+			data: docToBytes(D{{"foo", D{{"bar", true}}}}),
 		},
-		docToBytes(D{{"foo", A{true}}}),
-	},
-	{
-		"struct with mixed case fields",
-		nil,
-		reflect.TypeOf(struct {
-			FooBar int32
-		}{}),
-		&struct {
-			FooBar int32
-		}{
-			FooBar: 10,
+		{
+			name: "simple array",
+			sType: reflect.TypeOf(struct {
+				Foo []bool
+			}{}),
+			want: &struct {
+				Foo []bool
+			}{
+				Foo: []bool{true},
+			},
+			data: docToBytes(D{{"foo", A{true}}}),
 		},
-		docToBytes(D{{"fooBar", int32(10)}}),
-	},
+		{
+			name: "struct with mixed case fields",
+			sType: reflect.TypeOf(struct {
+				FooBar int32
+			}{}),
+			want: &struct {
+				FooBar int32
+			}{
+				FooBar: 10,
+			},
+			data: docToBytes(D{{"fooBar", int32(10)}}),
+		},
+		// GODRIVER-2252
+		// Test that a struct of pointer types with UnmarshalBSON functions defined marshal and
+		// unmarshal to the same Go values when the pointer values are "nil".
+		{
+			name:  "fields with UnmarshalBSON function should marshal and unmarshal to the same values",
+			sType: reflect.TypeOf(myStruct{}),
+			want:  &myStruct{},
+			data:  docToBytes(myStruct{}),
+		},
+		// GODRIVER-2252
+		// Test that a struct of pointer types with UnmarshalBSON functions defined marshal and
+		// unmarshal to the same Go values when the pointer values are the respective zero values.
+		{
+			name:  "TODO",
+			sType: reflect.TypeOf(myStruct{}),
+			want:  &zeroMyStruct,
+			data:  docToBytes(zeroMyStruct),
+		},
+		// GODRIVER-2252
+		// Test that a struct of pointer types with UnmarshalBSON functions defined marshal and
+		// unmarshal to the same Go values when the pointer values are non-zero values.
+		{
+			name:  "TODO",
+			sType: reflect.TypeOf(myStruct{}),
+			want:  &valMyStruct,
+			data:  docToBytes(valMyStruct),
+		},
+	}
+}()
+
+type myStruct struct {
+	I *myInt64
+	M *myMap
+	B *myBytes
+	S *myString
+}
+
+type myInt64 int64
+
+func (mi *myInt64) UnmarshalBSON(bytes []byte) error {
+	i, err := bsonrw.NewBSONValueReader(bsontype.Int64, bytes).ReadInt64()
+	if err != nil {
+		return err
+	}
+	*mi = myInt64(i)
+	return nil
+}
+
+type myMap map[string]string
+
+func (mm *myMap) UnmarshalBSON(bytes []byte) error {
+	var m map[string]string
+	err := Unmarshal(bytes, &m)
+	*mm = myMap(m)
+	return err
+}
+
+type myBytes []byte
+
+func (mb *myBytes) UnmarshalBSON(bytes []byte) error {
+	b, _, err := bsonrw.NewBSONValueReader(bsontype.Binary, bytes).ReadBinary()
+	if err != nil {
+		return err
+	}
+	*mb = b
+	return nil
+}
+
+type myString string
+
+func (ms *myString) UnmarshalBSON(bytes []byte) error {
+	s, err := bsonrw.NewBSONValueReader(bsontype.String, bytes).ReadString()
+	if err != nil {
+		return err
+	}
+	*ms = myString(s)
+	return nil
 }


### PR DESCRIPTION
[GODRIVER-2252](https://jira.mongodb.org/browse/GODRIVER-2252)

When unmarshaling BSON, If the target Go value is a pointer, has a custom `UnmarshalBSON` function, and the BSON field value is empty, set the Go value to the zero value of the pointer (`nil`) and don't call `UnmarshalBSON`. `UnmarshalBSON` has no way to change the pointer value from within the function (only the value at the pointer address), so it can't set the pointer to `nil` itself. Since the most common Go value for an empty BSON field value is `nil`, we set the Go value to `nil` and don't call `UnmarshalBSON`. This behavior matches the behavior of the Go `"encoding/json"` unmarshaler when the target Go value is a pointer, has a custom `UnmarshalJSON` function, and the JSON field value is `null`.

See this [StackOverflow post](https://stackoverflow.com/questions/34163625/in-go-why-is-json-null-sometimes-not-passed-to-unmarshaljson-for-decoding/34163626#34163626) for a discussion about the same behavior of the Go `"encoding/json"` unmarshaler.