### PR TITLE
GODRIVER-2305 Correctly append empty TagSet

### DIFF
--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -746,7 +746,9 @@ func (p *parser) addOption(pair string) error {
 		p.ReadPreference = value
 	case "readpreferencetags":
 		if value == "" {
-			// for when readPreferenceTags= at end of URI
+			// If "readPreferenceTags=" is supplied, append an empty map to tag sets to
+			// represent a wild-card.
+			p.ReadPreferenceTagSets = append(p.ReadPreferenceTagSets, map[string]string{})
 			break
 		}
 

--- a/x/mongo/driver/connstring/connstring_test.go
+++ b/x/mongo/driver/connstring/connstring_test.go
@@ -382,8 +382,8 @@ func TestReadPreferenceTags(t *testing.T) {
 		{s: "readPreferenceTags=one:1,two:2", expected: []map[string]string{{"one": "1", "two": "2"}}},
 		{s: "readPreferenceTags=one:1&readPreferenceTags=two:2", expected: []map[string]string{{"one": "1"}, {"two": "2"}}},
 		{s: "readPreferenceTags=one:1:3,two:2", err: true},
-		{s: "readPreferenceTags=one:1&readPreferenceTags=two:2&readPreferenceTags=", expected: []map[string]string{{"one": "1"}, {"two": "2"}}},
-		{s: "readPreferenceTags=", expected: nil},
+		{s: "readPreferenceTags=one:1&readPreferenceTags=two:2&readPreferenceTags=", expected: []map[string]string{{"one": "1"}, {"two": "2"}, {}}},
+		{s: "readPreferenceTags=", expected: []map[string]string{{}}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
GODRIVER-2305

GODRIVER-1078 previously "fixed" behavior for empty tag sets provided in the URI (`readPreferenceTags=`) to simply skip instead of error. In reality, `readPreferenceTags=` in the URI represents a wild-card that should match any server with any tags (see docs [here](https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.readPreferenceTags)).

Appends `map[string]string{}` to tag sets if `readPreferenceTags=` is encountered. Fixes associated tests in `connstring_test.go`.