### PR TITLE
Remove unused ConnectionOption error.

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -72,11 +72,8 @@ type connection struct {
 }
 
 // newConnection handles the creation of a connection. It does not connect the connection.
-func newConnection(addr address.Address, opts ...ConnectionOption) (*connection, error) {
-	cfg, err := newConnectionConfig(opts...)
-	if err != nil {
-		return nil, err
-	}
+func newConnection(addr address.Address, opts ...ConnectionOption) *connection {
+	cfg := newConnectionConfig(opts...)
 
 	id := fmt.Sprintf("%s[-%d]", addr, nextConnectionID())
 
@@ -98,7 +95,7 @@ func newConnection(addr address.Address, opts ...ConnectionOption) (*connection,
 	}
 	atomic.StoreInt64(&c.connected, initialized)
 
-	return c, nil
+	return c
 }
 
 // setGenerationNumber sets the connection's generation number if a callback has been provided to do so in connection

--- a/x/mongo/driver/topology/connection_errors_test.go
+++ b/x/mongo/driver/topology/connection_errors_test.go
@@ -25,16 +25,15 @@ func TestConnectionErrors(t *testing.T) {
 		t.Run("dial error", func(t *testing.T) {
 			dialError := errors.New("foo")
 
-			conn, err := newConnection(address.Address(""), WithDialer(func(Dialer) Dialer {
+			conn := newConnection(address.Address(""), WithDialer(func(Dialer) Dialer {
 				return DialerFunc(func(context.Context, string, string) (net.Conn, error) { return nil, dialError })
 			}))
-			assert.Nil(t, err, "newConnection error: %v", err)
 
-			err = conn.connect(context.Background())
+			err := conn.connect(context.Background())
 			assert.True(t, errors.Is(err, dialError), "expected error %v, got %v", dialError, err)
 		})
 		t.Run("handshake error", func(t *testing.T) {
-			conn, err := newConnection(address.Address(""),
+			conn := newConnection(address.Address(""),
 				WithHandshaker(func(Handshaker) Handshaker {
 					return auth.Handshaker(nil, &auth.HandshakeOptions{})
 				}),
@@ -44,12 +43,11 @@ func TestConnectionErrors(t *testing.T) {
 					})
 				}),
 			)
-			assert.Nil(t, err, "newConnection error: %v", err)
 			defer conn.close()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			err = conn.connect(ctx)
+			err := conn.connect(ctx)
 			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
 		})
 		t.Run("write error", func(t *testing.T) {

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -58,7 +58,7 @@ type connectionConfig struct {
 	getGenerationFn          generationNumberFn
 }
 
-func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
+func newConnectionConfig(opts ...ConnectionOption) *connectionConfig {
 	cfg := &connectionConfig{
 		connectTimeout:      30 * time.Second,
 		dialer:              nil,
@@ -66,124 +66,108 @@ func newConnectionConfig(opts ...ConnectionOption) (*connectionConfig, error) {
 	}
 
 	for _, opt := range opts {
-		err := opt(cfg)
-		if err != nil {
-			return nil, err
-		}
+		opt(cfg)
 	}
 
 	if cfg.dialer == nil {
 		cfg.dialer = &net.Dialer{}
 	}
 
-	return cfg, nil
+	return cfg
 }
 
 // ConnectionOption is used to configure a connection.
-type ConnectionOption func(*connectionConfig) error
+type ConnectionOption func(*connectionConfig)
 
 func withTLSConnectionSource(fn func(tlsConnectionSource) tlsConnectionSource) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.tlsConnectionSource = fn(c.tlsConnectionSource)
-		return nil
 	}
 }
 
 // WithCompressors sets the compressors that can be used for communication.
 func WithCompressors(fn func([]string) []string) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.compressors = fn(c.compressors)
-		return nil
 	}
 }
 
 // WithConnectTimeout configures the maximum amount of time a dial will wait for a
 // Connect to complete. The default is 30 seconds.
 func WithConnectTimeout(fn func(time.Duration) time.Duration) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.connectTimeout = fn(c.connectTimeout)
-		return nil
 	}
 }
 
 // WithDialer configures the Dialer to use when making a new connection to MongoDB.
 func WithDialer(fn func(Dialer) Dialer) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.dialer = fn(c.dialer)
