### PR TITLE
GODRIVER-2278 Support CustomOptions on ChangeStreamOptions and AggregateOptions

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -151,6 +151,7 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 			bsonType, bsonData, err := bson.MarshalValueWithRegistry(cs.registry, optionValue)
 			if err != nil {
 				cs.err = err
+				closeImplicitSession(cs.sess)
 				return nil, cs.Err()
 			}
 			optionValueBSON := bsoncore.Value{Type: bsonType, Data: bsonData}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -852,6 +852,20 @@ func aggregate(a aggregateParams) (cur *Cursor, err error) {
 		}
 		op.Let(let)
 	}
+	if ao.CustomOptions != nil {
+		// Marshal all custom options before passing to the aggregate operation. Return
+		// any errors from Marshaling.
+		customOptions := make(map[string]bsoncore.Value)
+		for optionName, optionValue := range ao.CustomOptions {
+			bsonType, bsonData, err := bson.MarshalValueWithRegistry(a.registry, optionValue)
+			if err != nil {
+				return nil, err
+			}
+			optionValueBSON := bsoncore.Value{Type: bsonType, Data: bsonData}
+			customOptions[optionName] = optionValueBSON
+		}
+		op.CustomOptions(customOptions)
+	}
 
 	retry := driver.RetryNone
 	if a.retryRead && !hasOutputStage {

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -635,10 +635,9 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
 	})
 	mt.Run("CustomOptions", func(mt *mtest.T) {
-		// Custom options should be a map of option names (strings) to Marshalable option values.
+		// Custom options should be a BSON map of option names to Marshalable option values.
 		// We use "allowDiskUse" as an example.
-		customOpts := make(map[string]interface{})
-		customOpts["allowDiskUse"] = true
+		customOpts := bson.M{"allowDiskUse": true}
 		opts := options.ChangeStream().SetCustomOptions(customOpts)
 
 		// Create change stream with custom options set.

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -634,6 +634,29 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		evt := mt.GetStartedEvent()
 		assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
 	})
+	mt.Run("CustomOptions", func(mt *mtest.T) {
+		// Custom options should be a map of option names (strings) to Marshalable option values.
+		// We use "allowDiskUse" as an example.
+		customOpts := make(map[string]interface{})
+		customOpts["allowDiskUse"] = true
+		opts := options.ChangeStream().SetCustomOptions(customOpts)
+
+		// Create change stream with custom options set.
+		mt.ClearEvents()
+		cs, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{}, opts)
+		assert.Nil(mt, err, "Watch error: %v", err)
+		defer closeStream(cs)
+
+		// Assert that custom option is passed to the initial aggregate.
+		evt := mt.GetStartedEvent()
+		assert.Equal(mt, "aggregate", evt.CommandName, "expected command 'aggregate' got, %q", evt.CommandName)
+
+		aduVal, err := evt.Command.LookupErr("allowDiskUse")
+		assert.Nil(mt, err, "expected field 'allowDiskUse' in started command not found")
+		adu, ok := aduVal.BooleanOK()
+		assert.True(mt, ok, "expected field 'allowDiskUse' to be boolean, got %v", aduVal.Type.String())
+		assert.True(mt, adu, "expected field 'allowDiskUse' to be true, got false")
+	})
 }
 
 func closeStream(cs *mongo.ChangeStream) {

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -800,10 +800,9 @@ func TestCollection(t *testing.T) {
 			})
 		})
 		mt.Run("CustomOptions", func(mt *mtest.T) {
-			// Custom options should be a map of option names (strings) to Marshalable option values.
+			// Custom options should be a BSON map of option names to Marshalable option values.
 			// We use "allowDiskUse" as an example.
-			customOpts := make(map[string]interface{})
-			customOpts["allowDiskUse"] = true
+			customOpts := bson.M{"allowDiskUse": true}
 			opts := options.Aggregate().SetCustomOptions(customOpts)
 
 			// Run aggregate with custom options set.

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -799,6 +799,28 @@ func TestCollection(t *testing.T) {
 				return mt.Coll.Aggregate(context.Background(), mongo.Pipeline{}, options.Aggregate().SetBatchSize(3))
 			})
 		})
