### PR TITLE
GODRIVER-1824 Test that Client waits 500ms between failed Hellos

### DIFF
--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -13,7 +13,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -124,18 +123,15 @@ func TestSDAMProse(t *testing.T) {
 			},
 		})
 
-		// Create Client and Connect after setting failpoint and before Ping.
+		// Reset client options to use direct connection, app name, and 5s SS timeout.
 		clientOpts := options.Client().SetDirect(true).
 			SetAppName("SDAMMinHeartbeatFrequencyTest").
 			SetServerSelectionTimeout(5 * time.Second)
-		client, err := mongo.NewClient(clientOpts)
-		assert.Nil(mt, err, "NewClient error: %v", err)
-		err = client.Connect(mtest.Background)
-		assert.Nil(mt, err, "Connect error: %v", err)
+		mt.ResetClient(clientOpts)
 
 		// Assert that Ping completes successfully within 2 to 3.5 seconds.
 		start := time.Now()
-		err = client.Ping(mtest.Background, nil)
+		err := mt.Client.Ping(mtest.Background, nil)
 		assert.Nil(mt, err, "Ping error: %v", err)
 		pingTime := time.Since(start)
 		assert.True(mt, pingTime > 2000*time.Millisecond && pingTime < 3500*time.Millisecond,

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -109,7 +109,7 @@ func TestSDAMProse(t *testing.T) {
 		})
 	})
 
-	mt.RunOpts("client waits between failed Hellos", mtest.NewOptions().MinServerVersion("4.9"), func(mt *mtest.T) {
+	mt.RunOpts("client waits between failed Hellos", mtest.NewOptions().MinServerVersion("4.9").Topologies(mtest.Single), func(mt *mtest.T) {
 		// Force hello requests to fail 5 times.
 		mt.SetFailPoint(mtest.FailPoint{
 			ConfigureFailPoint: "failCommand",


### PR DESCRIPTION
GODRIVER-1824

Implement the prose test described in [DRIVERS-1251](https://jira.mongodb.org/browse/DRIVERS-1251). This test verifies that the driver waits approximately 500ms between failing hellos and legacy hellos.