### PR TITLE
GODRIVER-2317 Correct usage of readPref for listCollections

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -331,6 +331,8 @@ func (db *Database) ListCollectionSpecifications(ctx context.Context, filter int
 }
 
 // ListCollections executes a listCollections command and returns a cursor over the collections in the database.
+// The command will always be run with primary read preference, as a call to listCollections against a secondary
+// may result in a list that is not up-to-date.
 //
 // The filter parameter must be a document containing query operators and can be used to select which collections
 // are included in the result. It cannot be nil. An empty document (e.g. bson.D{}) should be used to include all
@@ -375,7 +377,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 
 	lco := options.MergeListCollectionsOptions(opts...)
 	op := operation.NewListCollections(filterDoc).
-		Session(sess).ReadPreference(db.readPreference).CommandMonitor(db.client.monitor).
+		Session(sess).ReadPreference(readpref.Primary()).CommandMonitor(db.client.monitor).
 		ServerSelector(selector).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI)


### PR DESCRIPTION
GODRIVER-2317

Adds a line to `ListCollections` documentation to clarify that the command will always be run with primary read preference. Correctly passes `readpref.Primary()` to the created operation instead of the `db.readPreference` (this will mean the reported read preference on the command is the effective read preference `primary` and not the read preference set on the `Database` which may differ).