### PR TITLE
GODRIVER-2276 Use OP_MSG and hello with loadBalanced

### DIFF
--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -813,10 +813,10 @@ func (Operation) decompressWireMessage(wm []byte) ([]byte, error) {
 
 func (op Operation) createWireMessage(ctx context.Context, dst []byte,
 	desc description.SelectedServer, conn Connection) ([]byte, startedInformation, error) {
-
-	// If API version is not declared and wire version is unknown or less than 6, use OP_QUERY.
-	// Otherwise, use OP_MSG.
-	if op.ServerAPI == nil && (desc.WireVersion == nil || desc.WireVersion.Max < wiremessage.OpmsgWireVersion) {
+	// If topology is not LoadBalanced, API version is not declared, and wire version is unknown
+	// or less than 6, use OP_QUERY. Otherwise, use OP_MSG.
+	if desc.Kind != description.LoadBalanced && op.ServerAPI == nil &&
+		(desc.WireVersion == nil || desc.WireVersion.Max < wiremessage.OpmsgWireVersion) {
 		return op.createQueryWireMessage(dst, desc)
 	}
 	return op.createMsgWireMessage(ctx, dst, desc, conn)

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -159,7 +159,9 @@ func (h *Hello) handshakeCommand(dst []byte, desc description.SelectedServer) ([
 
 // command appends all necessary command fields.
 func (h *Hello) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
-	if h.serverAPI != nil || desc.Server.HelloOK {
+	// Use "hello" if topology is LoadBalanced, API version is declared or server
+	// has responded with "helloOk". Otherwise, use legacy hello.
+	if desc.Kind == description.LoadBalanced || h.serverAPI != nil || desc.Server.HelloOK {
 		dst = bsoncore.AppendInt32Element(dst, "hello", 1)
 	} else {
 		dst = bsoncore.AppendInt32Element(dst, internal.LegacyHello, 1)


### PR DESCRIPTION
GODRIVER-2276

Always use the `OP_MSG` `OpCode` and a `hello` command for wire messages when the topology is load balanced.