-		return nil
 	}
 }
 
 // WithHandshaker configures the Handshaker that wll be used to initialize newly
 // dialed connections.
 func WithHandshaker(fn func(Handshaker) Handshaker) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.handshaker = fn(c.handshaker)
-		return nil
 	}
 }
 
 // WithIdleTimeout configures the maximum idle time to allow for a connection.
 func WithIdleTimeout(fn func(time.Duration) time.Duration) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.idleTimeout = fn(c.idleTimeout)
-		return nil
 	}
 }
 
 // WithReadTimeout configures the maximum read time for a connection.
 func WithReadTimeout(fn func(time.Duration) time.Duration) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.readTimeout = fn(c.readTimeout)
-		return nil
 	}
 }
 
 // WithWriteTimeout configures the maximum write time for a connection.
 func WithWriteTimeout(fn func(time.Duration) time.Duration) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.writeTimeout = fn(c.writeTimeout)
-		return nil
 	}
 }
 
 // WithTLSConfig configures the TLS options for a connection.
 func WithTLSConfig(fn func(*tls.Config) *tls.Config) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.tlsConfig = fn(c.tlsConfig)
-		return nil
 	}
 }
 
 // WithMonitor configures a event for command monitoring.
 func WithMonitor(fn func(*event.CommandMonitor) *event.CommandMonitor) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.cmdMonitor = fn(c.cmdMonitor)
-		return nil
 	}
 }
 
 // WithZlibLevel sets the zLib compression level.
 func WithZlibLevel(fn func(*int) *int) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.zlibLevel = fn(c.zlibLevel)
-		return nil
 	}
 }
 
 // WithZstdLevel sets the zstd compression level.
 func WithZstdLevel(fn func(*int) *int) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.zstdLevel = fn(c.zstdLevel)
-		return nil
 	}
 }
 
 // WithOCSPCache specifies a cache to use for OCSP verification.
 func WithOCSPCache(fn func(ocsp.Cache) ocsp.Cache) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.ocspCache = fn(c.ocspCache)
-		return nil
 	}
 }
 
@@ -191,23 +175,20 @@ func WithOCSPCache(fn func(ocsp.Cache) ocsp.Cache) ConnectionOption {
 // to true, the driver will only check stapled responses and will continue the connection without reaching out to
 // OCSP responders.
 func WithDisableOCSPEndpointCheck(fn func(bool) bool) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.disableOCSPEndpointCheck = fn(c.disableOCSPEndpointCheck)
-		return nil
 	}
 }
 
 // WithConnectionLoadBalanced specifies whether or not the connection is to a server behind a load balancer.
 func WithConnectionLoadBalanced(fn func(bool) bool) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.loadBalanced = fn(c.loadBalanced)
