### PR TITLE
GODRIVER-2281 Implement ServerError for WriteError

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -207,6 +207,7 @@ type ServerError interface {
 }
 
 var _ ServerError = CommandError{}
+var _ ServerError = WriteError{}
 var _ ServerError = WriteException{}
 var _ ServerError = BulkWriteException{}
 
@@ -285,6 +286,30 @@ func (we WriteError) Error() string {
 	}
 	return msg
 }
+
+// HasErrorCode returns true if the error has the specified code.
+func (we WriteError) HasErrorCode(code int) bool {
+	return int(we.Code) == code
+}
+
+// HasErrorLabel returns true if the error contains the specified label. WriteErrors do not contain labels,
+// so we inspect the message for the provided label instead.
+func (we WriteError) HasErrorLabel(label string) bool {
+	return strings.Contains(we.Message, label)
+}
+
+// HasErrorMessage returns true if the error contains the specified message.
+func (we WriteError) HasErrorMessage(message string) bool {
+	return strings.Contains(we.Message, message)
+}
+
+// HasErrorCodeWithMessage returns true if the error has the specified code and Message contains the specified message.
+func (we WriteError) HasErrorCodeWithMessage(code int, message string) bool {
+	return int(we.Code) == code && strings.Contains(we.Message, message)
+}
+
+// serverError implements the ServerError interface.
+func (we WriteError) serverError() {}
 
 // WriteErrors is a group of write errors that occurred during execution of a write operation.
 type WriteErrors []WriteError

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -289,7 +289,7 @@ func (we WriteError) Error() string {
 
 // HasErrorCode returns true if the error has the specified code.
 func (we WriteError) HasErrorCode(code int) bool {
-	return int(we.Code) == code
+	return we.Code == code
 }
 
 // HasErrorLabel returns true if the error contains the specified label. WriteErrors do not contain labels,
@@ -305,7 +305,7 @@ func (we WriteError) HasErrorMessage(message string) bool {
 
 // HasErrorCodeWithMessage returns true if the error has the specified code and Message contains the specified message.
 func (we WriteError) HasErrorCodeWithMessage(code int, message string) bool {
-	return int(we.Code) == code && strings.Contains(we.Message, message)
+	return we.Code == code && strings.Contains(we.Message, message)
 }
 
 // serverError implements the ServerError interface.

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -293,9 +293,9 @@ func (we WriteError) HasErrorCode(code int) bool {
 }
 
 // HasErrorLabel returns true if the error contains the specified label. WriteErrors do not contain labels,
-// so we inspect the message for the provided label instead.
+// so we always return false.
 func (we WriteError) HasErrorLabel(label string) bool {
-	return strings.Contains(we.Message, label)
+	return false
 }
 
 // HasErrorMessage returns true if the error contains the specified message.

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -333,6 +333,8 @@ func TestErrors(t *testing.T) {
 			}{
 				{"CommandError true", mongo.CommandError{11000, "", nil, "blah", nil}, true},
 				{"CommandError false", mongo.CommandError{100, "", nil, "blah", nil}, false},
+				{"WriteError true", mongo.WriteError{0, 11000, "", nil}, true},
+				{"WriteError false", mongo.WriteError{0, 100, "", nil}, false},
 				{
 					"WriteException true in writeConcernError",
 					mongo.WriteException{


### PR DESCRIPTION
GODRIVER-2281

Implements the `ServerError` interface for `WriteError` so that the helpers like `IsDuplicateKeyError` can be used on individual `WriteError`s. Adds unit tests to `errors_test.go`.