### PR TITLE
GODRIVER-2304 CSOT POC with Find

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	serverAPI       *driver.ServerAPIOptions
 	serverMonitor   *event.ServerMonitor
 	sessionPool     *session.Pool
+	timeout         *time.Duration
 
 	// client-side encryption fields
 	keyVaultClientFLE *Client
@@ -623,6 +624,10 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 			topology.WithReadTimeout(func(time.Duration) time.Duration { return *opts.SocketTimeout }),
 			topology.WithWriteTimeout(func(time.Duration) time.Duration { return *opts.SocketTimeout }),
 		)
+	}
+	// Timeout
+	if opts.Timeout != nil {
+		c.timeout = opts.Timeout
 	}
 	// TLSConfig
 	if opts.TLSConfig != nil {

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -38,6 +38,7 @@ type Collection struct {
 	readSelector   description.ServerSelector
 	writeSelector  description.ServerSelector
 	registry       *bsoncodec.Registry
+	timeout        *time.Duration
 }
 
 // aggregateParams is used to store information to configure an Aggregate operation.
@@ -86,6 +87,11 @@ func newCollection(db *Database, name string, opts ...*options.CollectionOptions
 		reg = collOpt.Registry
 	}
 
+	to := db.timeout
+	if collOpt.Timeout != nil {
+		to = collOpt.Timeout
+	}
+
 	readSelector := description.CompositeSelector([]description.ServerSelector{
 		description.ReadPrefSelector(rp),
 		description.LatencySelector(db.client.localThreshold),
@@ -106,6 +112,7 @@ func newCollection(db *Database, name string, opts ...*options.CollectionOptions
 		readSelector:   readSelector,
 		writeSelector:  writeSelector,
 		registry:       reg,
+		timeout:        to,
 	}
 
 	return coll
@@ -122,6 +129,7 @@ func (coll *Collection) copy() *Collection {
 		readSelector:   coll.readSelector,
 		writeSelector:  coll.writeSelector,
 		registry:       coll.registry,
+		timeout:        coll.timeout,
 	}
 }
 
@@ -146,6 +154,10 @@ func (coll *Collection) Clone(opts ...*options.CollectionOptions) (*Collection, 
 
 	if optsColl.Registry != nil {
 		copyColl.registry = optsColl.Registry
+	}
+
+	if optsColl.Timeout != nil {
+		copyColl.timeout = optsColl.Timeout
 	}
 
 	copyColl.readSelector = description.CompositeSelector([]description.ServerSelector{
@@ -1171,7 +1183,8 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		Session(sess).ReadConcern(rc).ReadPreference(coll.readPreference).
 		CommandMonitor(coll.client.monitor).ServerSelector(selector).
 		ClusterClock(coll.client.clock).Database(coll.db.name).Collection(coll.name).
-		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI)
+		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
+		Timeout(coll.timeout)
 
 	fo := options.MergeFindOptions(opts...)
 	cursorOpts := coll.client.createBaseCursorOptions()
@@ -1275,6 +1288,9 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 			return nil, err
 		}
 		op.Sort(sort)
+	}
+	if fo.Timeout != nil {
+		op.Timeout(fo.Timeout)
 	}
 	retry := driver.RetryNone
 	if coll.client.retryReads {

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1289,9 +1289,6 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		}
 		op.Sort(sort)
 	}
-	if fo.Timeout != nil {
-		op.Timeout(fo.Timeout)
-	}
 	retry := driver.RetryNone
 	if coll.client.retryReads {
 		retry = driver.RetryOncePerCommand

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
@@ -39,6 +40,7 @@ type Database struct {
 	readSelector   description.ServerSelector
 	writeSelector  description.ServerSelector
 	registry       *bsoncodec.Registry
+	timeout        *time.Duration
 }
 
 func newDatabase(client *Client, name string, opts ...*options.DatabaseOptions) *Database {
@@ -64,6 +66,11 @@ func newDatabase(client *Client, name string, opts ...*options.DatabaseOptions) 
 		reg = dbOpt.Registry
 	}
 
+	to := client.timeout
+	if dbOpt.Timeout != nil {
+		to = dbOpt.Timeout
+	}
+
 	db := &Database{
 		client:         client,
 		name:           name,
@@ -71,6 +78,7 @@ func newDatabase(client *Client, name string, opts ...*options.DatabaseOptions) 
 		readConcern:    rc,
 		writeConcern:   wc,
 		registry:       reg,
+		timeout:        to,
 	}
 
 	db.readSelector = description.CompositeSelector([]description.ServerSelector{

--- a/mongo/description/server.go
+++ b/mongo/description/server.go
@@ -51,6 +51,8 @@ type Server struct {
 	Passive               bool
 	Primary               address.Address
 	ReadOnly              bool
+	RTT90                 time.Duration
+	RTT90Set              bool
 	ServiceID             *primitive.ObjectID // Only set for servers that are deployed behind a load balancer.
 	SessionTimeoutMinutes uint32
 	SetName               string
@@ -345,6 +347,13 @@ func NewServerFromError(addr address.Address, err error, tv *TopologyVersion) Se
 func (s Server) SetAverageRTT(rtt time.Duration) Server {
 	s.AverageRTT = rtt
 	s.AverageRTTSet = true
+	return s
+}
+
+// SetRTT90 sets the 90th percentile round trip time for this server description.
+func (s Server) SetRTT90(rtt time.Duration) Server {
+	s.RTT90 = rtt
+	s.RTT90Set = true
 	return s
 }
 

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -102,6 +102,9 @@ func IsTimeout(err error) bool {
 		if err == context.DeadlineExceeded {
 			return true
 		}
+		if err == driver.ErrDeadlineWouldBeExceeded {
+			return true
+		}
 		if ne, ok := err.(net.Error); ok {
 			return ne.Timeout()
 		}

--- a/mongo/integration/timeout_test.go
+++ b/mongo/integration/timeout_test.go
@@ -7,6 +7,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,8 +57,8 @@ func TestTimeoutClient(t *testing.T) {
 		// Since there is no deadline on the provided context, the operation should honor the
 		// Timeout of 0, and the operation should fail due to an exceeded deadline.
 		_, err = mt.Coll.Find(context.Background(), bson.D{})
-		assert.True(mt, err.Error() == context.DeadlineExceeded.Error(),
-			"expected context.DeadlineExceeded error, got %v", err.Error())
+		assert.True(mt, strings.Contains(err.Error(), "context deadline exceeded"),
+			"expected error to contain 'context deadline exceeded', got %v", err.Error())
 	})
 	mt.RunOpts("context with deadline supersedes Timeout", mtOpts, func(mt *mtest.T) {
 		// Normally, a Timeout of 0 on the client would cause context deadline exceeded errors

--- a/mongo/integration/timeout_test.go
+++ b/mongo/integration/timeout_test.go
@@ -1,0 +1,171 @@
+// This set of tests is temporary and is meant to confirm the behavior of the new
+// global Timeout options on Client, Database, Collection and Find work as intended.
+// The tests will mostly be removed in favor of spec and prose tests. If we still
+// require more test coverage, it may be placed in mongo/integration/client_test.go
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestTimeoutClient(t *testing.T) {
+	mt := mtest.New(t)
+	defer mt.Close()
+
+	cliOpts := options.Client().SetTimeout(10 * time.Second)
+	mtOpts := mtest.NewOptions().ClientOptions(cliOpts)
+	mt.RunOpts("maxTimeMS is appended", mtOpts, func(mt *mtest.T) {
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		mt.ClearEvents()
+		_, err = mt.Coll.Find(context.Background(), bson.D{})
+		assert.Nil(mt, err, "Find error: %v", err)
+		evt := mt.GetStartedEvent()
+
+		val, err := evt.Command.LookupErr("maxTimeMS")
+		assert.Nil(mt, err, "'maxTimeMS' not present in Find command")
+		mtms, ok := val.AsInt64OK()
+		assert.True(mt, ok, "expected 'maxTimeMS' to be of type int64, got %T", mtms)
+
+		// Remaining Timeout appended to Find command should be somewhere between 9500 and 10000
+		// milliseconds because a few milliseconds will have passed between the start of the
+		// operation and the appension of 'maxTimeMS'.
+		timeoutWithinBounds := 9500 < mtms && mtms < 10000
+		assert.True(mt, timeoutWithinBounds,
+			"expected 'maxTimeMS' to be within 9500 and 10000 ms, got %v", mtms)
+	})
+
+	lowTOCliOpts := options.Client().SetTimeout(0)
+	mtOpts = mtest.NewOptions().ClientOptions(lowTOCliOpts)
+	mt.RunOpts("deadline exceeded error", mtOpts, func(mt *mtest.T) {
+		// Normally, a Timeout of 0 on the client would cause context deadline exceeded errors
+		// on the below InsertOne and the preceding setup commands. For now, though, Timeout is
+		// only passed down to Find.
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		// Since there is no deadline on the provided context, the operation should honor the
+		// Timeout of 0, and the operation should fail due to an exceeded deadline.
+		_, err = mt.Coll.Find(context.Background(), bson.D{})
+		assert.True(mt, err.Error() == context.DeadlineExceeded.Error(),
+			"expected context.DeadlineExceeded error, got %v", err.Error())
+	})
+	mt.RunOpts("context with deadline supersedes Timeout", mtOpts, func(mt *mtest.T) {
+		// Normally, a Timeout of 0 on the client would cause context deadline exceeded errors
+		// on the below InsertOne and the preceding setup commands. For now, though, Timeout is
+		// only passed down to Find.
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelFunc()
+
+		// Using a new context with a deadline should ignore the Timeout of 0, and the operation
+		// should succeed.
+		_, err = mt.Coll.Find(ctx, bson.D{})
+		assert.Nil(mt, err, "Find error: %v", err)
+	})
+}
+
+func TestTimeoutDatabase(t *testing.T) {
+	mt := mtest.New(t)
+	defer mt.Close()
+
+	mt.Run("maxTimeMS is appended", func(mt *mtest.T) {
+		dbOptions := options.Database().SetTimeout(10 * time.Second)
+		coll := mt.Client.Database("test", dbOptions).Collection("test")
+		defer func() {
+			_ = coll.Drop(context.Background())
+		}()
+
+		_, err := coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		mt.ClearEvents()
+		_, err = coll.Find(context.Background(), bson.D{})
+		assert.Nil(mt, err, "Find error: %v", err)
+		evt := mt.GetStartedEvent()
+
+		val, err := evt.Command.LookupErr("maxTimeMS")
+		assert.Nil(mt, err, "'maxTimeMS' not present in Find command")
+		mtms, ok := val.AsInt64OK()
+		assert.True(mt, ok, "expected 'maxTimeMS' to be of type int64, got %T", mtms)
+
+		// Remaining timeout appended to Find command should be somewhere between 9500 and 10000
+		// milliseconds because a few milliseconds will have passed between the start of the
+		// operation and the appension of 'maxTimeMS'.
+		timeoutWithinBounds := 9500 < mtms && mtms < 10000
+		assert.True(mt, timeoutWithinBounds,
+			"expected 'maxTimeMS' to be within 9500 and 10000 ms, got %v", mtms)
+	})
+}
+
+func TestTimeoutCollection(t *testing.T) {
+	mt := mtest.New(t)
+	defer mt.Close()
+
+	mt.Run("maxTimeMS is appended", func(mt *mtest.T) {
+		collOptions := options.Collection().SetTimeout(10 * time.Second)
+		coll := mt.Client.Database("test").Collection("test", collOptions)
+		defer func() {
+			_ = coll.Drop(context.Background())
+		}()
+
+		_, err := coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		mt.ClearEvents()
+		_, err = coll.Find(context.Background(), bson.D{})
+		assert.Nil(mt, err, "Find error: %v", err)
+		evt := mt.GetStartedEvent()
+
+		val, err := evt.Command.LookupErr("maxTimeMS")
+		assert.Nil(mt, err, "'maxTimeMS' not present in Find command")
+		mtms, ok := val.AsInt64OK()
+		assert.True(mt, ok, "expected 'maxTimeMS' to be of type int64, got %T", mtms)
+
+		// Remaining timeout appended to Find command should be somewhere between 9500 and 10000
+		// milliseconds because a few milliseconds will have passed between the start of the
+		// operation and the appension of 'maxTimeMS'.
+		timeoutWithinBounds := 9500 < mtms && mtms < 10000
+		assert.True(mt, timeoutWithinBounds,
+			"expected 'maxTimeMS' to be within 9500 and 10000 ms, got %v", mtms)
+	})
+}
+
+func TestTimeoutFind(t *testing.T) {
+	mt := mtest.New(t)
+	defer mt.Close()
+
+	mt.Run("maxTimeMS is appended", func(mt *mtest.T) {
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
+		assert.Nil(mt, err, "InsertOne error: %v", err)
+
+		mt.ClearEvents()
+		findOpts := options.Find().SetTimeout(10 * time.Second)
+		_, err = mt.Coll.Find(context.Background(), bson.D{}, findOpts)
+		assert.Nil(mt, err, "Find error: %v", err)
+		evt := mt.GetStartedEvent()
+
+		val, err := evt.Command.LookupErr("maxTimeMS")
+		assert.Nil(mt, err, "'maxTimeMS' not present in Find command")
+		mtms, ok := val.AsInt64OK()
+		assert.True(mt, ok, "expected 'maxTimeMS' to be of type int64, got %T", mtms)
+
+		// Remaining timeout appended to Find command should be somewhere between 9500 and 10000
+		// milliseconds because a few milliseconds will have passed between the start of the
+		// operation and the appension of 'maxTimeMS'.
+		timeoutWithinBounds := 9500 < mtms && mtms < 10000
+		assert.True(mt, timeoutWithinBounds,
+			"expected 'maxTimeMS' to be within 9500 and 10000 ms, got %v", mtms)
+	})
+}

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -154,9 +154,9 @@ type ClientOptions struct {
 
 	// SocketTimeout specifies the timeout to be used for the Client's socket reads and writes.
 	//
-	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-	// used in its place to control the amount of time that a single operation can run on the Client before returning an
-	// error.
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that a single operation can run on the Client
+	// before returning an error. SocketTimeout is still usable through the deprecated setter.
 	SocketTimeout *time.Duration
 }
 
@@ -714,9 +714,9 @@ func (c *ClientOptions) SetServerSelectionTimeout(d time.Duration) *ClientOption
 // network error. This can also be set through the "socketTimeoutMS" URI option (e.g. "socketTimeoutMS=1000"). The
 // default value is 0, meaning no timeout is used and socket operations can block indefinitely.
 //
-// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-// used in its place to control the amount of time that a single operation can run on the Client before returning an
-// error.
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that a single operation can run on the Client
+// before returning an error.
 func (c *ClientOptions) SetSocketTimeout(d time.Duration) *ClientOptions {
 	c.SocketTimeout = &d
 	return c

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -725,6 +725,9 @@ func (c *ClientOptions) SetSocketTimeout(d time.Duration) *ClientOptions {
 // SetTimeout specifies the amount of time that a single operation run on this Client can execute before returning an error.
 // This can also be set through the "timeoutMS" URI option (e.g. "timeoutMS=1000"). The default value is 0, meaning no
 // timeout is used and operations will not inherit a timeout from the Client.
+//
+// If any Timeout is set on the Client, the values of other, deprecated timeout-related options will be ignored. In particular:
+// ClientOptions.SocketTimeout, WriteConcern.wTimeout, Operation.MaxTime and TransactionOptions.MaxCommitTime.
 func (c *ClientOptions) SetTimeout(d time.Duration) *ClientOptions {
 	c.Timeout = &d
 	return c

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -121,9 +121,9 @@ type ClientOptions struct {
 	RetryWrites              *bool
 	ServerAPIOptions         *ServerAPIOptions
 	ServerSelectionTimeout   *time.Duration
-	SocketTimeout            *time.Duration
 	SRVMaxHosts              *int
 	SRVServiceName           *string
+	Timeout                  *time.Duration
 	TLSConfig                *tls.Config
 	WriteConcern             *writeconcern.WriteConcern
 	ZlibLevel                *int
@@ -151,6 +151,13 @@ type ClientOptions struct {
 	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
 	// release.
 	Deployment driver.Deployment
+
+	// SocketTimeout specifies the timeout to be used for the Client's socket reads and writes.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+	// used in its place to control the amount of time that a single operation can run on the Client before returning an
+	// error.
+	SocketTimeout *time.Duration
 }
 
 // Client creates a new ClientOptions instance.
@@ -445,6 +452,10 @@ func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 		c.DisableOCSPEndpointCheck = &cs.SSLDisableOCSPEndpointCheck
 	}
 
+	if cs.TimeoutSet {
+		c.Timeout = &cs.Timeout
+	}
+
 	return c
 }
 
@@ -702,8 +713,20 @@ func (c *ClientOptions) SetServerSelectionTimeout(d time.Duration) *ClientOption
 // SetSocketTimeout specifies how long the driver will wait for a socket read or write to return before returning a
 // network error. This can also be set through the "socketTimeoutMS" URI option (e.g. "socketTimeoutMS=1000"). The
 // default value is 0, meaning no timeout is used and socket operations can block indefinitely.
+//
+// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+// used in its place to control the amount of time that a single operation can run on the Client before returning an
+// error.
 func (c *ClientOptions) SetSocketTimeout(d time.Duration) *ClientOptions {
 	c.SocketTimeout = &d
+	return c
+}
+
+// SetTimeout specifies the amount of time that a single operation run on this Client can execute before returning an error.
+// This can also be set through the "timeoutMS" URI option (e.g. "timeoutMS=1000"). The default value is 0, meaning no
+// timeout is used and operations will not inherit a timeout from the Client.
+func (c *ClientOptions) SetTimeout(d time.Duration) *ClientOptions {
+	c.Timeout = &d
 	return c
 }
 
@@ -919,6 +942,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.SRVServiceName != nil {
 			c.SRVServiceName = opt.SRVServiceName
+		}
+		if opt.Timeout != nil {
+			c.Timeout = opt.Timeout
 		}
 		if opt.TLSConfig != nil {
 			c.TLSConfig = opt.TLSConfig

--- a/mongo/options/collectionoptions.go
+++ b/mongo/options/collectionoptions.go
@@ -7,6 +7,8 @@
 package options
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -15,21 +17,25 @@ import (
 
 // CollectionOptions represents options that can be used to configure a Collection.
 type CollectionOptions struct {
-	// The read concern to use for operations executed on the Collection. The default value is nil, which means that
-	// the read concern of the database used to configure the Collection will be used.
+	// ReadConcern is the read concern to use for operations executed on the Collection. The default value is nil, which means that
+	// the read concern of the Database used to configure the Collection will be used.
 	ReadConcern *readconcern.ReadConcern
 
-	// The write concern to use for operations executed on the Collection. The default value is nil, which means that
-	// the write concern of the database used to configure the Collection will be used.
+	// WriteConcern is the write concern to use for operations executed on the Collection. The default value is nil, which means that
+	// the write concern of the Database used to configure the Collection will be used.
 	WriteConcern *writeconcern.WriteConcern
 
-	// The read preference to use for operations executed on the Collection. The default value is nil, which means that
-	// the read preference of the database used to configure the Collection will be used.
+	// ReadPreference is the read preference to use for operations executed on the Collection. The default value is nil, which means that
+	// the read preference of the Database used to configure the Collection will be used.
 	ReadPreference *readpref.ReadPref
 
-	// The BSON registry to marshal and unmarshal documents for operations executed on the Collection. The default value
-	// is nil, which means that the registry of the database used to configure the Collection will be used.
+	// Registry is the BSON registry to marshal and unmarshal documents for operations executed on the Collection. The default value
+	// is nil, which means that the registry of the Database used to configure the Collection will be used.
 	Registry *bsoncodec.Registry
+
+	// Timeout is the amount of time that a single operation run on the Collection can execute before returning an error. The default value
+	// is nil, which means that the timeout of the Database used to configure the Collection will be used.
+	Timeout *time.Duration
 }
 
 // Collection creates a new CollectionOptions instance.
@@ -61,6 +67,12 @@ func (c *CollectionOptions) SetRegistry(r *bsoncodec.Registry) *CollectionOption
 	return c
 }
 
+// SetTimeout sets the value for the Timeout field.
+func (c *CollectionOptions) SetTimeout(to time.Duration) *CollectionOptions {
+	c.Timeout = &to
+	return c
+}
+
 // MergeCollectionOptions combines the given CollectionOptions instances into a single *CollectionOptions in a
 // last-one-wins fashion.
 func MergeCollectionOptions(opts ...*CollectionOptions) *CollectionOptions {
@@ -81,6 +93,9 @@ func MergeCollectionOptions(opts ...*CollectionOptions) *CollectionOptions {
 		}
 		if opt.Registry != nil {
 			c.Registry = opt.Registry
+		}
+		if opt.Timeout != nil {
+			c.Timeout = opt.Timeout
 		}
 	}
 

--- a/mongo/options/collectionoptions.go
+++ b/mongo/options/collectionoptions.go
@@ -68,6 +68,9 @@ func (c *CollectionOptions) SetRegistry(r *bsoncodec.Registry) *CollectionOption
 }
 
 // SetTimeout sets the value for the Timeout field.
+//
+// If any Timeout is set on the Collection, the values of other, deprecated timeout-related options will be ignored. In particular:
+// ClientOptions.SocketTimeout, WriteConcern.wTimeout, Operation.MaxTime and TransactionOptions.MaxCommitTime.
 func (c *CollectionOptions) SetTimeout(to time.Duration) *CollectionOptions {
 	c.Timeout = &to
 	return c

--- a/mongo/options/dboptions.go
+++ b/mongo/options/dboptions.go
@@ -7,6 +7,8 @@
 package options
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -15,21 +17,25 @@ import (
 
 // DatabaseOptions represents options that can be used to configure a Database.
 type DatabaseOptions struct {
-	// The read concern to use for operations executed on the Database. The default value is nil, which means that
-	// the read concern of the client used to configure the Database will be used.
+	// ReadConcern is the read concern to use for operations executed on the Database. The default value is nil, which means that
+	// the read concern of the Client used to configure the Database will be used.
 	ReadConcern *readconcern.ReadConcern
 
-	// The write concern to use for operations executed on the Database. The default value is nil, which means that the
-	// write concern of the client used to configure the Database will be used.
+	// WriteConcern is the write concern to use for operations executed on the Database. The default value is nil, which means that the
+	// write concern of the Client used to configure the Database will be used.
 	WriteConcern *writeconcern.WriteConcern
 
-	// The read preference to use for operations executed on the Database. The default value is nil, which means that
-	// the read preference of the client used to configure the Database will be used.
+	// ReadPreference is the read preference to use for operations executed on the Database. The default value is nil, which means that
+	// the read preference of the Client used to configure the Database will be used.
 	ReadPreference *readpref.ReadPref
 
-	// The BSON registry to marshal and unmarshal documents for operations executed on the Database. The default value
-	// is nil, which means that the registry of the client used to configure the Database will be used.
+	// Registry is the BSON registry to marshal and unmarshal documents for operations executed on the Database. The default value
+	// is nil, which means that the registry of the Client used to configure the Database will be used.
 	Registry *bsoncodec.Registry
+
+	// Timeout is the amount of time that a single operation run on the Database can execute before returning an error. The default value
+	// nil, which means that the timeout of the Client used to configure the Database will be used.
+	Timeout *time.Duration
 }
 
 // Database creates a new DatabaseOptions instance.
@@ -61,6 +67,12 @@ func (d *DatabaseOptions) SetRegistry(r *bsoncodec.Registry) *DatabaseOptions {
 	return d
 }
 
+// SetTimeout sets the value for the Timeout field.
+func (d *DatabaseOptions) SetTimeout(to time.Duration) *DatabaseOptions {
+	d.Timeout = &to
+	return d
+}
+
 // MergeDatabaseOptions combines the given DatabaseOptions instances into a single DatabaseOptions in a last-one-wins
 // fashion.
 func MergeDatabaseOptions(opts ...*DatabaseOptions) *DatabaseOptions {
@@ -81,6 +93,9 @@ func MergeDatabaseOptions(opts ...*DatabaseOptions) *DatabaseOptions {
 		}
 		if opt.Registry != nil {
 			d.Registry = opt.Registry
+		}
+		if opt.Timeout != nil {
+			d.Timeout = opt.Timeout
 		}
 	}
 

--- a/mongo/options/dboptions.go
+++ b/mongo/options/dboptions.go
@@ -68,6 +68,9 @@ func (d *DatabaseOptions) SetRegistry(r *bsoncodec.Registry) *DatabaseOptions {
 }
 
 // SetTimeout sets the value for the Timeout field.
+//
+// If any Timeout is set on the Database, the values of other, deprecated timeout-related options will be ignored. In particular:
+// ClientOptions.SocketTimeout, WriteConcern.wTimeout, Operation.MaxTime and TransactionOptions.MaxCommitTime.
 func (d *DatabaseOptions) SetTimeout(to time.Duration) *DatabaseOptions {
 	d.Timeout = &to
 	return d

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -258,6 +258,12 @@ func (f *FindOptions) SetSort(sort interface{}) *FindOptions {
 	return f
 }
 
+// SetTimeout sets the value for the Timeout field.
+func (f *FindOptions) SetTimeout(to time.Duration) *FindOptions {
+	f.Timeout = &to
+	return f
+}
+
 // MergeFindOptions combines the given FindOptions instances into a single FindOptions in a last-one-wins fashion.
 func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 	fo := Find()

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -56,15 +56,17 @@ type FindOptions struct {
 	// query. This option is only valid for tailable await cursors (see the CursorType option for more information) and
 	// MongoDB versions >= 3.2. For other cursor types or previous server versions, this option is ignored.
 	//
-	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-	// used in its place to control the amount of time that the Find operation can run before returning an error.
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the Find operation can run before
+	// returning an error. MaxAwaitTime is still usable through the deprecated setter.
 	MaxAwaitTime *time.Duration
 
 	// MaxTime is the maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-	// used in its place to control the amount of time that the Find operation can run before returning an error.
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the Find operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// Min is a document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
@@ -180,8 +182,9 @@ func (f *FindOptions) SetMax(max interface{}) *FindOptions {
 
 // SetMaxAwaitTime sets the value for the MaxAwaitTime field.
 //
-// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-// used in its place to control the amount of time that the Find operation can run before returning an error.
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver.
+// The more general Timeout option should be used in its place to control the amount of time that the
+// Find operation can run before returning an error.
 func (f *FindOptions) SetMaxAwaitTime(d time.Duration) *FindOptions {
 	f.MaxAwaitTime = &d
 	return f
@@ -189,8 +192,9 @@ func (f *FindOptions) SetMaxAwaitTime(d time.Duration) *FindOptions {
 
 // SetMaxTime specifies the max time to allow the query to run.
 //
-// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-// used in its place to control the amount of time that the Find operation can run before returning an error.
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver.
+// The more general Timeout option should be used in its place to control the amount of time that the
+// Find operation can run before returning an error.
 func (f *FindOptions) SetMaxTime(d time.Duration) *FindOptions {
 	f.MaxTime = &d
 	return f

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -111,10 +111,6 @@ type FindOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
-
-	// Timeout is the amount of time that this Find run on the Collection can execute before returning an error. The default value
-	// is nil, which means that the timeout of the Database used to configure the Collection will be used.
-	Timeout *time.Duration
 }
 
 // Find creates a new FindOptions instance.
@@ -258,12 +254,6 @@ func (f *FindOptions) SetSort(sort interface{}) *FindOptions {
 	return f
 }
 
-// SetTimeout sets the value for the Timeout field.
-func (f *FindOptions) SetTimeout(to time.Duration) *FindOptions {
-	f.Timeout = &to
-	return f
-}
-
 // MergeFindOptions combines the given FindOptions instances into a single FindOptions in a last-one-wins fashion.
 func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 	fo := Find()
@@ -333,9 +323,6 @@ func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 		}
 		if opt.Sort != nil {
 			fo.Sort = opt.Sort
-		}
-		if opt.Timeout != nil {
-			fo.Timeout = opt.Timeout
 		}
 	}
 

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -12,99 +12,109 @@ import (
 
 // FindOptions represents options that can be used to configure a Find operation.
 type FindOptions struct {
-	// If true, the server can write temporary data to disk while executing the find operation. This option is only
-	// valid for MongoDB versions >= 4.4. Server versions >= 3.2 will report an error if this option is specified. For
-	// server versions < 3.2, the driver will return a client-side error if this option is specified. The default value
-	// is false.
+	// AllowDiskUse specifies whether the server can write temporary data to disk while executing the Find operation.
+	// This option is only valid for MongoDB versions >= 4.4. Server versions >= 3.2 will report an error if this option
+	// is specified. For server versions < 3.2, the driver will return a client-side error if this option is specified.
+	// The default value is false.
 	AllowDiskUse *bool
 
-	// If true, an operation on a sharded cluster can return partial results if some shards are down rather than
-	// returning an error. The default value is false.
+	// AllowPartial results specifies whether the Find operation on a sharded cluster can return partial results if some
+	// shards are down rather than returning an error. The default value is false.
 	AllowPartialResults *bool
 
-	// The maximum number of documents to be included in each batch returned by the server.
+	// BatchSize is the maximum number of documents to be included in each batch returned by the server.
 	BatchSize *int32
 
-	// Specifies a collation to use for string comparisons during the operation. This option is only valid for MongoDB
-	// versions >= 3.4. For previous server versions, the driver will return an error if this option is used. The
+	// Collation specifies a collation to use for string comparisons during the operation. This option is only valid for
+	// MongoDB versions >= 3.4. For previous server versions, the driver will return an error if this option is used. The
 	// default value is nil, which means the default collation of the collection will be used.
 	Collation *Collation
 
-	// A string that will be included in server logs, profiling logs, and currentOp queries to help trace the operation.
-	// The default is the empty string, which means that no comment will be included in the logs.
+	// Comment is a string that will be included in server logs, profiling logs, and currentOp queries to help trace the
+	// Find operation. The default is the empty string, which means that no comment will be included in the logs.
 	Comment *string
 
-	// Specifies the type of cursor that should be created for the operation. The default is NonTailable, which means
-	// that the cursor will be closed by the server when the last batch of documents is retrieved.
+	// CursorType specifies the type of cursor that should be created for the operation. The default is NonTailable, which
+	// means that the cursor will be closed by the server when the last batch of documents is retrieved.
 	CursorType *CursorType
 
-	// The index to use for the operation. This should either be the index name as a string or the index specification
-	// as a document. The driver will return an error if the hint parameter is a multi-key map. The default value is nil,
-	// which means that no hint will be sent.
+	// Hint is the index to use for the Find operation. This should either be the index name as a string or the index
+	// specification as a document. The driver will return an error if the hint parameter is a multi-key map. The default
+	// value is nil, which means that no hint will be sent.
 	Hint interface{}
 
-	// The maximum number of documents to return. The default value is 0, which means that all documents matching the
+	// Limit is the maximum number of documents to return. The default value is 0, which means that all documents matching the
 	// filter will be returned. A negative limit specifies that the resulting documents should be returned in a single
 	// batch. The default value is 0.
 	Limit *int64
 
-	// A document specifying the exclusive upper bound for a specific index. The default value is nil, which means that
+	// Max is a document specifying the exclusive upper bound for a specific index. The default value is nil, which means that
 	// there is no maximum value.
 	Max interface{}
 
-	// The maximum amount of time that the server should wait for new documents to satisfy a tailable cursor query.
-	// This option is only valid for tailable await cursors (see the CursorType option for more information) and
+	// MaxAwaitTime is the maximum amount of time that the server should wait for new documents to satisfy a tailable cursor
+	// query. This option is only valid for tailable await cursors (see the CursorType option for more information) and
 	// MongoDB versions >= 3.2. For other cursor types or previous server versions, this option is ignored.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+	// used in its place to control the amount of time that the Find operation can run before returning an error.
 	MaxAwaitTime *time.Duration
 
-	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
+	// MaxTime is the maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+	// used in its place to control the amount of time that the Find operation can run before returning an error.
 	MaxTime *time.Duration
 
-	// A document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
+	// Min is a document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
 	// there is no minimum value.
 	Min interface{}
 
-	// If true, the cursor created by the operation will not timeout after a period of inactivity. The default value
-	// is false.
+	// NoCursorTimeout specifies whether the cursor created by the operation will not timeout after a period of inactivity.
+	// The default value is false.
 	NoCursorTimeout *bool
 
-	// This option is for internal replication use only and should not be set.
+	// OplogReplay is for internal replication use only and should not be set.
 	//
 	// Deprecated: This option has been deprecated in MongoDB version 4.4 and will be ignored by the server if it is
 	// set.
 	OplogReplay *bool
 
-	// A document describing which fields will be included in the documents returned by the operation. The default value
-	// is nil, which means all fields will be included.
+	// Project is a document describing which fields will be included in the documents returned by the Find operation. The
+	// default value is nil, which means all fields will be included.
 	Projection interface{}
 
-	// If true, the documents returned by the operation will only contain fields corresponding to the index used. The
-	// default value is false.
+	// ReturnKey specifies whether the documents returned by the Find operation will only contain fields corresponding to the
+	// index used. The default value is false.
 	ReturnKey *bool
 
-	// If true, a $recordId field with a record identifier will be included in the documents returned by the operation.
-	// The default value is false.
+	// ShowRecordID specifies whether a $recordId field with a record identifier will be included in the documents returned by
+	// the Find operation. The default value is false.
 	ShowRecordID *bool
 
-	// The number of documents to skip before adding documents to the result. The default value is 0.
+	// Skip is the number of documents to skip before adding documents to the result. The default value is 0.
 	Skip *int64
 
-	// If true, the cursor will not return a document more than once because of an intervening write operation. The
-	// default value is false.
+	// Snapshot specifies whether the cursor will not return a document more than once because of an intervening write operation.
+	// The default value is false.
 	//
 	// Deprecated: This option has been deprecated in MongoDB version 3.6 and removed in MongoDB version 4.0.
 	Snapshot *bool
 
-	// A document specifying the order in which documents should be returned.  The driver will return an error if the
+	// Sort is a document specifying the order in which documents should be returned.  The driver will return an error if the
 	// sort parameter is a multi-key map.
 	Sort interface{}
 
-	// Specifies parameters for the find expression. This option is only valid for MongoDB versions >= 5.0. Older
+	// Let specifies parameters for the find expression. This option is only valid for MongoDB versions >= 5.0. Older
 	// servers will report an error for using this option. This must be a document mapping parameter names to values.
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// Timeout is the amount of time that this Find run on the Collection can execute before returning an error. The default value
+	// is nil, which means that the timeout of the Database used to configure the Collection will be used.
+	Timeout *time.Duration
 }
 
 // Find creates a new FindOptions instance.
@@ -173,12 +183,18 @@ func (f *FindOptions) SetMax(max interface{}) *FindOptions {
 }
 
 // SetMaxAwaitTime sets the value for the MaxAwaitTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+// used in its place to control the amount of time that the Find operation can run before returning an error.
 func (f *FindOptions) SetMaxAwaitTime(d time.Duration) *FindOptions {
 	f.MaxAwaitTime = &d
 	return f
 }
 
 // SetMaxTime specifies the max time to allow the query to run.
+//
+// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+// used in its place to control the amount of time that the Find operation can run before returning an error.
 func (f *FindOptions) SetMaxTime(d time.Duration) *FindOptions {
 	f.MaxTime = &d
 	return f
@@ -311,6 +327,9 @@ func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 		}
 		if opt.Sort != nil {
 			fo.Sort = opt.Sort
+		}
+		if opt.Timeout != nil {
+			fo.Timeout = opt.Timeout
 		}
 	}
 

--- a/mongo/options/transactionoptions.go
+++ b/mongo/options/transactionoptions.go
@@ -34,6 +34,9 @@ type TransactionOptions struct {
 	// The maximum amount of time that a CommitTransaction operation can executed in the transaction can run on the
 	// server. The default value is nil, which means that the default maximum commit time of the session used to
 	// start the transaction will be used.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+	// used in its place to control the amount of time that the transaction can run before returning an error.
 	MaxCommitTime *time.Duration
 }
 
@@ -61,6 +64,9 @@ func (t *TransactionOptions) SetWriteConcern(wc *writeconcern.WriteConcern) *Tra
 }
 
 // SetMaxCommitTime sets the value for the MaxCommitTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
+// used in its place to control the amount of time that the transaction can run before returning an error.
 func (t *TransactionOptions) SetMaxCommitTime(mct *time.Duration) *TransactionOptions {
 	t.MaxCommitTime = mct
 	return t

--- a/mongo/options/transactionoptions.go
+++ b/mongo/options/transactionoptions.go
@@ -35,8 +35,9 @@ type TransactionOptions struct {
 	// server. The default value is nil, which means that the default maximum commit time of the session used to
 	// start the transaction will be used.
 	//
-	// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-	// used in its place to control the amount of time that the transaction can run before returning an error.
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more
+	// general Timeout option should be used in its place to control the amount of time that the transaction can run
+	// before returning an error. MaxCommitTime is still usable through the deprecated setter.
 	MaxCommitTime *time.Duration
 }
 
@@ -65,8 +66,9 @@ func (t *TransactionOptions) SetWriteConcern(wc *writeconcern.WriteConcern) *Tra
 
 // SetMaxCommitTime sets the value for the MaxCommitTime field.
 //
-// Deprecated: This option is deprecated and will eventually be removed. The more general Timeout option should be
-// used in its place to control the amount of time that the transaction can run before returning an error.
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver.
+// The more general Timeout option should be used in its place to control the amount of time that the
+// transaction can run before returning an error.
 func (t *TransactionOptions) SetMaxCommitTime(mct *time.Duration) *TransactionOptions {
 	t.MaxCommitTime = mct
 	return t

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -33,9 +33,10 @@ type WriteConcern struct {
 	w interface{}
 	j bool
 
-	// Deprecated: This option is deprecated and will eventually be removed. The more general
-	// Client, Database or Collection Timeout options should be used in its place to control
-	// the amount of time that a single operation can run before returning an error.
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the
+	// driver. The more general Client, Database or Collection Timeout options should be used in
+	// its place to control the amount of time that a single operation can run before returning an
+	// error. wTimeout is still usable through the deprecated setter.
 	wTimeout time.Duration
 }
 
@@ -87,9 +88,10 @@ func J(j bool) Option {
 
 // WTimeout specifies specifies a time limit for the write concern.
 //
-// Deprecated: This option is deprecated and will eventually be removed. The more general
-// Client, Database or Collection Timeout options should be used in its place to control
-// the amount of time that a single operation can run before returning an error.
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0
+// of the driver. The more general Client, Database or Collection Timeout options should
+// be used in its place to control the amount of time that a single operation can run before
+// returning an error.
 func WTimeout(d time.Duration) Option {
 	return func(concern *WriteConcern) {
 		concern.wTimeout = d

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -30,8 +30,12 @@ var ErrNegativeWTimeout = errors.New("write concern `wtimeout` field cannot be n
 // WriteConcern describes the level of acknowledgement requested from MongoDB for write operations
 // to a standalone mongod or to replica sets or to sharded clusters.
 type WriteConcern struct {
-	w        interface{}
-	j        bool
+	w interface{}
+	j bool
+
+	// Deprecated: This option is deprecated and will eventually be removed. The more general
+	// Client, Database or Collection Timeout options should be used in its place to control
+	// the amount of time that a single operation can run before returning an error.
 	wTimeout time.Duration
 }
 
@@ -82,6 +86,10 @@ func J(j bool) Option {
 }
 
 // WTimeout specifies specifies a time limit for the write concern.
+//
+// Deprecated: This option is deprecated and will eventually be removed. The more general
+// Client, Database or Collection Timeout options should be used in its place to control
+// the amount of time that a single operation can run before returning an error.
 func WTimeout(d time.Duration) Option {
 	return func(concern *WriteConcern) {
 		concern.wTimeout = d

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -122,6 +122,8 @@ type ConnString struct {
 	SSLCaFileSet                       bool
 	SSLDisableOCSPEndpointCheck        bool
 	SSLDisableOCSPEndpointCheckSet     bool
+	Timeout                            time.Duration
+	TimeoutSet                         bool
 	WString                            string
 	WNumber                            int
 	WNumberSet                         bool
@@ -883,6 +885,13 @@ func (p *parser) addOption(pair string) error {
 		p.SSLSet = true
 		p.SSLCaFile = value
 		p.SSLCaFileSet = true
+	case "timeoutms":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return fmt.Errorf("invalid value for %s: %s", key, value)
+		}
+		p.Timeout = time.Duration(n) * time.Millisecond
+		p.TimeoutSet = true
 	case "tlsdisableocspendpointcheck":
 		p.SSL = true
 		p.SSLSet = true

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -39,6 +39,9 @@ var (
 	// ErrUnsupportedStorageEngine is returned when a retryable write is attempted against a server
 	// that uses a storage engine that does not support retryable writes
 	ErrUnsupportedStorageEngine = errors.New("this MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string")
+	// ErrDeadlineWouldBeExceeded is returned when a Timeout set on an operation would be exceeded
+	// if the operation were sent to the server.
+	ErrDeadlineWouldBeExceeded = errors.New("operation not sent to server, as a global timeout would be exceeded")
 )
 
 // QueryFailureError is an error representing a command failure as a document.

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -41,7 +41,7 @@ var (
 	ErrUnsupportedStorageEngine = errors.New("this MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string")
 	// ErrDeadlineWouldBeExceeded is returned when a Timeout set on an operation would be exceeded
 	// if the operation were sent to the server.
-	ErrDeadlineWouldBeExceeded = errors.New("operation not sent to server, as a global timeout would be exceeded")
+	ErrDeadlineWouldBeExceeded = errors.New("operation not sent to server, as Timeout would be exceeded")
 )
 
 // QueryFailureError is an error representing a command failure as a document.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -308,9 +308,9 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		return err
 	}
 
-	// If no deadline is set on the passed-in context, and op.Timeout is set, honor op.Timeout
+	// If no deadline is set on the passed-in context, and op.Timeout is set and non-zero, honor op.Timeout
 	// in new context for operation execution.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && op.Timeout != nil {
+	if _, deadlineSet := ctx.Deadline(); !deadlineSet && op.Timeout != nil && *op.Timeout != 0 {
 		newCtx, cancelFunc := context.WithTimeout(ctx, *op.Timeout)
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx
@@ -1106,7 +1106,8 @@ func (op Operation) addMaxTimeMS(ctx context.Context, dst []byte, desc descripti
 			// of attempting to send message to server.
 			// TODO(CSOT): Uncomment this once RTT90 is actually being calculated.
 			// if desc.RTT90 < remainingTimeout {
-			//	return ErrDeadlineWouldBeExceeded
+			//	return dst, internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
+			//		"Remaining timeout %v applied from Timeout is less than 90th percentile RTT", remainingTimeout)
 			// }
 			maxTimeMS := int64(remainingTimeout/time.Millisecond) - int64(desc.RTT90/time.Millisecond)
 			dst = bsoncore.AppendInt64Element(dst, "maxTimeMS", maxTimeMS)

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -484,7 +484,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 				if desc.RTT90 < remainingTimeout {
 					return ErrDeadlineWouldBeExceeded
 				}
-				maxTimeMS := remainingTimeout.Milliseconds() - desc.RTT90.Milliseconds()
+				maxTimeMS := int64(remainingTimeout/time.Millisecond) - int64(desc.RTT90/time.Millisecond)
 				wm = bsoncore.AppendInt64Element(wm, "maxTimeMS", maxTimeMS)
 			}
 		}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -524,7 +524,7 @@ func TestOperation(t *testing.T) {
 						Kind: tc.server,
 					},
 				}
-				wm, _, err := op.createQueryWireMessage(wm, desc)
+				wm, _, err := op.createQueryWireMessage(context.Background(), wm, desc)
 				noerr(t, err)
 
 				// We know where the $query would be within the OP_QUERY, so we'll just index into there.

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -524,7 +524,7 @@ func TestOperation(t *testing.T) {
 						Kind: tc.server,
 					},
 				}
-				wm, _, err := op.createQueryWireMessage(context.Background(), wm, desc)
+				wm, _, err := op.createQueryWireMessage(nil, wm, desc)
 				noerr(t, err)
 
 				// We know where the $query would be within the OP_QUERY, so we'll just index into there.

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -373,6 +373,8 @@ func (p *pool) unpinConnectionFromTransaction() {
 // ready, checkOut returns an error.
 // Based partially on https://cs.opensource.google/go/go/+/refs/tags/go1.16.6:src/net/http/transport.go;l=1324
 func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
+	// TODO(CSOT): If a Timeout was specified at any level, respect the Timeout is server selection, connection
+	// checkout and creation.
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
 			Type:    event.GetStarted,

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -772,9 +772,10 @@ func (s *Server) check() (description.Server, error) {
 	}
 
 	if descPtr != nil {
-		// The check was successful. Set the average RTT and return.
+		// The check was successful. Set the average RTT and the 90th percentile RTT and return.
 		desc := *descPtr
 		desc = desc.SetAverageRTT(s.rttMonitor.getRTT())
+		// TODO(CSOT): Set 90th percentile RTT with SetRTT90.
 		desc.HeartbeatInterval = s.cfg.heartbeatInterval
 		return desc, nil
 	}


### PR DESCRIPTION
GODRIVER-2304

This is a proof-of-concept for the implementation of [client-side-operations-timeout](https://github.com/mongodb/specifications/blob/master/source/client-side-operations-timeout/client-side-operations-timeout.rst) in the Go driver. 

Adds a `Timeout` option to `Client`, `Database`, `Collection`, `Find` and `Operation` and sets up inheritance of the option in that order. Creates a new context in `operation.Execute()` based on the current context deadline and the `Timeout` option. Appends `maxTimeMS` if `Timeout` is specified based on the remaining timeout. Adds a new `driver.ErrDeadlineWouldBeExceeded` error. Deprecates a number of timeout-related options.

Let me know what you think of this pattern for adding `Timeout` to basic operations. The scope of CSOT in the Go driver extends beyond basic operations, but this will be the first piece of the puzzle 🧩 .