### PR TITLE
GODRIVER-1827 Implement a pausable connection pool.

### DIFF
--- a/data/connection-monitoring-and-pooling/connection-must-have-id.json
+++ b/data/connection-monitoring-and-pooling/connection-must-have-id.json
@@ -4,6 +4,9 @@
   "description": "must have an ID number associated with it",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
     },
     {
@@ -42,6 +45,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionPoolClosed",
     "ConnectionReady"
   ]

--- a/data/connection-monitoring-and-pooling/connection-must-have-id.yml
+++ b/data/connection-monitoring-and-pooling/connection-must-have-id.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must have an ID number associated with it
 operations:
+  - name: ready
   - name: checkOut
   - name: checkOut
 events:
@@ -23,5 +24,6 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionPoolClosed
   - ConnectionReady

--- a/data/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
+++ b/data/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
@@ -2,8 +2,10 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy checked in connection if pool has been closed",
-  "skipReason" : "test requires that close does not aggressively close used connections",
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn"
@@ -40,6 +42,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/data/connection-monitoring-and-pooling/pool-checkin-destroy-closed.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkin-destroy-closed.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must destroy checked in connection if pool has been closed
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: close
@@ -22,6 +23,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
+++ b/data/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
@@ -4,6 +4,9 @@
   "description": "must destroy checked in connection if it is stale",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -39,6 +42,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/data/connection-monitoring-and-pooling/pool-checkin-destroy-stale.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkin-destroy-stale.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must destroy checked in connection if it is stale
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: clear
@@ -22,6 +23,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-checkin-make-available.json
+++ b/data/connection-monitoring-and-pooling/pool-checkin-make-available.json
@@ -4,6 +4,9 @@
   "description": "must make valid checked in connection available",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -34,6 +37,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/data/connection-monitoring-and-pooling/pool-checkin-make-available.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkin-make-available.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must make valid checked in connection available
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -19,6 +20,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-checkin.json
+++ b/data/connection-monitoring-and-pooling/pool-checkin.json
@@ -4,6 +4,9 @@
   "description": "must have a method of allowing the driver to check in a connection",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -21,6 +24,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",

--- a/data/connection-monitoring-and-pooling/pool-checkin.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkin.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must have a method of allowing the driver to check in a connection
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -12,6 +13,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed

--- a/data/connection-monitoring-and-pooling/pool-checkout-connection.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-connection.json
@@ -4,6 +4,9 @@
   "description": "must be able to check out a connection",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
     }
   ],
@@ -29,6 +32,7 @@
     }
   ],
   "ignore": [
+    "ConnectionPoolReady",
     "ConnectionPoolCreated"
   ]
 }

--- a/data/connection-monitoring-and-pooling/pool-checkout-connection.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-connection.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must be able to check out a connection
 operations:
+  - name: ready
   - name: checkOut
 events:
   - type: ConnectionCheckOutStarted
@@ -16,4 +17,5 @@ events:
     connectionId: 1
     address: 42
 ignore:
+  - ConnectionPoolReady
   - ConnectionPoolCreated

--- a/data/connection-monitoring-and-pooling/pool-checkout-error-closed.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-error-closed.json
@@ -4,6 +4,9 @@
   "description": "must throw error if checkOut is called on a closed pool",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn1"
     },
@@ -57,6 +60,7 @@
     }
   ],
   "ignore": [
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed"

--- a/data/connection-monitoring-and-pooling/pool-checkout-error-closed.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-error-closed.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must throw error if checkOut is called on a closed pool
 operations:
+  - name: ready
   - name: checkOut
     label: conn1
   - name: checkIn
@@ -31,6 +32,7 @@ events:
     address: 42
     reason: poolClosed
 ignore:
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed

--- a/data/connection-monitoring-and-pooling/pool-checkout-multiple.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-multiple.json
@@ -4,6 +4,9 @@
   "description": "must be able to check out multiple connections at the same time",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "start",
       "target": "thread1"
     },
@@ -59,6 +62,7 @@
   ],
   "ignore": [
     "ConnectionCreated",
+    "ConnectionPoolReady",
     "ConnectionReady",
     "ConnectionPoolCreated",
     "ConnectionCheckOutStarted"

--- a/data/connection-monitoring-and-pooling/pool-checkout-multiple.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-multiple.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must be able to check out multiple connections at the same time
 operations:
+  - name: ready
   - name: start
     target: thread1
   - name: start
@@ -32,6 +33,7 @@ events:
     address: 42
 ignore:
   - ConnectionCreated
+  - ConnectionPoolReady
   - ConnectionReady
   - ConnectionPoolCreated
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-checkout-no-idle.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-no-idle.json
@@ -3,9 +3,13 @@
   "style": "unit",
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
-    "maxIdleTimeMS": 10
+    "maxIdleTimeMS": 10,
+    "backgroundThreadIntervalMS": -1
   },
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn"
@@ -20,6 +24,11 @@
     },
     {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [
@@ -52,6 +61,7 @@
   ],
   "ignore": [
     "ConnectionReady",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionCheckOutStarted"
   ]

--- a/data/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
@@ -3,7 +3,9 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
+  backgroundThreadIntervalMS: -1
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -11,6 +13,9 @@ operations:
   - name: wait
     ms: 50
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42
@@ -31,5 +36,6 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-checkout-no-stale.json
+++ b/data/connection-monitoring-and-pooling/pool-checkout-no-stale.json
@@ -2,7 +2,13 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
+  "poolOptions": {
+    "backgroundThreadIntervalMS": -1
+  },
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn"
@@ -15,7 +21,15 @@
       "name": "clear"
     },
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [
@@ -52,6 +66,7 @@
   ],
   "ignore": [
     "ConnectionReady",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionCheckOutStarted"
   ]

--- a/data/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
+++ b/data/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
@@ -1,13 +1,20 @@
 version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
+poolOptions:
+  backgroundThreadIntervalMS: -1
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
     connection: conn
   - name: clear
