### PR TITLE
GODRIVER-2300 remove example.com from CSFLE tests

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -679,12 +679,12 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				"tenantId":                 azureTenantID,
 				"clientId":                 azureClientID,
 				"clientSecret":             azureClientSecret,
-				"identityPlatformEndpoint": "example.com:443",
+				"identityPlatformEndpoint": "doesnotexist.invalid:443",
 			},
 			"gcp": {
 				"email":      gcpEmail,
 				"privateKey": gcpPrivateKey,
-				"endpoint":   "example.com:443",
+				"endpoint":   "doesnotexist.invalid:443",
 			},
 			"kmip": {
 				"endpoint": "doesnotexist.local:5698",
@@ -723,7 +723,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		awsFailureParseError := map[string]interface{}{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-			"endpoint": "example.com",
+			"endpoint": "doesnotexist.invalid",
 		}
 		azure := map[string]interface{}{
 			"keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
@@ -741,7 +741,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			"location":  "global",
 			"keyRing":   "key-ring-csfle",
 			"keyName":   "key-name-csfle",
-			"endpoint":  "example.com:443",
+			"endpoint":  "doesnotexist.invalid:443",
 		}
 		kmipSuccessWithoutEndpoint := map[string]interface{}{
 			"keyId": "1",
@@ -768,9 +768,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			{"Case 3: aws success with https endpoint", "aws", awsSuccessWithHTTPSEndpoint, "", false, ""},
 			{"Case 4: aws failure with connection error", "aws", awsFailureConnectionError, "connection refused", false, ""},
 			{"Case 5: aws failure with wrong endpoint", "aws", awsFailureInvalidEndpoint, "us-east-1", false, ""},
-			{"Case 6: aws failure with parse error", "aws", awsFailureParseError, "parse error", false, ""},
-			{"Case 7: azure success", "azure", azure, "", true, "parse error"},
-			{"Case 8: gcp success", "gcp", gcpSuccess, "", true, "parse error"},
+			{"Case 6: aws failure with parse error", "aws", awsFailureParseError, "no such host", false, ""},
+			{"Case 7: azure success", "azure", azure, "", true, "no such host"},
+			{"Case 8: gcp success", "gcp", gcpSuccess, "", true, "no such host"},
 			{"Case 9: gcp failure", "gcp", gcpFailure, "Invalid KMS response", false, ""},
 			{"Case 10: kmip success without endpoint", "kmip", kmipSuccessWithoutEndpoint, "", true, "no such host"},
 			{"Case 11: kmip success with endpoint", "kmip", kmipSuccessWithEndpoint, "", false, ""},

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -763,18 +763,18 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			testInvalidClientEncryption           bool
 			invalidClientEncryptionErrorSubstring string
 		}{
-			{"aws success without endpoint", "aws", awsSuccessWithoutEndpoint, "", false, ""},
-			{"aws success with endpoint", "aws", awsSuccessWithEndpoint, "", false, ""},
-			{"aws success with https endpoint", "aws", awsSuccessWithHTTPSEndpoint, "", false, ""},
-			{"aws failure with connection error", "aws", awsFailureConnectionError, "connection refused", false, ""},
-			{"aws failure with wrong endpoint", "aws", awsFailureInvalidEndpoint, "us-east-1", false, ""},
-			{"aws failure with parse error", "aws", awsFailureParseError, "parse error", false, ""},
-			{"azure success", "azure", azure, "", true, "parse error"},
-			{"gcp success", "gcp", gcpSuccess, "", true, "parse error"},
-			{"gcp failure", "gcp", gcpFailure, "Invalid KMS response", false, ""},
-			{"kmip success without endpoint", "kmip", kmipSuccessWithoutEndpoint, "", true, "no such host"},
-			{"kmip success with endpoint", "kmip", kmipSuccessWithEndpoint, "", false, ""},
-			{"kmip failure with invalid endpoint", "kmip", kmipFailureInvalidEndpoint, "no such host", false, ""},
+			{"Case 1: aws success without endpoint", "aws", awsSuccessWithoutEndpoint, "", false, ""},
+			{"Case 2: aws success with endpoint", "aws", awsSuccessWithEndpoint, "", false, ""},
+			{"Case 3: aws success with https endpoint", "aws", awsSuccessWithHTTPSEndpoint, "", false, ""},
+			{"Case 4: aws failure with connection error", "aws", awsFailureConnectionError, "connection refused", false, ""},
+			{"Case 5: aws failure with wrong endpoint", "aws", awsFailureInvalidEndpoint, "us-east-1", false, ""},
+			{"Case 6: aws failure with parse error", "aws", awsFailureParseError, "parse error", false, ""},
+			{"Case 7: azure success", "azure", azure, "", true, "parse error"},
+			{"Case 8: gcp success", "gcp", gcpSuccess, "", true, "parse error"},
+			{"Case 9: gcp failure", "gcp", gcpFailure, "Invalid KMS response", false, ""},
+			{"Case 10: kmip success without endpoint", "kmip", kmipSuccessWithoutEndpoint, "", true, "no such host"},
+			{"Case 11: kmip success with endpoint", "kmip", kmipSuccessWithEndpoint, "", false, ""},
+			{"Case 12: kmip failure with invalid endpoint", "kmip", kmipFailureInvalidEndpoint, "no such host", false, ""},
 		}
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {


### PR DESCRIPTION
# Summary
- Replace "example.com" with "doesnotexist.invalid"
- Add case numbers to Custom Endpoint prose tests

# Background and Motivation
Signed AWS requests were frequently returning HTTP 404s in the C driver CSFLE prose tests. The 404s were unexpected and resulted in test failures. The test does not require successfully connecting to an endpoint. See DRIVERS-2191 for more information.