### PR TITLE
GODRIVER-2285 Use HandshakeContext for TLS handshakes when using Go 1.17+

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -822,7 +822,7 @@ func configureTLS(ctx context.Context,
 	client := tlsConnSource.Client(nc, config)
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- client.Handshake()
+		errChan <- clientHandshake(client, ctx)
 	}()
 
 	select {

--- a/x/mongo/driver/topology/handshake_1_16.go
+++ b/x/mongo/driver/topology/handshake_1_16.go
@@ -1,0 +1,15 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// +build !go1.17
+
+package topology
+
+import "context"
+
+func clientHandshake(client tlsConn, _ context.Context) error {
+	return client.Handshake()
+}

--- a/x/mongo/driver/topology/handshake_1_17.go
+++ b/x/mongo/driver/topology/handshake_1_17.go
@@ -1,0 +1,15 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// +build go1.17
+
+package topology
+
+import "context"
+
+func clientHandshake(client tlsConn, ctx context.Context) error {
+	return client.HandshakeContext(ctx)
+}

--- a/x/mongo/driver/topology/tls_connection_source_1_16.go
+++ b/x/mongo/driver/topology/tls_connection_source_1_16.go
@@ -3,6 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// +build !go1.17
 
 package topology
 

--- a/x/mongo/driver/topology/tls_connection_source_1_17.go
+++ b/x/mongo/driver/topology/tls_connection_source_1_17.go
@@ -1,0 +1,39 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// +build go1.17
+
+package topology
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+)
+
+type tlsConn interface {
+	net.Conn
+	HandshakeContext(ctx context.Context) error
+	ConnectionState() tls.ConnectionState
+}
+
+var _ tlsConn = (*tls.Conn)(nil)
+
+type tlsConnectionSource interface {
+	Client(net.Conn, *tls.Config) tlsConn
+}
+
+type tlsConnectionSourceFn func(net.Conn, *tls.Config) tlsConn
+
+var _ tlsConnectionSource = (tlsConnectionSourceFn)(nil)
+
+func (t tlsConnectionSourceFn) Client(nc net.Conn, cfg *tls.Config) tlsConn {
+	return t(nc, cfg)
+}
+
+var defaultTLSConnectionSource tlsConnectionSourceFn = func(nc net.Conn, cfg *tls.Config) tlsConn {
+	return tls.Client(nc, cfg)
+}


### PR DESCRIPTION
GODRIVER-2285

Uses the new [`HandshakeContext`](https://pkg.go.dev/crypto/tls#Conn.HandshakeContext) function to pass down `configureTLS`'s `Context` when using Go 1.17+ (when the method was introduced).

Passing down the context should prevent any leaking of the handshake goroutine in the event that `configureTLS`'s `Context` expires or is canceled.