+  - name: ready
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42
@@ -29,5 +36,6 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.json
+++ b/data/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "clearing pool clears the WaitQueue",
+  "poolOptions": {
+    "maxPoolSize": 1,
+    "waitQueueTimeoutMS": 30000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 3,
+      "timeout": 1000
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolReady",
+    "ConnectionPoolCleared",
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionCheckedIn",
+    "ConnectionClosed"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.yml
+++ b/data/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.yml
@@ -1,0 +1,63 @@
+version: 1
+style: unit
+description: clearing pool clears the WaitQueue
+poolOptions:
+  maxPoolSize: 1
+  waitQueueTimeoutMS: 30000
+operations:
+  - name: ready
+  # check out only connection in the pool
+  - name: checkOut
+  # start a few threads that all will enter
+  # the wait queue
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: start
+    target: thread2
+  - name: checkOut
+    thread: thread2
+  - name: start
+    target: thread3 
+  - name: checkOut
+    thread: thread3
+  # wait for the 3 threads to start checking out a connection
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
+    count: 4
+  # clear the pool, ejecting the previous three threads
+  # from the WaitQueue
+  - name: clear
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 3
+    timeout: 1000
+events:
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+ignore:
+  - ConnectionPoolReady
+  - ConnectionPoolCleared
+  - ConnectionPoolCreated
+  - ConnectionCreated
+  - ConnectionReady
+  - ConnectionCheckedIn
+  - ConnectionClosed

--- a/data/connection-monitoring-and-pooling/pool-clear-min-size.json
+++ b/data/connection-monitoring-and-pooling/pool-clear-min-size.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "pool clear halts background minPoolSize establishments",
+  "poolOptions": {
+    "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 1
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "wait",
+      "ms": 200
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 2
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionClosed"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-clear-min-size.yml
+++ b/data/connection-monitoring-and-pooling/pool-clear-min-size.yml
@@ -1,0 +1,37 @@
+version: 1
+style: unit
+description: pool clear halts background minPoolSize establishments
+poolOptions:
+  minPoolSize: 1
+  backgroundThreadIntervalMS: 50
+operations:
+  - name: ready
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 1
+  - name: clear
+  # ensure no connections created after clear
+  - name: wait
+    ms: 200
+  - name: ready
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 2
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionReady
+    address: 42
+ignore:
+  - ConnectionPoolCreated
+  - ConnectionClosed

--- a/data/connection-monitoring-and-pooling/pool-clear-paused.json
+++ b/data/connection-monitoring-and-pooling/pool-clear-paused.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "clearing a paused pool emits no events",
+  "operations": [
+    {
+      "name": "clear"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "clear"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-clear-paused.yml
+++ b/data/connection-monitoring-and-pooling/pool-clear-paused.yml
@@ -1,0 +1,15 @@
+version: 1
+style: unit
+description: clearing a paused pool emits no events
+operations:
+  - name: clear
+  - name: ready
+  - name: clear
+  - name: clear
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+ignore:
+  - ConnectionPoolCreated

--- a/data/connection-monitoring-and-pooling/pool-clear-ready.json
+++ b/data/connection-monitoring-and-pooling/pool-clear-ready.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "after clear, cannot check out connections until pool ready",
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42,
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "address": 42,
+      "reason": "connectionError"
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted",
+    "ConnectionCreated"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-clear-ready.yml
+++ b/data/connection-monitoring-and-pooling/pool-clear-ready.yml
@@ -1,0 +1,36 @@
+version: 1
+style: unit
+description: after clear, cannot check out connections until pool ready
+operations:
+  - name: ready
+  - name: checkOut
+  - name: clear
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  - name: ready
+  - name: checkOut
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+    connectionId: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionCheckOutFailed
+    address: 42
+    reason: connectionError
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+ignore:
+  - ConnectionPoolCreated
+  - ConnectionReady
+  - ConnectionCheckOutStarted
+  - ConnectionCreated

--- a/data/connection-monitoring-and-pooling/pool-close-destroy-conns.json
+++ b/data/connection-monitoring-and-pooling/pool-close-destroy-conns.json
@@ -2,8 +2,10 @@
   "version": 1,
   "style": "unit",
   "description": "When a pool is closed, it MUST first destroy all available connections in that pool",
-  "skipReason" : "test requires that close does not aggressively close used connections",
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut"
     },
@@ -41,6 +43,7 @@
   ],
   "ignore": [
     "ConnectionCreated",
+    "ConnectionPoolReady",
     "ConnectionReady",
     "ConnectionPoolCreated",
     "ConnectionCheckOutStarted",

--- a/data/connection-monitoring-and-pooling/pool-close-destroy-conns.yml
+++ b/data/connection-monitoring-and-pooling/pool-close-destroy-conns.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: When a pool is closed, it MUST first destroy all available connections in that pool
 operations:
+  - name: ready
   - name: checkOut
   - name: checkOut
     label: conn
@@ -21,6 +22,7 @@ events:
     address: 42
 ignore:
   - ConnectionCreated
+  - ConnectionPoolReady
   - ConnectionReady
   - ConnectionPoolCreated
   - ConnectionCheckOutStarted

--- a/data/connection-monitoring-and-pooling/pool-create-max-size.json
+++ b/data/connection-monitoring-and-pooling/pool-create-max-size.json
@@ -7,6 +7,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn1"
     },
@@ -124,6 +127,7 @@
     }
   ],
   "ignore": [
-    "ConnectionReady"
+    "ConnectionReady",
+    "ConnectionPoolReady"
   ]
 }

--- a/data/connection-monitoring-and-pooling/pool-create-max-size.yml
+++ b/data/connection-monitoring-and-pooling/pool-create-max-size.yml
@@ -4,6 +4,7 @@ description: must never exceed maxPoolSize total connections
 poolOptions:
   maxPoolSize: 3
 operations:
+  - name: ready
   - name: checkOut
     label: conn1
   - name: checkOut
@@ -69,3 +70,4 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady

--- a/data/connection-monitoring-and-pooling/pool-create-min-size.json
+++ b/data/connection-monitoring-and-pooling/pool-create-min-size.json
@@ -7,6 +7,13 @@
   },
   "operations": [
     {
+      "name": "wait",
+      "ms": 200
+    },
+    {
+      "name": "ready"
+    },
+    {
       "name": "waitForEvent",
       "event": "ConnectionCreated",
       "count": 3
@@ -25,6 +32,10 @@
       "type": "ConnectionPoolCreated",
       "address": 42,
       "options": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",

--- a/data/connection-monitoring-and-pooling/pool-create-min-size.yml
+++ b/data/connection-monitoring-and-pooling/pool-create-min-size.yml
@@ -4,6 +4,10 @@ description: must be able to start a pool with minPoolSize connections
 poolOptions:
   minPoolSize: 3
 operations:
+  # ensure no connections are created until this pool is ready
+  - name: wait
+    ms: 200
+  - name: ready
   - name: waitForEvent
     event: ConnectionCreated
     count: 3
@@ -15,6 +19,8 @@ events:
   - type: ConnectionPoolCreated
     address: 42
     options: 42
+  - type: ConnectionPoolReady
+    address: 42
   - type: ConnectionCreated
     connectionId: 42
     address: 42

--- a/data/connection-monitoring-and-pooling/pool-ready-ready.json
+++ b/data/connection-monitoring-and-pooling/pool-ready-ready.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "readying a ready pool emits no events",
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "ready"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated"
+  ]
+}

--- a/data/connection-monitoring-and-pooling/pool-ready-ready.yml
+++ b/data/connection-monitoring-and-pooling/pool-ready-ready.yml
@@ -1,0 +1,19 @@
+version: 1
+style: unit
+description: readying a ready pool emits no events
+operations:
+  - name: ready
+  - name: ready
+  - name: ready
+  # the first ready after this clear should emit an event
+  - name: clear
+  - name: ready
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionPoolReady
+    address: 42
+ignore:
+  - ConnectionPoolCreated

--- a/data/connection-monitoring-and-pooling/pool-ready.json
+++ b/data/connection-monitoring-and-pooling/pool-ready.json
@@ -1,13 +1,23 @@
 {
   "version": 1,
   "style": "unit",
-  "description": "must have IDs assigned in order of creation",
+  "description": "pool starts as cleared and becomes ready",
   "operations": [
     {
-      "name": "ready"
+      "name": "start",
+      "target": "thread1"
     },
     {
-      "name": "checkOut"
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "ready"
     },
     {
       "name": "checkOut"
@@ -19,13 +29,12 @@
       "address": 42
     },
     {
-      "type": "ConnectionCreated",
-      "connectionId": 1,
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
       "address": 42
     },
     {
-      "type": "ConnectionCheckedOut",
-      "connectionId": 1,
+      "type": "ConnectionPoolReady",
       "address": 42
     },
     {
@@ -34,19 +43,15 @@
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 2,
       "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2,
       "address": 42
     }
   ],
   "ignore": [
     "ConnectionPoolCreated",
-    "ConnectionPoolReady",
-    "ConnectionPoolClosed",
     "ConnectionReady"
   ]
 }

--- a/data/connection-monitoring-and-pooling/pool-ready.yml
+++ b/data/connection-monitoring-and-pooling/pool-ready.yml
@@ -1,29 +1,30 @@
 version: 1
 style: unit
-description: must have IDs assigned in order of creation
+description: pool starts as cleared and becomes ready
 operations:
-  - name: ready
+  - name: start
+    target: thread1
   - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  - name: ready
   - name: checkOut
 events:
   - type: ConnectionCheckOutStarted
     address: 42
-  - type: ConnectionCreated
-    connectionId: 1
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
     address: 42
-  - type: ConnectionCheckedOut
-    connectionId: 1
+  - type: ConnectionPoolReady
     address: 42
   - type: ConnectionCheckOutStarted
     address: 42
   - type: ConnectionCreated
-    connectionId: 2
     address: 42
   - type: ConnectionCheckedOut
-    connectionId: 2
     address: 42
 ignore:
   - ConnectionPoolCreated
-  - ConnectionPoolReady
-  - ConnectionPoolClosed
   - ConnectionReady

--- a/data/connection-monitoring-and-pooling/wait-queue-fairness.json
+++ b/data/connection-monitoring-and-pooling/wait-queue-fairness.json
@@ -8,6 +8,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn0"
     },
@@ -187,6 +190,7 @@
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",
+    "ConnectionPoolReady",
     "ConnectionPoolCreated"
   ]
 }

