### PR TITLE
Replace all uses of mtest.Background with context.Background()

### DIFF
--- a/mongo/integration/causal_consistency_test.go
+++ b/mongo/integration/causal_consistency_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -36,14 +37,14 @@ func TestCausalConsistency_Supported(t *testing.T) {
 
 		sess, err := mt.Client.StartSession()
 		assert.Nil(mt, err, "StartSession error: %v", err)
-		defer sess.EndSession(mtest.Background)
+		defer sess.EndSession(context.Background())
 		assert.Nil(mt, sess.OperationTime(), "expected nil operation time, got %v", sess.OperationTime())
 	})
 	mt.Run("no cluster time on first command", func(mt *mtest.T) {
 		// first read in a causally consistent session must not send afterClusterTime to the server
 
 		ccOpts := options.Session().SetCausalConsistency(true)
-		_ = mt.Client.UseSessionWithOptions(mtest.Background, ccOpts, func(sc mongo.SessionContext) error {
+		_ = mt.Client.UseSessionWithOptions(context.Background(), ccOpts, func(sc mongo.SessionContext) error {
 			_, _ = mt.Coll.Find(sc, bson.D{})
 			return nil
 		})
@@ -57,9 +58,9 @@ func TestCausalConsistency_Supported(t *testing.T) {
 
 		sess, err := mt.Client.StartSession()
 		assert.Nil(mt, err, "StartSession error: %v", err)
-		defer sess.EndSession(mtest.Background)
+		defer sess.EndSession(context.Background())
 
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_, _ = mt.Coll.Find(sc, bson.D{})
 			return nil
 		})
@@ -85,9 +86,9 @@ func TestCausalConsistency_Supported(t *testing.T) {
 			mt.Run(sf.name, func(mt *mtest.T) {
 				sess, err := mt.Client.StartSession()
 				assert.Nil(mt, err, "StartSession error: %v", err)
-				defer sess.EndSession(mtest.Background)
+				defer sess.EndSession(context.Background())
 
-				_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+				_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 					_ = mt.Coll.FindOne(sc, bson.D{})
 					return nil
 				})
@@ -115,14 +116,14 @@ func TestCausalConsistency_Supported(t *testing.T) {
 			mt.Run(sf.name, func(mt *mtest.T) {
 				sess, err := mt.Client.StartSession()
 				assert.Nil(mt, err, "StartSession error: %v", err)
-				defer sess.EndSession(mtest.Background)
+				defer sess.EndSession(context.Background())
 
 				_ = sf.execute(mt, sess)
 				currOptime := sess.OperationTime()
 				assert.NotNil(mt, currOptime, "expected session operation time, got nil")
 
 				mt.ClearEvents()
-				_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+				_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 					_ = mt.Coll.FindOne(sc, bson.D{})
 					return nil
 				})
@@ -136,7 +137,7 @@ func TestCausalConsistency_Supported(t *testing.T) {
 		// a read operation in a non causally-consistent session should not include afterClusterTime
 
 		sessOpts := options.Session().SetCausalConsistency(false)
-		_ = mt.Client.UseSessionWithOptions(mtest.Background, sessOpts, func(sc mongo.SessionContext) error {
+		_ = mt.Client.UseSessionWithOptions(context.Background(), sessOpts, func(sc mongo.SessionContext) error {
 			_, _ = mt.Coll.Find(sc, bson.D{})
 			mt.ClearEvents()
 			_, _ = mt.Coll.Find(sc, bson.D{})
@@ -152,15 +153,15 @@ func TestCausalConsistency_Supported(t *testing.T) {
 
 		sess, err := mt.Client.StartSession()
 		assert.Nil(mt, err, "StartSession error: %v", err)
-		defer sess.EndSession(mtest.Background)
+		defer sess.EndSession(context.Background())
 
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_ = mt.Coll.FindOne(sc, bson.D{})
 			return nil
 		})
 		currOptime := sess.OperationTime()
 		mt.ClearEvents()
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_ = mt.Coll.FindOne(sc, bson.D{})
 			return nil
 		})
@@ -174,15 +175,15 @@ func TestCausalConsistency_Supported(t *testing.T) {
 	mt.RunOpts("custom read concern", mtest.NewOptions().ClientOptions(localRcOpts), func(mt *mtest.T) {
 		sess, err := mt.Client.StartSession()
 		assert.Nil(mt, err, "StartSession error: %v", err)
-		defer sess.EndSession(mtest.Background)
+		defer sess.EndSession(context.Background())
 
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_ = mt.Coll.FindOne(sc, bson.D{})
 			return nil
 		})
 		currOptime := sess.OperationTime()
 		mt.ClearEvents()
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_ = mt.Coll.FindOne(sc, bson.D{})
 			return nil
 		})
@@ -198,9 +199,9 @@ func TestCausalConsistency_Supported(t *testing.T) {
 
 		sess, err := mt.Client.StartSession()
 		assert.Nil(mt, err, "StartSession error: %v", err)
-		defer sess.EndSession(mtest.Background)
+		defer sess.EndSession(context.Background())
 
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			_, _ = mt.Coll.InsertOne(sc, bson.D{{"x", 1}})
 			return nil
 		})
@@ -210,7 +211,7 @@ func TestCausalConsistency_Supported(t *testing.T) {
 	mt.Run("clusterTime included", func(mt *mtest.T) {
 		// $clusterTime should be included in commands if the deployment supports cluster times
 
-		_ = mt.Coll.FindOne(mtest.Background, bson.D{})
+		_ = mt.Coll.FindOne(context.Background(), bson.D{})
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "find", evt.CommandName, "expected command 'find', got '%v'", evt.CommandName)
 		_, err := evt.Command.LookupErr("$clusterTime")
@@ -233,7 +234,7 @@ func TestCausalConsistency_NotSupported(t *testing.T) {
 		// support cluster times
 
 		sessOpts := options.Session().SetCausalConsistency(true)
-		_ = mt.Client.UseSessionWithOptions(mtest.Background, sessOpts, func(sc mongo.SessionContext) error {
+		_ = mt.Client.UseSessionWithOptions(context.Background(), sessOpts, func(sc mongo.SessionContext) error {
 			_, _ = mt.Coll.Find(sc, bson.D{})
 			return nil
 		})
@@ -245,7 +246,7 @@ func TestCausalConsistency_NotSupported(t *testing.T) {
 	mt.Run("clusterTime not included", func(mt *mtest.T) {
 		// $clusterTime should not be included in commands if the deployment does not support cluster times
 
-		_ = mt.Coll.FindOne(mtest.Background, bson.D{})
+		_ = mt.Coll.FindOne(context.Background(), bson.D{})
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "find", evt.CommandName, "expected command 'find', got '%v'", evt.CommandName)
 		_, err := evt.Command.LookupErr("$clusterTime")

--- a/mongo/integration/change_stream_spec_test.go
+++ b/mongo/integration/change_stream_spec_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -133,20 +134,20 @@ func runChangeStreamTest(mt *mtest.T, test changeStreamTest, testFile changeStre
 			mt.Fatalf("unrecognized change stream target: %v", test.Target)
 		}
 		csOpts := createChangeStreamOptions(mt, test.Options)
-		changeStream, err := watcher.Watch(mtest.Background, test.Pipeline, csOpts)
+		changeStream, err := watcher.Watch(context.Background(), test.Pipeline, csOpts)
 		if err == nil {
 			err = runChangeStreamOperations(mt, test)
 		}
 		if err == nil && test.Result.Error != nil {
 			// if there was no error and an error is expected, capture the result from iterating the stream once
-			changeStream.Next(mtest.Background)
+			changeStream.Next(context.Background())
 			err = changeStream.Err()
 		}
 		if err == nil && len(test.Result.Success) != 0 {
 			// if there was no error and success array is non-empty, iterate stream until it returns as many changes
 			// as there are elements in the success array or an error is thrown
 			for i := 0; i < len(test.Result.Success); i++ {
-				if !changeStream.Next(mtest.Background) {
+				if !changeStream.Next(context.Background()) {
 					break
 				}
 
@@ -158,7 +159,7 @@ func runChangeStreamTest(mt *mtest.T, test changeStreamTest, testFile changeStre
 			err = changeStream.Err()
 		}
 		if changeStream != nil {
-			closeErr := changeStream.Close(mtest.Background)
+			closeErr := changeStream.Close(context.Background())
 			assert.Nil(mt, closeErr, "Close error: %v", err)
 		}
 
@@ -213,7 +214,7 @@ func runChangeStreamOperations(mt *mtest.T, test changeStreamTest) error {
 			}, false)
 			err = res.Err()
 		case "drop":
-			err = mt.Coll.Drop(mtest.Background)
+			err = mt.Coll.Drop(context.Background())
 		default:
 			mt.Fatalf("unrecognized operation: %v", op.Name)
 		}

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func TestChangeStream_Standalone(t *testing.T) {
 	defer mt.Close()
 
 	mt.Run("no custom standalone error", func(mt *mtest.T) {
-		_, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		_, ok := err.(mongo.CommandError)
 		assert.True(mt, ok, "expected error type %T, got %T", mongo.CommandError{}, err)
 	})
@@ -61,7 +62,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 	mt.Run("first stage is $changeStream", func(mt *mtest.T) {
 		// first stage in the aggregate pipeline must be $changeStream
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 		started := mt.GetStartedEvent()
@@ -78,34 +79,34 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 	mt.Run("track resume token", func(mt *mtest.T) {
 		// ChangeStream must continuously track the last seen resumeToken
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
 		generateEvents(mt, 1)
-		assert.True(mt, cs.Next(mtest.Background), "expected next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected next to return true, got false")
 		assert.NotNil(mt, cs.ResumeToken(), "expected resume token, got nil")
 	})
 	mt.RunOpts("resume token updated on empty batch", mtest.NewOptions().MinServerVersion("4.0.7"), func(mt *mtest.T) {
 		// The resume token is updated when an empty batch is returned using the server's post batch resume token.
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
 		// cause an event to occur so the resume token is updated
 		generateEvents(mt, 1)
-		assert.True(mt, cs.Next(mtest.Background), "expected next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected next to return true, got false")
 		firstToken := cs.ResumeToken()
 
 		// cause an event on a different collection than the one being watched so the server's PBRT is updated
 		diffColl := mt.CreateCollection(mtest.Collection{Name: "diffCollUpdatePbrt"}, false)
-		_, err = diffColl.InsertOne(mtest.Background, bson.D{{"x", 1}})
+		_, err = diffColl.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.Nil(mt, err, "InsertOne error: %v", err)
 
 		// verify that the resume token is updated using the PBRT from an empty batch
 		mt.ClearEvents()
-		assert.False(mt, cs.TryNext(mtest.Background), "unexpected event document: %v", cs.Current)
+		assert.False(mt, cs.TryNext(context.Background()), "unexpected event document: %v", cs.Current)
 		assert.Nil(mt, cs.Err(), "change stream error getting new batch: %v", cs.Err())
 		newToken := cs.ResumeToken()
 		assert.NotEqual(mt, newToken, firstToken, "resume token was not updated after an empty batch was returned")
@@ -123,12 +124,12 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				{"_id", 0},
 			}},
 		}
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{projectDoc})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{projectDoc})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
 		generateEvents(mt, 2)
-		assert.False(mt, cs.Next(mtest.Background), "expected Next to return false, got true")
+		assert.False(mt, cs.Next(context.Background()), "expected Next to return false, got true")
 		assert.NotNil(mt, cs.Err(), "expected error, got nil")
 	})
 	mt.RunOpts("resume once", mtest.NewOptions().ClientType(mtest.Mock), func(mt *mtest.T) {
@@ -161,15 +162,15 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			resumedAggregateRes,
 		)
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 		// Consume the first document
-		assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 
 		// Clear existing events and expect a resume attempt to happen.
 		mt.ClearEvents()
-		assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 
 		// Next should cause getMore, killCursors, and aggregate to run
 		assert.NotNil(mt, mt.GetStartedEvent(), "expected getMore event, got nil")
@@ -209,11 +210,11 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		})
 		mt.AddMockResponses(aggRes, getMoreRes, killCursorsRes, resumedAggRes)
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
-		assert.False(mt, cs.Next(mtest.Background), "expected Next to return false, got true")
+		assert.False(mt, cs.Next(context.Background()), "expected Next to return false, got true")
 	})
 	mt.RunOpts("server selection before resume", mtest.NewOptions().CreateClient(false), func(mt *mtest.T) {
 		// ChangeStream will perform server selection before attempting to resume, using initial readPreference
@@ -222,7 +223,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 	mt.Run("empty batch cursor not closed", func(mt *mtest.T) {
 		// Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 		assert.True(mt, cs.ID() > 0, "expected non-zero ID, got 0")
@@ -247,11 +248,11 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		resumedAggRes := mtest.CreateCursorResponse(1, ns, mtest.FirstBatch, changeDoc)
 		mt.AddMockResponses(aggRes, getMoreRes, killCursorsRes, resumedAggRes)
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
-		assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 		assert.Nil(mt, cs.Err(), "change stream error: %v", cs.Err())
 	})
 
@@ -260,7 +261,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		// $changeStream stage for ChangeStream against a server >=4.0 and <4.0.7 that has not received any results yet
 		// MUST include a startAtOperationTime option when resuming a changestream.
 
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
@@ -270,7 +271,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 		mt.ClearEvents()
 		// change stream should resume once and get new change
-		assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 		// Next should cause getMore, killCursors, and aggregate to run
 		assert.NotNil(mt, mt.GetStartedEvent(), "expected getMore event, got nil")
 		assert.NotNil(mt, mt.GetStartedEvent(), "expected killCursors event, got nil")
@@ -303,17 +304,17 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				var err error
 				switch tc.st {
 				case client:
-					cs, err = mt.Client.Watch(mtest.Background, mongo.Pipeline{})
+					cs, err = mt.Client.Watch(context.Background(), mongo.Pipeline{})
 				case database:
-					cs, err = mt.DB.Watch(mtest.Background, mongo.Pipeline{})
+					cs, err = mt.DB.Watch(context.Background(), mongo.Pipeline{})
 				case collection:
-					cs, err = mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+					cs, err = mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 				}
 				assert.Nil(mt, err, "Watch error: %v", err)
 				defer closeStream(cs)
 
 				generateEvents(mt, 1)
-				assert.True(mt, cs.Next(mtest.Background), "expected Next true, got false")
+				assert.True(mt, cs.Next(context.Background()), "expected Next true, got false")
 				var res bson.D
 				err = cs.Decode(&res)
 				assert.Nil(mt, err, "Decode error: %v", err)
@@ -325,14 +326,14 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		// maxAwaitTimeMS option should be sent as maxTimeMS on getMore
 
 		opts := options.ChangeStream().SetMaxAwaitTime(100 * time.Millisecond)
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{}, opts)
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{}, opts)
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
-		_, err = mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+		_, err = mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.Nil(mt, err, "InsertOne error: %v", err)
 		mt.ClearEvents()
-		assert.True(mt, cs.Next(mtest.Background), "expected Next true, got false")
+		assert.True(mt, cs.Next(context.Background()), "expected Next true, got false")
 
 		e := mt.GetStartedEvent()
 		assert.NotNil(mt, e, "expected getMore event, got nil")
@@ -359,7 +360,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 					mt.RunOpts(tc.name, tcOpts, func(mt *mtest.T) {
 						// create temp stream to get a resume token
 						mt.ClearEvents()
-						cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+						cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 						assert.Nil(mt, err, "Watch error: %v", err)
 
 						// Initial resume token should equal the PBRT in the aggregate command
@@ -370,7 +371,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 						generateEvents(mt, numEvents)
 
 						// Iterate over one event to get resume token
-						assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+						assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 						token := cs.ResumeToken()
 						closeStream(cs)
 
@@ -393,7 +394,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 						// clear slate and create new change stream
 						mt.ClearEvents()
-						cs, err = mt.Coll.Watch(mtest.Background, mongo.Pipeline{}, opts)
+						cs, err = mt.Coll.Watch(context.Background(), mongo.Pipeline{}, opts)
 						assert.Nil(mt, err, "Watch error: %v", err)
 						defer closeStream(cs)
 
@@ -401,7 +402,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 						compareResumeTokens(mt, cs, initialToken)
 
 						for i := 0; i < numExpectedEvents; i++ {
-							assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+							assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 							// while we're not at the last doc in the batch, the resume token should be the _id of the
 							// document
 							if i != numExpectedEvents-1 {
@@ -418,7 +419,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			mt.RunOpts("without PBRT support", noPbrtOpts, func(mt *mtest.T) {
 				collName := mt.Coll.Name()
 				dbName := mt.Coll.Database().Name()
-				cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+				cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 				assert.Nil(mt, err, "Watch error: %v", err)
 				defer closeStream(cs)
 
@@ -426,7 +427,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				numEvents := 5
 				generateEvents(mt, numEvents)
 				// iterate once to get a resume token
-				assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+				assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 				token := cs.ResumeToken()
 				assert.NotNil(mt, token, "expected resume token, got nil")
 
@@ -443,7 +444,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				for _, tc := range testCases {
 					mt.Run(tc.name, func(mt *mtest.T) {
 						coll := mt.Client.Database(dbName).Collection(collName)
-						cs, err := coll.Watch(mtest.Background, mongo.Pipeline{}, tc.opts)
+						cs, err := coll.Watch(context.Background(), mongo.Pipeline{}, tc.opts)
 						assert.Nil(mt, err, "Watch error: %v", err)
 						defer closeStream(cs)
 
@@ -453,7 +454,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 						}
 
 						for i := 0; i < tc.numDocsExpected; i++ {
-							assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+							assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 							// current resume token should always equal _id of current document
 							compareResumeTokens(mt, cs, cs.Current.Lookup("_id").Document())
 						}
@@ -466,18 +467,18 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		mt.Run("existing non-empty batch", func(mt *mtest.T) {
 			// If there's already documents in the current batch, TryNext should return true without doing a getMore
 
-			cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.Nil(mt, err, "Watch error: %v", err)
 			defer closeStream(cs)
 			generateEvents(mt, 5)
 			// call Next to make sure a batch is retrieved
-			assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false")
+			assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false")
 			tryNextExistingBatchTest(mt, cs)
 		})
 		mt.Run("one getMore sent", func(mt *mtest.T) {
 			// If the current batch is empty, TryNext should send one getMore and return.
 
-			cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.Nil(mt, err, "Watch error: %v", err)
 			defer closeStream(cs)
 
@@ -486,7 +487,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			// without doing a getMore
 			// next call to TryNext should attempt a getMore
 			for i := 0; i < 2; i++ {
-				assert.False(mt, cs.TryNext(mtest.Background), "TryNext returned true on iteration %v", i)
+				assert.False(mt, cs.TryNext(context.Background()), "TryNext returned true on iteration %v", i)
 			}
 			verifyOneGetmoreSent(mt)
 		})
@@ -495,7 +496,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 			aggRes := mtest.CreateCursorResponse(50, "foo.bar", mtest.FirstBatch)
 			mt.AddMockResponses(aggRes)
-			cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.Nil(mt, err, "Watch error: %v", err)
 			defer closeStream(cs)
 			tryNextGetmoreError(mt, cs)
@@ -530,7 +531,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				},
 			})
 
-			_, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.NotNil(mt, err, "expected Watch error, got nil")
 			assert.True(mt, isPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
 		})
@@ -547,14 +548,14 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				},
 			})
 
-			cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.Nil(mt, err, "Watch error: %v", err)
 			defer closeStream(cs)
 
-			_, err = mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+			_, err = mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			assert.True(mt, cs.Next(mtest.Background), "expected Next to return true, got false (iteration error %v)",
+			assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false (iteration error %v)",
 				cs.Err())
 			assert.True(mt, isPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
 		})
@@ -574,7 +575,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 				},
 			})
 
-			_, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+			_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.NotNil(mt, err, "expected Watch error, got nil")
 
 			var numClearedEvents int
@@ -589,46 +590,46 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 	})
 	// Setting min server version as 4.0 since v3.6 does not send a "dropEvent"
 	mt.RunOpts("call to cursor.Next after cursor closed", mtest.NewOptions().MinServerVersion("4.0"), func(mt *mtest.T) {
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
 		// Generate insert events
 		generateEvents(mt, 5)
 		// Call Coll.Drop to generate drop and invalidate event
-		err = mt.Coll.Drop(mtest.Background)
+		err = mt.Coll.Drop(context.Background())
 		assert.Nil(mt, err, "Drop error: %v", err)
 
 		// Test that all events were successful
 		for i := 0; i < 7; i++ {
-			assert.True(mt, cs.Next(mtest.Background), "Next returned false at index %d; iteration error: %v", i, cs.Err())
+			assert.True(mt, cs.Next(context.Background()), "Next returned false at index %d; iteration error: %v", i, cs.Err())
 		}
 
 		operationType := cs.Current.Lookup("operationType").StringValue()
 		assert.Equal(mt, operationType, "invalidate", "expected invalidate event but returned %q event", operationType)
 		// next call to cs.Next should return False since cursor is closed
-		assert.False(mt, cs.Next(mtest.Background), "expected to return false, but returned true")
+		assert.False(mt, cs.Next(context.Background()), "expected to return false, but returned true")
 	})
 	mt.Run("getMore commands are monitored", func(mt *mtest.T) {
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
-		_, err = mt.Coll.InsertOne(mtest.Background, bson.M{"x": 1})
+		_, err = mt.Coll.InsertOne(context.Background(), bson.M{"x": 1})
 		assert.Nil(mt, err, "InsertOne error: %v", err)
 
 		mt.ClearEvents()
-		assert.True(mt, cs.Next(mtest.Background), "Next returned false with error %v", cs.Err())
+		assert.True(mt, cs.Next(context.Background()), "Next returned false with error %v", cs.Err())
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "getMore", evt.CommandName, "expected command 'getMore', got %q", evt.CommandName)
 	})
 	mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
-		cs, err := mt.Coll.Watch(mtest.Background, mongo.Pipeline{})
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 		assert.Nil(mt, err, "Watch error: %v", err)
 		defer closeStream(cs)
 
 		mt.ClearEvents()
-		err = cs.Close(mtest.Background)
+		err = cs.Close(context.Background())
 		assert.Nil(mt, err, "Close error: %v", err)
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
@@ -636,7 +637,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 }
 
 func closeStream(cs *mongo.ChangeStream) {
-	_ = cs.Close(mtest.Background)
+	_ = cs.Close(context.Background())
 }
 
 func generateEvents(mt *mtest.T, numEvents int) {
@@ -644,7 +645,7 @@ func generateEvents(mt *mtest.T, numEvents int) {
 
 	for i := 0; i < numEvents; i++ {
 		doc := bson.D{{"x", i}}
-		_, err := mt.Coll.InsertOne(mtest.Background, doc)
+		_, err := mt.Coll.InsertOne(context.Background(), doc)
 		assert.Nil(mt, err, "InsertOne error on document %v: %v", doc, err)
 	}
 }
@@ -653,7 +654,7 @@ func killChangeStreamCursor(mt *mtest.T, cs *mongo.ChangeStream) {
 	mt.Helper()
 
 	db := mt.Coll.Database().Client().Database("admin")
-	err := db.RunCommand(mtest.Background, bson.D{
+	err := db.RunCommand(context.Background(), bson.D{
 		{"killCursors", mt.Coll.Name()},
 		{"cursors", bson.A{cs.ID()}},
 	}).Err()

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -101,17 +101,17 @@ func TestClient(t *testing.T) {
 	registryOpts := options.Client().
 		SetRegistry(bson.NewRegistryBuilder().RegisterCodec(reflect.TypeOf(int64(0)), &negateCodec{}).Build())
 	mt.RunOpts("registry passed to cursors", mtest.NewOptions().ClientOptions(registryOpts), func(mt *mtest.T) {
-		_, err := mt.Coll.InsertOne(mtest.Background, negateCodec{ID: 10})
+		_, err := mt.Coll.InsertOne(context.Background(), negateCodec{ID: 10})
 		assert.Nil(mt, err, "InsertOne error: %v", err)
 		var got negateCodec
-		err = mt.Coll.FindOne(mtest.Background, bson.D{}).Decode(&got)
+		err = mt.Coll.FindOne(context.Background(), bson.D{}).Decode(&got)
 		assert.Nil(mt, err, "Find error: %v", err)
 
 		assert.Equal(mt, int64(-10), got.ID, "expected ID -10, got %v", got.ID)
 	})
 	mt.RunOpts("tls connection", mtest.NewOptions().MinServerVersion("3.0").SSL(true), func(mt *mtest.T) {
 		var result bson.Raw
-		err := mt.Coll.Database().RunCommand(mtest.Background, bson.D{
+		err := mt.Coll.Database().RunCommand(context.Background(), bson.D{
 			{"serverStatus", 1},
 		}).Decode(&result)
 		assert.Nil(mt, err, "serverStatus error: %v", err)
@@ -149,11 +149,11 @@ func TestClient(t *testing.T) {
 
 				// We don't care if the user doesn't already exist.
 				_ = db.RunCommand(
-					mtest.Background,
+					context.Background(),
 					bson.D{{"dropUser", user}},
 				)
 				err := db.RunCommand(
-					mtest.Background,
+					context.Background(),
 					bson.D{
 						{"createUser", user},
 						{"roles", bson.A{
@@ -178,11 +178,11 @@ func TestClient(t *testing.T) {
 				)
 				authClientOpts := options.Client().ApplyURI(cs)
 				testutil.AddTestServerAPIVersion(authClientOpts)
-				authClient, err := mongo.Connect(mtest.Background, authClientOpts)
+				authClient, err := mongo.Connect(context.Background(), authClientOpts)
 				assert.Nil(mt, err, "authClient Connect error: %v", err)
-				defer func() { _ = authClient.Disconnect(mtest.Background) }()
+				defer func() { _ = authClient.Disconnect(context.Background()) }()
 
-				rdr, err := authClient.Database("test").RunCommand(mtest.Background, bson.D{
+				rdr, err := authClient.Database("test").RunCommand(context.Background(), bson.D{
 					{"connectionStatus", 1},
 				}).DecodeBytes()
 				assert.Nil(mt, err, "connectionStatus error: %v", err)
@@ -228,7 +228,7 @@ func TestClient(t *testing.T) {
 				}
 
 				mt.RunOpts(tc.name, opts, func(mt *mtest.T) {
-					res, err := mt.Client.ListDatabases(mtest.Background, tc.filter)
+					res, err := mt.Client.ListDatabases(context.Background(), tc.filter)
 					assert.Nil(mt, err, "ListDatabases error: %v", err)
 
 					var found bool
@@ -246,7 +246,7 @@ func TestClient(t *testing.T) {
 			allOpts := options.ListDatabases().SetNameOnly(true).SetAuthorizedDatabases(true)
 			mt.ClearEvents()
 
-			_, err := mt.Client.ListDatabases(mtest.Background, bson.D{}, allOpts)
+			_, err := mt.Client.ListDatabases(context.Background(), bson.D{}, allOpts)
 			assert.Nil(mt, err, "ListDatabases error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -279,7 +279,7 @@ func TestClient(t *testing.T) {
 				}
 
 				mt.RunOpts(tc.name, opts, func(mt *mtest.T) {
-					dbs, err := mt.Client.ListDatabaseNames(mtest.Background, tc.filter)
+					dbs, err := mt.Client.ListDatabaseNames(context.Background(), tc.filter)
 					assert.Nil(mt, err, "ListDatabaseNames error: %v", err)
 
 					var found bool
@@ -297,7 +297,7 @@ func TestClient(t *testing.T) {
 			allOpts := options.ListDatabases().SetNameOnly(true).SetAuthorizedDatabases(true)
 			mt.ClearEvents()
 
-			_, err := mt.Client.ListDatabaseNames(mtest.Background, bson.D{}, allOpts)
+			_, err := mt.Client.ListDatabaseNames(context.Background(), bson.D{}, allOpts)
 			assert.Nil(mt, err, "ListDatabaseNames error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -313,7 +313,7 @@ func TestClient(t *testing.T) {
 	})
 	mt.RunOpts("ping", noClientOpts, func(mt *mtest.T) {
 		mt.Run("default read preference", func(mt *mtest.T) {
-			err := mt.Client.Ping(mtest.Background, nil)
+			err := mt.Client.Ping(context.Background(), nil)
 			assert.Nil(mt, err, "Ping error: %v", err)
 		})
 		mt.Run("invalid host", func(mt *mtest.T) {
@@ -323,11 +323,11 @@ func TestClient(t *testing.T) {
 				SetServerSelectionTimeout(100 * time.Millisecond).SetHosts([]string{"invalid:123"}).
 				SetConnectTimeout(500 * time.Millisecond).SetSocketTimeout(500 * time.Millisecond)
 			testutil.AddTestServerAPIVersion(invalidClientOpts)
-			client, err := mongo.Connect(mtest.Background, invalidClientOpts)
+			client, err := mongo.Connect(context.Background(), invalidClientOpts)
 			assert.Nil(mt, err, "Connect error: %v", err)
-			err = client.Ping(mtest.Background, readpref.Primary())
+			err = client.Ping(context.Background(), readpref.Primary())
 			assert.NotNil(mt, err, "expected error for pinging invalid host, got nil")
-			_ = client.Disconnect(mtest.Background)
+			_ = client.Disconnect(context.Background())
 		})
 	})
 	mt.RunOpts("disconnect", noClientOpts, func(mt *mtest.T) {
@@ -340,23 +340,23 @@ func TestClient(t *testing.T) {
 		mt.Run("disconnected", func(mt *mtest.T) {
 			c, err := mongo.NewClient(options.Client().ApplyURI(mtest.ClusterURI()))
 			assert.Nil(mt, err, "NewClient error: %v", err)
-			_, err = c.Watch(mtest.Background, mongo.Pipeline{})
+			_, err = c.Watch(context.Background(), mongo.Pipeline{})
 			assert.Equal(mt, mongo.ErrClientDisconnected, err, "expected error %v, got %v", mongo.ErrClientDisconnected, err)
 		})
 	})
 	mt.RunOpts("end sessions", mtest.NewOptions().MinServerVersion("3.6"), func(mt *mtest.T) {
-		_, err := mt.Client.ListDatabases(mtest.Background, bson.D{})
+		_, err := mt.Client.ListDatabases(context.Background(), bson.D{})
 		assert.Nil(mt, err, "ListDatabases error: %v", err)
 
 		mt.ClearEvents()
-		err = mt.Client.Disconnect(mtest.Background)
+		err = mt.Client.Disconnect(context.Background())
 		assert.Nil(mt, err, "Disconnect error: %v", err)
 
 		started := mt.GetStartedEvent()
 		assert.Equal(mt, "endSessions", started.CommandName, "expected cmd name endSessions, got %v", started.CommandName)
 	})
 	mt.RunOpts("hello lastWriteDate", mtest.NewOptions().Topologies(mtest.ReplicaSet), func(mt *mtest.T) {
-		_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.Nil(mt, err, "InsertOne error: %v", err)
 	})
 	sessionOpts := mtest.NewOptions().MinServerVersion("3.6.0").CreateClient(false)
@@ -375,7 +375,7 @@ func TestClient(t *testing.T) {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				sess, err := mt.Client.StartSession(tc.opts)
 				assert.Nil(mt, err, "StartSession error: %v", err)
-				defer sess.EndSession(mtest.Background)
+				defer sess.EndSession(context.Background())
 				xs := sess.(mongo.XSession)
 				consistent := xs.ClientSession().Consistent
 				assert.Equal(mt, tc.consistent, consistent, "expected consistent to be %v, got %v", tc.consistent, consistent)
@@ -428,9 +428,9 @@ func TestClient(t *testing.T) {
 
 				sess, err := mt.Client.StartSession()
 				assert.Nil(mt, err, "StartSession error: %v", err)
-				defer sess.EndSession(mtest.Background)
+				defer sess.EndSession(context.Background())
 
-				_, err = mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+				_, err = mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 				assert.NotNil(mt, err, "expected err but got nil")
 				if tc.expectUnsupportedMsg {
 					assert.Equal(mt, driver.ErrUnsupportedStorageEngine.Error(), err.Error(),
@@ -451,7 +451,7 @@ func TestClient(t *testing.T) {
 		ClientOptions(appNameClientOpts).
 		Topologies(mtest.Single)
 	mt.RunOpts("app name is always sent", appNameMtOpts, func(mt *mtest.T) {
-		err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
+		err := mt.Client.Ping(context.Background(), mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)
 
 		msgPairs := mt.GetProxiedMessages()
@@ -489,7 +489,7 @@ func TestClient(t *testing.T) {
 		MinServerVersion("3.6").     // Minimum server version 3.6 to force OP_MSG.
 		Topologies(mtest.ReplicaSet) // Read preference isn't sent to standalones so we can test on replica sets.
 	mt.RunOpts("direct connection made", mtOpts, func(mt *mtest.T) {
-		_, err := mt.Coll.Find(mtest.Background, bson.D{})
+		_, err := mt.Coll.Find(context.Background(), bson.D{})
 		assert.Nil(mt, err, "Find error: %v", err)
 
 		// When connected directly, the primary read preference should be overwritten to primaryPreferred.

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -48,16 +48,16 @@ func TestCollection(t *testing.T) {
 		mt.Run("success", func(mt *mtest.T) {
 			id := primitive.NewObjectID()
 			doc := bson.D{{"_id", id}, {"x", 1}}
-			res, err := mt.Coll.InsertOne(mtest.Background, doc)
+			res, err := mt.Coll.InsertOne(context.Background(), doc)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 			assert.Equal(mt, id, res.InsertedID, "expected inserted ID %v, got %v", id, res.InsertedID)
 		})
 		mt.Run("write error", func(mt *mtest.T) {
 			doc := bson.D{{"_id", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, doc)
+			_, err := mt.Coll.InsertOne(context.Background(), doc)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			_, err = mt.Coll.InsertOne(mtest.Background, doc)
+			_, err = mt.Coll.InsertOne(context.Background(), doc)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
 			assert.Equal(mt, 1, len(we.WriteErrors), "expected 1 write error, got %v", len(we.WriteErrors))
@@ -69,7 +69,7 @@ func TestCollection(t *testing.T) {
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet)
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			doc := bson.D{{"_id", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, doc)
+			_, err := mt.Coll.InsertOne(context.Background(), doc)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
@@ -103,7 +103,7 @@ func TestCollection(t *testing.T) {
 			for _, testCase := range nilOptsTestCases {
 				mt.Run(testCase.name, func(mt *mtest.T) {
 					doc := bson.D{{"x", 1}}
-					_, err := mt.Coll.InsertOne(mtest.Background, doc, testCase.opts...)
+					_, err := mt.Coll.InsertOne(context.Background(), doc, testCase.opts...)
 					assert.Nil(mt, err, "InsertOne error: %v", err)
 					optName := "bypassDocumentValidation"
 					evt := mt.GetStartedEvent()
@@ -129,7 +129,7 @@ func TestCollection(t *testing.T) {
 				bson.D{{"_id", want2}},
 			}
 
-			res, err := mt.Coll.InsertMany(mtest.Background, docs)
+			res, err := mt.Coll.InsertMany(context.Background(), docs)
 			assert.Nil(mt, err, "InsertMany error: %v", err)
 			assert.Equal(mt, 3, len(res.InsertedIDs), "expected 3 inserted IDs, got %v", len(res.InsertedIDs))
 			assert.Equal(mt, want1, res.InsertedIDs[0], "expected inserted ID %v, got %v", want1, res.InsertedIDs[0])
@@ -174,7 +174,7 @@ func TestCollection(t *testing.T) {
 			}
 
 			docs := []interface{}{create16MBDocument(mt), create16MBDocument(mt)}
-			_, err := mt.Coll.InsertMany(mtest.Background, docs)
+			_, err := mt.Coll.InsertMany(context.Background(), docs)
 			assert.Nil(mt, err, "InsertMany error: %v", err)
 			evt := mt.GetStartedEvent()
 			assert.Equal(mt, "insert", evt.CommandName, "expected 'insert' event, got '%v'", evt.CommandName)
@@ -198,9 +198,9 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					_, err := mt.Coll.InsertMany(mtest.Background, docs)
+					_, err := mt.Coll.InsertMany(context.Background(), docs)
 					assert.Nil(mt, err, "InsertMany error: %v", err)
-					_, err = mt.Coll.InsertMany(mtest.Background, docs, options.InsertMany().SetOrdered(tc.ordered))
+					_, err = mt.Coll.InsertMany(context.Background(), docs, options.InsertMany().SetOrdered(tc.ordered))
 
 					we, ok := err.(mongo.BulkWriteException)
 					assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteException{}, err)
@@ -231,7 +231,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					res, err := mt.Coll.InsertMany(mtest.Background, docs, options.InsertMany().SetOrdered(tc.ordered))
+					res, err := mt.Coll.InsertMany(context.Background(), docs, options.InsertMany().SetOrdered(tc.ordered))
 
 					assert.Equal(mt, tc.numInserted, len(res.InsertedIDs), "expected %v inserted IDs, got %v", tc.numInserted, len(res.InsertedIDs))
 					assert.Equal(mt, id, res.InsertedIDs[0], "expected inserted ID %v, got %v", id, res.InsertedIDs[0])
@@ -282,7 +282,7 @@ func TestCollection(t *testing.T) {
 		wcCollOpts := options.Collection().SetWriteConcern(impossibleWc)
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet)
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
-			_, err := mt.Coll.InsertMany(mtest.Background, []interface{}{bson.D{{"_id", 1}}})
+			_, err := mt.Coll.InsertMany(context.Background(), []interface{}{bson.D{{"_id", 1}}})
 			we, ok := err.(mongo.BulkWriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
@@ -291,20 +291,20 @@ func TestCollection(t *testing.T) {
 	mt.RunOpts("delete one", noClientOpts, func(mt *mtest.T) {
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 1}})
+			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 1}})
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 0}})
+			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}})
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("not found with options", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			opts := options.Delete().SetCollation(&options.Collation{Locale: "en_US"})
-			res, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 0}}, opts)
+			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
@@ -314,7 +314,7 @@ func TestCollection(t *testing.T) {
 				Name:       "deleteOne_capped",
 				CreateOpts: cappedOpts,
 			}, true)
-			_, err := capped.DeleteOne(mtest.Background, bson.D{{"x", 1}})
+			_, err := capped.DeleteOne(context.Background(), bson.D{{"x", 1}})
 
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
@@ -327,11 +327,11 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write concern error", mtest.NewOptions().Topologies(mtest.ReplicaSet), func(mt *mtest.T) {
 			// 2.6 returns right away if the document doesn't exist
 			filter := bson.D{{"x", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.DeleteOne(mtest.Background, filter)
+			_, err = mt.Coll.DeleteOne(context.Background(), filter)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got nil")
@@ -345,33 +345,33 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 
 			opts := options.Delete().SetHint(bson.M{"x": 1})
-			res, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 1}}, opts)
+			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 1}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("multikey map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
 			opts := options.Delete().SetHint(bson.M{"x": 1, "y": 1})
-			_, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 0}}, opts)
+			_, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
 	})
 	mt.RunOpts("delete many", noClientOpts, func(mt *mtest.T) {
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.DeleteMany(mtest.Background, bson.D{{"x", bson.D{{"$gte", 3}}}})
+			res, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$gte", 3}}}})
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(3), res.DeletedCount, "expected DeletedCount 3, got %v", res.DeletedCount)
 		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.DeleteMany(mtest.Background, bson.D{{"x", bson.D{{"$lt", 1}}}})
+			res, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$lt", 1}}}})
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("not found with options", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			opts := options.Delete().SetCollation(&options.Collation{Locale: "en_US"})
-			res, err := mt.Coll.DeleteMany(mtest.Background, bson.D{{"x", bson.D{{"$lt", 1}}}}, opts)
+			res, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$lt", 1}}}}, opts)
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
@@ -381,7 +381,7 @@ func TestCollection(t *testing.T) {
 				Name:       "deleteMany_capped",
 				CreateOpts: cappedOpts,
 			}, true)
-			_, err := capped.DeleteMany(mtest.Background, bson.D{{"x", 1}})
+			_, err := capped.DeleteMany(context.Background(), bson.D{{"x", 1}})
 
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
@@ -394,11 +394,11 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write concern error", mtest.NewOptions().Topologies(mtest.ReplicaSet), func(mt *mtest.T) {
 			// 2.6 server returns right away if the document doesn't exist
 			filter := bson.D{{"x", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.DeleteMany(mtest.Background, filter)
+			_, err = mt.Coll.DeleteMany(context.Background(), filter)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
@@ -412,19 +412,19 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "index CreateOne error: %v", err)
 
 			opts := options.Delete().SetHint(bson.M{"x": 1})
-			res, err := mt.Coll.DeleteOne(mtest.Background, bson.D{{"x", 1}}, opts)
+			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 1}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("multikey map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
 			opts := options.Delete().SetHint(bson.M{"x": 1, "y": 1})
-			_, err := mt.Coll.DeleteMany(mtest.Background, bson.D{{"x", 0}}, opts)
+			_, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
 	})
 	mt.RunOpts("update one", noClientOpts, func(mt *mtest.T) {
 		mt.Run("empty update", func(mt *mtest.T) {
-			_, err := mt.Coll.UpdateOne(mtest.Background, bson.D{}, bson.D{})
+			_, err := mt.Coll.UpdateOne(context.Background(), bson.D{}, bson.D{})
 			assert.NotNil(mt, err, "expected error, got nil")
 		})
 		mt.Run("found", func(mt *mtest.T) {
@@ -432,7 +432,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 1}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateOne(mtest.Background, filter, update)
+			res, err := mt.Coll.UpdateOne(context.Background(), filter, update)
 			assert.Nil(mt, err, "UpdateOne error: %v", err)
 			assert.Equal(mt, int64(1), res.MatchedCount, "expected matched count 1, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(1), res.ModifiedCount, "expected matched count 1, got %v", res.ModifiedCount)
@@ -443,7 +443,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 0}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateOne(mtest.Background, filter, update)
+			res, err := mt.Coll.UpdateOne(context.Background(), filter, update)
 			assert.Nil(mt, err, "UpdateOne error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected matched count 0, got %v", res.ModifiedCount)
@@ -454,7 +454,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 0}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateOne(mtest.Background, filter, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateOne(context.Background(), filter, update, options.Update().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateOne error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected matched count 0, got %v", res.ModifiedCount)
@@ -463,10 +463,10 @@ func TestCollection(t *testing.T) {
 		mt.Run("write error", func(mt *mtest.T) {
 			filter := bson.D{{"_id", "foo"}}
 			update := bson.D{{"$set", bson.D{{"_id", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			_, err = mt.Coll.UpdateOne(mtest.Background, filter, update)
+			_, err = mt.Coll.UpdateOne(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			numWriteErrors := len(we.WriteErrors)
@@ -478,11 +478,11 @@ func TestCollection(t *testing.T) {
 			// 2.6 returns right away if the document doesn't exist
 			filter := bson.D{{"_id", "foo"}}
 			update := bson.D{{"$set", bson.D{{"pi", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.UpdateOne(mtest.Background, filter, update)
+			_, err = mt.Coll.UpdateOne(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
@@ -509,10 +509,10 @@ func TestCollection(t *testing.T) {
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
 					filter := bson.D{{"x", 1}}
-					_, err := mt.Coll.InsertOne(mtest.Background, filter)
+					_, err := mt.Coll.InsertOne(context.Background(), filter)
 					assert.Nil(mt, err, "InsertOne error: %v", err)
 
-					res, err := mt.Coll.UpdateOne(mtest.Background, filter, tc.update)
+					res, err := mt.Coll.UpdateOne(context.Background(), filter, tc.update)
 					assert.Nil(mt, err, "UpdateOne error: %v", err)
 					assert.Equal(mt, int64(1), res.MatchedCount, "expected matched count 1, got %v", res.MatchedCount)
 					assert.Equal(mt, int64(1), res.ModifiedCount, "expected modified count 1, got %v", res.ModifiedCount)
@@ -522,11 +522,11 @@ func TestCollection(t *testing.T) {
 	})
 	mt.RunOpts("update by id", noClientOpts, func(mt *mtest.T) {
 		mt.Run("empty update", func(mt *mtest.T) {
-			_, err := mt.Coll.UpdateByID(mtest.Background, "foo", bson.D{})
+			_, err := mt.Coll.UpdateByID(context.Background(), "foo", bson.D{})
 			assert.NotNil(mt, err, "expected error, got nil")
 		})
 		mt.Run("nil id", func(mt *mtest.T) {
-			_, err := mt.Coll.UpdateByID(mtest.Background, nil, bson.D{{"$inc", bson.D{{"x", 1}}}})
+			_, err := mt.Coll.UpdateByID(context.Background(), nil, bson.D{{"$inc", bson.D{{"x", 1}}}})
 			assert.Equal(mt, err, mongo.ErrNilValue, "expected %v, got %v", mongo.ErrNilValue, err)
 		})
 		mt.RunOpts("found", noClientOpts, func(mt *mtest.T) {
@@ -541,12 +541,12 @@ func TestCollection(t *testing.T) {
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
 					doc := bson.D{{"_id", tc.id}, {"x", 1}}
-					_, err := mt.Coll.InsertOne(mtest.Background, doc)
+					_, err := mt.Coll.InsertOne(context.Background(), doc)
 					assert.Nil(mt, err, "InsertOne error: %v", err)
 
 					update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-					res, err := mt.Coll.UpdateByID(mtest.Background, tc.id, update)
+					res, err := mt.Coll.UpdateByID(context.Background(), tc.id, update)
 					assert.Nil(mt, err, "UpdateByID error: %v", err)
 					assert.Equal(mt, int64(1), res.MatchedCount, "expected matched count 1, got %v", res.MatchedCount)
 					assert.Equal(mt, int64(1), res.ModifiedCount, "expected modified count 1, got %v", res.ModifiedCount)
@@ -557,12 +557,12 @@ func TestCollection(t *testing.T) {
 		mt.Run("not found", func(mt *mtest.T) {
 			id := primitive.NewObjectID()
 			doc := bson.D{{"_id", id}, {"x", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, doc)
+			_, err := mt.Coll.InsertOne(context.Background(), doc)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateByID(mtest.Background, 0, update)
+			res, err := mt.Coll.UpdateByID(context.Background(), 0, update)
 			assert.Nil(mt, err, "UpdateByID error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -570,13 +570,13 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("upsert", func(mt *mtest.T) {
 			doc := bson.D{{"_id", primitive.NewObjectID()}, {"x", 1}}
-			_, err := mt.Coll.InsertOne(mtest.Background, doc)
+			_, err := mt.Coll.InsertOne(context.Background(), doc)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
 			id := "blah"
-			res, err := mt.Coll.UpdateByID(mtest.Background, id, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateByID(context.Background(), id, update, options.Update().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateByID error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -585,10 +585,10 @@ func TestCollection(t *testing.T) {
 		mt.Run("write error", func(mt *mtest.T) {
 			id := "foo"
 			update := bson.D{{"$set", bson.D{{"_id", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"_id", id}})
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"_id", id}})
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			_, err = mt.Coll.UpdateByID(mtest.Background, id, update)
+			_, err = mt.Coll.UpdateByID(context.Background(), id, update)
 			se, ok := err.(mongo.ServerError)
 			assert.True(mt, ok, "expected ServerError, got %v", err)
 			assert.True(mt, se.HasErrorCode(errorModifiedID), "expected error code %v, got %v", errorModifiedID, err)
@@ -597,11 +597,11 @@ func TestCollection(t *testing.T) {
 			// 2.6 returns right away if the document doesn't exist
 			id := "foo"
 			update := bson.D{{"$set", bson.D{{"pi", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"_id", id}})
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"_id", id}})
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.UpdateByID(mtest.Background, id, update)
+			_, err = mt.Coll.UpdateByID(context.Background(), id, update)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
@@ -609,7 +609,7 @@ func TestCollection(t *testing.T) {
 	})
 	mt.RunOpts("update many", noClientOpts, func(mt *mtest.T) {
 		mt.Run("empty update", func(mt *mtest.T) {
-			_, err := mt.Coll.UpdateMany(mtest.Background, bson.D{}, bson.D{})
+			_, err := mt.Coll.UpdateMany(context.Background(), bson.D{}, bson.D{})
 			assert.NotNil(mt, err, "expected error, got nil")
 		})
 		mt.Run("found", func(mt *mtest.T) {
@@ -617,7 +617,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", bson.D{{"$gte", 3}}}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateMany(mtest.Background, filter, update)
+			res, err := mt.Coll.UpdateMany(context.Background(), filter, update)
 			assert.Nil(mt, err, "UpdateMany error: %v", err)
 			assert.Equal(mt, int64(3), res.MatchedCount, "expected matched count 3, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(3), res.ModifiedCount, "expected modified count 3, got %v", res.ModifiedCount)
@@ -628,7 +628,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", bson.D{{"$lt", 1}}}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateMany(mtest.Background, filter, update)
+			res, err := mt.Coll.UpdateMany(context.Background(), filter, update)
 			assert.Nil(mt, err, "UpdateMany error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -639,7 +639,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", bson.D{{"$lt", 1}}}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateMany(mtest.Background, filter, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateMany(context.Background(), filter, update, options.Update().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateMany error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -648,10 +648,10 @@ func TestCollection(t *testing.T) {
 		mt.Run("write error", func(mt *mtest.T) {
 			filter := bson.D{{"_id", "foo"}}
 			update := bson.D{{"$set", bson.D{{"_id", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			_, err = mt.Coll.UpdateMany(mtest.Background, filter, update)
+			_, err = mt.Coll.UpdateMany(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			numWriteErrors := len(we.WriteErrors)
@@ -663,11 +663,11 @@ func TestCollection(t *testing.T) {
 			// 2.6 returns right away if the document doesn't exist
 			filter := bson.D{{"_id", "foo"}}
 			update := bson.D{{"$set", bson.D{{"pi", 3.14159}}}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.UpdateMany(mtest.Background, filter, update)
+			_, err = mt.Coll.UpdateMany(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
@@ -679,7 +679,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 1}}
 			replacement := bson.D{{"y", 1}}
 
-			res, err := mt.Coll.ReplaceOne(mtest.Background, filter, replacement)
+			res, err := mt.Coll.ReplaceOne(context.Background(), filter, replacement)
 			assert.Nil(mt, err, "ReplaceOne error: %v", err)
 			assert.Equal(mt, int64(1), res.MatchedCount, "expected matched count 1, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(1), res.ModifiedCount, "expected modified count 1, got %v", res.ModifiedCount)
@@ -690,7 +690,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 0}}
 			replacement := bson.D{{"y", 1}}
 
-			res, err := mt.Coll.ReplaceOne(mtest.Background, filter, replacement)
+			res, err := mt.Coll.ReplaceOne(context.Background(), filter, replacement)
 			assert.Nil(mt, err, "ReplaceOne error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -701,7 +701,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 0}}
 			replacement := bson.D{{"y", 1}}
 
-			res, err := mt.Coll.ReplaceOne(mtest.Background, filter, replacement, options.Replace().SetUpsert(true))
+			res, err := mt.Coll.ReplaceOne(context.Background(), filter, replacement, options.Replace().SetUpsert(true))
 			assert.Nil(mt, err, "ReplaceOne error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -710,10 +710,10 @@ func TestCollection(t *testing.T) {
 		mt.Run("write error", func(mt *mtest.T) {
 			filter := bsonx.Doc{{"_id", bsonx.String("foo")}}
 			replacement := bsonx.Doc{{"_id", bsonx.Double(3.14159)}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			_, err = mt.Coll.ReplaceOne(mtest.Background, filter, replacement)
+			_, err = mt.Coll.ReplaceOne(context.Background(), filter, replacement)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			numWriteErrors := len(we.WriteErrors)
@@ -726,11 +726,11 @@ func TestCollection(t *testing.T) {
 			// 2.6 returns right away if document doesn't exist
 			filter := bson.D{{"_id", "foo"}}
 			replacement := bson.D{{"pi", 3.14159}}
-			_, err := mt.Coll.InsertOne(mtest.Background, filter)
+			_, err := mt.Coll.InsertOne(context.Background(), filter)
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
-			_, err = mt.Coll.ReplaceOne(mtest.Background, filter, replacement)
+			_, err = mt.Coll.ReplaceOne(context.Background(), filter, replacement)
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got nil")
@@ -747,11 +747,11 @@ func TestCollection(t *testing.T) {
 				}}},
 				bson.D{{"$sort", bson.D{{"x", 1}}}},
 			}
-			cursor, err := mt.Coll.Aggregate(mtest.Background, pipeline)
+			cursor, err := mt.Coll.Aggregate(context.Background(), pipeline)
 			assert.Nil(mt, err, "Aggregate error: %v", err)
 
 			for i := 2; i < 5; i++ {
-				assert.True(mt, cursor.Next(mtest.Background), "expected Next true, got false (i=%v)", i)
+				assert.True(mt, cursor.Next(context.Background()), "expected Next true, got false (i=%v)", i)
 				elems, _ := cursor.Current.Elements()
 				assert.Equal(mt, 1, len(elems), "expected doc with 1 element, got %v", cursor.Current)
 
@@ -774,7 +774,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.RunOpts("multikey map hint", mtest.NewOptions().MinServerVersion("3.6"), func(mt *mtest.T) {
 			pipeline := mongo.Pipeline{bson.D{{"$out", mt.Coll.Name()}}}
-			cursor, err := mt.Coll.Aggregate(mtest.Background, pipeline, options.Aggregate().SetHint(bson.M{"x": 1, "y": 1}))
+			cursor, err := mt.Coll.Aggregate(context.Background(), pipeline, options.Aggregate().SetHint(bson.M{"x": 1, "y": 1}))
 			assert.Nil(mt, cursor, "expected cursor nil, got %v", cursor)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
@@ -782,7 +782,7 @@ func TestCollection(t *testing.T) {
 		wcTestOpts := mtest.NewOptions().Topologies(mtest.ReplicaSet).MinServerVersion("3.6").CollectionOptions(wcCollOpts)
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			pipeline := mongo.Pipeline{{{"$out", mt.Coll.Name()}}}
-			cursor, err := mt.Coll.Aggregate(mtest.Background, pipeline)
+			cursor, err := mt.Coll.Aggregate(context.Background(), pipeline)
 			assert.Nil(mt, cursor, "expected cursor nil, got %v", cursor)
 			_, ok := err.(mongo.WriteConcernError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteConcernError{}, err)
@@ -790,13 +790,13 @@ func TestCollection(t *testing.T) {
 		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertGetMoreCommandsAreMonitored(mt, "aggregate", func() (*mongo.Cursor, error) {
-				return mt.Coll.Aggregate(mtest.Background, mongo.Pipeline{}, options.Aggregate().SetBatchSize(3))
+				return mt.Coll.Aggregate(context.Background(), mongo.Pipeline{}, options.Aggregate().SetBatchSize(3))
 			})
 		})
 		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertKillCursorsCommandsAreMonitored(mt, "aggregate", func() (*mongo.Cursor, error) {
-				return mt.Coll.Aggregate(mtest.Background, mongo.Pipeline{}, options.Aggregate().SetBatchSize(3))
+				return mt.Coll.Aggregate(context.Background(), mongo.Pipeline{}, options.Aggregate().SetBatchSize(3))
 			})
 		})
 	})
@@ -825,7 +825,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					count, err := mt.Coll.CountDocuments(mtest.Background, tc.filter, tc.opts)
+					count, err := mt.Coll.CountDocuments(context.Background(), tc.filter, tc.opts)
 					assert.Nil(mt, err, "CountDocuments error: %v", err)
 					assert.Equal(mt, tc.count, count, "expected count %v, got %v", tc.count, count)
 				})
@@ -833,7 +833,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("multikey map hint", func(mt *mtest.T) {
 			opts := options.Count().SetHint(bson.M{"x": 1, "y": 1})
-			_, err := mt.Coll.CountDocuments(mtest.Background, bson.D{}, opts)
+			_, err := mt.Coll.CountDocuments(context.Background(), bson.D{}, opts)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
 	})
@@ -849,7 +849,7 @@ func TestCollection(t *testing.T) {
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				initCollection(mt, mt.Coll)
-				count, err := mt.Coll.EstimatedDocumentCount(mtest.Background, tc.opts)
+				count, err := mt.Coll.EstimatedDocumentCount(context.Background(), tc.opts)
 				assert.Nil(mt, err, "EstimatedDocumentCount error: %v", err)
 				assert.Equal(mt, tc.count, count, "expected count %v, got %v", tc.count, count)
 			})
@@ -871,7 +871,7 @@ func TestCollection(t *testing.T) {
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				initCollection(mt, mt.Coll)
-				res, err := mt.Coll.Distinct(mtest.Background, "x", tc.filter, tc.opts)
+				res, err := mt.Coll.Distinct(context.Background(), "x", tc.filter, tc.opts)
 				assert.Nil(mt, err, "Distinct error: %v", err)
 				assert.Equal(mt, tc.expected, res, "expected result %v, got %v", tc.expected, res)
 			})
@@ -880,11 +880,11 @@ func TestCollection(t *testing.T) {
 	mt.RunOpts("find", noClientOpts, func(mt *mtest.T) {
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetSort(bson.D{{"x", 1}}))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetSort(bson.D{{"x", 1}}))
 			assert.Nil(mt, err, "Find error: %v", err)
 
 			results := make([]int, 0, 5)
-			for cursor.Next(mtest.Background) {
+			for cursor.Next(context.Background()) {
 				x, err := cursor.Current.LookupErr("x")
 				assert.Nil(mt, err, "x not found in document %v", cursor.Current)
 				assert.Equal(mt, bson.TypeInt32, x.Type, "expected x type %v, got %v", bson.TypeInt32, x.Type)
@@ -897,11 +897,11 @@ func TestCollection(t *testing.T) {
 		mt.Run("limit and batch size", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			for _, batchSize := range []int32{2, 3, 4} {
-				cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetLimit(3).SetBatchSize(batchSize))
+				cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetLimit(3).SetBatchSize(batchSize))
 				assert.Nil(mt, err, "Find error: %v", err)
 
 				numReceived := 0
-				for cursor.Next(mtest.Background) {
+				for cursor.Next(context.Background()) {
 					numReceived++
 				}
 				err = cursor.Err()
@@ -911,62 +911,62 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{{"x", 6}})
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{{"x", 6}})
 			assert.Nil(mt, err, "Find error: %v", err)
-			assert.False(mt, cursor.Next(mtest.Background), "expected no documents, found %v", cursor.Current)
+			assert.False(mt, cursor.Next(context.Background()), "expected no documents, found %v", cursor.Current)
 		})
 		mt.Run("invalid identifier error", func(mt *mtest.T) {
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{{"$foo", 1}})
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{{"$foo", 1}})
 			assert.NotNil(mt, err, "expected error for invalid identifier, got nil")
 			assert.Nil(mt, cursor, "expected nil cursor, got %v", cursor)
 		})
 		mt.Run("negative limit", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			c, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetLimit(-2))
+			c, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetLimit(-2))
 			assert.Nil(mt, err, "Find error: %v", err)
 			// single batch returned so cursor should have ID 0
 			assert.Equal(mt, int64(0), c.ID(), "expected cursor ID 0, got %v", c.ID())
 
 			var numDocs int
-			for c.Next(mtest.Background) {
+			for c.Next(context.Background()) {
 				numDocs++
 			}
 			assert.Equal(mt, 2, numDocs, "expected 2 documents, got %v", numDocs)
 		})
 		mt.Run("exhaust cursor", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			c, err := mt.Coll.Find(mtest.Background, bson.D{})
+			c, err := mt.Coll.Find(context.Background(), bson.D{})
 			assert.Nil(mt, err, "Find error: %v", err)
 
 			var numDocs int
-			for c.Next(mtest.Background) {
+			for c.Next(context.Background()) {
 				numDocs++
 			}
 			assert.Equal(mt, 5, numDocs, "expected 5 documents, got %v", numDocs)
-			err = c.Close(mtest.Background)
+			err = c.Close(context.Background())
 			assert.Nil(mt, err, "Close error: %v", err)
 		})
 		mt.Run("hint", func(mt *mtest.T) {
-			_, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetHint("_id_"))
+			_, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetHint("_id_"))
 			assert.Nil(mt, err, "Find error with string hint: %v", err)
 
-			_, err = mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetHint(bson.D{{"_id", 1}}))
+			_, err = mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetHint(bson.D{{"_id", 1}}))
 			assert.Nil(mt, err, "Find error with document hint: %v", err)
 
-			_, err = mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetHint("foobar"))
+			_, err = mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetHint("foobar"))
 			_, ok := err.(mongo.CommandError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.CommandError{}, err)
 
-			_, err = mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetHint(bson.M{"_id": 1}))
+			_, err = mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetHint(bson.M{"_id": 1}))
 			assert.Nil(mt, err, "Find error with single key map hint: %v", err)
 
-			_, err = mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetHint(bson.M{"_id": 1, "x": 1}))
+			_, err = mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetHint(bson.M{"_id": 1, "x": 1}))
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
 		mt.Run("sort", func(mt *mtest.T) {
-			_, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetSort(bson.M{"_id": 1}))
+			_, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetSort(bson.M{"_id": 1}))
 			assert.Nil(mt, err, "Find error with single key map sort: %v", err)
-			_, err = mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetSort(bson.M{"_id": 1, "x": 1}))
+			_, err = mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetSort(bson.M{"_id": 1, "x": 1}))
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"sort"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"sort"}, err)
 		})
 		mt.Run("limit and batch size and skip", func(mt *mtest.T) {
@@ -1004,16 +1004,16 @@ func TestCollection(t *testing.T) {
 						insertDocs = append(insertDocs, bson.D{{"x", int32(i)}})
 					}
 
-					_, err := mt.Coll.InsertMany(mtest.Background, insertDocs)
+					_, err := mt.Coll.InsertMany(context.Background(), insertDocs)
 					assert.Nil(mt, err, "InsertMany error for initial data: %v", err)
 
 					findOptions := options.Find().SetLimit(tc.limit).SetBatchSize(tc.batchSize).
 						SetSkip(tc.skip)
-					cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, findOptions)
+					cursor, err := mt.Coll.Find(context.Background(), bson.D{}, findOptions)
 					assert.Nil(mt, err, "Find error: %v", err)
 
 					var docs []interface{}
-					err = cursor.All(mtest.Background, &docs)
+					err = cursor.All(context.Background(), &docs)
 					assert.Nil(mt, err, "All error: %v", err)
 					if (201 - tc.skip) < tc.limit {
 						assert.Equal(mt, int(201-tc.skip), len(docs), "expected number of docs to be %v, got %v", int(201-tc.skip), len(docs))
@@ -1052,14 +1052,14 @@ func TestCollection(t *testing.T) {
 						insertDocs = append(insertDocs, bson.D{{"x", int32(i)}})
 					}
 
-					_, err := mt.Coll.InsertMany(mtest.Background, insertDocs)
+					_, err := mt.Coll.InsertMany(context.Background(), insertDocs)
 					assert.Nil(mt, err, "InsertMany error for initial data: %v", err)
 					opts := options.Find().SetSkip(0).SetLimit(tc.limit)
-					cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, opts)
+					cursor, err := mt.Coll.Find(context.Background(), bson.D{}, opts)
 					assert.Nil(mt, err, "Find error with limit %v: %v", tc.limit, err)
 
 					var docs []interface{}
-					err = cursor.All(mtest.Background, &docs)
+					err = cursor.All(context.Background(), &docs)
 					assert.Nil(mt, err, "All error with limit %v: %v", tc.limit, err)
 
 					assert.Equal(mt, int(tc.limit), len(docs), "expected number of docs to be %v, got %v", tc.limit, len(docs))
@@ -1069,19 +1069,19 @@ func TestCollection(t *testing.T) {
 		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertGetMoreCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
-				return mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(3))
+				return mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(3))
 			})
 		})
 		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			assertKillCursorsCommandsAreMonitored(mt, "find", func() (*mongo.Cursor, error) {
-				return mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(3))
+				return mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(3))
 			})
 		})
 	})
 	mt.RunOpts("find one", noClientOpts, func(mt *mtest.T) {
 		mt.Run("limit", func(mt *mtest.T) {
-			err := mt.Coll.FindOne(mtest.Background, bson.D{}).Err()
+			err := mt.Coll.FindOne(context.Background(), bson.D{}).Err()
 			assert.Equal(mt, mongo.ErrNoDocuments, err, "expected error %v, got %v", mongo.ErrNoDocuments, err)
 
 			started := mt.GetStartedEvent()
@@ -1093,7 +1093,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.FindOne(mtest.Background, bson.D{{"x", 1}}).DecodeBytes()
+			res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}).DecodeBytes()
 			assert.Nil(mt, err, "FindOne error: %v", err)
 
 			x, err := res.LookupErr("x")
@@ -1135,7 +1135,7 @@ func TestCollection(t *testing.T) {
 				SetShowRecordID(false).
 				SetSkip(0).
 				SetSort(bson.D{{"x", int32(1)}})
-			res, err := mt.Coll.FindOne(mtest.Background, bson.D{}, opts).DecodeBytes()
+			res, err := mt.Coll.FindOne(context.Background(), bson.D{}, opts).DecodeBytes()
 			assert.Nil(mt, err, "FindOne error: %v", err)
 
 			x, err := res.LookupErr("x")
@@ -1172,7 +1172,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			err := mt.Coll.FindOne(mtest.Background, bson.D{{"x", 6}}).Err()
+			err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 6}}).Err()
 			assert.Equal(mt, mongo.ErrNoDocuments, err, "expected error %v, got %v", mongo.ErrNoDocuments, err)
 		})
 		mt.RunOpts("maps for sorted opts", noClientOpts, func(mt *mtest.T) {
@@ -1195,7 +1195,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOne(mtest.Background, bson.D{{"x", 1}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}, tc.opts).DecodeBytes()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1216,7 +1216,7 @@ func TestCollection(t *testing.T) {
 	mt.RunOpts("find one and delete", noClientOpts, func(mt *mtest.T) {
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.FindOneAndDelete(mtest.Background, bson.D{{"x", 3}}).DecodeBytes()
+			res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).DecodeBytes()
 			assert.Nil(mt, err, "FindOneAndDelete error: %v", err)
 
 			elem, err := res.LookupErr("x")
@@ -1227,12 +1227,12 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("found ignore result", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			err := mt.Coll.FindOneAndDelete(mtest.Background, bson.D{{"x", 3}}).Err()
+			err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).Err()
 			assert.Nil(mt, err, "FindOneAndDelete error: %v", err)
 		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			err := mt.Coll.FindOneAndDelete(mtest.Background, bson.D{{"x", 6}}).Err()
+			err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 6}}).Err()
 			assert.Equal(mt, mongo.ErrNoDocuments, err, "expected error %v, got %v", mongo.ErrNoDocuments, err)
 		})
 		mt.RunOpts("maps for sorted opts", noClientOpts, func(mt *mtest.T) {
@@ -1255,7 +1255,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndDelete(mtest.Background, bson.D{{"x", 1}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 1}}, tc.opts).DecodeBytes()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1275,7 +1275,7 @@ func TestCollection(t *testing.T) {
 		wcCollOpts := options.Collection().SetWriteConcern(impossibleWc)
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet).MinServerVersion("3.2")
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
-			err := mt.Coll.FindOneAndDelete(mtest.Background, bson.D{{"x", 3}}).Err()
+			err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).Err()
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
@@ -1287,7 +1287,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			replacement := bson.D{{"y", 3}}
 
-			res, err := mt.Coll.FindOneAndReplace(mtest.Background, filter, replacement).DecodeBytes()
+			res, err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).DecodeBytes()
 			assert.Nil(mt, err, "FindOneAndReplace error: %v", err)
 			elem, err := res.LookupErr("x")
 			assert.Nil(mt, err, "x not found in result %v", res)
@@ -1300,7 +1300,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			replacement := bson.D{{"y", 3}}
 
-			err := mt.Coll.FindOneAndReplace(mtest.Background, filter, replacement).Err()
+			err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).Err()
 			assert.Nil(mt, err, "FindOneAndReplace error: %v", err)
 		})
 		mt.Run("not found", func(mt *mtest.T) {
@@ -1308,7 +1308,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 6}}
 			replacement := bson.D{{"y", 6}}
 
-			err := mt.Coll.FindOneAndReplace(mtest.Background, filter, replacement).Err()
+			err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).Err()
 			assert.Equal(mt, mongo.ErrNoDocuments, err, "expected error %v, got %v", mongo.ErrNoDocuments, err)
 		})
 		mt.RunOpts("maps for sorted opts", noClientOpts, func(mt *mtest.T) {
@@ -1331,7 +1331,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndReplace(mtest.Background, bson.D{{"x", 1}}, bson.D{{"y", 3}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndReplace(context.Background(), bson.D{{"x", 1}}, bson.D{{"y", 3}}, tc.opts).DecodeBytes()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1353,7 +1353,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			filter := bson.D{{"x", 3}}
 			replacement := bson.D{{"y", 3}}
-			err := mt.Coll.FindOneAndReplace(mtest.Background, filter, replacement).Err()
+			err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).Err()
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
@@ -1365,7 +1365,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			update := bson.D{{"$set", bson.D{{"x", 6}}}}
 
-			res, err := mt.Coll.FindOneAndUpdate(mtest.Background, filter, update).DecodeBytes()
+			res, err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).DecodeBytes()
 			assert.Nil(mt, err, "FindOneAndUpdate error: %v", err)
 			elem, err := res.LookupErr("x")
 			assert.Nil(mt, err, "x not found in result %v", res)
@@ -1374,7 +1374,7 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, int32(3), x, "expected x value 3, got %v", x)
 		})
 		mt.Run("empty update", func(mt *mtest.T) {
-			err := mt.Coll.FindOneAndUpdate(mtest.Background, bson.D{}, bson.D{})
+			err := mt.Coll.FindOneAndUpdate(context.Background(), bson.D{}, bson.D{})
 			assert.NotNil(mt, err, "expected error, got nil")
 		})
 		mt.Run("found ignore result", func(mt *mtest.T) {
@@ -1382,7 +1382,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			update := bson.D{{"$set", bson.D{{"x", 6}}}}
 
-			err := mt.Coll.FindOneAndUpdate(mtest.Background, filter, update).Err()
+			err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).Err()
 			assert.Nil(mt, err, "FindOneAndUpdate error: %v", err)
 		})
 		mt.Run("not found", func(mt *mtest.T) {
@@ -1390,7 +1390,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 6}}
 			update := bson.D{{"$set", bson.D{{"y", 6}}}}
 
-			err := mt.Coll.FindOneAndUpdate(mtest.Background, filter, update).Err()
+			err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).Err()
 			assert.Equal(mt, mongo.ErrNoDocuments, err, "expected error %v, got %v", mongo.ErrNoDocuments, err)
 		})
 		mt.RunOpts("maps for sorted opts", noClientOpts, func(mt *mtest.T) {
@@ -1413,7 +1413,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndUpdate(mtest.Background, bson.D{{"x", 1}}, bson.D{{"$set", bson.D{{"x", 6}}}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndUpdate(context.Background(), bson.D{{"x", 1}}, bson.D{{"$set", bson.D{{"x", 6}}}}, tc.opts).DecodeBytes()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1435,7 +1435,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			filter := bson.D{{"x", 3}}
 			update := bson.D{{"$set", bson.D{{"x", 6}}}}
-			err := mt.Coll.FindOneAndUpdate(mtest.Background, filter, update).Err()
+			err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).Err()
 			we, ok := err.(mongo.WriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
@@ -1461,7 +1461,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					_, err := mt.Coll.BulkWrite(mtest.Background, tc.models)
+					_, err := mt.Coll.BulkWrite(context.Background(), tc.models)
 					bwe, ok := err.(mongo.BulkWriteException)
 					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
@@ -1487,7 +1487,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					res, err := mt.Coll.BulkWrite(mtest.Background, models, options.BulkWrite().SetOrdered(tc.ordered))
+					res, err := mt.Coll.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(tc.ordered))
 					assert.Equal(mt, tc.insertedCount, res.InsertedCount,
 						"expected inserted count %v, got %v", tc.insertedCount, res.InsertedCount)
 
@@ -1520,7 +1520,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					_, err := capped.BulkWrite(mtest.Background, models, options.BulkWrite().SetOrdered(tc.ordered))
+					_, err := capped.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(tc.ordered))
 					bwe, ok := err.(mongo.BulkWriteException)
 					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
@@ -1549,9 +1549,9 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					_, err := mt.Coll.InsertOne(mtest.Background, filter)
+					_, err := mt.Coll.InsertOne(context.Background(), filter)
 					assert.Nil(mt, err, "InsertOne error: %v", err)
-					res, err := mt.Coll.BulkWrite(mtest.Background, models, options.BulkWrite().SetOrdered(tc.ordered))
+					res, err := mt.Coll.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(tc.ordered))
 					assert.Equal(mt, tc.modifiedCount, res.ModifiedCount,
 						"expected modified count %v, got %v", tc.modifiedCount, res.ModifiedCount)
 
@@ -1589,7 +1589,7 @@ func TestCollection(t *testing.T) {
 				}),
 			}
 
-			_, err := mt.Coll.BulkWrite(mtest.Background, models)
+			_, err := mt.Coll.BulkWrite(context.Background(), models)
 			bwException, ok := err.(mongo.BulkWriteException)
 			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteException{}, err)
 
@@ -1609,7 +1609,7 @@ func TestCollection(t *testing.T) {
 				mongo.NewInsertOneModel().SetDocument(bson.D{{"_id", "id1"}}),
 				mongo.NewInsertOneModel().SetDocument(bson.D{{"_id", "id3"}}),
 			}
-			_, err := capped.BulkWrite(mtest.Background, models, options.BulkWrite())
+			_, err := capped.BulkWrite(context.Background(), models, options.BulkWrite())
 			assert.Nil(t, err, "BulkWrite error: %v", err)
 
 			// UpdateOne and ReplaceOne models are batched together, so they each appear once
@@ -1625,7 +1625,7 @@ func TestCollection(t *testing.T) {
 				mongo.NewReplaceOneModel().SetFilter(bson.D{{"_id", "id3"}}).SetReplacement(bson.D{{"_id", 3.14159}}),
 				mongo.NewUpdateManyModel().SetFilter(bson.D{{"_id", "id3"}}).SetUpdate(bson.D{{"$set", bson.D{{"_id", 3.14159}}}}),
 			}
-			_, err = capped.BulkWrite(mtest.Background, models, options.BulkWrite().SetOrdered(false))
+			_, err = capped.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(false))
 			bwException, ok := err.(mongo.BulkWriteException)
 			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteException{}, err)
 
@@ -1662,7 +1662,7 @@ func TestCollection(t *testing.T) {
 				mongo.NewReplaceOneModel().SetFilter(bson.D{{"_id", id3}}).SetReplacement(bson.D{{"_id", id3}}).SetUpsert(true),
 				mongo.NewDeleteOneModel().SetFilter(bson.D{{"_id", "id4"}}),
 			}
-			res, err := mt.Coll.BulkWrite(mtest.Background, models, options.BulkWrite().SetOrdered(false))
+			res, err := mt.Coll.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(false))
 			assert.Nil(mt, err, "bulkwrite error: %v", err)
 
 			assert.Equal(mt, len(res.UpsertedIDs), 2, "expected 2 UpsertedIDs, got %v", len(res.UpsertedIDs))
@@ -1678,7 +1678,7 @@ func TestCollection(t *testing.T) {
 			models := []mongo.WriteModel{
 				mongo.NewInsertOneModel().SetDocument(bson.D{{"x", 1}}),
 			}
-			_, err := mt.Coll.BulkWrite(mtest.Background, models)
+			_, err := mt.Coll.BulkWrite(context.Background(), models)
 			if err != mongo.ErrUnacknowledgedWrite {
 				// Use a direct comparison rather than assert.Equal because assert.Equal will compare the error strings,
 				// so the assertion would succeed even if the error had not been wrapped.
@@ -1716,7 +1716,7 @@ func TestCollection(t *testing.T) {
 			mt.AddMockResponses(append(responses, responses...)...)
 
 			mt.ClearEvents()
-			res, err := mt.Coll.BulkWrite(mtest.Background, insertModels)
+			res, err := mt.Coll.BulkWrite(context.Background(), insertModels)
 			assert.Nil(mt, err, "BulkWrite error: %v", err)
 			assert.Equal(mt, int64(numDocs), res.InsertedCount, "expected %v inserted documents, got %v", numDocs, res.InsertedCount)
 			mt.FilterStartedEvents(func(evt *event.CommandStartedEvent) bool {
@@ -1727,7 +1727,7 @@ func TestCollection(t *testing.T) {
 			assert.True(mt, inserts > 1, "expected multiple batches, got %v", inserts)
 
 			mt.ClearEvents()
-			res, err = mt.Coll.BulkWrite(mtest.Background, deleteModels)
+			res, err = mt.Coll.BulkWrite(context.Background(), deleteModels)
 			assert.Nil(mt, err, "BulkWrite error: %v", err)
 			assert.Equal(mt, int64(numDocs), res.DeletedCount, "expected %v deleted documents, got %v", numDocs, res.DeletedCount)
 			mt.FilterStartedEvents(func(evt *event.CommandStartedEvent) bool {
@@ -1784,7 +1784,7 @@ func TestCollection(t *testing.T) {
 			mt.AddMockResponses([]primitive.D{firstBatchResponse, secondBatchResponse}...)
 
 			mt.ClearEvents()
-			res, err := mt.Coll.BulkWrite(mtest.Background, models)
+			res, err := mt.Coll.BulkWrite(context.Background(), models)
 			assert.Nil(mt, err, "BulkWrite error: %v", err)
 
 			mt.FilterStartedEvents(func(evt *event.CommandStartedEvent) bool {
@@ -1827,9 +1827,9 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.RunOpts(tc.name, mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
-					_, err := mt.Coll.InsertOne(mtest.Background, filter)
+					_, err := mt.Coll.InsertOne(context.Background(), filter)
 					assert.Nil(mt, err, "InsertOne error: %v", err)
-					_, err = mt.Coll.BulkWrite(mtest.Background, tc.models)
+					_, err = mt.Coll.BulkWrite(context.Background(), tc.models)
 					if tc.errParam == "" {
 						assert.Nil(mt, err, "expected nil error, got %v", err)
 						return
@@ -1850,7 +1850,7 @@ func initCollection(mt *mtest.T, coll *mongo.Collection) {
 		docs = append(docs, bson.D{{"x", int32(i)}})
 	}
 
-	_, err := coll.InsertMany(mtest.Background, docs)
+	_, err := coll.InsertMany(context.Background(), docs)
 	assert.Nil(mt, err, "InsertMany error for initial data: %v", err)
 }
 
@@ -1876,7 +1876,7 @@ func testAggregateWithOptions(mt *mtest.T, createIndex bool, opts *options.Aggre
 	assert.Nil(mt, err, "Aggregate error: %v", err)
 
 	for i := 2; i < 5; i++ {
-		assert.True(mt, cursor.Next(mtest.Background), "expected Next true, got false")
+		assert.True(mt, cursor.Next(context.Background()), "expected Next true, got false")
 		elems, _ := cursor.Current.Elements()
 		assert.Equal(mt, 1, len(elems), "expected doc with 1 element, got %v", cursor.Current)
 
@@ -1927,7 +1927,7 @@ func assertGetMoreCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn fun
 	cursor, err := cursorFn()
 	assert.Nil(mt, err, "error creating cursor: %v", err)
 	var docs []bson.D
-	err = cursor.All(mtest.Background, &docs)
+	err = cursor.All(context.Background(), &docs)
 	assert.Nil(mt, err, "All error: %v", err)
 
 	// Only assert that the initial command and at least one getMore were sent. The exact number of getMore's required
@@ -1946,7 +1946,7 @@ func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn
 
 	cursor, err := cursorFn()
 	assert.Nil(mt, err, "error creating cursor: %v", err)
-	err = cursor.Close(mtest.Background)
+	err = cursor.Close(context.Background())
 	assert.Nil(mt, err, "Close error: %v", err)
 
 	evt := mt.GetStartedEvent()

--- a/mongo/integration/command_monitoring_test.go
+++ b/mongo/integration/command_monitoring_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -100,7 +101,7 @@ func runMonitoringOperation(mt *mtest.T, operation monitoringOperation) {
 		if err != nil {
 			return
 		}
-		for cursor.Next(mtest.Background) {
+		for cursor.Next(context.Background()) {
 		}
 	case "bulkWrite":
 		_, _ = executeBulkWrite(mt, nil, operation.Arguments)
@@ -113,7 +114,7 @@ func runMonitoringOperation(mt *mtest.T, operation monitoringOperation) {
 		if err != nil {
 			return
 		}
-		for cursor.Next(mtest.Background) {
+		for cursor.Next(context.Background()) {
 		}
 	case "deleteOne":
 		_, _ = executeDeleteOne(mt, nil, operation.Arguments)

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -105,7 +105,7 @@ func killSessions(mt *mtest.T) {
 	// killAllSessions has to be run against each mongos in a sharded cluster, so we use the runCommandOnAllServers
 	// helper.
 	err := runCommandOnAllServers(func(client *mongo.Client) error {
-		return client.Database("admin").RunCommand(mtest.Background, cmd, runCmdOpts).Err()
+		return client.Database("admin").RunCommand(context.Background(), cmd, runCmdOpts).Err()
 	})
 
 	if err == nil {
@@ -123,23 +123,23 @@ func runCommandOnAllServers(commandFn func(client *mongo.Client) error) error {
 	testutil.AddTestServerAPIVersion(opts)
 
 	if mtest.ClusterTopologyKind() != mtest.Sharded {
-		client, err := mongo.Connect(mtest.Background, opts)
+		client, err := mongo.Connect(context.Background(), opts)
 		if err != nil {
 			return fmt.Errorf("error creating replica set client: %v", err)
 		}
-		defer func() { _ = client.Disconnect(mtest.Background) }()
+		defer func() { _ = client.Disconnect(context.Background()) }()
 
 		return commandFn(client)
 	}
 
 	for _, host := range opts.Hosts {
-		shardClient, err := mongo.Connect(mtest.Background, opts.SetHosts([]string{host}))
+		shardClient, err := mongo.Connect(context.Background(), opts.SetHosts([]string{host}))
 		if err != nil {
 			return fmt.Errorf("error creating client for mongos %v: %v", host, err)
 		}
 
 		err = commandFn(shardClient)
-		_ = shardClient.Disconnect(mtest.Background)
+		_ = shardClient.Disconnect(context.Background())
 		if err != nil {
 			return err
 		}
@@ -188,14 +188,14 @@ func executeAggregate(mt *mtest.T, agg aggregator, sess mongo.Session, args bson
 
 	if sess != nil {
 		var cur *mongo.Cursor
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var aerr error
 			cur, aerr = agg.Aggregate(sc, pipeline, opts)
 			return aerr
 		})
 		return cur, err
 	}
-	return agg.Aggregate(mtest.Background, pipeline, opts)
+	return agg.Aggregate(context.Background(), pipeline, opts)
 }
 
 func executeWatch(mt *mtest.T, w watcher, sess mongo.Session, args bson.Raw) (*mongo.ChangeStream, error) {
@@ -217,14 +217,14 @@ func executeWatch(mt *mtest.T, w watcher, sess mongo.Session, args bson.Raw) (*m
 
 	if sess != nil {
 		var stream *mongo.ChangeStream
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var csErr error
 			stream, csErr = w.Watch(sc, pipeline)
 			return csErr
 		})
 		return stream, err
 	}
-	return w.Watch(mtest.Background, pipeline)
+	return w.Watch(context.Background(), pipeline)
 }
 
 func executeCountDocuments(mt *mtest.T, sess mongo.Session, args bson.Raw) (int64, error) {
@@ -255,14 +255,14 @@ func executeCountDocuments(mt *mtest.T, sess mongo.Session, args bson.Raw) (int6
 
 	if sess != nil {
 		var count int64
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var countErr error
 			count, countErr = mt.Coll.CountDocuments(sc, filter, opts)
 			return countErr
 		})
 		return count, err
 	}
-	return mt.Coll.CountDocuments(mtest.Background, filter, opts)
+	return mt.Coll.CountDocuments(context.Background(), filter, opts)
 }
 
 func executeInsertOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.InsertOneResult, error) {
@@ -289,14 +289,14 @@ func executeInsertOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.In
 
 	if sess != nil {
 		var res *mongo.InsertOneResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var insertErr error
 			res, insertErr = mt.Coll.InsertOne(sc, doc, opts)
 			return insertErr
 		})
 		return res, err
 	}
-	return mt.Coll.InsertOne(mtest.Background, doc, opts)
+	return mt.Coll.InsertOne(context.Background(), doc, opts)
 }
 
 func executeInsertMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.InsertManyResult, error) {
@@ -327,14 +327,14 @@ func executeInsertMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.I
 
 	if sess != nil {
 		var res *mongo.InsertManyResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var insertErr error
 			res, insertErr = mt.Coll.InsertMany(sc, docs, opts)
 			return insertErr
 		})
 		return res, err
 	}
-	return mt.Coll.InsertMany(mtest.Background, docs, opts)
+	return mt.Coll.InsertMany(context.Background(), docs, opts)
 }
 
 func setFindModifiers(modifiersDoc bson.Raw, opts *options.FindOptions) {
@@ -400,14 +400,14 @@ func executeFind(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Cursor,
 
 	if sess != nil {
 		var c *mongo.Cursor
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var findErr error
 			c, findErr = mt.Coll.Find(sc, filter, opts)
 			return findErr
 		})
 		return c, err
 	}
-	return mt.Coll.Find(mtest.Background, filter, opts)
+	return mt.Coll.Find(context.Background(), filter, opts)
 }
 
 func executeRunCommand(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.SingleResult {
@@ -434,13 +434,13 @@ func executeRunCommand(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.Si
 
 	if sess != nil {
 		var sr *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			sr = mt.DB.RunCommand(sc, cmd, opts)
 			return nil
 		})
 		return sr
 	}
-	return mt.DB.RunCommand(mtest.Background, cmd, opts)
+	return mt.DB.RunCommand(context.Background(), cmd, opts)
 }
 
 func executeListCollections(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Cursor, error) {
@@ -462,14 +462,14 @@ func executeListCollections(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mo
 
 	if sess != nil {
 		var c *mongo.Cursor
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var lcErr error
 			c, lcErr = mt.DB.ListCollections(sc, filter)
 			return lcErr
 		})
 		return c, err
 	}
-	return mt.DB.ListCollections(mtest.Background, filter)
+	return mt.DB.ListCollections(context.Background(), filter)
 }
 
 func executeListCollectionNames(mt *mtest.T, sess mongo.Session, args bson.Raw) ([]string, error) {
@@ -491,14 +491,14 @@ func executeListCollectionNames(mt *mtest.T, sess mongo.Session, args bson.Raw) 
 
 	if sess != nil {
 		var res []string
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var lcErr error
 			res, lcErr = mt.DB.ListCollectionNames(sc, filter)
 			return lcErr
 		})
 		return res, err
 	}
-	return mt.DB.ListCollectionNames(mtest.Background, filter)
+	return mt.DB.ListCollectionNames(context.Background(), filter)
 }
 
 func executeListDatabaseNames(mt *mtest.T, sess mongo.Session, args bson.Raw) ([]string, error) {
@@ -520,14 +520,14 @@ func executeListDatabaseNames(mt *mtest.T, sess mongo.Session, args bson.Raw) ([
 
 	if sess != nil {
 		var res []string
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var ldErr error
 			res, ldErr = mt.Client.ListDatabaseNames(sc, filter)
 			return ldErr
 		})
 		return res, err
 	}
-	return mt.Client.ListDatabaseNames(mtest.Background, filter)
+	return mt.Client.ListDatabaseNames(context.Background(), filter)
 }
 
 func executeListDatabases(mt *mtest.T, sess mongo.Session, args bson.Raw) (mongo.ListDatabasesResult, error) {
@@ -549,14 +549,14 @@ func executeListDatabases(mt *mtest.T, sess mongo.Session, args bson.Raw) (mongo
 
 	if sess != nil {
 		var res mongo.ListDatabasesResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var ldErr error
 			res, ldErr = mt.Client.ListDatabases(sc, filter)
 			return ldErr
 		})
 		return res, err
 	}
-	return mt.Client.ListDatabases(mtest.Background, filter)
+	return mt.Client.ListDatabases(context.Background(), filter)
 }
 
 func executeFindOne(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.SingleResult {
@@ -578,13 +578,13 @@ func executeFindOne(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.Singl
 
 	if sess != nil {
 		var res *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			res = mt.Coll.FindOne(sc, filter)
 			return nil
 		})
 		return res
 	}
-	return mt.Coll.FindOne(mtest.Background, filter)
+	return mt.Coll.FindOne(context.Background(), filter)
 }
 
 func executeListIndexes(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Cursor, error) {
@@ -594,14 +594,14 @@ func executeListIndexes(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.
 	assert.Equal(mt, 0, len(args), "unexpected listIndexes arguments: %v", args)
 	if sess != nil {
 		var cursor *mongo.Cursor
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var listErr error
 			cursor, listErr = mt.Coll.Indexes().List(sc)
 			return listErr
 		})
 		return cursor, err
 	}
-	return mt.Coll.Indexes().List(mtest.Background)
+	return mt.Coll.Indexes().List(context.Background())
 }
 
 func executeDistinct(mt *mtest.T, sess mongo.Session, args bson.Raw) ([]interface{}, error) {
@@ -631,14 +631,14 @@ func executeDistinct(mt *mtest.T, sess mongo.Session, args bson.Raw) ([]interfac
 
 	if sess != nil {
 		var res []interface{}
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var derr error
 			res, derr = mt.Coll.Distinct(sc, fieldName, filter, opts)
 			return derr
 		})
 		return res, err
 	}
-	return mt.Coll.Distinct(mtest.Background, fieldName, filter, opts)
+	return mt.Coll.Distinct(context.Background(), fieldName, filter, opts)
 }
 
 func executeFindOneAndDelete(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.SingleResult {
@@ -671,13 +671,13 @@ func executeFindOneAndDelete(mt *mtest.T, sess mongo.Session, args bson.Raw) *mo
 
 	if sess != nil {
 		var res *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			res = mt.Coll.FindOneAndDelete(sc, filter, opts)
 			return nil
 		})
 		return res
 	}
-	return mt.Coll.FindOneAndDelete(mtest.Background, filter, opts)
+	return mt.Coll.FindOneAndDelete(context.Background(), filter, opts)
 }
 
 func executeFindOneAndUpdate(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.SingleResult {
@@ -728,13 +728,13 @@ func executeFindOneAndUpdate(mt *mtest.T, sess mongo.Session, args bson.Raw) *mo
 
 	if sess != nil {
 		var res *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			res = mt.Coll.FindOneAndUpdate(sc, filter, update, opts)
 			return nil
 		})
 		return res
 	}
-	return mt.Coll.FindOneAndUpdate(mtest.Background, filter, update, opts)
+	return mt.Coll.FindOneAndUpdate(context.Background(), filter, update, opts)
 }
 
 func executeFindOneAndReplace(mt *mtest.T, sess mongo.Session, args bson.Raw) *mongo.SingleResult {
@@ -781,13 +781,13 @@ func executeFindOneAndReplace(mt *mtest.T, sess mongo.Session, args bson.Raw) *m
 
 	if sess != nil {
 		var res *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			res = mt.Coll.FindOneAndReplace(sc, filter, replacement, opts)
 			return nil
 		})
 		return res
 	}
-	return mt.Coll.FindOneAndReplace(mtest.Background, filter, replacement, opts)
+	return mt.Coll.FindOneAndReplace(context.Background(), filter, replacement, opts)
 }
 
 func executeDeleteOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.DeleteResult, error) {
@@ -816,14 +816,14 @@ func executeDeleteOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.De
 
 	if sess != nil {
 		var res *mongo.DeleteResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var derr error
 			res, derr = mt.Coll.DeleteOne(sc, filter, opts)
 			return derr
 		})
 		return res, err
 	}
-	return mt.Coll.DeleteOne(mtest.Background, filter, opts)
+	return mt.Coll.DeleteOne(context.Background(), filter, opts)
 }
 
 func executeDeleteMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.DeleteResult, error) {
@@ -852,14 +852,14 @@ func executeDeleteMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.D
 
 	if sess != nil {
 		var res *mongo.DeleteResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var derr error
 			res, derr = mt.Coll.DeleteMany(sc, filter, opts)
 			return derr
 		})
 		return res, err
 	}
-	return mt.Coll.DeleteMany(mtest.Background, filter, opts)
+	return mt.Coll.DeleteMany(context.Background(), filter, opts)
 }
 
 func executeUpdateOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.UpdateResult, error) {
@@ -900,14 +900,14 @@ func executeUpdateOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Up
 
 	if sess != nil {
 		var res *mongo.UpdateResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var uerr error
 			res, uerr = mt.Coll.UpdateOne(sc, filter, update, opts)
 			return uerr
 		})
 		return res, err
 	}
-	return mt.Coll.UpdateOne(mtest.Background, filter, update, opts)
+	return mt.Coll.UpdateOne(context.Background(), filter, update, opts)
 }
 
 func executeUpdateMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.UpdateResult, error) {
@@ -948,14 +948,14 @@ func executeUpdateMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.U
 
 	if sess != nil {
 		var res *mongo.UpdateResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var uerr error
 			res, uerr = mt.Coll.UpdateMany(sc, filter, update, opts)
 			return uerr
 		})
 		return res, err
 	}
-	return mt.Coll.UpdateMany(mtest.Background, filter, update, opts)
+	return mt.Coll.UpdateMany(context.Background(), filter, update, opts)
 }
 
 func executeReplaceOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.UpdateResult, error) {
@@ -992,14 +992,14 @@ func executeReplaceOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.U
 
 	if sess != nil {
 		var res *mongo.UpdateResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var uerr error
 			res, uerr = mt.Coll.ReplaceOne(sc, filter, replacement, opts)
 			return uerr
 		})
 		return res, err
 	}
-	return mt.Coll.ReplaceOne(mtest.Background, filter, replacement, opts)
+	return mt.Coll.ReplaceOne(context.Background(), filter, replacement, opts)
 }
 
 type withTransactionArgs struct {
@@ -1076,14 +1076,14 @@ func executeBulkWrite(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Bu
 
 	if sess != nil {
 		var res *mongo.BulkWriteResult
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var bwerr error
 			res, bwerr = mt.Coll.BulkWrite(sc, models, opts)
 			return bwerr
 		})
 		return res, err
 	}
-	return mt.Coll.BulkWrite(mtest.Background, models, opts)
+	return mt.Coll.BulkWrite(context.Background(), models, opts)
 }
 
 func createBulkWriteModels(mt *mtest.T, rawModels bson.Raw) []mongo.WriteModel {
@@ -1205,14 +1205,14 @@ func executeEstimatedDocumentCount(mt *mtest.T, sess mongo.Session, args bson.Ra
 
 	if sess != nil {
 		var res int64
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var countErr error
 			res, countErr = mt.Coll.EstimatedDocumentCount(sc)
 			return countErr
 		})
 		return res, err
 	}
-	return mt.Coll.EstimatedDocumentCount(mtest.Background)
+	return mt.Coll.EstimatedDocumentCount(context.Background())
 }
 
 func executeGridFSDownload(mt *mtest.T, bucket *gridfs.Bucket, args bson.Raw) (int64, error) {
@@ -1281,13 +1281,13 @@ func executeRenameCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) (*m
 
 	if sess != nil {
 		var res *mongo.SingleResult
-		_ = mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		_ = mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			res = admin.RunCommand(sc, renameCmd)
 			return nil
 		})
 		return res, toName
 	}
-	return admin.RunCommand(mtest.Background, renameCmd), toName
+	return admin.RunCommand(context.Background(), renameCmd), toName
 }
 
 func executeCreateIndex(mt *mtest.T, sess mongo.Session, args bson.Raw) (string, error) {
@@ -1314,14 +1314,14 @@ func executeCreateIndex(mt *mtest.T, sess mongo.Session, args bson.Raw) (string,
 
 	if sess != nil {
 		var indexName string
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var indexErr error
 			indexName, indexErr = mt.Coll.Indexes().CreateOne(sc, model)
 			return indexErr
 		})
 		return indexName, err
 	}
-	return mt.Coll.Indexes().CreateOne(mtest.Background, model)
+	return mt.Coll.Indexes().CreateOne(context.Background(), model)
 }
 
 func executeDropIndex(mt *mtest.T, sess mongo.Session, args bson.Raw) (bson.Raw, error) {
@@ -1343,14 +1343,14 @@ func executeDropIndex(mt *mtest.T, sess mongo.Session, args bson.Raw) (bson.Raw,
 
 	if sess != nil {
 		var res bson.Raw
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			var indexErr error
 			res, indexErr = mt.Coll.Indexes().DropOne(sc, name)
 			return indexErr
 		})
 		return res, err
 	}
-	return mt.Coll.Indexes().DropOne(mtest.Background, name)
+	return mt.Coll.Indexes().DropOne(context.Background(), name)
 }
 
 func executeDropCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) error {
@@ -1372,12 +1372,12 @@ func executeDropCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) error
 
 	coll := mt.DB.Collection(collName)
 	if sess != nil {
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			return coll.Drop(sc)
 		})
 		return err
 	}
