### PR TITLE
GODRIVER-2312 Update and unskip initial DNS seedlist discovery spec tests

### DIFF
--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
@@ -1,12 +1,12 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
 # DRIVERS-1721 introduced this test as passing.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
@@ -1,5 +1,5 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset"
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
+uri: "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset"
 seeds: []
 hosts: []
 error: true

--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
@@ -1,10 +1,10 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/"
+uri: "mongodb+srv://test24.test.build.10gen.cc/"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1"
 seeds: []
 hosts: []
 error: true

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true (TXT) is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/data/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
+uri: "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -76,15 +76,6 @@ func runSeedlistDiscoveryTest(mt *mtest.T, file string) {
 		mt.Skip("skipping to avoid go1.11 problem with multiple strings in one TXT record")
 	}
 
-	// TODO(GODRIVER-2312): Unskip these tests when the DNS SRV records are updated to point to the
-	// load balancer instead of directly to the mongos.
-	if strings.HasSuffix(file, "load-balanced/loadBalanced-directConnection.json") ||
-		strings.HasSuffix(file, "load-balanced/loadBalanced-true-txt.json") ||
-		strings.HasSuffix(file, "load-balanced/srvMaxHosts-zero-txt.json") ||
-		strings.HasSuffix(file, "load-balanced/srvMaxHosts-zero.json") {
-		mt.Skip("skipping because the DNS SRV records need to be updated to work correctly (GODRIVER-2312)")
-	}
-
 	cs, err := connstring.ParseAndValidate(test.URI)
 	if test.Error {
 		assert.NotNil(mt, err, "expected URI parsing error, got nil")

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -190,6 +190,7 @@ func WithConnString(fn func(connstring.ConnString) connstring.ConnString) Option
 					AppName:       cs.AppName,
 					Authenticator: authenticator,
 					Compressors:   cs.Compressors,
+					LoadBalanced:  cs.LoadBalancedSet && cs.LoadBalanced,
 				}
 				if cs.AuthMechanism == "" {
 					// Required for SASL mechanism negotiation during handshake
@@ -200,7 +201,10 @@ func WithConnString(fn func(connstring.ConnString) connstring.ConnString) Option
 		} else {
 			// We need to add a non-auth Handshaker to the connection options
 			connOpts = append(connOpts, WithHandshaker(func(h driver.Handshaker) driver.Handshaker {
-				return operation.NewHello().AppName(cs.AppName).Compressors(cs.Compressors)
+				return operation.NewHello().
+					AppName(cs.AppName).
+					Compressors(cs.Compressors).
+					LoadBalanced(cs.LoadBalancedSet && cs.LoadBalanced)
 			}))
 		}
 


### PR DESCRIPTION
[GODRIVER-2312](https://jira.mongodb.org/browse/GODRIVER-2312)

Now that https://github.com/mongodb/specifications/pull/1148 is merged, we can update and re-enable the initial DNS seedlist discovery spec tests for load balancers. Also fixes a bug in `topology.WithConnString` that doesn't set the `LoadBalanced` option correctly on the connection handshakers.