--- a/data/connection-monitoring-and-pooling/wait-queue-fairness.yml
+++ b/data/connection-monitoring-and-pooling/wait-queue-fairness.yml
@@ -5,6 +5,7 @@ poolOptions:
   maxPoolSize: 1
   waitQueueTimeoutMS: 5000
 operations:
+  - name: ready
     # Check out sole connection in pool
   - name: checkOut
     label: conn0
@@ -121,4 +122,5 @@ ignore:
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed
+  - ConnectionPoolReady
   - ConnectionPoolCreated

--- a/data/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/data/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -8,6 +8,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn0"
     },
@@ -66,6 +69,7 @@
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",
-    "ConnectionPoolCreated"
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
   ]
 }

--- a/data/connection-monitoring-and-pooling/wait-queue-timeout.yml
+++ b/data/connection-monitoring-and-pooling/wait-queue-timeout.yml
@@ -5,6 +5,7 @@ poolOptions:
   maxPoolSize: 1
   waitQueueTimeoutMS: 50
 operations:
+  - name: ready
   # Check out only possible connection
   - name: checkOut
     label: conn0
@@ -44,3 +45,4 @@ ignore:
   - ConnectionReady
   - ConnectionClosed
   - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -74,15 +74,16 @@ const (
 
 // strings for pool command monitoring types
 const (
-	ConnectionClosed   = "ConnectionClosed"
 	PoolCreated        = "ConnectionPoolCreated"
+	PoolReady          = "ConnectionPoolReady"
+	PoolCleared        = "ConnectionPoolCleared"
+	PoolClosedEvent    = "ConnectionPoolClosed"
 	ConnectionCreated  = "ConnectionCreated"
 	ConnectionReady    = "ConnectionReady"
+	ConnectionClosed   = "ConnectionClosed"
 	GetFailed          = "ConnectionCheckOutFailed"
 	GetSucceeded       = "ConnectionCheckedOut"
 	ConnectionReturned = "ConnectionCheckedIn"
-	PoolCleared        = "ConnectionPoolCleared"
-	PoolClosedEvent    = "ConnectionPoolClosed"
 )
 
 // MonitorPoolOptions contains pool options as formatted in pool events

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -81,6 +81,7 @@ const (
 	ConnectionCreated  = "ConnectionCreated"
 	ConnectionReady    = "ConnectionReady"
 	ConnectionClosed   = "ConnectionClosed"
+	GetStarted         = "ConnectionCheckOutStarted"
 	GetFailed          = "ConnectionCheckOutFailed"
 	GetSucceeded       = "ConnectionCheckedOut"
 	ConnectionReturned = "ConnectionCheckedIn"

--- a/mongo/integration/unified/event.go
+++ b/mongo/integration/unified/event.go
@@ -14,10 +14,6 @@ import (
 
 type monitoringEventType string
 
-// monitoringEventTypes poolReadyEvent and connectionCheckOutStartedEvent are included
-// to support logging in the atlas planned maintenance executor, which stores events
-// without making assertions on them. The matching published event types will be
-// created in GODRIVER-1827
 const (
 	commandStartedEvent            monitoringEventType = "CommandStartedEvent"
 	commandSucceededEvent          monitoringEventType = "CommandSucceededEvent"
@@ -71,10 +67,11 @@ func monitoringEventTypeFromString(eventStr string) (monitoringEventType, bool) 
 }
 
 func monitoringEventTypeFromPoolEvent(evt *event.PoolEvent) monitoringEventType {
-	// TODO GODRIVER-1827: add storePoolReady and storeConnectionCheckOutStarted events
 	switch evt.Type {
 	case event.PoolCreated:
 		return poolCreatedEvent
+	case event.PoolReady:
+		return poolReadyEvent
 	case event.PoolCleared:
 		return poolClearedEvent
 	case event.PoolClosedEvent:
@@ -85,6 +82,8 @@ func monitoringEventTypeFromPoolEvent(evt *event.PoolEvent) monitoringEventType 
 		return connectionReadyEvent
 	case event.ConnectionClosed:
 		return connectionClosedEvent
+	case event.GetStarted:
+		return connectionCheckOutStartedEvent
 	case event.GetFailed:
 		return connectionCheckOutFailedEvent
 	case event.GetSucceeded:

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -54,7 +54,12 @@ type Connection interface {
 	WriteWireMessage(context.Context, []byte) error
 	ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error)
 	Description() description.Server
+
+	// Close closes any underlying connection and returns or frees any resources held by the
+	// connection. Close is idempotent and can be called multiple times, although subsequent calls
+	// to Close may return an error. A connection cannot be used after it is closed.
 	Close() error
+
 	ID() string
 	ServerConnectionID() *int32
 	Address() address.Address

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -18,10 +18,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/address"
 )
 
+// skippedTestDescriptions is a collection of test descriptions that the test runner will skip. The
+// map format is {"test description": "reason", }.
 var skippedTestDescriptions = map[string]string{
 	// GODRIVER-1827: These 2 tests assert that in-use connections are not closed until checked
-	// back into a closed pool, but the Go connection pool aggressively closes in-use
-	// connections. That behavior is currently required by the "Client.Disconnect" API.
+	// back into a closed pool, but the Go connection pool aggressively closes in-use connections.
+	// That behavior is currently required by the "Client.Disconnect" API, so skip the tests.
 	"When a pool is closed, it MUST first destroy all available connections in that pool": "test requires that close does not aggressively close used connections",
 	"must destroy checked in connection if pool has been closed":                          "test requires that close does not aggressively close used connections",
 }

--- a/x/mongo/driver/topology/cmap_prose_test.go
+++ b/x/mongo/driver/topology/cmap_prose_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
@@ -48,8 +49,17 @@ func TestCMAPProse(t *testing.T) {
 		assertConnectionCounts := func(t *testing.T, p *pool, numCreated, numClosed int) {
 			t.Helper()
 
-			assert.Equal(t, numCreated, len(created), "expected %d creation events, got %d", numCreated, len(created))
-			assert.Equal(t, numClosed, len(closed), "expected %d closed events, got %d", numClosed, len(closed))
+			require.Eventuallyf(t,
+				func() bool {
+					return numCreated == len(created) && numClosed == len(closed)
+				},
+				1*time.Second,
+				10*time.Millisecond,
+				"expected %d creation events, got %d; expected %d closed events, got %d",
+				numCreated,
+				len(created),
+				numClosed,
+				len(closed))
 
 			netCount := numCreated - numClosed
 			assert.Equal(t, netCount, p.totalConnectionCount(), "expected %d total connections, got %d", netCount,

--- a/x/mongo/driver/topology/connection_errors_test.go
+++ b/x/mongo/driver/topology/connection_errors_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build go1.13
 // +build go1.13
 
 package topology
@@ -29,8 +30,7 @@ func TestConnectionErrors(t *testing.T) {
 			}))
 			assert.Nil(t, err, "newConnection error: %v", err)
 
-			conn.connect(context.Background())
-			err = conn.wait()
+			err = conn.connect(context.Background())
 			assert.True(t, errors.Is(err, dialError), "expected error %v, got %v", dialError, err)
 		})
 		t.Run("handshake error", func(t *testing.T) {
@@ -49,9 +49,7 @@ func TestConnectionErrors(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			conn.connect(ctx)
-			err = conn.wait()
-
+			err = conn.connect(ctx)
 			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
 		})
 		t.Run("write error", func(t *testing.T) {

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -53,7 +53,6 @@ type connectionConfig struct {
 	zstdLevel                *int
 	ocspCache                ocsp.Cache
 	disableOCSPEndpointCheck bool
-	errorHandlingCallback    func(err error, startGenNum uint64, svcID *primitive.ObjectID)
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
@@ -86,13 +85,6 @@ type ConnectionOption func(*connectionConfig) error
 func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) ConnectionOption {
 	return func(c *connectionConfig) error {
 		c.tlsConnectionSource = fn(c.tlsConnectionSource)
-		return nil
-	}
-}
-
-func withErrorHandlingCallback(fn func(err error, startGenNum uint64, svcID *primitive.ObjectID)) ConnectionOption {
-	return func(c *connectionConfig) error {
-		c.errorHandlingCallback = fn
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -368,6 +368,13 @@ func (p *pool) unpinConnectionFromTransaction() {
 // ready, checkOut returns an error.
 // Based partially on https://cs.opensource.google/go/go/+/refs/tags/go1.16.6:src/net/http/transport.go;l=1324
 func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
+	if p.monitor != nil {
+		p.monitor.Event(&event.PoolEvent{
+			Type:    event.GetStarted,
+			Address: p.address.String(),
+		})
+	}
+
 	p.createConnectionsCond.L.Lock()
 	switch p.state {
 	case poolClosed:

--- a/x/mongo/driver/topology/pool_generation_counter.go
+++ b/x/mongo/driver/topology/pool_generation_counter.go
@@ -127,6 +127,17 @@ func (p *poolGenerationMap) getGeneration(serviceIDPtr *primitive.ObjectID) uint
 	return 0
 }
 
+func (p *poolGenerationMap) getNumConns(serviceIDPtr *primitive.ObjectID) uint64 {
+	serviceID := getServiceID(serviceIDPtr)
+	p.Lock()
+	defer p.Unlock()
+
+	if stats, ok := p.generationMap[serviceID]; ok {
+		return stats.numConns
+	}
+	return 0
+}
+
 func getServiceID(oid *primitive.ObjectID) primitive.ObjectID {
 	if oid == nil {
 		return primitive.NilObjectID

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,17 +17,13 @@ func TestPool(t *testing.T) {
 	t.Run("newPool", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("should be connected", func(t *testing.T) {
+		t.Run("should be paused", func(t *testing.T) {
 			t.Parallel()
 
 			p := newPool(poolConfig{})
-			err := p.connect()
-			noerr(t, err)
+			assert.Equalf(t, poolPaused, p.getState(), "expected new pool to be paused")
 
-			assert.Equalf(t, connected, p.connected, "expected new pool to be connected")
-
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 	})
 	t.Run("closeConnection", func(t *testing.T) {
@@ -47,45 +42,35 @@ func TestPool(t *testing.T) {
 			p1 := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p1.connect()
+			err := p1.ready()
 			noerr(t, err)
 
 			c, err := p1.checkOut(context.Background())
 			noerr(t, err)
 
 			p2 := newPool(poolConfig{})
-			err = p2.connect()
+			err = p2.ready()
 			noerr(t, err)
 
 			err = p2.closeConnection(c)
 			assert.Equalf(t, ErrWrongPool, err, "expected ErrWrongPool error")
 
-			err = p1.disconnect(context.Background())
-			noerr(t, err)
-			err = p2.disconnect(context.Background())
-			noerr(t, err)
+			p1.close(context.Background())
+			p2.close(context.Background())
 		})
 	})
-	t.Run("disconnect", func(t *testing.T) {
+	t.Run("close", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("cannot disconnect multiple times without connect", func(t *testing.T) {
+		t.Run("calling close multiple times does not panic", func(t *testing.T) {
 			t.Parallel()
 
 			p := newPool(poolConfig{})
-			err := p.connect()
-			noerr(t, err)
-
-			err = p.disconnect(context.Background())
+			err := p.ready()
 			noerr(t, err)
 
 			for i := 0; i < 5; i++ {
-				err = p.disconnect(context.Background())
-				assert.Equalf(
-					t,
-					ErrPoolDisconnected,
-					err,
-					"disconnecting an already disconnected pool should return ErrPoolDisconnected")
+				p.close(context.Background())
 			}
 		})
 		t.Run("closes idle connections", func(t *testing.T) {
@@ -102,7 +87,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			conns := make([]*connection, 3)
@@ -119,8 +104,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 3, p.availableConnectionCount(), "should have 3 available connections")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should have 3 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 			assertConnectionsClosed(t, d, 3)
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 available connections")
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 total connections")
@@ -139,7 +123,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			conns := make([]*connection, 3)
@@ -156,8 +140,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 2, p.availableConnectionCount(), "should have 2 available connections")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should have 3 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 			assertConnectionsClosed(t, d, 3)
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 available connections")
 			assert.Equalf(t, 0, p.totalConnectionCount(), "should have 0 total connections")
@@ -175,20 +158,20 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			_, err = p.checkOut(context.Background())
 			noerr(t, err)
 
-			disconnected := make(chan struct{})
+			closed := make(chan struct{})
 			started := make(chan struct{})
 			go func() {
 				close(started)
 
 				for {
 					select {
-					case <-disconnected:
+					case <-closed:
 						return
 					default:
 						c, _ := p.checkOut(context.Background())
@@ -198,16 +181,15 @@ func TestPool(t *testing.T) {
 				}
 			}()
 
-			// Wait for the background goroutine to start running before trying to disconnect the
+			// Wait for the background goroutine to start running before trying to close the
 			// connection pool.
 			<-started
 			_, err = p.checkOut(context.Background())
 			noerr(t, err)
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 
-			close(disconnected)
+			close(closed)
 		})
 		t.Run("shuts down gracefully if Context has a deadline", func(t *testing.T) {
 			t.Parallel()
@@ -222,7 +204,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// Check out 2 connections from the pool and add them to a conns slice.
@@ -242,11 +224,11 @@ func TestPool(t *testing.T) {
 			err = p.checkIn(c)
 			noerr(t, err)
 
-			// Start a goroutine that waits for the pool to start disconnecting, then checks in the
+			// Start a goroutine that waits for the pool to start closing, then checks in the
 			// 2 in-use connections. Assert that both connections are still connected during
 			// graceful shutdown before they are checked in.
 			go func() {
-				for atomic.LoadInt64(&p.connected) == connected {
+				for p.getState() == poolReady {
 					time.Sleep(time.Millisecond)
 				}
 				for _, c := range conns {
@@ -257,15 +239,14 @@ func TestPool(t *testing.T) {
 				}
 			}()
 
-			// Disconnect the pool with a 1-hour graceful shutdown timeout. Expect that the call to
-			// disconnect() returns when all of the connections are checked in. If disconnect()
-			// doesn't return when all of the connections are checked in, the test will time out.
+			// Close the pool with a 1-hour graceful shutdown timeout. Expect that the call to
+			// close() returns when all of the connections are checked in. If close() doesn't return
+			// when all of the connections are checked in, the test will time out.
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
 			defer cancel()
-			err = p.disconnect(ctx)
-			noerr(t, err)
+			p.close(ctx)
 		})
-		t.Run("closing a Connection does not cause an error after pool is disconnected", func(t *testing.T) {
+		t.Run("closing a Connection does not cause an error after pool is closed", func(t *testing.T) {
 			t.Parallel()
 
 			cleanup := make(chan struct{})
@@ -278,24 +259,23 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			c, err := p.checkOut(context.Background())
 			noerr(t, err)
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 
 			c1 := &Connection{connection: c}
 			err = c1.Close()
 			noerr(t, err)
 		})
 	})
-	t.Run("connect", func(t *testing.T) {
+	t.Run("ready", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("can reconnect a disconnected pool", func(t *testing.T) {
+		t.Run("can ready a paused pool", func(t *testing.T) {
 			t.Parallel()
 
 			cleanup := make(chan struct{})
@@ -308,22 +288,27 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
-			for i := 0; i < 3; i++ {
-				_, err := p.checkOut(context.Background())
+			conns := make([]*connection, 3)
+			for i := range conns {
+				conn, err := p.checkOut(context.Background())
 				noerr(t, err)
+				conns[i] = conn
 			}
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 available connections")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should have 3 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.clear(nil, nil)
+			for _, conn := range conns {
+				err = p.checkIn(conn)
+				noerr(t, err)
+			}
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 available connections")
 			assert.Equalf(t, 0, p.totalConnectionCount(), "should have 0 total connections")
 
-			err = p.connect()
+			err = p.ready()
 			noerr(t, err)
 
 			for i := 0; i < 3; i++ {
@@ -333,40 +318,109 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 available connections")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should have 3 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
-		t.Run("cannot connect multiple times without disconnect", func(t *testing.T) {
+		t.Run("calling ready multiple times does not return an error", func(t *testing.T) {
 			t.Parallel()
 
 			p := newPool(poolConfig{})
-			err := p.connect()
-			noerr(t, err)
-
 			for i := 0; i < 5; i++ {
-				err := p.connect()
-				assert.Equalf(
-					t,
-					ErrPoolConnected,
-					err,
-					"connecting an already connected pool should return ErrPoolConnected")
+				err := p.ready()
+				noerr(t, err)
 			}
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
-		t.Run("can disconnect and reconnect multiple times", func(t *testing.T) {
+		t.Run("can clear and ready multiple times", func(t *testing.T) {
 			t.Parallel()
 
-			p := newPool(poolConfig{})
+			cleanup := make(chan struct{})
+			defer close(cleanup)
+			addr := bootstrapConnections(t, 2, func(nc net.Conn) {
+				<-cleanup
+				_ = nc.Close()
+			})
+
+			p := newPool(poolConfig{
+				Address: address.Address(addr.String()),
+			})
+			err := p.ready()
+			noerr(t, err)
+
+			c, err := p.checkOut(context.Background())
+			noerr(t, err)
+			err = p.checkIn(c)
+			noerr(t, err)
+
 			for i := 0; i < 100; i++ {
-				err := p.connect()
+				err = p.ready()
 				noerr(t, err)
 
-				err = p.disconnect(context.Background())
-				noerr(t, err)
+				p.clear(nil, nil)
 			}
+
+			err = p.ready()
+			noerr(t, err)
+
+			c, err = p.checkOut(context.Background())
+			noerr(t, err)
+			err = p.checkIn(c)
+			noerr(t, err)
+
+			p.close(context.Background())
 		})
+		// t.Run("can clear and ready multiple times concurrently", func(t *testing.T) {
+		// 	t.Parallel()
+
+		// 	cleanup := make(chan struct{})
+		// 	defer close(cleanup)
+		// 	addr := bootstrapConnections(t, 2, func(nc net.Conn) {
+		// 		<-cleanup
+		// 		_ = nc.Close()
+		// 	})
+
+		// 	p := newPool(poolConfig{
+		// 		Address: address.Address(addr.String()),
+		// 	})
+		// 	err := p.ready()
+		// 	noerr(t, err)
+
+		// 	c, err := p.checkOut(context.Background())
+		// 	noerr(t, err)
+		// 	err = p.checkIn(c)
+		// 	noerr(t, err)
+
+		// 	var wg sync.WaitGroup
+		// 	for i := 0; i < 10; i++ {
+		// 		wg.Add(1)
+		// 		go func() {
+		// 			defer wg.Done()
+		// 			for i := 0; i < 1000; i++ {
+		// 				err := p.ready()
+		// 				noerr(t, err)
+		// 			}
+		// 		}()
+
+		// 		wg.Add(1)
+		// 		go func() {
+		// 			defer wg.Done()
+		// 			for i := 0; i < 1000; i++ {
+		// 				p.clear(nil)
+		// 			}
+		// 		}()
+		// 	}
+
+		// 	wg.Wait()
+		// 	err = p.ready()
+		// 	noerr(t, err)
+
+		// 	c, err = p.checkOut(context.Background())
+		// 	noerr(t, err)
+		// 	err = p.checkIn(c)
+		// 	noerr(t, err)
+
+		// 	p.close(context.Background())
+		// })
 	})
 	t.Run("checkOut", func(t *testing.T) {
 		t.Parallel()
@@ -380,7 +434,7 @@ func TestPool(t *testing.T) {
 					return nil, dialErr
 				})
 			}))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			_, err = p.checkOut(context.Background())
@@ -388,8 +442,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, want, err, "should return error from calling checkOut()")
 			assert.Equalf(t, 0, p.totalConnectionCount(), "pool should have 0 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("closes perished connections", func(t *testing.T) {
 			t.Parallel()
@@ -409,7 +462,7 @@ func TestPool(t *testing.T) {
 				},
 				WithDialer(func(Dialer) Dialer { return d }),
 			)
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// Check out a connection and assert that the idle timeout is properly set then check it
@@ -433,8 +486,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 2, d.lenopened(), "should have opened 2 connections")
 			assert.Equalf(t, 1, p.totalConnectionCount(), "pool should have 1 total connection")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("recycles connections", func(t *testing.T) {
 			t.Parallel()
@@ -450,7 +502,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			for i := 0; i < 100; i++ {
@@ -461,8 +513,10 @@ func TestPool(t *testing.T) {
 				noerr(t, err)
 			}
 			assert.Equalf(t, 1, d.lenopened(), "should have opened 1 connection")
+
+			p.close(context.Background())
 		})
-		t.Run("cannot checkOut from disconnected pool", func(t *testing.T) {
+		t.Run("cannot checkOut from closed pool", func(t *testing.T) {
 			t.Parallel()
 
 			cleanup := make(chan struct{})
@@ -475,18 +529,17 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 
 			_, err = p.checkOut(context.Background())
 			assert.Equalf(
 				t,
-				ErrPoolDisconnected,
+				ErrPoolClosed,
 				err,
-				"expected an error from checkOut() from a disconnected pool")
+				"expected an error from checkOut() from a closed pool")
 		})
 		t.Run("handshaker i/o fails", func(t *testing.T) {
 			t.Parallel()
@@ -502,7 +555,7 @@ func TestPool(t *testing.T) {
 					})
 				}),
 			)
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			_, err = p.checkOut(context.Background())
@@ -516,8 +569,7 @@ func TestPool(t *testing.T) {
 			}
 			assert.Equalf(t, 0, p.totalConnectionCount(), "pool should have 0 total connections")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		// Test that if a checkOut() times out, it returns a WaitQueueTimeout error that wraps a
 		// context.DeadlineExceeded error.
@@ -535,7 +587,7 @@ func TestPool(t *testing.T) {
 				Address:     address.Address(addr.String()),
 				MaxPoolSize: 1,
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// check out first connection.
@@ -554,8 +606,7 @@ func TestPool(t *testing.T) {
 				assert.Equalf(t, context.DeadlineExceeded, err.Unwrap(), "expected wrapped error to be a context.Timeout")
 			}
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		// Test that an indefinitely blocked checkOut() doesn't cause the wait queue to overflow
 		// if there are many other checkOut() calls that time out. This tests a scenario where a
@@ -575,7 +626,7 @@ func TestPool(t *testing.T) {
 				Address:     address.Address(addr.String()),
 				MaxPoolSize: 1,
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// Check out the 1 connection that the pool will create.
@@ -609,6 +660,8 @@ func TestPool(t *testing.T) {
 			err = p.checkIn(c)
 			noerr(t, err)
 			wg.Wait()
+
+			p.close(context.Background())
 		})
 		// Test that checkOut() on a full connection pool creates and returns a new connection
 		// immediately as soon as the pool is no longer full.
@@ -630,7 +683,7 @@ func TestPool(t *testing.T) {
 				},
 				WithDialer(func(Dialer) Dialer { return d }),
 			)
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// Check out two connections (MaxPoolSize) so that subsequent checkOut() calls should
@@ -679,8 +732,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 2, p.totalConnectionCount(), "pool should have 2 total connection")
 			assert.Equalf(t, 0, p.availableConnectionCount(), "pool should have 0 idle connection")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 	})
 	t.Run("checkIn", func(t *testing.T) {
@@ -699,7 +751,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			c, err := p.checkOut(context.Background())
@@ -716,8 +768,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 1, p.availableConnectionCount(), "should have returned 1 idle connection to the pool")
 			assert.Equalf(t, 1, p.totalConnectionCount(), "should have 1 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("closes connections if the pool is closed", func(t *testing.T) {
 			t.Parallel()
@@ -733,7 +784,7 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			c, err := p.checkOut(context.Background())
@@ -742,8 +793,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 idle connections in pool")
 			assert.Equalf(t, 1, p.totalConnectionCount(), "should have 1 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 
 			err = p.checkIn(c)
 			noerr(t, err)
@@ -764,29 +814,27 @@ func TestPool(t *testing.T) {
 			p1 := newPool(poolConfig{
 				Address: address.Address(addr.String()),
 			})
-			err := p1.connect()
+			err := p1.ready()
 			noerr(t, err)
 
 			c, err := p1.checkOut(context.Background())
 			noerr(t, err)
 
 			p2 := newPool(poolConfig{})
-			err = p2.connect()
+			err = p2.ready()
 			noerr(t, err)
 
 			err = p2.checkIn(c)
 			assert.Equalf(t, ErrWrongPool, err, "expected ErrWrongPool error")
 
-			err = p1.disconnect(context.Background())
-			noerr(t, err)
-			err = p2.disconnect(context.Background())
-			noerr(t, err)
+			p1.close(context.Background())
+			p2.close(context.Background())
 		})
 	})
 	t.Run("maintain", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("creates MinPoolSize connections shortly after calling connect()", func(t *testing.T) {
+		t.Run("creates MinPoolSize connections shortly after calling ready", func(t *testing.T) {
 			t.Parallel()
 
 			cleanup := make(chan struct{})
@@ -801,15 +849,14 @@ func TestPool(t *testing.T) {
 				Address:     address.Address(addr.String()),
 				MinPoolSize: 3,
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			assertConnectionsOpened(t, d, 3)
 			assert.Equalf(t, 3, p.availableConnectionCount(), "should be 3 idle connections in pool")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should be 3 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("when MinPoolSize > MaxPoolSize should not exceed MaxPoolSize connections", func(t *testing.T) {
 			t.Parallel()
@@ -827,15 +874,14 @@ func TestPool(t *testing.T) {
 				MinPoolSize: 20,
 				MaxPoolSize: 2,
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			assertConnectionsOpened(t, d, 2)
 			assert.Equalf(t, 2, p.availableConnectionCount(), "should be 2 idle connections in pool")
 			assert.Equalf(t, 2, p.totalConnectionCount(), "should be 2 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("removes perished connections", func(t *testing.T) {
 			t.Parallel()
@@ -850,10 +896,10 @@ func TestPool(t *testing.T) {
 			d := newdialer(&net.Dialer{})
 			p := newPool(poolConfig{
 				Address: address.Address(addr.String()),
+				// Set the pool's maintain interval to 10ms so that it allows the test to run quickly.
+				MaintainInterval: 10 * time.Millisecond,
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			// Set the pool's maintain interval to 10ms so that it allows the test to run quickly.
-			p.maintainInterval = 10 * time.Millisecond
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 
 			// Check out and check in 3 connections. Assert that there are 3 total and 3 idle
@@ -884,8 +930,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 1, p.availableConnectionCount(), "should be 1 idle connections in pool")
 			assert.Equalf(t, 1, p.totalConnectionCount(), "should be 1 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 		t.Run("removes perished connections and replaces them to maintain MinPoolSize", func(t *testing.T) {
 			t.Parallel()
@@ -901,10 +946,10 @@ func TestPool(t *testing.T) {
 			p := newPool(poolConfig{
 				Address:     address.Address(addr.String()),
 				MinPoolSize: 3,
+				// Set the pool's maintain interval to 10ms so that it allows the test to run quickly.
+				MaintainInterval: 10 * time.Millisecond,
 			}, WithDialer(func(Dialer) Dialer { return d }))
-			// Set the pool's maintain interval to 10ms so that it allows the test to run quickly.
-			p.maintainInterval = 10 * time.Millisecond
-			err := p.connect()
+			err := p.ready()
 			noerr(t, err)
 			assertConnectionsOpened(t, d, 3)
 			assert.Equalf(t, 3, p.availableConnectionCount(), "should be 3 idle connections in pool")
@@ -921,8 +966,7 @@ func TestPool(t *testing.T) {
 			assert.Equalf(t, 3, p.availableConnectionCount(), "should be 3 idle connections in pool")
 			assert.Equalf(t, 3, p.totalConnectionCount(), "should be 3 total connection in pool")
 
-			err = p.disconnect(context.Background())
-			noerr(t, err)
+			p.close(context.Background())
 		})
 	})
 }

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -369,58 +369,58 @@ func TestPool(t *testing.T) {
 
 			p.close(context.Background())
 		})
-		// t.Run("can clear and ready multiple times concurrently", func(t *testing.T) {
-		// 	t.Parallel()
+		t.Run("can clear and ready multiple times concurrently", func(t *testing.T) {
+			t.Parallel()
 
-		// 	cleanup := make(chan struct{})
-		// 	defer close(cleanup)
-		// 	addr := bootstrapConnections(t, 2, func(nc net.Conn) {
-		// 		<-cleanup
-		// 		_ = nc.Close()
-		// 	})
+			cleanup := make(chan struct{})
+			defer close(cleanup)
+			addr := bootstrapConnections(t, 2, func(nc net.Conn) {
+				<-cleanup
+				_ = nc.Close()
+			})
 
-		// 	p := newPool(poolConfig{
-		// 		Address: address.Address(addr.String()),
-		// 	})
-		// 	err := p.ready()
-		// 	noerr(t, err)
+			p := newPool(poolConfig{
+				Address: address.Address(addr.String()),
+			})
+			err := p.ready()
+			noerr(t, err)
 
-		// 	c, err := p.checkOut(context.Background())
-		// 	noerr(t, err)
-		// 	err = p.checkIn(c)
-		// 	noerr(t, err)
+			c, err := p.checkOut(context.Background())
+			noerr(t, err)
+			err = p.checkIn(c)
+			noerr(t, err)
 
-		// 	var wg sync.WaitGroup
-		// 	for i := 0; i < 10; i++ {
-		// 		wg.Add(1)
-		// 		go func() {
-		// 			defer wg.Done()
-		// 			for i := 0; i < 1000; i++ {
-		// 				err := p.ready()
-		// 				noerr(t, err)
-		// 			}
-		// 		}()
+			var wg sync.WaitGroup
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for i := 0; i < 1000; i++ {
+						err := p.ready()
+						noerr(t, err)
+					}
+				}()
 
-		// 		wg.Add(1)
-		// 		go func() {
-		// 			defer wg.Done()
-		// 			for i := 0; i < 1000; i++ {
-		// 				p.clear(nil)
-		// 			}
-		// 		}()
-		// 	}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for i := 0; i < 1000; i++ {
+						p.clear(errors.New("test error"), nil)
+					}
+				}()
+			}
 
-		// 	wg.Wait()
-		// 	err = p.ready()
-		// 	noerr(t, err)
+			wg.Wait()
+			err = p.ready()
+			noerr(t, err)
 
-		// 	c, err = p.checkOut(context.Background())
-		// 	noerr(t, err)
-		// 	err = p.checkIn(c)
-		// 	noerr(t, err)
+			c, err = p.checkOut(context.Background())
+			noerr(t, err)
+			err = p.checkIn(c)
+			noerr(t, err)
 
-		// 	p.close(context.Background())
-		// })
+			p.close(context.Background())
+		})
 	})
 	t.Run("checkOut", func(t *testing.T) {
 		t.Parallel()

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -720,7 +720,7 @@ func TestPool(t *testing.T) {
 			// Start a goroutine that closes one of the checked-out conections and checks it in.
 			// Expect that the checked-in connection is closed and allows blocked checkOut() to
 			// complete. Assert that the time between checking in the closed connection and when the
-			// checkOut() completes is within 50ms.
+			// checkOut() completes is within 100ms.
 			var start time.Time
 			go func() {
 				c.close()
@@ -734,8 +734,8 @@ func TestPool(t *testing.T) {
 				t,
 				time.Now(),
 				start,
-				50*time.Millisecond,
-				"expected checkOut to complete within 50ms of checking in a closed connection")
+				100*time.Millisecond,
+				"expected checkOut to complete within 100ms of checking in a closed connection")
 
 			assert.Equalf(t, 1, d.lenclosed(), "should have closed 1 connection")
 			assert.Equalf(t, 3, d.lenopened(), "should have opened 3 connection")

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -80,11 +80,11 @@ func (r *rttMonitor) start() {
 	var conn *connection
 	defer func() {
 		if conn != nil {
-			// If the connection exists, we need to wait for it to be connected. We can ignore the
-			// error from conn.wait(). If the connection wasn't successfully opened, its state was
-			// set back to disconnected, so calling conn.close() will be a noop.
+			// If the connection exists, we need to wait for it to be connected. If the connection
+			// wasn't successfully opened, its state was set back to disconnected, so calling
+			// conn.close() will be a noop.
 			conn.closeConnectContext()
-			_ = conn.wait()
+			conn.wait()
 			_ = conn.close()
 		}
 	}()
@@ -111,10 +111,8 @@ func (r *rttMonitor) runHello(conn *connection) *connection {
 			return nil
 		}
 
-		conn.connect(r.ctx)
-		err = conn.wait()
+		err = conn.connect(r.ctx)
 		if err != nil {
-			_ = conn.close()
 			return nil
 		}
 

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -80,9 +80,10 @@ func (r *rttMonitor) start() {
 	var conn *connection
 	defer func() {
 		if conn != nil {
-			// If the connection exists, we need to wait for it to be connected. If the connection
+			// If the connection exists, we need to wait for it to be connected because
+			// conn.connect() and conn.close() cannot be called concurrently. If the connection
 			// wasn't successfully opened, its state was set back to disconnected, so calling
-			// conn.close() will be a noop.
+			// conn.close() will be a no-op.
 			conn.closeConnectContext()
 			conn.wait()
 			_ = conn.close()

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -217,6 +217,14 @@ func (s *Server) Connect(updateCallback updateTopologyCallback) error {
 		s.closewg.Add(1)
 		go s.update()
 	}
+
+	// The CMAP spec describes that pools should only be marked "ready" when the server description
+	// is updated to something other than "Unknown". However, we maintain the previous Server
+	// behavior here and immediately mark the pool as ready during Connect() to simplify and speed
+	// up the Client startup behavior. The risk of marking a pool as ready proactively during
+	// Connect() is that we could attempt to create connections to a server that was configured
+	// erroneously until the first server check or checkOut() failure occurs, when the SDAM error
+	// handler would transition the Server back to "Unknown" and set the pool to "paused".
 	return s.pool.ready()
 }
 

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -261,7 +261,6 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 
 	connImpl, err := s.pool.checkOut(ctx)
 	if err != nil {
-		// The error has already been handled by connection.connect, which calls Server.ProcessHandshakeError.
 		return nil, err
 	}
 
@@ -654,12 +653,7 @@ func (s *Server) setupHeartbeatConnection() error {
 	s.conn = conn
 	s.heartbeatLock.Unlock()
 
-	err = s.conn.connect(s.heartbeatCtx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.conn.connect(s.heartbeatCtx)
 }
 
 // cancelCheck cancels in-progress connection dials and reads. It does not set any fields on the server.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -565,18 +565,18 @@ func (s *Server) updateDescription(desc description.Server) {
 		_ = recover()
 	}()
 
-	// Anytime we update the server description to something other than "unknown", set the pool to
-	// "ready". If the pool is already ready, this operation is a no-op.
-	if desc.Kind != description.Unknown {
-		_ = s.pool.ready()
-	}
-
 	// Use the updateTopologyCallback to update the parent Topology and get the description that should be stored.
 	callback, ok := s.updateTopologyCallback.Load().(updateTopologyCallback)
 	if ok && callback != nil {
 		desc = callback(desc)
 	}
 	s.desc.Store(desc)
+
+	// Anytime we update the server description to something other than "unknown", set the pool to
+	// "ready". If the pool is already ready, this operation is a no-op.
+	if desc.Kind != description.Unknown {
+		_ = s.pool.ready()
+	}
 
 	s.subLock.Lock()
 	for _, c := range s.subscribers {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -255,14 +255,6 @@ func (s *Server) Disconnect(ctx context.Context) error {
 
 // Connection gets a connection to the server.
 func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
-
-	if s.pool.monitor != nil {
-		s.pool.monitor.Event(&event.PoolEvent{
-			Type:    "ConnectionCheckOutStarted",
-			Address: s.pool.address.String(),
-		})
-	}
-
 	if atomic.LoadInt64(&s.connectionstate) != connected {
 		return nil, ErrServerClosed
 	}

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -19,23 +19,25 @@ import (
 var defaultRegistry = bson.NewRegistryBuilder().Build()
 
 type serverConfig struct {
-	clock                          *session.ClusterClock
-	compressionOpts                []string
-	connectionOpts                 []ConnectionOption
-	appname                        string
-	heartbeatInterval              time.Duration
-	heartbeatTimeout               time.Duration
-	maxConns                       uint64
-	minConns                       uint64
-	maxConnecting                  uint64
-	poolMonitor                    *event.PoolMonitor
-	serverMonitor                  *event.ServerMonitor
-	connectionPoolMaxIdleTime      time.Duration
-	connectionPoolMaintainInterval time.Duration
-	registry                       *bsoncodec.Registry
-	monitoringDisabled             bool
-	serverAPI                      *driver.ServerAPIOptions
-	loadBalanced                   bool
+	clock              *session.ClusterClock
+	compressionOpts    []string
+	connectionOpts     []ConnectionOption
+	appname            string
+	heartbeatInterval  time.Duration
+	heartbeatTimeout   time.Duration
+	serverMonitor      *event.ServerMonitor
+	registry           *bsoncodec.Registry
+	monitoringDisabled bool
+	serverAPI          *driver.ServerAPIOptions
+	loadBalanced       bool
+
+	// Connection pool options.
+	maxConns             uint64
+	minConns             uint64
+	maxConnecting        uint64
+	poolMonitor          *event.PoolMonitor
+	poolMaxIdleTime      time.Duration
+	poolMaintainInterval time.Duration
 }
 
 func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
@@ -141,15 +143,16 @@ func WithMaxConnecting(fn func(uint64) uint64) ServerOption {
 // because of their age
 func WithConnectionPoolMaxIdleTime(fn func(time.Duration) time.Duration) ServerOption {
 	return func(cfg *serverConfig) error {
-		cfg.connectionPoolMaxIdleTime = fn(cfg.connectionPoolMaxIdleTime)
+		cfg.poolMaxIdleTime = fn(cfg.poolMaxIdleTime)
 		return nil
 	}
 }
 
-// WithConnectionPoolMaintainInterval ... TODO
+// WithConnectionPoolMaintainInterval configures the interval that the background connection pool
+// maintenance goroutine runs.
 func WithConnectionPoolMaintainInterval(fn func(time.Duration) time.Duration) ServerOption {
 	return func(cfg *serverConfig) error {
-		cfg.connectionPoolMaintainInterval = fn(cfg.connectionPoolMaintainInterval)
+		cfg.poolMaintainInterval = fn(cfg.poolMaintainInterval)
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -19,22 +19,23 @@ import (
 var defaultRegistry = bson.NewRegistryBuilder().Build()
 
 type serverConfig struct {
-	clock                     *session.ClusterClock
-	compressionOpts           []string
-	connectionOpts            []ConnectionOption
-	appname                   string
-	heartbeatInterval         time.Duration
-	heartbeatTimeout          time.Duration
-	maxConns                  uint64
-	minConns                  uint64
-	maxConnecting             uint64
-	poolMonitor               *event.PoolMonitor
-	serverMonitor             *event.ServerMonitor
-	connectionPoolMaxIdleTime time.Duration
-	registry                  *bsoncodec.Registry
-	monitoringDisabled        bool
-	serverAPI                 *driver.ServerAPIOptions
-	loadBalanced              bool
+	clock                          *session.ClusterClock
+	compressionOpts                []string
+	connectionOpts                 []ConnectionOption
+	appname                        string
+	heartbeatInterval              time.Duration
+	heartbeatTimeout               time.Duration
+	maxConns                       uint64
+	minConns                       uint64
+	maxConnecting                  uint64
+	poolMonitor                    *event.PoolMonitor
+	serverMonitor                  *event.ServerMonitor
+	connectionPoolMaxIdleTime      time.Duration
+	connectionPoolMaintainInterval time.Duration
+	registry                       *bsoncodec.Registry
+	monitoringDisabled             bool
+	serverAPI                      *driver.ServerAPIOptions
+	loadBalanced                   bool
 }
 
 func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
@@ -141,6 +142,14 @@ func WithMaxConnecting(fn func(uint64) uint64) ServerOption {
 func WithConnectionPoolMaxIdleTime(fn func(time.Duration) time.Duration) ServerOption {
 	return func(cfg *serverConfig) error {
 		cfg.connectionPoolMaxIdleTime = fn(cfg.connectionPoolMaxIdleTime)
+		return nil
+	}
+}
+
+// WithConnectionPoolMaintainInterval ... TODO
+func WithConnectionPoolMaintainInterval(fn func(time.Duration) time.Duration) ServerOption {
+	return func(cfg *serverConfig) error {
+		cfg.connectionPoolMaintainInterval = fn(cfg.connectionPoolMaintainInterval)
 		return nil
 	}
 }

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -418,7 +418,7 @@ func TestServer(t *testing.T) {
 					// With the default maxConnecting (2), there are multiple goroutines creating
 					// connections. Because handshake errors are processed after returning the error
 					// to checkOut(), it's possible for extra connection requests to be processed
-					// after a handshake erorr before the connection pool is cleared and paused. Set
+					// after a handshake error before the connection pool is cleared and paused. Set
 					// maxConnecting=1 to minimize the number of extra connection requests processed
 					// before the connection pool is cleared and paused.
 					WithMaxConnecting(func(uint64) uint64 { return 1 }),

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -319,13 +319,25 @@ func TestServer(t *testing.T) {
 	}
 
 	t.Run("multiple connection initialization errors are processed correctly", func(t *testing.T) {
-		assertGenerationStats := func(t *testing.T, server *Server, serviceID primitive.ObjectID, wantMinGeneration, wantMaxConns uint64) {
+		assertGenerationStats := func(t *testing.T, server *Server, serviceID primitive.ObjectID, wantGeneration, wantNumConns uint64) {
 			t.Helper()
 
-			generation := server.pool.generation.getGeneration(&serviceID)
-			numConns := server.pool.generation.getNumConns(&serviceID)
-			assert.True(t, generation >= wantMinGeneration, "expected generation number to be at least %d, got %d", wantMinGeneration, generation)
-			assert.True(t, numConns <= wantMaxConns, "expected connection count to be at most %d, got %d", wantMaxConns, numConns)
+			// On connection failure, the connection is removed and closed after delivering the
+			// error to Connection(), so it may still count toward the generation connection count
+			// briefly. Wait up to 100ms for the generation connection count to reach the target.
+			assert.Eventuallyf(t,
+				func() bool {
+					generation := server.pool.generation.getGeneration(&serviceID)
+					numConns := server.pool.generation.getNumConns(&serviceID)
+					return generation == wantGeneration && numConns == wantNumConns
+				},
+				100*time.Millisecond,
+				1*time.Millisecond,
+				"expected generation number %v, got %v; expected connection count %v, got %v",
+				wantGeneration,
+				server.pool.generation.getGeneration(&serviceID),
+				wantNumConns,
+				server.pool.generation.getNumConns(&serviceID))
 		}
 
 		testCases := []struct {
@@ -334,8 +346,8 @@ func TestServer(t *testing.T) {
 			dialErr            error
 			getInfoErr         error
 			finishHandshakeErr error
-			minFinalGeneration uint64
-			maxConns           uint64
+			finalGeneration    uint64
+			numNewConns        uint64
 		}{
 			// For LB clusters, errors for dialing and the initial handshake are ignored.
 			{"dial errors are ignored for load balancers", true, netErr.Wrapped, nil, nil, 0, 1},
@@ -343,14 +355,14 @@ func TestServer(t *testing.T) {
 
 			// For LB clusters, post-handshake errors clear the pool, but do not update the server
 			// description or pause the pool.
-			{"post-handshake errors are not ignored for load balancers", true, nil, nil, netErr.Wrapped, 4, 2},
+			{"post-handshake errors are not ignored for load balancers", true, nil, nil, netErr.Wrapped, 5, 1},
 
 			// For non-LB clusters, the first error sets the server to Unknown and clears and pauses
 			// the pool. All subsequent attempts to check out a connection without updating the
 			// server description return an error because the pool is paused.
-			{"dial errors are not ignored for non-lb clusters", false, netErr.Wrapped, nil, nil, 1, 2},
-			{"initial handshake errors are not ignored for non-lb clusters", false, nil, netErr.Wrapped, nil, 1, 2},
-			{"post-handshake errors are not ignored for non-lb clusters", false, nil, nil, netErr.Wrapped, 1, 2},
+			{"dial errors are not ignored for non-lb clusters", false, netErr.Wrapped, nil, nil, 1, 1},
+			{"initial handshake errors are not ignored for non-lb clusters", false, nil, netErr.Wrapped, nil, 1, 1},
+			{"post-handshake errors are not ignored for non-lb clusters", false, nil, nil, netErr.Wrapped, 1, 1},
 		}
 		for _, tc := range testCases {
 			tc := tc // Capture range variable.
@@ -439,7 +451,7 @@ func TestServer(t *testing.T) {
 						assert.Nil(t, err, "Connection error at iteration %d: %v", i, err)
 					}
 				}
-				assertGenerationStats(t, server, serviceID, tc.minFinalGeneration, tc.maxConns)
+				assertGenerationStats(t, server, serviceID, tc.finalGeneration, tc.numNewConns)
 			})
 		}
 	})

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -353,6 +353,7 @@ func (t *Topology) RequestImmediateCheck() {
 // server selection spec, and will time out after severSelectionTimeout or when the
 // parent context is done.
 func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelector) (driver.Server, error) {
+	// fmt.Println("SELECTSERVER")
 	if atomic.LoadInt64(&t.connectionstate) != connected {
 		return nil, ErrTopologyClosed
 	}
@@ -395,9 +396,11 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 		}
 
 		if len(suitable) == 0 {
+			// fmt.Println("SELECTSERVER: none suitable, waiting")
 			// try again if there are no servers available
 			continue
 		}
+		// fmt.Println("SELECTSERVER: suitable:", suitable)
 
 		selected := suitable[random.Intn(len(suitable))]
 		selectedS, err := t.FindServer(selected)
@@ -429,6 +432,7 @@ func (t *Topology) FindServer(selected description.Server) (*SelectedServer, err
 	}
 
 	desc := t.Description()
+	// fmt.Println("FindServer: Topology:", t.Kind(), "Selected:", desc.String())
 	return &SelectedServer{
 		Server: server,
 		Kind:   desc.Kind,

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -353,7 +353,6 @@ func (t *Topology) RequestImmediateCheck() {
 // server selection spec, and will time out after severSelectionTimeout or when the
 // parent context is done.
 func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelector) (driver.Server, error) {
-	// fmt.Println("SELECTSERVER")
 	if atomic.LoadInt64(&t.connectionstate) != connected {
 		return nil, ErrTopologyClosed
 	}
@@ -396,11 +395,9 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 		}
 
 		if len(suitable) == 0 {
-			// fmt.Println("SELECTSERVER: none suitable, waiting")
 			// try again if there are no servers available
 			continue
 		}
-		// fmt.Println("SELECTSERVER: suitable:", suitable)
 
 		selected := suitable[random.Intn(len(suitable))]
 		selectedS, err := t.FindServer(selected)
@@ -432,7 +429,6 @@ func (t *Topology) FindServer(selected description.Server) (*SelectedServer, err
 	}
 
 	desc := t.Description()
-	// fmt.Println("FindServer: Topology:", t.Kind(), "Selected:", desc.String())
 	return &SelectedServer{
 		Server: server,
 		Kind:   desc.Kind,


### PR DESCRIPTION
[GODRIVER-1827](https://jira.mongodb.org/browse/GODRIVER-1827)

Update the connection pool to use the "paused", "ready", and "closed" state transitions and corresponding actions. 

Behavior changes:
* Update the `pool` state transitions to use "paused", "ready", and "closed" as described in the updated CMAP spec.
* Update a `Server` to call `pool.ready()` whenever the `Server` state changes to anything except "Unknown".
* Move responsibility for calling SDAM connection handshake error handling from `connection.connect()` into the callers of `connection.connect()`
  * Allows delivering the original connection error to callers of `pool.checkOut()` _before_ the SDAM handshake error handler calls `pool.clear()`, which delivers a different error to all goroutines waiting on `pool.checkOut()`.
  * Allows preventing the RTT monitor from updating server state (SDAM spec does not describe that the RTT monitor should use SDAM error handling rules).
* Make the error returned when the pool is cleared retryable.
  * Refactor `Operation.Execute()` retry logic to allow making connection check-out retryable.
* Add constants for `ConnectionCheckOutStartedEvent` and `PoolReadyEvent`.

Code improvements:
* Simplify `connection.connect()` API by returning connection errors directly from `connect()` instead of requiring callers to call `wait()` immediately after to get the error.
* Send `ConnectionCheckOutStartedEvent` in `pool.checkOut()` instead of `Server.Connection()`

Test changes:
* Sync all non-integration CMAP spec tests.
* Update CMAP spec test runner to work with new "ready" command.
* Update unified spec test runner to support `ConnectionCheckOutStartedEvent` and `PoolReadyEvent`.