### PR TITLE
Only install Go linters in sa-lint task.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -134,14 +134,21 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
-          # Install any go tools that we need. Use "go install" instead of "go get" to prevent
-          # modifying the go.mod file.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          go install github.com/walle/lll/...@latest
-
           # initialize submodules
           git submodule init
           git submodule update
+
+  install-linters:
+    - command: shell.exec
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+
+          # Install linters. Use "go install" instead of "go get" to prevent modifying the go.mod
+          # file.
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/walle/lll/...@latest
 
   upload-mo-artifacts:
     - command: shell.exec
@@ -953,6 +960,7 @@ tasks:
   - name: sa-lint
     tags: ["static-analysis"]
     commands:
+      - func: install-linters
       - func: run-make
         vars:
           targets: lint


### PR DESCRIPTION
Currently we install the Go linters in any task that calls the `prepare-resources` function (most tasks). Those linters (specifically the `golangci-lint` linter) download a bunch of Go modules and generally slow down the CI build. Only install those linters in the `sa-lint` task, which actually uses them.