### PR TITLE
Honor context in Go 1.17+ version of hangingTLSConn.

### DIFF
--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -285,7 +285,7 @@ func TestConnection(t *testing.T) {
 								})
 							}),
 							WithTLSConfig(func(*tls.Config) *tls.Config {
-								return &tls.Config{}
+								return &tls.Config{ServerName: "test"}
 							}),
 							withTLSConnectionSource(func(tlsConnectionSource) tlsConnectionSource {
 								return hangingTLSConnectionSource

--- a/x/mongo/driver/topology/hanging_tls_conn_1_17.go
+++ b/x/mongo/driver/topology/hanging_tls_conn_1_17.go
@@ -33,6 +33,12 @@ func newHangingTLSConn(conn *tls.Conn, sleepTime time.Duration) *hangingTLSConn 
 
 // HandshakeContext implements the tlsConn interface on Go 1.17 and higher.
 func (h *hangingTLSConn) HandshakeContext(ctx context.Context) error {
-	time.Sleep(h.sleepTime)
+	timer := time.NewTimer(h.sleepTime)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+
 	return h.Conn.HandshakeContext(ctx)
 }


### PR DESCRIPTION
Changes:
* Honor the context passed in to `hangingTLSConn.HandshakeContext()` (i.e. exit when either the sleep time is reached or the context times out, whichever comes first).
* Add a `ServerName` to the `tls.Config` in one of the `TestConnection` test cases to resolve error "tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config".