### PR TITLE
GODRIVER-2270 Bump maxWireVersion for MongoDB 5.2

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(2, 14)
+	SupportedWireVersions = description.NewVersionRange(2, 15)
 )
 
 const (


### PR DESCRIPTION
GODRIVER-2270

Bumps the max supported wire version to 15, which correlates with MongoDB server version 5.2.