-	return coll.Drop(mtest.Background)
+	return coll.Drop(context.Background())
 }
 
 func executeCreateCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) error {
@@ -1402,22 +1402,22 @@ func executeCreateCollection(mt *mtest.T, sess mongo.Session, args bson.Raw) err
 		{"create", collName},
 	}
 	if sess != nil {
-		err := mongo.WithSession(mtest.Background, sess, func(sc mongo.SessionContext) error {
+		err := mongo.WithSession(context.Background(), sess, func(sc mongo.SessionContext) error {
 			return mt.DB.RunCommand(sc, createCmd).Err()
 		})
 		return err
 	}
-	return mt.DB.RunCommand(mtest.Background, createCmd).Err()
+	return mt.DB.RunCommand(context.Background(), createCmd).Err()
 }
 
 func executeAdminCommand(mt *mtest.T, op *operation) {
 	// Per the streamable hello test format description, a separate client must be used to execute this operation.
 	clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
 	testutil.AddTestServerAPIVersion(clientOpts)
-	client, err := mongo.Connect(mtest.Background, clientOpts)
+	client, err := mongo.Connect(context.Background(), clientOpts)
 	assert.Nil(mt, err, "Connect error: %v", err)
 	defer func() {
-		_ = client.Disconnect(mtest.Background)
+		_ = client.Disconnect(context.Background())
 	}()
 
 	cmd := op.Arguments.Lookup("command").Document()
@@ -1441,14 +1441,14 @@ func executeAdminCommand(mt *mtest.T, op *operation) {
 	}
 
 	db := client.Database("admin")
-	err = db.RunCommand(mtest.Background, cmd, rco).Err()
+	err = db.RunCommand(context.Background(), cmd, rco).Err()
 	assert.Nil(mt, err, "RunCommand error for command %q: %v", op.CommandName, err)
 }
 
 func executeAdminCommandWithRetry(mt *mtest.T, client *mongo.Client, cmd interface{}, opts ...*options.RunCmdOptions) {
 	mt.Helper()
 
-	ctx, cancel := context.WithTimeout(mtest.Background, 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	for {
@@ -1651,7 +1651,7 @@ func verifyCursorResult(mt *mtest.T, cur *mongo.Cursor, result interface{}) {
 	// To account for this, we fetch all documents via cursor.All and then compare them to the result if it's non-nil.
 	assert.NotNil(mt, cur, "expected cursor to not be nil")
 	var actual []bson.Raw
-	err := cur.All(mtest.Background, &actual)
+	err := cur.All(context.Background(), &actual)
 	assert.Nil(mt, err, "All error: %v", err)
 
 	if result == nil {

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -44,7 +44,7 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 			},
 		})
 
-		_, err := mt.Coll.InsertMany(mtest.Background,
+		_, err := mt.Coll.InsertMany(context.Background(),
 			[]interface{}{
 				bson.D{
 					{"a", 1},
@@ -75,7 +75,7 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 			},
 		})
 
-		_, err := mt.Coll.DeleteMany(mtest.Background, bson.D{{"a", 1}})
+		_, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"a", 1}})
 		assert.NotNil(mt, err, "expected non-nil error, got nil")
 
 		we, ok := err.(mongo.WriteException)
@@ -102,7 +102,7 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 			&mongo.InsertOneModel{bson.D{{"a", 2}}},
 			&mongo.DeleteOneModel{bson.D{{"a", 2}}, nil, nil},
 		}