+		mt.Run("CustomOptions", func(mt *mtest.T) {
+			// Custom options should be a map of option names (strings) to Marshalable option values.
+			// We use "allowDiskUse" as an example.
+			customOpts := make(map[string]interface{})
+			customOpts["allowDiskUse"] = true
+			opts := options.Aggregate().SetCustomOptions(customOpts)
+
+			// Run aggregate with custom options set.
+			mt.ClearEvents()
+			_, err := mt.Coll.Aggregate(context.Background(), mongo.Pipeline{}, opts)
+			assert.Nil(mt, err, "Aggregate error: %v", err)
+
+			// Assert that custom option is passed to the aggregate expression.
+			evt := mt.GetStartedEvent()
+			assert.Equal(mt, "aggregate", evt.CommandName, "expected command 'aggregate' got, %q", evt.CommandName)
+
+			aduVal, err := evt.Command.LookupErr("allowDiskUse")
+			assert.Nil(mt, err, "expected field 'allowDiskUse' in started command not found")
+			adu, ok := aduVal.BooleanOK()
+			assert.True(mt, ok, "expected field 'allowDiskUse' to be boolean, got %v", aduVal.Type.String())
+			assert.True(mt, adu, "expected field 'allowDiskUse' to be true, got false")
+		})
 	})
 	mt.RunOpts("count documents", noClientOpts, func(mt *mtest.T) {
 		mt.Run("success", func(mt *mtest.T) {

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -50,6 +50,10 @@ type AggregateOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// Custom options to be added to aggregate expression. Key-value pairs should correlate with desired option names
+	// and values. Values must be Marshalable.
+	CustomOptions map[string]interface{}
 }
 
 // Aggregate creates a new AggregateOptions instance.
@@ -111,6 +115,13 @@ func (ao *AggregateOptions) SetLet(let interface{}) *AggregateOptions {
 	return ao
 }
 
+// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
+// desired option names and values. Values must be Marshalable.
+func (ao *AggregateOptions) SetCustomOptions(co map[string]interface{}) *AggregateOptions {
+	ao.CustomOptions = co
+	return ao
+}
+
 // MergeAggregateOptions combines the given AggregateOptions instances into a single AggregateOptions in a last-one-wins
 // fashion.
 func MergeAggregateOptions(opts ...*AggregateOptions) *AggregateOptions {
@@ -145,6 +156,9 @@ func MergeAggregateOptions(opts ...*AggregateOptions) *AggregateOptions {
 		}
 		if ao.Let != nil {
 			aggOpts.Let = ao.Let
+		}
+		if ao.CustomOptions != nil {
+			aggOpts.CustomOptions = ao.CustomOptions
 		}
 	}
 

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -6,7 +6,11 @@
 
 package options
 
-import "time"
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
 
 // AggregateOptions represents options that can be used to configure an Aggregate operation.
 type AggregateOptions struct {
@@ -51,10 +55,10 @@ type AggregateOptions struct {
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
 
-	// Custom options to be added to aggregate expression. Key-value pairs should correlate with desired option names
-	// and values. Values must be Marshalable. Custom options may conflict with non-custom options, and custom options
-	// bypass client-side validation. Prefer using non-custom options where possible.
-	CustomOptions map[string]interface{}
+	// Custom options to be added to aggregate expression. Key-value pairs of the BSON map should correlate with desired
+	// option names and values. Values must be Marshalable. Custom options may conflict with non-custom options, and custom
+	// options bypass client-side validation. Prefer using non-custom options where possible.
+	CustomOptions bson.M
 }
 
 // Aggregate creates a new AggregateOptions instance.
@@ -116,11 +120,11 @@ func (ao *AggregateOptions) SetLet(let interface{}) *AggregateOptions {
 	return ao
 }
 
-// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
-// desired option names and values. Values must be Marshalable. Custom options may conflict with
-// non-custom options, and custom options bypass client-side validation. Prefer using non-custom
-// options where possible.
-func (ao *AggregateOptions) SetCustomOptions(co map[string]interface{}) *AggregateOptions {
+// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs of the BSON map
+// should correlate with desired option names and values. Values must be Marshalable. Custom options
+// may conflict with non-custom options, and custom options bypass client-side validation. Prefer
+// using non-custom options where possible.
+func (ao *AggregateOptions) SetCustomOptions(co bson.M) *AggregateOptions {
 	ao.CustomOptions = co
 	return ao
 }

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -52,7 +52,8 @@ type AggregateOptions struct {
 	Let interface{}
 
 	// Custom options to be added to aggregate expression. Key-value pairs should correlate with desired option names
-	// and values. Values must be Marshalable.
+	// and values. Values must be Marshalable. Custom options may conflict with non-custom options, and custom options
+	// bypass client-side validation. Prefer using non-custom options where possible.
 	CustomOptions map[string]interface{}
 }
 
@@ -116,7 +117,9 @@ func (ao *AggregateOptions) SetLet(let interface{}) *AggregateOptions {
 }
 
 // SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
-// desired option names and values. Values must be Marshalable.
+// desired option names and values. Values must be Marshalable. Custom options may conflict with
+// non-custom options, and custom options bypass client-side validation. Prefer using non-custom
+// options where possible.
 func (ao *AggregateOptions) SetCustomOptions(co map[string]interface{}) *AggregateOptions {
 	ao.CustomOptions = co
 	return ao

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -9,6 +9,7 @@ package options
 import (
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -47,10 +48,10 @@ type ChangeStreamOptions struct {
 	// ResumeAfter and StartAtOperationTime must not be set. This option is only valid for MongoDB versions >= 4.1.1.
 	StartAfter interface{}
 
-	// Custom options to be added to the initial aggregate for the change stream. Key-value pairs should correlate with
-	// desired option names and values. Values must be Marshalable. Custom options may conflict with non-custom options,
-	// and custom options bypass client-side validation. Prefer using non-custom options where possible.
-	CustomOptions map[string]interface{}
+	// Custom options to be added to the initial aggregate for the change stream. Key-value pairs of the BSON map should
+	// correlate with desired option names and values. Values must be Marshalable. Custom options may conflict with
+	// non-custom options, and custom options bypass client-side validation. Prefer using non-custom options where possible.
+	CustomOptions bson.M
 }
 
 // ChangeStream creates a new ChangeStreamOptions instance.
@@ -102,11 +103,11 @@ func (cso *ChangeStreamOptions) SetStartAfter(sa interface{}) *ChangeStreamOptio
 	return cso
 }
 
-// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
-// desired option names and values. Values must be Marshalable. Custom options may conflict with
-// non-custom options, and custom options bypass client-side validation. Prefer using non-custom
-// options where possible.
-func (cso *ChangeStreamOptions) SetCustomOptions(co map[string]interface{}) *ChangeStreamOptions {
+// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs of the BSON map
+// should correlate with desired option names and values. Values must be Marshalable. Custom options
+// may conflict with non-custom options, and custom options bypass client-side validation. Prefer
+// using non-custom options where possible.
+func (cso *ChangeStreamOptions) SetCustomOptions(co bson.M) *ChangeStreamOptions {
 	cso.CustomOptions = co
 	return cso
 }

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -48,7 +48,8 @@ type ChangeStreamOptions struct {
 	StartAfter interface{}
 
 	// Custom options to be added to the initial aggregate for the change stream. Key-value pairs should correlate with
-	// desired option names and values. Values must be Marshalable.
+	// desired option names and values. Values must be Marshalable. Custom options may conflict with non-custom options,
+	// and custom options bypass client-side validation. Prefer using non-custom options where possible.
 	CustomOptions map[string]interface{}
 }
 
@@ -102,7 +103,9 @@ func (cso *ChangeStreamOptions) SetStartAfter(sa interface{}) *ChangeStreamOptio
 }
 
 // SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
-// desired option names and values. Values must be Marshalable.
+// desired option names and values. Values must be Marshalable. Custom options may conflict with
+// non-custom options, and custom options bypass client-side validation. Prefer using non-custom
+// options where possible.
 func (cso *ChangeStreamOptions) SetCustomOptions(co map[string]interface{}) *ChangeStreamOptions {
 	cso.CustomOptions = co
 	return cso

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -46,6 +46,10 @@ type ChangeStreamOptions struct {
 	// corresponding to an oplog entry immediately after the specified token will be returned. If this is specified,
 	// ResumeAfter and StartAtOperationTime must not be set. This option is only valid for MongoDB versions >= 4.1.1.
 	StartAfter interface{}
+
+	// Custom options to be added to the initial aggregate for the change stream. Key-value pairs should correlate with
+	// desired option names and values. Values must be Marshalable.
+	CustomOptions map[string]interface{}
 }
 
 // ChangeStream creates a new ChangeStreamOptions instance.
@@ -97,6 +101,13 @@ func (cso *ChangeStreamOptions) SetStartAfter(sa interface{}) *ChangeStreamOptio
 	return cso
 }
 
+// SetCustomOptions sets the value for the CustomOptions field. Key-value pairs should correlate with
+// desired option names and values. Values must be Marshalable.
+func (cso *ChangeStreamOptions) SetCustomOptions(co map[string]interface{}) *ChangeStreamOptions {
+	cso.CustomOptions = co
+	return cso
+}
+
 // MergeChangeStreamOptions combines the given ChangeStreamOptions instances into a single ChangeStreamOptions in a
 // last-one-wins fashion.
 func MergeChangeStreamOptions(opts ...*ChangeStreamOptions) *ChangeStreamOptions {
@@ -125,6 +136,9 @@ func MergeChangeStreamOptions(opts ...*ChangeStreamOptions) *ChangeStreamOptions
 		}
 		if cso.StartAfter != nil {
 			csOpts.StartAfter = cso.StartAfter
+		}
+		if cso.CustomOptions != nil {
+			csOpts.CustomOptions = cso.CustomOptions
 		}
 	}
 

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -46,6 +46,7 @@ type Aggregate struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	hasOutputStage           bool
+	customOptions            map[string]bsoncore.Value
 
 	result driver.CursorResponse
 }
@@ -154,6 +155,9 @@ func (a *Aggregate) command(dst []byte, desc description.SelectedServer) ([]byte
 	}
 	if a.let != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "let", a.let)
+	}
+	for optionName, optionValue := range a.customOptions {
+		dst = bsoncore.AppendValueElement(dst, optionName, optionValue)
 	}
 	cursorDoc, _ = bsoncore.AppendDocumentEnd(cursorDoc, cursorIdx)
 	dst = bsoncore.AppendDocumentElement(dst, "cursor", cursorDoc)
@@ -391,5 +395,15 @@ func (a *Aggregate) HasOutputStage(hos bool) *Aggregate {
 	}
 
 	a.hasOutputStage = hos
+	return a
+}
+
+// CustomOptions specifies extra options to use in the aggregate command.
+func (a *Aggregate) CustomOptions(co map[string]bsoncore.Value) *Aggregate {
+	if a == nil {
+		a = new(Aggregate)
+	}
+
+	a.customOptions = co
 	return a
 }


### PR DESCRIPTION
GODRIVER-2278

Adds `SetCustomOptions` on both `ChangeStreamOptions` and `AggregateOptions`. Also adds integration tests for the new functions to make sure extra options are actually sent across the wire. 

`CustomOptions` is a `map[string]interface{}` representing extra options to pass in the underlying "aggregate" command for change stream initiation and regular aggregates. The `map[string]interface{}` should be a map of names of options (`string`s) to Marshalable values (`interface{}`s).