### PR TITLE
GODRIVER-2292 Support dedicated load balancer port in tests.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -189,6 +189,7 @@ functions:
           SSL=${SSL} \
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
+          LOAD_BALANCER=${LOAD_BALANCER} \
           sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
@@ -1446,6 +1447,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "noauth"
           SSL: "nossl"
+          LOAD_BALANCER: "true"
       - func: run-load-balancer
       - func: run-load-balancer-tests
 
@@ -1457,6 +1459,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "ssl"
+          LOAD_BALANCER: "true"
       - func: run-load-balancer
       - func: run-load-balancer-tests
 
@@ -1855,6 +1858,10 @@ axes:
         display_name: "2.6"
         variables:
           VERSION: "2.6"
+      - id: "rapid"
+        display_name: "rapid"
+        variables:
+          VERSION: "rapid"
       - id: "latest"
         display_name: "latest"
         variables:
@@ -2155,7 +2162,10 @@ buildvariants:
 
   - matrix_name: "load-balancer-test"
     # The LB software is only available on Ubuntu 18.04, so we don't test on all OSes.
-    matrix_spec: { version: ["5.0", "latest"], os-ssl-40: ["ubuntu1804-64-go-1-16"] }
+    # The new "loadBalancerPort" option is supported starting with server 5.2, which responds
+    # correctly to "hello" commands with a service ID when behind a load balancer. Only run load
+    # balancer tests on server 5.2+ ("rapid", "latest" are always 5.2+).
+    matrix_spec: { version: ["rapid", "latest"], os-ssl-40: ["ubuntu1804-64-go-1-16"] }
     display_name: "Load Balancer Support ${version} ${os-ssl-40}"
     tasks:
       - name: ".load-balancer"

--- a/internal/const.go
+++ b/internal/const.go
@@ -9,11 +9,6 @@ package internal // import "go.mongodb.org/mongo-driver/internal"
 // Version is the current version of the driver.
 var Version = "local build"
 
-// SetMockServiceID enables a mode in which the driver mocks server support for returning a "serviceId" field in "hello"
-// command responses by using the value of "topologyVersion.processId".  This is used for testing load balancer support
-// until an upstream service can support running behind a load balancer.
-var SetMockServiceID = false
-
 // LegacyHello is the legacy version of the hello command.
 var LegacyHello = "isMaster"
 

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -286,10 +286,6 @@ func NewServer(addr address.Address, response bson.Raw) Server {
 				desc.LastError = err
 				return desc
 			}
-
-			if internal.SetMockServiceID {
-				desc.ServiceID = &desc.TopologyVersion.ProcessID
-			}
 		}
 	}
 

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -76,6 +76,15 @@ func runSeedlistDiscoveryTest(mt *mtest.T, file string) {
 		mt.Skip("skipping to avoid go1.11 problem with multiple strings in one TXT record")
 	}
 
+	// TODO(GODRIVER-2312): Unskip these tests when the DNS SRV records are updated to point to the
+	// load balancer instead of directly to the mongos.
+	if strings.HasSuffix(file, "load-balanced/loadBalanced-directConnection.json") ||
+		strings.HasSuffix(file, "load-balanced/loadBalanced-true-txt.json") ||
+		strings.HasSuffix(file, "load-balanced/srvMaxHosts-zero-txt.json") ||
+		strings.HasSuffix(file, "load-balanced/srvMaxHosts-zero.json") {
+		mt.Skip("skipping because the DNS SRV records need to be updated to work correctly (GODRIVER-2312)")
+	}
+
 	cs, err := connstring.ParseAndValidate(test.URI)
 	if test.Error {
 		assert.NotNil(mt, err, "expected URI parsing error, got nil")
@@ -116,7 +125,7 @@ func runSeedlistDiscoveryTest(mt *mtest.T, file string) {
 	}
 	for _, host := range test.Hosts {
 		_, err := getServerByAddress(host, topo)
-		assert.Nil(mt, err, "did not find host %v", host)
+		assert.Nil(mt, err, "error finding host %q: %v", host, err)
 	}
 }
 

--- a/mongo/integration/main_test.go
+++ b/mongo/integration/main_test.go
@@ -9,22 +9,12 @@ package integration
 import (
 	"log"
 	"os"
-	"strings"
 	"testing"
 
-	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 func TestMain(m *testing.M) {
-	// If the cluster is behind a load balancer, enable the SetMockServiceID flag to mock server-side LB support.
-	if strings.Contains(os.Getenv("MONGODB_URI"), "loadBalanced=true") {
-		internal.SetMockServiceID = true
-		defer func() {
-			internal.SetMockServiceID = false
-		}()
-	}
-
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/integration/unified/main_test.go
+++ b/mongo/integration/unified/main_test.go
@@ -9,22 +9,12 @@ package unified
 import (
 	"log"
 	"os"
-	"strings"
 	"testing"
 
-	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 func TestMain(m *testing.M) {
-	// If the cluster is behind a load balancer, enable the SetMockServiceID flag to mock server-side LB support.
-	if strings.Contains(os.Getenv("MONGODB_URI"), "loadBalanced=true") {
-		internal.SetMockServiceID = true
-		defer func() {
-			internal.SetMockServiceID = false
-		}()
-	}
-
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
[GODRIVER-2292](https://jira.mongodb.org/browse/GODRIVER-2292)

[DRIVERS-1983](https://jira.mongodb.org/browse/DRIVERS-1983) updated the load balancer mongo-orchestration config to support the new "loadBalancerPort" server option which allows the server to act more correctly in load balancer tests, including returning a "serviceID" in "hello" responses. Update the test runner to pass the new `LOAD_BALANCER="true"` option to mongo-orchestration and remove support for mocking "serviceID".

Changes:
* Set `LOAD_BALANCER="true"` and pass `LOAD_BALANCER` value to mongo-orchestration.
* Remove "serviceID" mocking.
* Skip some load-balanced initial DNS seedlist discovery tests until [GODRIVER-2312](https://jira.mongodb.org/browse/GODRIVER-2312) is done.