-		_, err := mt.Coll.BulkWrite(mtest.Background, models)
+		_, err := mt.Coll.BulkWrite(context.Background(), models)
 		assert.NotNil(mt, err, "expected non-nil error, got nil")
 
 		we, ok := err.(mongo.BulkWriteException)
@@ -299,7 +299,7 @@ func TestHintErrors(t *testing.T) {
 	expected := errors.New("the 'hint' command parameter requires a minimum server wire version of 5")
 	mt.Run("UpdateMany", func(mt *mtest.T) {
 
-		_, got := mt.Coll.UpdateMany(mtest.Background, bson.D{{"a", 1}}, bson.D{{"$inc", bson.D{{"a", 1}}}},
+		_, got := mt.Coll.UpdateMany(context.Background(), bson.D{{"a", 1}}, bson.D{{"$inc", bson.D{{"a", 1}}}},
 			options.Update().SetHint("_id_"))
 		assert.NotNil(mt, got, "expected non-nil error, got nil")
 		assert.Equal(mt, got, expected, "expected: %v got: %v", expected, got)
@@ -307,7 +307,7 @@ func TestHintErrors(t *testing.T) {
 
 	mt.Run("ReplaceOne", func(mt *mtest.T) {
 
-		_, got := mt.Coll.ReplaceOne(mtest.Background, bson.D{{"a", 1}}, bson.D{{"a", 2}},
+		_, got := mt.Coll.ReplaceOne(context.Background(), bson.D{{"a", 1}}, bson.D{{"a", 2}},
 			options.Replace().SetHint("_id_"))
 		assert.NotNil(mt, got, "expected non-nil error, got nil")
 		assert.Equal(mt, got, expected, "expected: %v got: %v", expected, got)
@@ -318,7 +318,7 @@ func TestHintErrors(t *testing.T) {
 			&mongo.InsertOneModel{bson.D{{"_id", 2}}},
 			&mongo.ReplaceOneModel{Filter: bson.D{{"_id", 2}}, Replacement: bson.D{{"a", 2}}, Hint: "_id_"},
 		}
-		_, got := mt.Coll.BulkWrite(mtest.Background, models)
+		_, got := mt.Coll.BulkWrite(context.Background(), models)
 		assert.NotNil(mt, got, "expected non-nil error, got nil")
 		assert.Equal(mt, got, expected, "expected: %v got: %v", expected, got)
 	})
@@ -355,7 +355,7 @@ func TestWriteConcernError(t *testing.T) {
 		}
 		mt.SetFailPoint(fp)
 
-		_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.NotNil(mt, err, "expected InsertOne error, got nil")
 		writeException, ok := err.(mongo.WriteException)
 		assert.True(mt, ok, "expected WriteException, got error %v of type %T", err, err)
@@ -382,7 +382,7 @@ func TestErrorsCodeNamePropagated(t *testing.T) {
 			{"insert", mt.Coll.Name()},
 			{"documents", []bson.D{}},
 		}
-		err := mt.DB.RunCommand(mtest.Background, cmd).Err()
+		err := mt.DB.RunCommand(context.Background(), cmd).Err()
 		assert.NotNil(mt, err, "expected RunCommand error, got nil")
 
 		ce, ok := err.(mongo.CommandError)
@@ -398,7 +398,7 @@ func TestErrorsCodeNamePropagated(t *testing.T) {
 	mt.RunOpts("write concern error", wcMtOpts, func(mt *mtest.T) {
 		// codeName is propagated for write concern errors.
 
-		_, err := mt.Coll.InsertOne(mtest.Background, bson.D{})
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
 		assert.NotNil(mt, err, "expected InsertOne error, got nil")
 
 		we, ok := err.(mongo.WriteException)

--- a/mongo/integration/crud_spec_test.go
+++ b/mongo/integration/crud_spec_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -111,7 +112,7 @@ func runCrudFile(t *testing.T, file string) {
 func runCrudTest(mt *mtest.T, test crudTest, testFile crudTestFile) {
 	if len(testFile.Data) > 0 {
 		docs := rawSliceToInterfaceSlice(testFile.Data)
-		_, err := mt.Coll.InsertMany(mtest.Background, docs)
+		_, err := mt.Coll.InsertMany(context.Background(), docs)
 		assert.Nil(mt, err, "InsertMany error: %v", err)
 	}
 

--- a/mongo/integration/cursor_test.go
+++ b/mongo/integration/cursor_test.go
@@ -31,15 +31,15 @@ func TestCursor(t *testing.T) {
 	// getMore cannot be sent with RunCommand as server API options will be attached when they should not be.
 	mt.RunOpts("cursor is killed on server", mtest.NewOptions().MinServerVersion("3.2").RequireAPIVersion(false), func(mt *mtest.T) {
 		initCollection(mt, mt.Coll)
-		c, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+		c, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 		assert.Nil(mt, err, "Find error: %v", err)
 
 		id := c.ID()
-		assert.True(mt, c.Next(mtest.Background), "expected Next true, got false")
-		err = c.Close(mtest.Background)
+		assert.True(mt, c.Next(context.Background()), "expected Next true, got false")
+		err = c.Close(context.Background())
 		assert.Nil(mt, err, "Close error: %v", err)
 
-		err = mt.DB.RunCommand(mtest.Background, bson.D{
+		err = mt.DB.RunCommand(context.Background(), bson.D{
 			{"getMore", id},
 			{"collection", mt.Coll.Name()},
 		}).Err()
@@ -51,9 +51,9 @@ func TestCursor(t *testing.T) {
 			// If there's already documents in the current batch, TryNext should return true without doing a getMore
 
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{})
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{})
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 			tryNextExistingBatchTest(mt, cursor)
 		})
 		mt.RunOpts("one getMore sent", mtest.NewOptions().CollectionCreateOptions(cappedCollectionOpts), func(mt *mtest.T) {
@@ -61,26 +61,26 @@ func TestCursor(t *testing.T) {
 
 			// insert a document because a tailable cursor will only have a non-zero ID if the initial Find matches
 			// at least one document
-			_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetCursorType(options.Tailable))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetCursorType(options.Tailable))
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 
 			// first call to TryNext should return 1 document
-			assert.True(mt, cursor.TryNext(mtest.Background), "expected Next to return true, got false")
+			assert.True(mt, cursor.TryNext(context.Background()), "expected Next to return true, got false")
 			// TryNext should attempt one getMore
 			mt.ClearEvents()
-			assert.False(mt, cursor.TryNext(mtest.Background), "unexpected document %v", cursor.Current)
+			assert.False(mt, cursor.TryNext(context.Background()), "unexpected document %v", cursor.Current)
 			verifyOneGetmoreSent(mt)
 		})
 		mt.RunOpts("getMore error", mtest.NewOptions().ClientType(mtest.Mock), func(mt *mtest.T) {
 			findRes := mtest.CreateCursorResponse(50, "foo.bar", mtest.FirstBatch)
 			mt.AddMockResponses(findRes)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{})
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{})
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 			tryNextGetmoreError(mt, cursor)
 		})
 	})
@@ -98,9 +98,9 @@ func TestCursor(t *testing.T) {
 				SetBatchSize(int32(batchSize)).
 				SetCursorType(options.TailableAwait).
 				SetMaxAwaitTime(100 * time.Millisecond)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, findOpts)
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, findOpts)
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 
 			mt.ClearEvents()
 
@@ -109,7 +109,7 @@ func TestCursor(t *testing.T) {
 			assertCursorBatchLength(mt, cursor, batchSize)
 			for i := 0; i < batchSize; i++ {
 				prevLength := cursor.RemainingBatchLength()
-				if !cursor.Next(mtest.Background) {
+				if !cursor.Next(context.Background()) {
 					mt.Fatalf("expected Next to return true on index %d; cursor err: %v", i, cursor.Err())
 				}
 
@@ -124,7 +124,7 @@ func TestCursor(t *testing.T) {
 			// one document.
 			assertCursorBatchLength(mt, cursor, 0)
 
-			assert.True(mt, cursor.Next(mtest.Background), "expected Next to return true; cursor err: %v", cursor.Err())
+			assert.True(mt, cursor.Next(context.Background()), "expected Next to return true; cursor err: %v", cursor.Err())
 			evt = mt.GetStartedEvent()
 			assert.NotNil(mt, evt, "expected CommandStartedEvent, got nil")
 			assert.Equal(mt, "getMore", evt.CommandName, "expected command %q, got %q", "getMore", evt.CommandName)
@@ -149,13 +149,13 @@ func TestCursor(t *testing.T) {
 			killCursors := mtest.CreateSuccessResponse()
 			mt.AddMockResponses(find, getMore, killCursors)
 
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{})
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{})
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 			mt.ClearEvents()
 
 			for {
-				if cursor.TryNext(mtest.Background) {
+				if cursor.TryNext(context.Background()) {
 					break
 				}
 
@@ -179,9 +179,9 @@ func TestCursor(t *testing.T) {
 				Data:               failpointData,
 			})
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 			assert.Nil(mt, err, "Find error: %v", err)
-			defer cursor.Close(mtest.Background)
+			defer cursor.Close(context.Background())
 
 			var docs []bson.D
 			err = cursor.All(context.Background(), &docs)
@@ -206,10 +206,10 @@ func TestCursor(t *testing.T) {
 				Data:               failpointData,
 			})
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 			assert.Nil(mt, err, "Find error: %v", err)
 
-			err = cursor.Close(mtest.Background)
+			err = cursor.Close(context.Background())
 			assert.NotNil(mt, err, "expected change stream error, got nil")
 
 			// make sure that a mongo.CommandError is returned instead of a driver.Error
@@ -224,9 +224,9 @@ func TestCursor(t *testing.T) {
 		mt.ClearEvents()
 
 		// create cursor with batchSize 0
-		cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(0))
+		cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(0))
 		assert.Nil(mt, err, "Find error: %v", err)
-		defer cursor.Close(mtest.Background)
+		defer cursor.Close(context.Background())
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "find", evt.CommandName, "expected 'find' event, got '%v'", evt.CommandName)
 		sizeVal, err := evt.Command.LookupErr("batchSize")
@@ -237,7 +237,7 @@ func TestCursor(t *testing.T) {
 		// make sure that the getMore sends the new batchSize
 		batchCursor := mongo.BatchCursorFromCursor(cursor)
 		batchCursor.SetBatchSize(4)
-		assert.True(mt, cursor.Next(mtest.Background), "expected Next true, got false")
+		assert.True(mt, cursor.Next(context.Background()), "expected Next true, got false")
 		evt = mt.GetStartedEvent()
 		assert.NotNil(mt, evt, "expected getMore event, got nil")
 		assert.Equal(mt, "getMore", evt.CommandName, "expected 'getMore' event, got '%v'", evt.CommandName)
@@ -257,7 +257,7 @@ func tryNextExistingBatchTest(mt *mtest.T, cursor tryNextCursor) {
 	mt.Helper()
 
 	mt.ClearEvents()
-	assert.True(mt, cursor.TryNext(mtest.Background), "expected TryNext to return true, got false")
+	assert.True(mt, cursor.TryNext(context.Background()), "expected TryNext to return true, got false")
 	evt := mt.GetStartedEvent()
 	if evt != nil {
 		mt.Fatalf("unexpected event sent during TryNext: %v", evt.CommandName)
@@ -292,7 +292,7 @@ func tryNextGetmoreError(mt *mtest.T, cursor tryNextCursor) {
 	// without doing a getMore
 	// next call to TryNext should attempt a getMore
 	for i := 0; i < 2; i++ {
-		assert.False(mt, cursor.TryNext(mtest.Background), "TryNext returned true on iteration %v", i)
+		assert.False(mt, cursor.TryNext(context.Background()), "TryNext returned true on iteration %v", i)
 	}
 
 	err := cursor.Err()

--- a/mongo/integration/data_lake_test.go
+++ b/mongo/integration/data_lake_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestAtlasDataLake(t *testing.T) {
 
 		// Run a Find and get the cursor ID and namespace returned by the server. Use a batchSize of 2 to force the
 		// server to keep the cursor open.
-		cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+		cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 		assert.Nil(mt, err, "Find error: %v", err)
 		findEvt := mt.GetSucceededEvent()
 		assert.Equal(mt, "find", findEvt.CommandName, "expected command name %q, got %q", "find", findEvt.CommandName)
@@ -39,7 +40,7 @@ func TestAtlasDataLake(t *testing.T) {
 
 		// Close the cursor, forcing a killCursors command.
 		mt.ClearEvents()
-		err = cursor.Close(mtest.Background)
+		err = cursor.Close(context.Background())
 		assert.Nil(mt, err, "Close error: %v", err)
 
 		// Extract information from the killCursors started event and assert that it sent the right cursor ID and ns.
@@ -88,7 +89,7 @@ func TestAtlasDataLake(t *testing.T) {
 			mtOpts := getMtOpts().ClientOptions(clientOpts)
 
 			mt.RunOpts(tc.name, mtOpts, func(mt *mtest.T) {
-				err := mt.Client.Ping(mtest.Background, mtest.PrimaryRp)
+				err := mt.Client.Ping(context.Background(), mtest.PrimaryRp)
 				assert.Nil(mt, err, "Ping error: %v", err)
 			})
 		}

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -41,7 +42,7 @@ func TestDatabase(t *testing.T) {
 
 	mt.RunOpts("run command", noClientOpts, func(mt *mtest.T) {
 		mt.Run("decode raw", func(mt *mtest.T) {
-			res, err := mt.DB.RunCommand(mtest.Background, bson.D{{internal.LegacyHello, 1}}).DecodeBytes()
+			res, err := mt.DB.RunCommand(context.Background(), bson.D{{internal.LegacyHello, 1}}).DecodeBytes()
 			assert.Nil(mt, err, "RunCommand error: %v", err)
 
 			ok, err := res.LookupErr("ok")
@@ -58,7 +59,7 @@ func TestDatabase(t *testing.T) {
 			result := struct {
 				Ok float64 `bson:"ok"`
 			}{}
-			err := mt.DB.RunCommand(mtest.Background, bson.D{{"ping", 1}}).Decode(&result)
+			err := mt.DB.RunCommand(context.Background(), bson.D{{"ping", 1}}).Decode(&result)
 			assert.Nil(mt, err, "RunCommand error: %v", err)
 			assert.Equal(mt, 1.0, result.Ok, "expected ok value 1.0, got %v", result.Ok)
 		})
@@ -75,7 +76,7 @@ func TestDatabase(t *testing.T) {
 
 			runCmdOpts := options.RunCmd().
 				SetReadPreference(readpref.SecondaryPreferred())
-			err := mt.DB.RunCommand(mtest.Background, bson.D{{internal.LegacyHello, 1}}, runCmdOpts).Err()
+			err := mt.DB.RunCommand(context.Background(), bson.D{{internal.LegacyHello, 1}}, runCmdOpts).Err()
 			assert.Nil(mt, err, "RunCommand error: %v", err)
 
 			expected := bson.Raw(bsoncore.NewDocumentBuilder().
@@ -105,7 +106,7 @@ func TestDatabase(t *testing.T) {
 				{"insert", "test"},
 				{"documents", bson.A{bson.D{{"a", 1}}}},
 			}
-			res, gotErr := mt.DB.RunCommand(mtest.Background, cmd).DecodeBytes()
+			res, gotErr := mt.DB.RunCommand(context.Background(), cmd).DecodeBytes()
 
 			n, ok := res.Lookup("n").Int32OK()
 			assert.True(mt, ok, "expected n in response")
@@ -117,17 +118,17 @@ func TestDatabase(t *testing.T) {
 			assert.Equal(mt, writeExcept.WriteConcernError.Code, 100, "expected error code 100, got %v", writeExcept.WriteConcernError.Code)
 		})
 		mt.Run("multi key map command", func(mt *mtest.T) {
-			err := mt.DB.RunCommand(mtest.Background, bson.M{"insert": "test", "documents": bson.A{bson.D{{"a", 1}}}}).Err()
+			err := mt.DB.RunCommand(context.Background(), bson.M{"insert": "test", "documents": bson.A{bson.D{{"a", 1}}}}).Err()
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"cmd"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"cmd"}, err)
 		})
 	})
 
 	dropOpts := mtest.NewOptions().DatabaseName("dropDb")
 	mt.RunOpts("drop", dropOpts, func(mt *mtest.T) {
-		err := mt.DB.Drop(mtest.Background)
+		err := mt.DB.Drop(context.Background())
 		assert.Nil(mt, err, "Drop error: %v", err)
 
-		list, err := mt.Client.ListDatabaseNames(mtest.Background, bson.D{})
+		list, err := mt.Client.ListDatabaseNames(context.Background(), bson.D{})
 		assert.Nil(mt, err, "ListDatabaseNames error: %v", err)
 		for _, db := range list {
 			if db == "dropDb" {
@@ -152,7 +153,7 @@ func TestDatabase(t *testing.T) {
 		}
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
-				colls, err := mt.DB.ListCollectionNames(mtest.Background, tc.filter)
+				colls, err := mt.DB.ListCollectionNames(context.Background(), tc.filter)
 				assert.Nil(mt, err, "ListCollectionNames error: %v", err)
 
 				var found bool
@@ -208,7 +209,7 @@ func TestDatabase(t *testing.T) {
 
 					var err error
 					for i := 0; i < 1; i++ {
-						cursor, err := mt.DB.ListCollections(mtest.Background, filter)
+						cursor, err := mt.DB.ListCollections(context.Background(), filter)
 						assert.Nil(mt, err, "ListCollections error (iteration %v): %v", i, err)
 
 						err = verifyListCollections(cursor, tc.cappedOnly)
@@ -234,7 +235,7 @@ func TestDatabase(t *testing.T) {
 
 			mt.ClearEvents()
 			lcOpts := options.ListCollections().SetBatchSize(2)
-			_, err := mt.DB.ListCollectionNames(mtest.Background, bson.D{}, lcOpts)
+			_, err := mt.DB.ListCollectionNames(context.Background(), bson.D{}, lcOpts)
 			assert.Nil(mt, err, "ListCollectionNames error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -251,7 +252,7 @@ func TestDatabase(t *testing.T) {
 		mt.RunOpts("authorizedCollections", mtest.NewOptions().MinServerVersion("4.0"), func(mt *mtest.T) {
 			mt.ClearEvents()
 			lcOpts := options.ListCollections().SetAuthorizedCollections(true)
-			_, err := mt.DB.ListCollections(mtest.Background, bson.D{}, lcOpts)
+			_, err := mt.DB.ListCollections(context.Background(), bson.D{}, lcOpts)
 			assert.Nil(mt, err, "ListCollections error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -264,13 +265,13 @@ func TestDatabase(t *testing.T) {
 		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
 			createCollections(mt, 2)
 			assertGetMoreCommandsAreMonitored(mt, cmdMonitoringCmdName, func() (*mongo.Cursor, error) {
-				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
+				return mt.DB.ListCollections(context.Background(), bson.D{}, options.ListCollections().SetBatchSize(2))
 			})
 		})
 		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
 			createCollections(mt, 2)
 			assertKillCursorsCommandsAreMonitored(mt, cmdMonitoringCmdName, func() (*mongo.Cursor, error) {
-				return mt.DB.ListCollections(mtest.Background, bson.D{}, options.ListCollections().SetBatchSize(2))
+				return mt.DB.ListCollections(context.Background(), bson.D{}, options.ListCollections().SetBatchSize(2))
 			})
 		})
 	})
@@ -290,10 +291,10 @@ func TestDatabase(t *testing.T) {
 			filter := bson.M{
 				"options.capped": true,
 			}
-			cursor, err := mt.DB.ListCollections(mtest.Background, filter)
+			cursor, err := mt.DB.ListCollections(context.Background(), filter)
 			assert.Nil(mt, err, "ListCollections error: %v", err)
-			defer cursor.Close(mtest.Background)
-			assert.True(mt, cursor.Next(mtest.Background), "expected Next to return true, got false; cursor error: %v",
+			defer cursor.Close(context.Background())
+			assert.True(mt, cursor.Next(context.Background()), "expected Next to return true, got false; cursor error: %v",
 				cursor.Err())
 
 			optionsDoc := bsoncore.NewDocumentBuilder().
@@ -323,7 +324,7 @@ func TestDatabase(t *testing.T) {
 				}
 			}
 
-			specs, err := mt.DB.ListCollectionSpecifications(mtest.Background, filter)
+			specs, err := mt.DB.ListCollectionSpecifications(context.Background(), filter)
 			assert.Nil(mt, err, "ListCollectionSpecifications error: %v", err)
 			assert.Equal(mt, 1, len(specs), "expected 1 CollectionSpecification, got %d", len(specs))
 			assert.Equal(mt, expectedSpec, specs[0], "expected specification %v, got %v", expectedSpec, specs[0])
@@ -333,7 +334,7 @@ func TestDatabase(t *testing.T) {
 			// Test that ListCollectionSpecifications correctly uses the supplied options.
 
 			opts := options.ListCollections().SetNameOnly(true)
-			_, err := mt.DB.ListCollectionSpecifications(mtest.Background, bson.D{}, opts)
+			_, err := mt.DB.ListCollectionSpecifications(context.Background(), bson.D{}, opts)
 			assert.Nil(mt, err, "ListCollectionSpecifications error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -382,18 +383,18 @@ func TestDatabase(t *testing.T) {
 
 			mt.RunOpts(tc.name, tcOpts, func(mt *mtest.T) {
 				if len(tc.toInsert) > 0 {
-					_, err := mt.Coll.InsertMany(mtest.Background, tc.toInsert)
+					_, err := mt.Coll.InsertMany(context.Background(), tc.toInsert)
 					assert.Nil(mt, err, "InsertMany error: %v", err)
 				}
 
-				cursor, err := mt.DB.RunCommandCursor(mtest.Background, tc.cmd)
+				cursor, err := mt.DB.RunCommandCursor(context.Background(), tc.cmd)
 				assert.Equal(mt, tc.expectedErr, err, "expected error %v, got %v", tc.expectedErr, err)
 				if tc.expectedErr != nil {
 					return
 				}
 
 				var count int
-				for cursor.Next(mtest.Background) {
+				for cursor.Next(context.Background()) {
 					count++
 				}
 				assert.Equal(mt, tc.numExpected, count, "expected document count %v, got %v", tc.numExpected, count)
@@ -409,7 +410,7 @@ func TestDatabase(t *testing.T) {
 					{"find", mt.Coll.Name()},
 					{"batchSize", 2},
 				}
-				return mt.DB.RunCommandCursor(mtest.Background, findCmd)
+				return mt.DB.RunCommandCursor(context.Background(), findCmd)
 			})
 		})
 		mt.RunOpts("killCursors commands are monitored", cmdMonitoringMtOpts, func(mt *mtest.T) {
@@ -419,7 +420,7 @@ func TestDatabase(t *testing.T) {
 					{"find", mt.Coll.Name()},
 					{"batchSize", 2},
 				}
-				return mt.DB.RunCommandCursor(mtest.Background, findCmd)
+				return mt.DB.RunCommandCursor(context.Background(), findCmd)
 			})
 		})
 	})
@@ -492,7 +493,7 @@ func TestDatabase(t *testing.T) {
 						Name: collectionName,
 					}, false)
 
-					err := mt.DB.CreateCollection(mtest.Background, collectionName, tc.createOpts)
+					err := mt.DB.CreateCollection(context.Background(), collectionName, tc.createOpts)
 					assert.Nil(mt, err, "CreateCollection error: %v", err)
 
 					actualOpts := getCollectionOptions(mt, collectionName)
@@ -510,7 +511,7 @@ func TestDatabase(t *testing.T) {
 			createOpts := options.CreateCollection().SetCollation(&options.Collation{
 				Locale: locale,
 			})
-			err := mt.DB.CreateCollection(mtest.Background, collectionName, createOpts)
+			err := mt.DB.CreateCollection(context.Background(), collectionName, createOpts)
 			assert.Nil(mt, err, "CreateCollection error: %v", err)
 
 			actualOpts := getCollectionOptions(mt, collectionName)
@@ -524,7 +525,7 @@ func TestDatabase(t *testing.T) {
 				Name: collectionName,
 			}, false)
 
-			err := mt.DB.CreateCollection(mtest.Background, collectionName)
+			err := mt.DB.CreateCollection(context.Background(), collectionName)
 			assert.Nil(mt, err, "CreateCollection error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -549,7 +550,7 @@ func TestDatabase(t *testing.T) {
 				Name: viewName,
 			}, false)
 
-			err := mt.DB.CreateView(mtest.Background, viewName, sourceCollectionName, pipeline)
+			err := mt.DB.CreateView(context.Background(), viewName, sourceCollectionName, pipeline)
 			assert.Nil(mt, err, "CreateView error: %v", err)
 
 			expectedOpts := bson.M{
@@ -569,7 +570,7 @@ func TestDatabase(t *testing.T) {
 			viewOpts := options.CreateView().SetCollation(&options.Collation{
 				Locale: locale,
 			})
-			err := mt.DB.CreateView(mtest.Background, viewName, sourceCollectionName, mongo.Pipeline{}, viewOpts)
+			err := mt.DB.CreateView(context.Background(), viewName, sourceCollectionName, mongo.Pipeline{}, viewOpts)
 			assert.Nil(mt, err, "CreateView error: %v", err)
 
 			actualOpts := getCollectionOptions(mt, viewName)
@@ -587,10 +588,10 @@ func getCollectionOptions(mt *mtest.T, collectionName string) bson.M {
 	filter := bson.M{
 		"name": collectionName,
 	}
-	cursor, err := mt.DB.ListCollections(mtest.Background, filter)
+	cursor, err := mt.DB.ListCollections(context.Background(), filter)
 	assert.Nil(mt, err, "ListCollections error: %v", err)
-	defer cursor.Close(mtest.Background)
-	assert.True(mt, cursor.Next(mtest.Background), "expected Next to return true, got false")
+	defer cursor.Close(context.Background())
+	assert.True(mt, cursor.Next(context.Background()), "expected Next to return true, got false")
 
 	var actualOpts bson.M
 	err = bson.UnmarshalWithRegistry(interfaceAsMapRegistry, cursor.Current.Lookup("options").Document(), &actualOpts)
@@ -602,7 +603,7 @@ func getCollectionOptions(mt *mtest.T, collectionName string) bson.M {
 func verifyListCollections(cursor *mongo.Cursor, cappedOnly bool) error {
 	var cappedFound, uncappedFound bool
 
-	for cursor.Next(mtest.Background) {
+	for cursor.Next(context.Background()) {
 		nameElem, err := cursor.Current.LookupErr("name")
 		if err != nil {
 			return fmt.Errorf("name element not found in document %v", cursor.Current)

--- a/mongo/integration/gridfs_spec_test.go
+++ b/mongo/integration/gridfs_spec_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"io/ioutil"
 	"path"
@@ -145,19 +146,19 @@ func checkGridfsResults(mt *mtest.T, test gridfsTest) {
 }
 
 func compareGridfsCollections(mt *mtest.T, expected, actual string) {
-	expectedCursor, err := mt.DB.Collection(expected).Find(mtest.Background, bson.D{})
+	expectedCursor, err := mt.DB.Collection(expected).Find(context.Background(), bson.D{})
 	assert.Nil(mt, err, "Find error for collection %v: %v", expected, err)
-	actualCursor, err := mt.DB.Collection(actual).Find(mtest.Background, bson.D{})
+	actualCursor, err := mt.DB.Collection(actual).Find(context.Background(), bson.D{})
 	assert.Nil(mt, err, "Find error for collection %v: %v", actual, err)
 
 	var idx int
-	for expectedCursor.Next(mtest.Background) {
-		assert.True(mt, actualCursor.Next(mtest.Background), "Next returned false at index %v", idx)
+	for expectedCursor.Next(context.Background()) {
+		assert.True(mt, actualCursor.Next(context.Background()), "Next returned false at index %v", idx)
 		idx++
 
 		compareGridfsDocs(mt, expectedCursor.Current, actualCursor.Current)
 	}
-	assert.False(mt, actualCursor.Next(mtest.Background),
+	assert.False(mt, actualCursor.Next(context.Background()),
 		"found unexpected document in collection %v: %s", expected, actualCursor.Current)
 }
 
@@ -447,9 +448,9 @@ func setupGridfsTest(mt *mtest.T, data gridfsData) int32 {
 		return chunkSize
 	}
 
-	_, err := chunksColl.InsertMany(mtest.Background, chunksDocs)
+	_, err := chunksColl.InsertMany(context.Background(), chunksDocs)
 	assert.Nil(mt, err, "InsertMany error for collection %v: %v", chunksColl.Name(), err)
-	_, err = expectedChunksColl.InsertMany(mtest.Background, chunksDocs)
+	_, err = expectedChunksColl.InsertMany(context.Background(), chunksDocs)
 	assert.Nil(mt, err, "InsertMany error for collection %v: %v", expectedChunksColl.Name(), err)
 	return chunkSize
 }
@@ -462,7 +463,7 @@ func hexStringToBytes(mt *mtest.T, hexStr string) []byte {
 
 func runCommands(mt *mtest.T, commands []interface{}) {
 	for _, cmd := range commands {
-		err := mt.DB.RunCommand(mtest.Background, cmd).Err()
+		err := mt.DB.RunCommand(context.Background(), cmd).Err()
 		assert.Nil(mt, err, "RunCommand error for command %v: %v", cmd, err)
 	}
 }
@@ -470,7 +471,7 @@ func runCommands(mt *mtest.T, commands []interface{}) {
 func clearGridfsCollections(mt *mtest.T) {
 	mt.Helper()
 	for _, coll := range []string{gridfsFiles, gridfsChunks, gridfsExpectedFiles, gridfsExpectedChunks} {
-		_, err := mt.DB.Collection(coll).DeleteMany(mtest.Background, bson.D{})
+		_, err := mt.DB.Collection(coll).DeleteMany(context.Background(), bson.D{})
 		assert.Nil(mt, err, "DeleteMany error for %v: %v", coll, err)
 	}
 }

--- a/mongo/integration/gridfs_test.go
+++ b/mongo/integration/gridfs_test.go
@@ -121,7 +121,7 @@ func TestGridFS(x *testing.T) {
 		_, err = bucket.UploadFromStream("filename", r)
 		assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
-		findCtx, cancel := context.WithTimeout(mtest.Background, 5*time.Second)
+		findCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		findIndex(findCtx, mt, mt.DB.Collection("fs.files"), false, "key", "filename")
 		findIndex(findCtx, mt, mt.DB.Collection("fs.chunks"), true, "key", "files_id")
@@ -299,7 +299,7 @@ func TestGridFS(x *testing.T) {
 					// The uploadDate field is calculated when the upload is complete. Manually fetch it from the
 					// fs.files collection to use in assertions.
 					filesColl := mt.DB.Collection("fs.files")
-					uploadedFileDoc, err := filesColl.FindOne(mtest.Background, bson.D{}).DecodeBytes()
+					uploadedFileDoc, err := filesColl.FindOne(context.Background(), bson.D{}).DecodeBytes()
 					assert.Nil(mt, err, "FindOne error: %v", err)
 					uploadTime := uploadedFileDoc.Lookup("uploadDate").Time().UTC()
 
@@ -360,7 +360,7 @@ func TestGridFS(x *testing.T) {
 				{"length", 10},
 				{"filename", "filename"},
 			}
-			_, err := mt.DB.Collection("fs.files").InsertOne(mtest.Background, filesDoc)
+			_, err := mt.DB.Collection("fs.files").InsertOne(context.Background(), filesDoc)
 			assert.Nil(mt, err, "InsertOne error for files collection: %v", err)
 
 			bucket, err := gridfs.NewBucket(mt.DB)
@@ -534,7 +534,7 @@ func assertGridFSCollectionState(mt *mtest.T, coll *mongo.Collection, expectedNa
 	mt.Helper()
 
 	assert.Equal(mt, expectedName, coll.Name(), "expected collection name %v, got %v", expectedName, coll.Name())
-	count, err := coll.CountDocuments(mtest.Background, bson.D{})
+	count, err := coll.CountDocuments(context.Background(), bson.D{})
 	assert.Nil(mt, err, "CountDocuments error: %v", err)
 	assert.Equal(mt, expectedNumDocuments, count, "expected %d documents in collection, got %d", expectedNumDocuments,
 		count)

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -43,7 +44,7 @@ func TestIndexView(t *testing.T) {
 				})
 			}
 
-			_, err := mt.Coll.Indexes().CreateMany(mtest.Background, models)
+			_, err := mt.Coll.Indexes().CreateMany(context.Background(), models)
 			assert.Nil(mt, err, "CreateMany error: %v", err)
 		}
 
@@ -63,13 +64,13 @@ func TestIndexView(t *testing.T) {
 		mt.Run("getMore commands are monitored", func(mt *mtest.T) {
 			createIndexes(mt, 2)
 			assertGetMoreCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
-				return mt.Coll.Indexes().List(mtest.Background, options.ListIndexes().SetBatchSize(2))
+				return mt.Coll.Indexes().List(context.Background(), options.ListIndexes().SetBatchSize(2))
 			})
 		})
 		mt.Run("killCursors commands are monitored", func(mt *mtest.T) {
 			createIndexes(mt, 2)
 			assertKillCursorsCommandsAreMonitored(mt, cmdName, func() (*mongo.Cursor, error) {
-				return mt.Coll.Indexes().List(mtest.Background, options.ListIndexes().SetBatchSize(2))
+				return mt.Coll.Indexes().List(context.Background(), options.ListIndexes().SetBatchSize(2))
 			})
 		})
 	})
@@ -82,7 +83,7 @@ func TestIndexView(t *testing.T) {
 			}
 			expectedName := "foo_1_bar_-1"
 
-			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+			indexName, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 				Keys: keysDoc,
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
@@ -98,7 +99,7 @@ func TestIndexView(t *testing.T) {
 			keysDoc := bson.D{{"foo", int32(-1)}}
 			name := "testname"
 
-			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+			indexName, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 				Keys:    keysDoc,
 				Options: options.Index().SetName(name),
 			})
@@ -138,7 +139,7 @@ func TestIndexView(t *testing.T) {
 				opts.SetBucketSize(1)
 			}
 			// Omits collation option because it's incompatible with version option
-			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{
+			_, err := mt.Coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 				Keys:    bson.D{{"foo", "text"}},
 				Options: opts,
 			})
@@ -146,7 +147,7 @@ func TestIndexView(t *testing.T) {
 		})
 		mt.RunOpts("collation", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 			// collation invalid for server versions < 3.4
-			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{
+			_, err := mt.Coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 				Keys: bson.D{{"bar", "text"}},
 				Options: options.Index().SetCollation(&options.Collation{
 					Locale: "simple",
@@ -159,7 +160,7 @@ func TestIndexView(t *testing.T) {
 
 			mt.Run("no options", func(mt *mtest.T) {
 				iv := mt.Coll.Indexes()
-				indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+				indexName, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 					Keys: keysDoc,
 				})
 				assert.Nil(mt, err, "CreateOne error: %v", err)
@@ -176,7 +177,7 @@ func TestIndexView(t *testing.T) {
 				// document and the format of the document returned by listIndexes was changed in 4.5.x to explicitly
 				// include "_id: false", so we include it here too.
 				proj := bson.D{{"a", true}, {"_id", false}}
-				_, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+				_, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 					Keys:    keysDoc,
 					Options: options.Index().SetWildcardProjection(proj),
 				})
@@ -198,7 +199,7 @@ func TestIndexView(t *testing.T) {
 				Options: options.Index().SetHidden(true),
 			}
 
-			_, err := iv.CreateOne(mtest.Background, model)
+			_, err := iv.CreateOne(context.Background(), model)
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 
 			indexDoc := getIndexDoc(mt, iv, keysDoc)
@@ -209,7 +210,7 @@ func TestIndexView(t *testing.T) {
 			})
 		})
 		mt.Run("nil keys", func(mt *mtest.T) {
-			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{
+			_, err := mt.Coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 				Keys: nil,
 			})
 			assert.NotNil(mt, err, "expected CreateOne error, got nil")
@@ -243,7 +244,7 @@ func TestIndexView(t *testing.T) {
 				mtOpts := mtest.NewOptions().MinServerVersion(tc.minServerVersion).MaxServerVersion(tc.maxServerVersion)
 				mt.RunOpts(tc.name, mtOpts, func(mt *mtest.T) {
 					mt.ClearEvents()
-					_, err := mt.Coll.Indexes().CreateOne(mtest.Background, indexModel, tc.opts)
+					_, err := mt.Coll.Indexes().CreateOne(context.Background(), indexModel, tc.opts)
 					if tc.expectError {
 						assert.NotNil(mt, err, "expected CreateOne error, got nil")
 						return
@@ -269,7 +270,7 @@ func TestIndexView(t *testing.T) {
 			ClientOptions(unackClientOpts).
 			MinServerVersion("3.6")
 		mt.RunOpts("unacknowledged write", unackMtOpts, func(mt *mtest.T) {
-			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{Keys: bson.D{{"x", 1}}})
+			_, err := mt.Coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{Keys: bson.D{{"x", 1}}})
 			if err != mongo.ErrUnacknowledgedWrite {
 				// Use a direct comparison rather than assert.Equal because assert.Equal will compare the error strings,
 				// so the assertion would succeed even if the error had not been wrapped.
@@ -287,7 +288,7 @@ func TestIndexView(t *testing.T) {
 				},
 			})
 
-			_, err := mt.Coll.Indexes().CreateOne(mtest.Background, mongo.IndexModel{Keys: bson.D{{"x", 1}}})
+			_, err := mt.Coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{Keys: bson.D{{"x", 1}}})
 			assert.NotNil(mt, err, "expected CreateOne error, got nil")
 			cmdErr, ok := err.(mongo.CommandError)
 			assert.True(mt, ok, "expected mongo.CommandError, got %T", err)
@@ -297,7 +298,7 @@ func TestIndexView(t *testing.T) {
 		mt.Run("multi-key map", func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
 
-			_, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+			_, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 				Keys: bson.M{"foo": 1, "bar": -1},
 			})
 			assert.NotNil(mt, err, "expected CreateOne error, got nil")
@@ -307,7 +308,7 @@ func TestIndexView(t *testing.T) {
 			iv := mt.Coll.Indexes()
 			expectedName := "foo_1"
 
-			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+			indexName, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 				Keys: bson.M{"foo": 1},
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
@@ -325,7 +326,7 @@ func TestIndexView(t *testing.T) {
 			firstKeysDoc := bson.D{{"foo", int32(-1)}}
 			secondKeysDoc := bson.D{{"bar", int32(1)}, {"baz", int32(-1)}}
 			expectedNames := []string{"foo_-1", "bar_1_baz_-1"}
-			indexNames, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+			indexNames, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys: firstKeysDoc,
 				},
@@ -349,7 +350,7 @@ func TestIndexView(t *testing.T) {
 		wcMtOpts := mtest.NewOptions().CollectionOptions(options.Collection().SetWriteConcern(wc))
 		mt.RunOpts("uses writeconcern", wcMtOpts, func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
-			_, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+			_, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys: bson.D{{"foo", -1}},
 				},
@@ -402,7 +403,7 @@ func TestIndexView(t *testing.T) {
 				mtOpts := mtest.NewOptions().MinServerVersion(tc.minServerVersion).MaxServerVersion(tc.maxServerVersion)
 				mt.RunOpts(tc.name, mtOpts, func(mt *mtest.T) {
 					mt.ClearEvents()
-					_, err := mt.Coll.Indexes().CreateMany(mtest.Background, []mongo.IndexModel{indexModel1, indexModel2}, tc.opts)
+					_, err := mt.Coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{indexModel1, indexModel2}, tc.opts)
 					if tc.expectError {
 						assert.NotNil(mt, err, "expected CreateMany error, got nil")
 						return
@@ -433,7 +434,7 @@ func TestIndexView(t *testing.T) {
 				},
 			})
 
-			_, err := mt.Coll.Indexes().CreateMany(mtest.Background, []mongo.IndexModel{
+			_, err := mt.Coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys: bson.D{{"foo", int32(-1)}},
 				},
@@ -449,7 +450,7 @@ func TestIndexView(t *testing.T) {
 		})
 		mt.Run("multi-key map", func(mt *mtest.T) {
 			iv := mt.Coll.Indexes()
-			_, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+			_, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys: bson.M{"foo": 1, "bar": -1},
 				},
@@ -465,7 +466,7 @@ func TestIndexView(t *testing.T) {
 			firstKeysDoc := bson.M{"foo": -1}
 			secondKeysDoc := bson.D{{"bar", int32(1)}, {"baz", int32(-1)}}
 			expectedNames := []string{"foo_-1", "bar_1_baz_-1"}
-			indexNames, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+			indexNames, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys: firstKeysDoc,
 				},
@@ -489,7 +490,7 @@ func TestIndexView(t *testing.T) {
 	mt.RunOpts("list specifications", noClientOpts, func(mt *mtest.T) {
 		mt.Run("verify results", func(mt *mtest.T) {
 			// Create a handful of indexes
-			_, err := mt.Coll.Indexes().CreateMany(mtest.Background, []mongo.IndexModel{
+			_, err := mt.Coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
 				{
 					Keys:    bson.D{{"foo", int32(-1)}},
 					Options: options.Index().SetUnique(true),
@@ -562,14 +563,14 @@ func TestIndexView(t *testing.T) {
 				}
 			}
 
-			specs, err := mt.Coll.Indexes().ListSpecifications(mtest.Background)
+			specs, err := mt.Coll.Indexes().ListSpecifications(context.Background())
 			assert.Nil(mt, err, "ListSpecifications error: %v", err)
 			assert.Equal(mt, len(expectedSpecs), len(specs), "expected %d specification, got %d", len(expectedSpecs), len(specs))
 			assert.True(mt, cmp.Equal(specs, expectedSpecs), "expected specifications to match: %v", cmp.Diff(specs, expectedSpecs))
 		})
 		mt.RunOpts("options passed to listIndexes", mtest.NewOptions().MinServerVersion("3.0"), func(mt *mtest.T) {
 			opts := options.ListIndexes().SetMaxTime(100 * time.Millisecond)
-			_, err := mt.Coll.Indexes().ListSpecifications(mtest.Background, opts)
+			_, err := mt.Coll.Indexes().ListSpecifications(context.Background(), opts)
 			assert.Nil(mt, err, "ListSpecifications error: %v", err)
 
 			evt := mt.GetStartedEvent()
@@ -582,7 +583,7 @@ func TestIndexView(t *testing.T) {
 	})
 	mt.Run("drop one", func(mt *mtest.T) {
 		iv := mt.Coll.Indexes()
-		indexNames, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+		indexNames, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 			{
 				Keys: bson.D{{"foo", -1}},
 			},
@@ -593,12 +594,12 @@ func TestIndexView(t *testing.T) {
 		assert.Nil(mt, err, "CreateMany error: %v", err)
 		assert.Equal(mt, 2, len(indexNames), "expected 2 index names, got %v", len(indexNames))
 
-		_, err = iv.DropOne(mtest.Background, indexNames[1])
+		_, err = iv.DropOne(context.Background(), indexNames[1])
 		assert.Nil(mt, err, "DropOne error: %v", err)
 
-		cursor, err := iv.List(mtest.Background)
+		cursor, err := iv.List(context.Background())
 		assert.Nil(mt, err, "List error: %v", err)
-		for cursor.Next(mtest.Background) {
+		for cursor.Next(context.Background()) {
 			var idx index
 			err = cursor.Decode(&idx)
 			assert.Nil(mt, err, "Decode error: %v (document %v)", err, cursor.Current)
@@ -608,7 +609,7 @@ func TestIndexView(t *testing.T) {
 	})
 	mt.Run("drop all", func(mt *mtest.T) {
 		iv := mt.Coll.Indexes()
-		names, err := iv.CreateMany(mtest.Background, []mongo.IndexModel{
+		names, err := iv.CreateMany(context.Background(), []mongo.IndexModel{
 			{
 				Keys: bson.D{{"foo", -1}},
 			},
@@ -618,12 +619,12 @@ func TestIndexView(t *testing.T) {
 		})
 		assert.Nil(mt, err, "CreateMany error: %v", err)
 		assert.Equal(mt, 2, len(names), "expected 2 index names, got %v", len(names))
-		_, err = iv.DropAll(mtest.Background)
+		_, err = iv.DropAll(context.Background())
 		assert.Nil(mt, err, "DropAll error: %v", err)
 
-		cursor, err := iv.List(mtest.Background)
+		cursor, err := iv.List(context.Background())
 		assert.Nil(mt, err, "List error: %v", err)
-		for cursor.Next(mtest.Background) {
+		for cursor.Next(context.Background()) {
 			var idx index
 			err = cursor.Decode(&idx)
 			assert.Nil(mt, err, "Decode error: %v (document %v)", err, cursor.Current)
@@ -635,10 +636,10 @@ func TestIndexView(t *testing.T) {
 }
 
 func getIndexDoc(mt *mtest.T, iv mongo.IndexView, expectedKeyDoc bson.D) bson.D {
-	c, err := iv.List(mtest.Background)
+	c, err := iv.List(context.Background())
 	assert.Nil(mt, err, "List error: %v", err)
 
-	for c.Next(mtest.Background) {
+	for c.Next(context.Background()) {
 		var index bson.D
 		err = c.Decode(&index)
 		assert.Nil(mt, err, "Decode error: %v", err)
@@ -672,11 +673,11 @@ func checkIndexDocContains(mt *mtest.T, indexDoc bson.D, expectedElem bson.E) {
 func verifyIndexExists(mt *mtest.T, iv mongo.IndexView, expected index) {
 	mt.Helper()
 
-	cursor, err := iv.List(mtest.Background)
+	cursor, err := iv.List(context.Background())
 	assert.Nil(mt, err, "List error: %v", err)
 
 	var found bool
-	for cursor.Next(mtest.Background) {
+	for cursor.Next(context.Background()) {
 		var idx index
 		err = cursor.Decode(&idx)
 		assert.Nil(mt, err, "Decode error: %v", err)

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -106,7 +106,7 @@ func runSeedlistDiscoveryTest(mt *mtest.T, file string) {
 	assert.Nil(mt, err, "topology.New error: %v", err)
 	err = topo.Connect()
 	assert.Nil(mt, err, "topology.Connect error: %v", err)
-	defer func() { _ = topo.Disconnect(mtest.Background) }()
+	defer func() { _ = topo.Disconnect(context.Background()) }()
 
 	// If NumHosts is set, check number of hosts currently stored on the Topology.
 	if test.NumHosts != nil {

--- a/mongo/integration/mock_find_test.go
+++ b/mongo/integration/mock_find_test.go
@@ -80,7 +80,7 @@ func TestMockFind(t *testing.T) {
 
 	mt.Run("mongo.Collection can be passed as interface", func(mt *mtest.T) {
 		// Actually insert documents to collection.
-		_, err := mt.Coll.InsertMany(mtest.Background, insertItems)
+		_, err := mt.Coll.InsertMany(context.Background(), insertItems)
 		assert.Nil(mt, err, "InsertMany error: %v", err)
 
 		// Assert that FindOne behaves as expected.

--- a/mongo/integration/mongos_pinning_test.go
+++ b/mongo/integration/mongos_pinning_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -31,7 +32,7 @@ func TestMongosPinning(t *testing.T) {
 
 	mt.Run("unpin for next transaction", func(mt *mtest.T) {
 		addresses := map[string]struct{}{}
-		_ = mt.Client.UseSession(mtest.Background, func(sc mongo.SessionContext) error {
+		_ = mt.Client.UseSession(context.Background(), func(sc mongo.SessionContext) error {
 			// Insert a document in a transaction to pin session to a mongos
 			err := sc.StartTransaction()
 			assert.Nil(mt, err, "StartTransaction error: %v", err)
@@ -47,9 +48,9 @@ func TestMongosPinning(t *testing.T) {
 
 				cursor, err := mt.Coll.Find(sc, bson.D{})
 				assert.Nil(mt, err, iterationErrmsg("Find", i, err))
-				assert.True(mt, cursor.Next(mtest.Background), "Next returned false on iteration %v", i)
+				assert.True(mt, cursor.Next(context.Background()), "Next returned false on iteration %v", i)
 
-				descConn, err := mongo.BatchCursorFromCursor(cursor).Server().Connection(mtest.Background)
+				descConn, err := mongo.BatchCursorFromCursor(cursor).Server().Connection(context.Background())
 				assert.Nil(mt, err, iterationErrmsg("Connection", i, err))
 				addresses[descConn.Description().Addr.String()] = struct{}{}
 				err = descConn.Close()
@@ -64,7 +65,7 @@ func TestMongosPinning(t *testing.T) {
 	})
 	mt.Run("unpin for non transaction operation", func(mt *mtest.T) {
 		addresses := map[string]struct{}{}
-		_ = mt.Client.UseSession(mtest.Background, func(sc mongo.SessionContext) error {
+		_ = mt.Client.UseSession(context.Background(), func(sc mongo.SessionContext) error {
 			// Insert a document in a transaction to pin session to a mongos
 			err := sc.StartTransaction()
 			assert.Nil(mt, err, "StartTransaction error: %v", err)
@@ -77,9 +78,9 @@ func TestMongosPinning(t *testing.T) {
 				// Call Find with the session but outside of a transaction
 				cursor, err := mt.Coll.Find(sc, bson.D{})
 				assert.Nil(mt, err, iterationErrmsg("Find", i, err))
-				assert.True(mt, cursor.Next(mtest.Background), "Next returned false on iteration %v", i)
+				assert.True(mt, cursor.Next(context.Background()), "Next returned false on iteration %v", i)
 
-				descConn, err := mongo.BatchCursorFromCursor(cursor).Server().Connection(mtest.Background)
+				descConn, err := mongo.BatchCursorFromCursor(cursor).Server().Connection(context.Background())
 				assert.Nil(mt, err, iterationErrmsg("Connection", i, err))
 				addresses[descConn.Description().Addr.String()] = struct{}{}
 				err = descConn.Close()

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -7,6 +7,7 @@
 package mtest
 
 import (
+	"context"
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -72,7 +73,7 @@ func ServerVersion() string {
 // SetFailPoint configures the provided fail point on the cluster under test using the provided Client.
 func SetFailPoint(fp FailPoint, client *mongo.Client) error {
 	admin := client.Database("admin")
-	if err := admin.RunCommand(Background, fp).Err(); err != nil {
+	if err := admin.RunCommand(context.Background(), fp).Err(); err != nil {
 		return fmt.Errorf("error creating fail point: %v", err)
 	}
 	return nil
@@ -82,7 +83,7 @@ func SetFailPoint(fp FailPoint, client *mongo.Client) error {
 // provided Client
 func SetRawFailPoint(fp bson.Raw, client *mongo.Client) error {
 	admin := client.Database("admin")
-	if err := admin.RunCommand(Background, fp).Err(); err != nil {
+	if err := admin.RunCommand(context.Background(), fp).Err(); err != nil {
 		return fmt.Errorf("error creating fail point: %v", err)
 	}
 	return nil

--- a/mongo/integration/operation_legacy_test.go
+++ b/mongo/integration/operation_legacy_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -79,64 +80,64 @@ func TestOperationLegacy(t *testing.T) {
 	mt.RunOpts("verify results", noClientOpts, func(mt *mtest.T) {
 		mt.RunOpts("find", mtest.NewOptions().MaxServerVersion("3.0"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetSort(bson.D{{"x", 1}}))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetSort(bson.D{{"x", 1}}))
 			assert.Nil(mt, err, "Find error: %v", err)
 
 			for i := 1; i <= 5; i++ {
-				assert.True(mt, cursor.Next(mtest.Background), "Next returned false on iteration %v", i)
+				assert.True(mt, cursor.Next(context.Background()), "Next returned false on iteration %v", i)
 				got := cursor.Current.Lookup("x").Int32()
 				assert.Equal(mt, int32(i), got, "expected x value %v, got %v", i, got)
 			}
-			assert.False(mt, cursor.Next(mtest.Background), "found extra document %v", cursor.Current)
+			assert.False(mt, cursor.Next(context.Background()), "found extra document %v", cursor.Current)
 			err = cursor.Err()
 			assert.Nil(mt, err, "cursor error: %v", err)
 		})
 		mt.RunOpts("list collections", mtest.NewOptions().MaxServerVersion("2.7.6").DatabaseName("test_legacy"), func(mt *mtest.T) {
 			// run on a separate database to avoid finding other collections if we run these tests in parallel
-			cursor, err := mt.DB.ListCollections(mtest.Background, bson.D{})
+			cursor, err := mt.DB.ListCollections(context.Background(), bson.D{})
 			assert.Nil(mt, err, "ListCollections error: %v", err)
 
 			for i := 0; i < 2; i++ {
-				assert.True(mt, cursor.Next(mtest.Background), "Next returned false on iteration %v", i)
+				assert.True(mt, cursor.Next(context.Background()), "Next returned false on iteration %v", i)
 				collName := cursor.Current.Lookup("name").StringValue()
 				assert.True(mt, collName == mt.Coll.Name() || collName == "system.indexes",
 					"unexpected collection %v", collName)
 			}
-			assert.False(mt, cursor.Next(mtest.Background), "found extra document %v", cursor.Current)
+			assert.False(mt, cursor.Next(context.Background()), "found extra document %v", cursor.Current)
 			err = cursor.Err()
 			assert.Nil(mt, err, "cursor error: %v", err)
 		})
 		mt.RunOpts("list indexes", mtest.NewOptions().MaxServerVersion("2.7.6"), func(mt *mtest.T) {
 			// create index so an index besides _id is found
 			iv := mt.Coll.Indexes()
-			indexName, err := iv.CreateOne(mtest.Background, mongo.IndexModel{
+			indexName, err := iv.CreateOne(context.Background(), mongo.IndexModel{
 				Keys: bson.D{{"x", 1}},
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 
-			cursor, err := iv.List(mtest.Background)
+			cursor, err := iv.List(context.Background())
 			expectedNs := fullCollName(mt, mt.Coll.Name())
 			assert.Nil(mt, err, "List error: %v", err)
 			for i := 0; i < 2; i++ {
-				assert.True(mt, cursor.Next(mtest.Background), "Next returned false on iteration %v", i)
+				assert.True(mt, cursor.Next(context.Background()), "Next returned false on iteration %v", i)
 				ns := cursor.Current.Lookup("ns").StringValue()
 				assert.Equal(mt, expectedNs, ns, "expected ns %v, got %v", expectedNs, ns)
 
 				name := cursor.Current.Lookup("name").StringValue()
 				assert.True(mt, name == "_id_" || name == indexName, "unexpected index %v", name)
 			}
-			assert.False(mt, cursor.Next(mtest.Background), "found extra document %v", cursor.Current)
+			assert.False(mt, cursor.Next(context.Background()), "found extra document %v", cursor.Current)
 			err = cursor.Err()
 			assert.Nil(mt, err, "cursor error: %v", err)
 		})
 		mt.RunOpts("find and killCursors", mtest.NewOptions().MaxServerVersion("3.0"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			// set batch size to force multiple batches
-			cursor, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+			cursor, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 			assert.Nil(mt, err, "Find error: %v", err)
 			// close cursor to force a killCursors to be sent
 			mt.ClearEvents()
-			err = cursor.Close(mtest.Background)
+			err = cursor.Close(context.Background())
 			assert.Nil(mt, err, "Close error: %v", err)
 			evt := mt.GetStartedEvent()
 			assert.NotNil(mt, evt, "expected CommandStartedEvent, got nil")
@@ -181,7 +182,7 @@ func runFindWithOptions(mt *mtest.T) opQuery {
 		SetSkip(1).
 		SetSnapshot(false).
 		SetSort(sort)
-	_, _ = mt.Coll.Find(mtest.Background, filter, opts)
+	_, _ = mt.Coll.Find(context.Background(), filter, opts)
 
 	// find expectations
 	findQueryDoc := bson.D{
@@ -207,7 +208,7 @@ func runFindWithOptions(mt *mtest.T) opQuery {
 }
 
 func runListCollectionsWithOptions(mt *mtest.T) opQuery {
-	_, _ = mt.DB.ListCollections(mtest.Background, bson.D{{"name", "foo"}})
+	_, _ = mt.DB.ListCollections(context.Background(), bson.D{{"name", "foo"}})
 
 	regexDoc := bson.D{{"name", primitive.Regex{Pattern: "^[^$]*$"}}}
 	modifiedFilterDoc := bson.D{{"name", fullCollName(mt, "foo")}}
@@ -222,7 +223,7 @@ func runListCollectionsWithOptions(mt *mtest.T) opQuery {
 }
 
 func runListIndexesWithOptions(mt *mtest.T) opQuery {
-	_, _ = mt.Coll.Indexes().List(mtest.Background, options.ListIndexes().SetBatchSize(2).SetMaxTime(10000*time.Millisecond))
+	_, _ = mt.Coll.Indexes().List(context.Background(), options.ListIndexes().SetBatchSize(2).SetMaxTime(10000*time.Millisecond))
 
 	listIndexesDoc := bson.D{
 		{"$query", bson.D{{"ns", fullCollName(mt, mt.Coll.Name())}}},

--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -119,10 +120,10 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 		clearPoolChan()
 
 		initCollection(mt, mt.Coll)
-		cur, err := mt.Coll.Find(mtest.Background, bson.D{}, options.Find().SetBatchSize(2))
+		cur, err := mt.Coll.Find(context.Background(), bson.D{}, options.Find().SetBatchSize(2))
 		assert.Nil(mt, err, "Find error: %v", err)
-		defer cur.Close(mtest.Background)
-		assert.True(mt, cur.Next(mtest.Background), "expected Next true, got false")
+		defer cur.Close(context.Background())
+		assert.True(mt, cur.Next(context.Background()), "expected Next true, got false")
 
 		// replSetStepDown can fail with transient errors, so we use executeAdminCommandWithRetry to handle them and
 		// retry until a timeout is hit.
@@ -133,7 +134,7 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 		stepDownOpts := options.RunCmd().SetReadPreference(mtest.PrimaryRp)
 		executeAdminCommandWithRetry(mt, mt.Client, stepDownCmd, stepDownOpts)
 
-		assert.True(mt, cur.Next(mtest.Background), "expected Next true, got false")
+		assert.True(mt, cur.Next(context.Background()), "expected Next true, got false")
 		assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
 	})
 	mt.RunOpts("server errors", noClientOpts, func(mt *mtest.T) {
@@ -174,7 +175,7 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 					},
 				})
 
-				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"test", 1}})
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"test", 1}})
 				assert.NotNil(mt, err, "expected InsertOne error, got nil")
 				cerr, ok := err.(mongo.CommandError)
 				assert.True(mt, ok, "expected error type %v, got %v", mongo.CommandError{}, err)
@@ -186,7 +187,7 @@ func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 				}
 
 				// if pool shouldn't be cleared, another operation should succeed
-				_, err = mt.Coll.InsertOne(mtest.Background, bson.D{{"test", 1}})
+				_, err = mt.Coll.InsertOne(context.Background(), bson.D{{"test", 1}})
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 				assert.False(mt, isPoolCleared(), "expected pool to not be cleared but was")
 			})

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build go1.13
 // +build go1.13
 
 package integration
@@ -138,7 +139,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 					tpm := newTestPoolMonitor()
 					mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
-					_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+					_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 					assert.NotNil(mt, err, "expected InsertOne error, got nil")
 					assert.False(mt, mongo.IsTimeout(err), "expected non-timeout error, got %v", err)
 					assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
@@ -167,7 +168,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				tpm := newTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
-				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"test", 1}})
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"test", 1}})
 				assert.NotNil(mt, err, "expected InsertOne error, got nil")
 				assert.False(mt, mongo.IsTimeout(err), "expected non-timeout error, got %v", err)
 				assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
@@ -176,13 +177,13 @@ func TestSDAMErrorHandling(t *testing.T) {
 				tpm := newTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetPoolMonitor(tpm.PoolMonitor))
 
-				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 
 				filter := bson.M{
 					"$where": "function() { sleep(1000); return false; }",
 				}
-				timeoutCtx, cancel := context.WithTimeout(mtest.Background, 100*time.Millisecond)
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 				defer cancel()
 				_, err = mt.Coll.Find(timeoutCtx, filter)
 				assert.NotNil(mt, err, "expected Find error, got %v", err)
@@ -193,10 +194,10 @@ func TestSDAMErrorHandling(t *testing.T) {
 				tpm := newTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetPoolMonitor(tpm.PoolMonitor))
 
-				_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 
-				findCtx, cancel := context.WithCancel(mtest.Background)
+				findCtx, cancel := context.WithCancel(context.Background())
 				go func() {
 					time.Sleep(100 * time.Millisecond)
 					cancel()
@@ -300,7 +301,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 func runServerErrorsTest(mt *mtest.T, isShutdownError bool, tpm *testPoolMonitor) {
 	mt.Helper()
 
-	_, err := mt.Coll.InsertOne(mtest.Background, bson.D{{"x", 1}})
+	_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 	assert.NotNil(mt, err, "expected InsertOne error, got nil")
 
 	// The pool should always be cleared for shutdown errors, regardless of server version.

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"context"
 	"runtime"
 	"testing"
 	"time"
@@ -148,7 +149,7 @@ func TestSDAMProse(t *testing.T) {
 
 		// Assert that Ping completes successfully within 2 to 3.5 seconds.
 		start := time.Now()
-		err := mt.Client.Ping(mtest.Background, nil)
+		err := mt.Client.Ping(context.Background(), nil)
 		assert.Nil(mt, err, "Ping error: %v", err)
 		pingTime := time.Since(start)
 		assert.True(mt, pingTime > 2000*time.Millisecond && pingTime < 3500*time.Millisecond,

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -203,7 +203,7 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 		return fmt.Errorf("schema version %q not supported: %v", tc.schemaVersion, err)
 	}
 
-	testCtx := newTestContext(mtest.Background, tc.entities)
+	testCtx := newTestContext(context.Background(), tc.entities)
 
 	defer func() {
 		// If anything fails while doing test cleanup, we only log the error because the actual test may have already
@@ -222,7 +222,7 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 		// if the test attempted to commit/abort the transaction because an abortTransaction command can fail if it's
 		// sent to a mongos that isn't aware of the transaction.
 		if tc.startsTransaction() && tc.killAllSessions {
-			if err := terminateOpenSessions(mtest.Background); err != nil {
+			if err := terminateOpenSessions(context.Background()); err != nil {
 				ls.Logf("error terminating open transactions after failed test: %v", err)
 			}
 		}

--- a/mongo/integration/unified/unified_spec_test.go
+++ b/mongo/integration/unified/unified_spec_test.go
@@ -7,10 +7,9 @@
 package unified
 
 import (
+	"context"
 	"path"
 	"testing"
-
-	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 var (
@@ -37,7 +36,7 @@ const (
 
 func TestUnifiedSpec(t *testing.T) {
 	// Ensure the cluster is in a clean state before test execution begins.
-	if err := terminateOpenSessions(mtest.Background); err != nil {
+	if err := terminateOpenSessions(context.Background()); err != nil {
 		t.Fatalf("error terminating open transactions: %v", err)
 	}
 

--- a/mongo/integration/unified_runner_events_helper_test.go
+++ b/mongo/integration/unified_runner_events_helper_test.go
@@ -144,7 +144,7 @@ func waitForPrimaryChange(mt *mtest.T, testCase *testCase, op *operation) {
 func getPrimaryAddress(mt *mtest.T, topo *topology.Topology, failFast bool) address.Address {
 	mt.Helper()
 
-	ctx, cancel := context.WithCancel(mtest.Background)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if failFast {
 		cancel()


### PR DESCRIPTION
There is currently an inconsistent mixture between use of `context.Background()` and `mtest.Background` context values in tests. Those two values are semantically and functionally identical, but `mtest.Background` requires additional knowledge of what that value is, where `context.Background()` is a more generally understood stdlib value.

Replace all uses of `mtest.Background` with `context.Background()` and remove the `mtest.Background` value.