### PR TITLE
GODRIVER-2120 GODRIVER-2192 Ensure OP_QUERY is only used when necessary

### DIFF
--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -30,6 +30,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -596,6 +597,47 @@ func TestClient(t *testing.T) {
 		// Assert that the Ping timeouts result in no connections being closed.
 		closed := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.ConnectionClosed }))
 		assert.Equal(t, 0, closed, "expected no connections to be closed")
+	})
+
+	// Test that OP_MSG is used for authentication-related commands on 3.6+ (WV 6+).
+	opMsgOpts := mtest.NewOptions().ClientType(mtest.Proxy).MinServerVersion("3.6").Auth(true)
+	mt.RunOpts("OP_MSG used for authentication on 3.6+", opMsgOpts, func(mt *mtest.T) {
+		err := mt.Client.Ping(context.Background(), mtest.PrimaryRp)
+		assert.Nil(mt, err, "Ping error: %v", err)
+
+		// Look for a saslContinue in the proxied messages and assert that it uses the OP_MSG OpCode.
+		msgPairs := mt.GetProxiedMessages()
+		var saslContinueFound bool
+		for _, pair := range msgPairs {
+			if pair.CommandName == "saslContinue" {
+				saslContinueFound = true
+				assert.Equal(mt, wiremessage.OpMsg, pair.Sent.OpCode,
+					"expected 'OP_MSG' OpCode in wire message, got %s", pair.Sent.OpCode.String())
+				break
+			}
+		}
+		assert.True(mt, saslContinueFound, "did not find 'saslContinue' command in proxied messages")
+	})
+
+	// Test that OP_MSG is used for handshakes when API version is declared.
+	opMsgSAPIOpts := mtest.NewOptions().ClientType(mtest.Proxy).MinServerVersion("3.6").RequireAPIVersion(true)
+	mt.RunOpts("OP_MSG used for handshakes when API version declared", opMsgSAPIOpts, func(mt *mtest.T) {
+		err := mt.Client.Ping(context.Background(), mtest.PrimaryRp)
+		assert.Nil(mt, err, "Ping error: %v", err)
+
+		msgPairs := mt.GetProxiedMessages()
+		assert.True(mt, len(msgPairs) >= 2, "expected at least 2 events, got %v", len(msgPairs))
+
+		// First two messages should be connection handshakes: one for the heartbeat connection and the other for the
+		// application connection.
+		for idx, pair := range msgPairs[:2] {
+			assert.Equal(mt, "hello", pair.CommandName, "expected command name 'hello' at index %d, got %s", idx,
+				pair.CommandName)
+
+			// Assert that appended OpCode is OP_MSG when API version is set.
+			assert.Equal(mt, wiremessage.OpMsg, pair.Sent.OpCode,
+				"expected 'OP_MSG' OpCode in wire message, got %q", pair.Sent.OpCode.String())
+		}
 	})
 }
 

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -613,13 +613,8 @@ func TestClient(t *testing.T) {
 		// application connection. These handshakes should use OP_QUERY as their OpCode, as wire version is not yet
 		// known.
 		for idx, pair := range msgPairs[:2] {
-			helloCommand := internal.LegacyHello
-			//  Expect "hello" command name with API version.
-			if os.Getenv("REQUIRE_API_VERSION") == "true" {
-				helloCommand = "hello"
-			}
-			assert.Equal(mt, helloCommand, pair.CommandName, "expected command name %s at index %d, got %s", helloCommand, idx,
-				pair.CommandName)
+			assert.Equal(mt, internal.LegacyHello, pair.CommandName, "expected command name %s at index %d, got %s",
+				internal.LegacyHello, idx, pair.CommandName)
 
 			// Assert that appended OpCode is OP_QUERY.
 			assert.Equal(mt, wiremessage.OpQuery, pair.Sent.OpCode,

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -607,24 +607,20 @@ func TestClient(t *testing.T) {
 		assert.Nil(mt, err, "Ping error: %v", err)
 
 		msgPairs := mt.GetProxiedMessages()
-		assert.True(mt, len(msgPairs) >= 2, "expected at least 2 events, got %v", len(msgPairs))
+		assert.True(mt, len(msgPairs) >= 3, "expected at least 3 events, got %v", len(msgPairs))
 
-		// First two messages should be connection handshakes: one for the heartbeat connection and the other for the
-		// application connection. These handshakes should use OP_QUERY as their OpCode, as wire version is not yet
-		// known.
-		for idx, pair := range msgPairs[:2] {
-			assert.Equal(mt, internal.LegacyHello, pair.CommandName, "expected command name %s at index %d, got %s",
-				internal.LegacyHello, idx, pair.CommandName)
-
-			// Assert that appended OpCode is OP_QUERY.
-			assert.Equal(mt, wiremessage.OpQuery, pair.Sent.OpCode,
-				"expected 'OP_QUERY' OpCode in wire message, got %q", pair.Sent.OpCode.String())
-		}
+		// First message should a be connection handshake. This handshake should use OP_QUERY as the OpCode, as wire
+		// version is not yet known.
+		pair := msgPairs[0]
+		assert.Equal(mt, internal.LegacyHello, pair.CommandName, "expected command name %s at index 0, got %s",
+			internal.LegacyHello, pair.CommandName)
+		assert.Equal(mt, wiremessage.OpQuery, pair.Sent.OpCode,
+			"expected 'OP_QUERY' OpCode in wire message, got %q", pair.Sent.OpCode.String())
 
 		// Look for a saslContinue in the remaining proxied messages and assert that it uses the OP_MSG OpCode, as wire
 		// version is now known to be >= 6.
 		var saslContinueFound bool
-		for _, pair := range msgPairs[2:] {
+		for _, pair := range msgPairs[1:] {
 			if pair.CommandName == "saslContinue" {
 				saslContinueFound = true
 				assert.Equal(mt, wiremessage.OpMsg, pair.Sent.OpCode,
@@ -636,17 +632,17 @@ func TestClient(t *testing.T) {
 	})
 
 	// Test that OP_MSG is used for handshakes when API version is declared.
-	opMsgSAPIOpts := mtest.NewOptions().ClientType(mtest.Proxy).MinServerVersion("3.6").RequireAPIVersion(true)
+	opMsgSAPIOpts := mtest.NewOptions().ClientType(mtest.Proxy).MinServerVersion("5.0").RequireAPIVersion(true)
 	mt.RunOpts("OP_MSG used for handshakes when API version declared", opMsgSAPIOpts, func(mt *mtest.T) {
 		err := mt.Client.Ping(context.Background(), mtest.PrimaryRp)
 		assert.Nil(mt, err, "Ping error: %v", err)
 
 		msgPairs := mt.GetProxiedMessages()
-		assert.True(mt, len(msgPairs) >= 2, "expected at least 2 events, got %v", len(msgPairs))
+		assert.True(mt, len(msgPairs) >= 3, "expected at least 3 events, got %v", len(msgPairs))
 
-		// First two messages should be connection handshakes: one for the heartbeat connection and the other for the
-		// application connection.
-		for idx, pair := range msgPairs[:2] {
+		// First three messages should be connection handshakes: one for the heartbeat connection, another for the
+		// application connection, and a final one for the RTT monitor connection.
+		for idx, pair := range msgPairs[:3] {
 			assert.Equal(mt, "hello", pair.CommandName, "expected command name 'hello' at index %d, got %s", idx,
 				pair.CommandName)
 

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -19,6 +19,7 @@ type SentMessage struct {
 	RequestID  int32
 	RawMessage wiremessage.WireMessage
 	Command    bsoncore.Document
+	OpCode     wiremessage.OpCode
 
 	// The $readPreference document. This is separated into its own field even though it's included in the larger
 	// command document in both OP_QUERY and OP_MSG because OP_QUERY separates the command into a $query sub-document
@@ -65,6 +66,7 @@ func parseSentMessage(wm []byte) (*SentMessage, error) {
 
 	sent.RequestID = requestID
 	sent.RawMessage = wm
+	sent.OpCode = opcode
 	return sent, nil
 }
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -814,7 +814,9 @@ func (Operation) decompressWireMessage(wm []byte) ([]byte, error) {
 func (op Operation) createWireMessage(ctx context.Context, dst []byte,
 	desc description.SelectedServer, conn Connection) ([]byte, startedInformation, error) {
 
-	if desc.WireVersion == nil || desc.WireVersion.Max < wiremessage.OpmsgWireVersion {
+	// If API version is not declared and wire version is unknown or less than 6, use OP_QUERY.
+	// Otherwise, use OP_MSG.
+	if op.ServerAPI == nil && (desc.WireVersion == nil || desc.WireVersion.Max < wiremessage.OpmsgWireVersion) {
 		return op.createQueryWireMessage(dst, desc)
 	}
 	return op.createMsgWireMessage(ctx, dst, desc, conn)


### PR DESCRIPTION
GODRIVER-2120
GODRIVER-2192

Tests that `OP_MSG` is used as an `OpCode` for authentication-related commands when wire version is >= 6 (MDB server 3.6+). Tests that `OP_MSG` is used as an `OpCode` for `hello` commands when an API version is declared (we were sending `OP_QUERY` before this PR's changes to `operation.go`). Exposes the `OpCode` used in the wire message in `mtest`'s `SentMessage` type. 