### PR TITLE
GODRIVER-1910 Test that PoolClearedErrors are retryable

### DIFF
--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -76,7 +76,7 @@ func (tpm *testPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*ev
 func (tpm *testPoolMonitor) ClearEvents() {
 	tpm.mu.Lock()
 	defer tpm.mu.Unlock()
-	tpm.events = nil
+	tpm.events = tpm.events[:0]
 }
 
 // IsPoolCleared returns true if there are any events of type "event.PoolCleared" in the events

--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -72,6 +72,13 @@ func (tpm *testPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*ev
 	return filtered
 }
 
+// ClearEvents will reset the events collected by the testPoolMonitor.
+func (tpm *testPoolMonitor) ClearEvents() {
+	tpm.mu.Lock()
+	defer tpm.mu.Unlock()
+	tpm.events = nil
+}
+
 // IsPoolCleared returns true if there are any events of type "event.PoolCleared" in the events
 // recorded by the testPoolMonitor.
 func (tpm *testPoolMonitor) IsPoolCleared() bool {

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -24,9 +24,12 @@ func TestRetryableReadsProse(t *testing.T) {
 
 	// Client options with MaxPoolSize of 1 and RetryReads used per the test description.
 	// Lower HeartbeatInterval used to speed the test up for any server that uses streaming
-	// heartbeats.
+	// heartbeats. Only connect to first host in list for sharded clusters.
+	hosts := mtest.ClusterConnString().Hosts
 	clientOpts := options.Client().SetMaxPoolSize(1).SetRetryReads(true).
-		SetPoolMonitor(tpm.PoolMonitor).SetHeartbeatInterval(500 * time.Millisecond)
+		SetPoolMonitor(tpm.PoolMonitor).SetHeartbeatInterval(500 * time.Millisecond).
+		SetHosts(hosts[:1])
+
 	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("4.3")
 	mt := mtest.New(t, mtOpts)
 	defer mt.Close()

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -72,13 +72,7 @@ func TestRetryableReadsProse(t *testing.T) {
 
 		// Assert that first check out succeeds, pool is cleared, and second check
 		// out fails due to connection error.
-		//
-		// FIXME-1910: this actually returns four events:
-		// 1. GetSucceeded
-		// 2. PoolCleared
-		// 3. GetSucceeded
-		// 4. GetSucceeded
-		assert.Equal(mt, 3, len(events), "expected 3 events, got %v", len(events))
+		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
 		assert.Equal(mt, event.GetSucceeded, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
 		assert.Equal(mt, event.PoolCleared, events[1].Type,

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -1,0 +1,99 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestRetryableReadsProse(t *testing.T) {
+	tpm := newTestPoolMonitor()
+	clientOpts := options.Client().SetMaxPoolSize(1).SetRetryReads(true).
+		SetPoolMonitor(tpm.PoolMonitor)
+	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("4.3")
+	mt := mtest.New(t, mtOpts)
+	defer mt.Close()
+
+	mt.Run("PoolClearedError retryability", func(mt *mtest.T) {
+		// Insert a document to test collection.
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		// Force Find to block for 1 second once.
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 1,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"find"},
+				ErrorCode:       91,
+				BlockConnection: true,
+				BlockTimeMS:     1000,
+			},
+		})
+
+		// Clear CMAP and command events.
+		tpm.ClearEvents()
+		mt.ClearEvents()
+
+		// Perform a FindOne on two different threads and assert both operations are
+		// successful.
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				res := mt.Coll.FindOne(context.Background(), bson.D{})
+				assert.Nil(mt, res.Err())
+			}()
+		}
+		wg.Wait()
+
+		// Gather GetSucceeded, GetFailed and PoolCleared pool events.
+		events := tpm.Events(func(e *event.PoolEvent) bool {
+			getSucceeded := e.Type == event.GetSucceeded
+			getFailed := e.Type == event.GetFailed
+			poolCleared := e.Type == event.PoolCleared
+			return getSucceeded || getFailed || poolCleared
+		})
+
+		// Assert that first check out succeeds, pool is cleared, and second check
+		// out fails due to connection error.
+		//
+		// FIXME-1910: this actually returns four events:
+		// 1. GetSucceeded
+		// 2. PoolCleared
+		// 3. GetSucceeded
+		// 4. GetSucceeded
+		assert.Equal(mt, 3, len(events), "expected 3 events, got %v", len(events))
+		assert.Equal(mt, event.GetSucceeded, events[0].Type,
+			"expected ConnectionCheckedOut event, got %v", events[0].Type)
+		assert.Equal(mt, event.PoolCleared, events[1].Type,
+			"expected ConnectionPoolCleared event, got %v", events[1].Type)
+		assert.Equal(mt, event.GetFailed, events[2].Type,
+			"expected ConnectionCheckedOutFailed event, got %v", events[2].Type)
+		assert.Equal(mt, event.ReasonConnectionErrored, events[2].Reason,
+			"expected check out failure due to connection error, failed due to %q", events[2].Reason)
+
+		// Assert that three find CommandStartedEvents were observed.
+		for i := 0; i < 3; i++ {
+			cmdEvt := mt.GetStartedEvent()
+			assert.NotNil(mt, cmdEvt, "expected a find event, got nil")
+			assert.Equal(mt, cmdEvt.CommandName, "find",
+				"expected a find event, got a(n) %v event", cmdEvt.CommandName)
+		}
+	})
+}

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
@@ -20,8 +21,12 @@ import (
 
 func TestRetryableReadsProse(t *testing.T) {
 	tpm := newTestPoolMonitor()
+
+	// Client options with MaxPoolSize of 1 and RetryReads used per the test description.
+	// Lower HeartbeatInterval used to speed the test up for any server that uses streaming
+	// heartbeats.
 	clientOpts := options.Client().SetMaxPoolSize(1).SetRetryReads(true).
-		SetPoolMonitor(tpm.PoolMonitor)
+		SetPoolMonitor(tpm.PoolMonitor).SetHeartbeatInterval(500 * time.Millisecond)
 	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("4.3")
 	mt := mtest.New(t, mtOpts)
 	defer mt.Close()

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -172,8 +172,6 @@ func TestRetryableWritesProse(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
-				// FIXME-1910: InsertOne fails and errors because of the failpoint; it looks
-				// like retry logic is not working.
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 			}()
 		}
@@ -189,7 +187,7 @@ func TestRetryableWritesProse(t *testing.T) {
 
 		// Assert that first check out succeeds, pool is cleared, and second check
 		// out fails due to connection error.
-		assert.Equal(mt, 3, len(events), "expected 3 events, got %v", len(events))
+		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
 		assert.Equal(mt, event.GetSucceeded, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
 		assert.Equal(mt, event.PoolCleared, events[1].Type,

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -144,9 +144,12 @@ func TestRetryableWritesProse(t *testing.T) {
 	tpm := newTestPoolMonitor()
 	// Client options with MaxPoolSize of 1 and RetryWrites used per the test description.
 	// Lower HeartbeatInterval used to speed the test up for any server that uses streaming
-	// heartbeats.
+	// heartbeats. Only connect to first host in list for sharded clusters.
+	hosts := mtest.ClusterConnString().Hosts
 	pceOpts := options.Client().SetMaxPoolSize(1).SetRetryWrites(true).
-		SetPoolMonitor(tpm.PoolMonitor).SetHeartbeatInterval(500 * time.Millisecond)
+		SetPoolMonitor(tpm.PoolMonitor).SetHeartbeatInterval(500 * time.Millisecond).
+		SetHosts(hosts[:1])
+
 	mtPceOpts := mtest.NewOptions().ClientOptions(pceOpts).MinServerVersion("4.3").
 		Topologies(mtest.ReplicaSet, mtest.Sharded)
 	mt.RunOpts("PoolClearedError retryability", mtPceOpts, func(mt *mtest.T) {


### PR DESCRIPTION
GODRIVER-1910

Tests that `PoolClearedError`s are retryable for both reads and writes. Implements the prose tests described in [DRIVERS-1483](https://jira.mongodb.org/browse/DRIVERS-1483).