### PR TITLE
GODRIVER-2301 Rename 'Versioned API' to 'Stable API' in docs

### DIFF
--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -2804,8 +2804,8 @@ func IndexExamples(t *testing.T, db *mongo.Database) {
 
 // Start Versioned API Example 1
 
-// VersionedAPIExample is an example of creating a client with versioned API.
-func VersionedAPIExample() {
+// StableAPIExample is an example of creating a client with stable API.
+func StableAPIExample() {
 	ctx := context.Background()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
@@ -2826,8 +2826,8 @@ func VersionedAPIExample() {
 
 // Start Versioned API Example 2
 
-// VersionedAPIStrictExample is an example of creating a client with strict versioned API.
-func VersionedAPIStrictExample() {
+// StableAPIStrictExample is an example of creating a client with strict stable API.
+func StableAPIStrictExample() {
 	ctx := context.Background()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
@@ -2848,8 +2848,8 @@ func VersionedAPIStrictExample() {
 
 // Start Versioned API Example 3
 
-// VersionedAPINonStrictExample is an example of creating a client with non-strict versioned API.
-func VersionedAPINonStrictExample() {
+// StableAPINonStrictExample is an example of creating a client with non-strict stable API.
+func StableAPINonStrictExample() {
 	ctx := context.Background()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
@@ -2870,9 +2870,9 @@ func VersionedAPINonStrictExample() {
 
 // Start Versioned API Example 4
 
-// VersionedAPIDeprecationErrorsExample is an example of creating a client with versioned API
+// StableAPIDeprecationErrorsExample is an example of creating a client with stable API
 // with deprecation errors.
-func VersionedAPIDeprecationErrorsExample() {
+func StableAPIDeprecationErrorsExample() {
 	ctx := context.Background()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
@@ -2891,9 +2891,9 @@ func VersionedAPIDeprecationErrorsExample() {
 
 // End Versioned API Example 4
 
-// VersionedAPIStrictCountExample is an example of using CountDocuments instead of a traditional count
-// with a strict API version since the count command does not belong to API version 1.
-func VersionedAPIStrictCountExample(t *testing.T) {
+// StableAPIStrictCountExample is an example of using CountDocuments instead of a traditional count
+// with a strict stable API since the count command does not belong to API version 1.
+func StableAPIStrictCountExample(t *testing.T) {
 	uri := "mongodb://localhost:27017"
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
@@ -2949,10 +2949,10 @@ func VersionedAPIStrictCountExample(t *testing.T) {
 	// End Versioned API Example 8
 }
 
-// VersionedAPIExamples runs all versioned API examples.
-func VersionedAPIExamples() {
-	VersionedAPIExample()
-	VersionedAPIStrictExample()
-	VersionedAPINonStrictExample()
-	VersionedAPIDeprecationErrorsExample()
+// StableAPIExamples runs all stable API examples.
+func StableAPIExamples() {
+	StableAPIExample()
+	StableAPIStrictExample()
+	StableAPINonStrictExample()
+	StableAPIDeprecationErrorsExample()
 }

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -48,7 +48,7 @@ func TestDocumentationExamples(t *testing.T) {
 	documentation_examples.DeleteExamples(t, db)
 	documentation_examples.RunCommandExamples(t, db)
 	documentation_examples.IndexExamples(t, db)
-	documentation_examples.VersionedAPIExamples()
+	documentation_examples.StableAPIExamples()
 
 	// Because it uses RunCommand with an apiVersion, the strict count example can only be
 	// run on 5.0+ without auth.
@@ -56,9 +56,9 @@ func TestDocumentationExamples(t *testing.T) {
 	require.NoError(t, err, "getServerVersion error: %v", err)
 	auth := os.Getenv("AUTH") == "auth"
 	if testutil.CompareVersions(t, ver, "5.0") >= 0 && !auth {
-		documentation_examples.VersionedAPIStrictCountExample(t)
+		documentation_examples.StableAPIStrictCountExample(t)
 	} else {
-		t.Log("skipping versioned API strict count example")
+		t.Log("skipping stable API strict count example")
 	}
 }
 

--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -359,10 +359,10 @@ func ExampleConnect_aWS() {
 	_ = ecClient
 }
 
-func ExampleConnect_versionedAPI() {
-	// Configure a Client with versioned API.
+func ExampleConnect_stableAPI() {
+	// Configure a Client with stable API.
 	//
-	// Versioned API is a new feature in MongoDB 5.0 that allows user-selectable
+	// Stable API is a new feature in MongoDB 5.0 that allows user-selectable
 	// API versions, subsets of MongoDB server semantics, to be declared on a
 	// Client. During communication with a server, Clients with a declared API
 	// version will force that server to behave in a manner compatible with the
@@ -372,7 +372,7 @@ func ExampleConnect_versionedAPI() {
 	//
 	// The declared API version is applied to all commands run through the
 	// Client, including those sent through the generic RunCommand helper.
-	// Specifying versioned API options in the command document AND declaring
+	// Specifying stable API options in the command document AND declaring
 	// an API version on the Client is not supported and will lead to undefined
 	// behavior. To run any command with a different API version or without
 	// declaring one, create a separate Client that declares the appropriate API


### PR DESCRIPTION
GODRIVER-2301

# Summary
- Replaces occurrences of "versioned" with "stable" in documentation when referring to the Stable API feature available in MongoDB 5.0+.

# Background and Motivation
The docs team has rebranded the versioned API feature to "stable" API. We should update our documentation accordingly.

## Notes
- The example annotations (`// Start/End Versioned API Example #`) should not be altered, as the docs team still expects that annotation format.