-		return nil
 	}
 }
 
 func withGenerationNumberFn(fn func(generationNumberFn) generationNumberFn) ConnectionOption {
-	return func(c *connectionConfig) error {
+	return func(c *connectionConfig) {
 		c.getGenerationFn = fn(c.getGenerationFn)
-		return nil
 	}
 }

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -801,12 +801,7 @@ func (p *pool) createConnections(ctx context.Context, wg *sync.WaitGroup) {
 			return nil, nil, false
 		}
 
-		conn, err := newConnection(p.address, p.connOpts...)
-		if err != nil {
-			w.tryDeliver(nil, err)
-			return nil, nil, false
-		}
-
+		conn := newConnection(p.address, p.connOpts...)
 		conn.pool = p
 		conn.poolID = atomic.AddUint64(&p.nextID, 1)
 		p.conns[conn.poolID] = conn

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -25,7 +25,7 @@ const (
 type rttConfig struct {
 	interval           time.Duration
 	minRTTWindow       time.Duration // Window size to calculate minimum RTT over.
-	createConnectionFn func() (*connection, error)
+	createConnectionFn func() *connection
 	createOperationFn  func(driver.Connection) *operation.Hello
 }
 
@@ -107,12 +107,9 @@ func (r *rttMonitor) start() {
 // error, runHello closes the connection.
 func (r *rttMonitor) runHello(conn *connection) *connection {
 	if conn == nil || conn.closed() {
-		conn, err := r.cfg.createConnectionFn()
-		if err != nil {
-			return nil
-		}
+		conn := r.cfg.createConnectionFn()
 
-		err = conn.connect(r.ctx)
+		err := conn.connect(r.ctx)
 		if err != nil {
 			return nil
 		}

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -64,7 +64,7 @@ func TestRTTMonitor(t *testing.T) {
 		})
 		rtt := newRTTMonitor(&rttConfig{
 			interval: 10 * time.Millisecond,
-			createConnectionFn: func() (*connection, error) {
+			createConnectionFn: func() *connection {
 				return newConnection("", WithDialer(func(Dialer) Dialer { return dialer }))
 			},
 			createOperationFn: func(conn driver.Connection) *operation.Hello {
@@ -135,7 +135,7 @@ func TestRTTMonitor(t *testing.T) {
 		})
 		rtt := newRTTMonitor(&rttConfig{
 			interval: 10 * time.Second,
-			createConnectionFn: func() (*connection, error) {
+			createConnectionFn: func() *connection {
 				return newConnection("", WithDialer(func(Dialer) Dialer {
 					return dialer
 				}))
@@ -158,7 +158,7 @@ func TestRTTMonitor(t *testing.T) {
 		})
 		rtt := newRTTMonitor(&rttConfig{
 			interval: 10 * time.Millisecond,
-			createConnectionFn: func() (*connection, error) {
+			createConnectionFn: func() *connection {
 				return newConnection("", WithDialer(func(Dialer) Dialer { return dialer }))
 			},
 			createOperationFn: func(conn driver.Connection) *operation.Hello {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -620,7 +620,7 @@ func (s *Server) updateDescription(desc description.Server) {
 
 // createConnection creates a new connection instance but does not call connect on it. The caller must call connect
 // before the connection can be used for network operations.
-func (s *Server) createConnection() (*connection, error) {
+func (s *Server) createConnection() *connection {
 	opts := copyConnectionOpts(s.cfg.connectionOpts)
 	opts = append(opts,
 		WithConnectTimeout(func(time.Duration) time.Duration { return s.cfg.heartbeatTimeout }),
@@ -646,10 +646,7 @@ func copyConnectionOpts(opts []ConnectionOption) []ConnectionOption {
 }
 
 func (s *Server) setupHeartbeatConnection() error {
-	conn, err := s.createConnection()
-	if err != nil {
-		return err
-	}
+	conn := s.createConnection()
 
 	// Take the lock when assigning the context and connection because they're accessed by cancelCheck.
 	s.heartbeatLock.Lock()

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -828,9 +828,7 @@ func TestServer(t *testing.T) {
 		)
 		assert.Nil(t, err, "NewServer error: %v", err)
 
-		conn, err := s.createConnection()
-		assert.Nil(t, err, "createConnection error: %v", err)
-
+		conn := s.createConnection()
 		assert.Equal(t, s.cfg.heartbeatTimeout, 10*time.Second, "expected heartbeatTimeout to be: %v, got: %v", 10*time.Second, s.cfg.heartbeatTimeout)
 		assert.Equal(t, s.cfg.heartbeatTimeout, conn.readTimeout, "expected readTimeout to be: %v, got: %v", s.cfg.heartbeatTimeout, conn.readTimeout)
 		assert.Equal(t, s.cfg.heartbeatTimeout, conn.writeTimeout, "expected writeTimeout to be: %v, got: %v", s.cfg.heartbeatTimeout, conn.writeTimeout)

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -102,8 +102,7 @@ func TestLoadBalancedFromConnString(t *testing.T) {
 			assert.Nil(t, err, "NewServer error: %v", err)
 			assert.Equal(t, tc.loadBalanced, srvr.cfg.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, srvr.cfg.loadBalanced)
 
-			conn, err := newConnection("", srvr.cfg.connectionOpts...)
-			assert.Nil(t, err, "newConnection error: %v", err)
+			conn := newConnection("", srvr.cfg.connectionOpts...)
 			assert.Equal(t, tc.loadBalanced, conn.config.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, conn.config.loadBalanced)
 		})
 	}


### PR DESCRIPTION
Type `ConnectionOption` is currently a `func(*connectionConfig) error`. However, no `ConnectionOption` functions return an error. Remove the error returned by the `ConnectionOption` type (now `func(*connectionConfig)`) and remove all of the now-unnecessary error handling logic.