### PR TITLE
GODRIVER-2315 Update tests that expect errors with capped collection deletes

### DIFF
--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -296,12 +296,13 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("found on capped collection", mtest.NewOptions().MinServerVersion("5.3"), func(mt *mtest.T) {
-			// Deletions should be allowed on capped collections on MongoDB 5.3+.
+			// Deletes should be allowed on capped collections on MongoDB 5.3+.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",
 				CreateOpts: cappedOpts,
 			}, true)
+			initCollection(mt, capped)
 			res, err := capped.DeleteOne(context.Background(), bson.D{{"x", 1}})
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
@@ -320,7 +321,7 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("write error on capped collection", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletsion are not not allowed on capped collections on MongoDB 5.2-.
+			// Deletes are not not allowed on capped collections on MongoDB 5.2-.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",
@@ -381,6 +382,7 @@ func TestCollection(t *testing.T) {
 				Name:       "deleteMany_capped",
 				CreateOpts: cappedOpts,
 			}, true)
+			initCollection(mt, capped)
 			res, err := capped.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$gte", 3}}}})
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(3), res.DeletedCount, "expected DeletedCount 3, got %v", res.DeletedCount)

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -295,18 +295,6 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("found on capped collection", mtest.NewOptions().MinServerVersion("5.3"), func(mt *mtest.T) {
-			// Deletes should be allowed on capped collections on MongoDB 5.3+.
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
-			capped := mt.CreateCollection(mtest.Collection{
-				Name:       "deleteOne_capped",
-				CreateOpts: cappedOpts,
-			}, true)
-			initCollection(mt, capped)
-			res, err := capped.DeleteOne(context.Background(), bson.D{{"x", 1}})
-			assert.Nil(mt, err, "DeleteOne error: %v", err)
-			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
-		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}})
@@ -320,8 +308,9 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("write error on capped collection", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not not allowed on capped collections on MongoDB 5.2-.
+		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",
@@ -375,18 +364,6 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(3), res.DeletedCount, "expected DeletedCount 3, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("found on capped collection", mtest.NewOptions().MinServerVersion("5.3"), func(mt *mtest.T) {
-			// Deletes should be allowed on capped collections on MongoDB 5.3+.
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
-			capped := mt.CreateCollection(mtest.Collection{
-				Name:       "deleteMany_capped",
-				CreateOpts: cappedOpts,
-			}, true)
-			initCollection(mt, capped)
-			res, err := capped.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$gte", 3}}}})
-			assert.Nil(mt, err, "DeleteMany error: %v", err)
-			assert.Equal(mt, int64(3), res.DeletedCount, "expected DeletedCount 3, got %v", res.DeletedCount)
-		})
 		mt.Run("not found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
 			res, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$lt", 1}}}})
@@ -400,8 +377,9 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("write error on capped collection", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-.
+		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteMany_capped",
@@ -1549,7 +1527,8 @@ func TestCollection(t *testing.T) {
 			}
 		})
 		mt.RunOpts("delete write errors", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-.
+			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+			// behavior to test the processing of write errors.
 			doc := mongo.NewDeleteOneModel().SetFilter(bson.D{{"x", 1}})
 			models := []mongo.WriteModel{doc, doc}
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
@@ -1647,8 +1626,8 @@ func TestCollection(t *testing.T) {
 				expectedModel, actualModel)
 		})
 		mt.RunOpts("unordered writeError index", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-. Use a capped collection to get
-			// WriteErrors for delete operations.
+			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",


### PR DESCRIPTION
GODRIVER-2315

[SERVER-63201](https://jira.mongodb.org/browse/SERVER-63201) recently allowed deletes on capped collections in the latest server versions (5.3). Some of our tests in `integration/collection_test.go` expect server-side write errors when running a delete operation against a capped collection. Updates these tests to only run against 5.2-.