### PR TITLE
GODRIVER-1825 Select the server with fewer in-progress operations.

### DIFF
--- a/data/server-selection/in_window/equilibrium.json
+++ b/data/server-selection/in_window/equilibrium.json
@@ -1,0 +1,46 @@
+{
+  "description": "When in equilibrium selection is evenly distributed",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 5
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.33,
+      "b:27017": 0.33,
+      "c:27017": 0.33
+    }
+  }
+}

--- a/data/server-selection/in_window/equilibrium.yml
+++ b/data/server-selection/in_window/equilibrium.yml
@@ -1,0 +1,27 @@
+description: When in equilibrium selection is evenly distributed
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 5
+  - address: b:27017
+    operation_count: 5
+  - address: c:27017
+    operation_count: 5
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.33
+    b:27017: 0.33
+    c:27017: 0.33

--- a/data/server-selection/in_window/many-choices.json
+++ b/data/server-selection/in_window/many-choices.json
@@ -1,0 +1,106 @@
+{
+  "description": "Selections from many choices occur at correct frequencies",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "d:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "e:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "f:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "h:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "i:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 0
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "d:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "e:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "f:27017",
+      "operation_count": 20
+    },
+    {
+      "address": "g:27017",
+      "operation_count": 20
+    },
+    {
+      "address": "h:27017",
+      "operation_count": 50
+    },
+    {
+      "address": "i:27017",
+      "operation_count": 60
+    }
+  ],
+  "iterations": 10000,
+  "outcome": {
+    "tolerance": 0.03,
+    "expected_frequencies": {
+      "a:27017": 0.22,
+      "b:27017": 0.18,
+      "c:27017": 0.18,
+      "d:27017": 0.125,
+      "e:27017": 0.125,
+      "f:27017": 0.074,
+      "g:27017": 0.074,
+      "h:27017": 0.0277,
+      "i:27017": 0
+    }
+  }
+}

--- a/data/server-selection/in_window/many-choices.yml
+++ b/data/server-selection/in_window/many-choices.yml
@@ -1,0 +1,63 @@
+description: Selections from many choices occur at correct frequencies
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: d:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: e:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: f:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: g:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: h:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: i:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 0
+  - address: b:27017
+    operation_count: 5
+  - address: c:27017
+    operation_count: 5
+  - address: d:27017
+    operation_count: 10
+  - address: e:27017
+    operation_count: 10
+  - address: f:27017
+    operation_count: 20
+  - address: g:27017
+    operation_count: 20
+  - address: h:27017
+    operation_count: 50
+  - address: i:27017
+    operation_count: 60
+iterations: 10000
+outcome:
+  tolerance: 0.03
+  expected_frequencies:
+    a:27017: 0.22
+    b:27017: 0.18
+    c:27017: 0.18
+    d:27017: 0.125
+    e:27017: 0.125
+    f:27017: 0.074
+    g:27017: 0.074
+    h:27017: 0.0277
+    i:27017: 0

--- a/data/server-selection/in_window/one-least-two-tied.json
+++ b/data/server-selection/in_window/one-least-two-tied.json
@@ -1,0 +1,46 @@
+{
+  "description": "Least operations gets most selections, two tied share the rest",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 16
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 16
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.165,
+      "b:27017": 0.66,
+      "c:27017": 0.165
+    }
+  }
+}

--- a/data/server-selection/in_window/one-least-two-tied.yml
+++ b/data/server-selection/in_window/one-least-two-tied.yml
@@ -1,0 +1,27 @@
+description: Least operations gets most selections, two tied share the rest
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 16
+  - address: b:27017
+    operation_count: 10
+  - address: c:27017
+    operation_count: 16
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.165
+    b:27017: 0.66
+    c:27017: 0.165

--- a/data/server-selection/in_window/rs-equilibrium.json
+++ b/data/server-selection/in_window/rs-equilibrium.json
@@ -1,0 +1,46 @@
+{
+  "description": "When in equilibrium selection is evenly distributed (replica set)",
+  "topology_description": {
+    "type": "ReplicaSetWithPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSPrimary"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 6
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.33,
+      "b:27017": 0.33,
+      "c:27017": 0.33
+    }
+  }
+}

--- a/data/server-selection/in_window/rs-equilibrium.yml
+++ b/data/server-selection/in_window/rs-equilibrium.yml
@@ -1,0 +1,27 @@
+description: When in equilibrium selection is evenly distributed (replica set)
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: RSPrimary
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 6
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 6
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.33
+    b:27017: 0.33
+    c:27017: 0.33

--- a/data/server-selection/in_window/rs-three-choices.json
+++ b/data/server-selection/in_window/rs-three-choices.json
@@ -1,0 +1,46 @@
+{
+  "description": "Selections from three servers occur at proper distributions (replica set)",
+  "topology_description": {
+    "type": "ReplicaSetWithPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSPrimary"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 3
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 20
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.66,
+      "b:27017": 0.33,
+      "c:27017": 0
+    }
+  }
+}

--- a/data/server-selection/in_window/rs-three-choices.yml
+++ b/data/server-selection/in_window/rs-three-choices.yml
@@ -1,0 +1,27 @@
+description: Selections from three servers occur at proper distributions (replica set)
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: RSPrimary
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 3
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 20
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.66
+    b:27017: 0.33
+    c:27017: 0

--- a/data/server-selection/in_window/three-choices.json
+++ b/data/server-selection/in_window/three-choices.json
@@ -1,0 +1,46 @@
+{
+  "description": "Selections from three servers occur at proper distributions",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 3
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 20
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.66,
+      "b:27017": 0.33,
+      "c:27017": 0
+    }
+  }
+}

--- a/data/server-selection/in_window/three-choices.yml
+++ b/data/server-selection/in_window/three-choices.yml
@@ -1,0 +1,27 @@
+description: Selections from three servers occur at proper distributions
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 3
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 20
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.66
+    b:27017: 0.33
+    c:27017: 0

--- a/data/server-selection/in_window/two-choices.json
+++ b/data/server-selection/in_window/two-choices.json
@@ -1,0 +1,36 @@
+{
+  "description": "Better of two choices always selected",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 0
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    }
+  ],
+  "iterations": 100,
+  "outcome": {
+    "tolerance": 0,
+    "expected_frequencies": {
+      "a:27017": 1,
+      "b:27017": 0
+    }
+  }
+}

--- a/data/server-selection/in_window/two-choices.yml
+++ b/data/server-selection/in_window/two-choices.yml
@@ -1,0 +1,21 @@
+description: Better of two choices always selected
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 0
+  - address: b:27017
+    operation_count: 5
+iterations: 100
+outcome:
+  tolerance: 0.0
+  expected_frequencies:
+    a:27017: 1
+    b:27017: 0

--- a/data/server-selection/in_window/two-least.json
+++ b/data/server-selection/in_window/two-least.json
@@ -1,0 +1,46 @@
+{
+  "description": "Two tied for least operations share all selections",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 16
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.5,
+      "b:27017": 0.5,
+      "c:27017": 0
+    }
+  }
+}

--- a/data/server-selection/in_window/two-least.yml
+++ b/data/server-selection/in_window/two-least.yml
@@ -1,0 +1,27 @@
+description: Two tied for least operations share all selections
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 10
+  - address: b:27017
+    operation_count: 10
+  - address: c:27017
+    operation_count: 16
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.5
+    b:27017: 0.5
+    c:27017: 0

--- a/mongo/integration/server_selection_prose_test.go
+++ b/mongo/integration/server_selection_prose_test.go
@@ -1,0 +1,151 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// TestServerSelectionProse implements the Server Selection prose tests:
+// https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection-tests.rst
+func TestServerSelectionProse(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+	defer mt.Close()
+
+	mtOpts := mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.9")
+	mt.RunOpts("operationCount-based selection within latency window, with failpoint", mtOpts, func(mt *mtest.T) {
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+		require.NoError(mt, err, "InsertOne() error")
+
+		hosts := options.Client().ApplyURI(mtest.ClusterURI()).Hosts
+		require.GreaterOrEqualf(mt, len(hosts), 2, "test cluster must have at least 2 mongos hosts")
+
+		// Set a failpoint on a specific mongos host that delays all "find" commands for 500ms. We
+		// need to know which mongos we set the failpoint on for our assertions later.
+		failpointHost := hosts[0]
+		mt.ResetClient(options.Client().
+			SetHosts([]string{failpointHost}))
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 10000,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"find"},
+				BlockConnection: true,
+				BlockTimeMS:     500,
+				AppName:         "loadBalancingTest",
+			},
+		})
+
+		// Reset the client with exactly 2 mongos hosts.
+		tpm := newTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetAppName("loadBalancingTest").
+			SetHosts(hosts[:2]).
+			SetPoolMonitor(tpm.PoolMonitor))
+
+		// Start 25 goroutines that each run 10 findOne operations. Run 25 goroutines instead of the
+		// 10 that the prose test specifies to reduce intermittent test failures caused by the
+		// random selections not being perfectly even over small numbers of operations.
+		var wg sync.WaitGroup
+		for i := 0; i < 25; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for i := 0; i < 10; i++ {
+					res := mt.Coll.FindOne(context.Background(), bson.D{})
+					assert.NoError(t, res.Err(), "FindOne() error")
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Get all checkOut events and calculate the number of times each server was selected. The
+		// prose test spec says to use command monitoring events, but those don't include the server
+		// address, so use checkOut events instead.
+		checkOutEvents := tpm.Events(func(evt *event.PoolEvent) bool {
+			return evt.Type == event.GetStarted
+		})
+		counts := make(map[string]int)
+		for _, evt := range checkOutEvents {
+			counts[evt.Address]++
+		}
+		assert.Equal(mt, 2, len(counts), "expected exactly 2 server addresses")
+
+		// Calculate the frequency that the server with the failpoint was selected. Assert that it
+		// was selected less than 25% of the time.
+		frequency := float64(counts[failpointHost]) / float64(len(checkOutEvents))
+		assert.Lessf(mt, frequency, 0.25, "expected failpoint host %q to be selected less than 25%% of the time", failpointHost)
+	})
+
+	mtOpts = mtest.NewOptions().Topologies(mtest.Sharded)
+	mt.RunOpts("operationCount-based selection within latency window, no failpoint", mtOpts, func(mt *mtest.T) {
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+		require.NoError(mt, err, "InsertOne() error")
+
+		hosts := options.Client().ApplyURI(mtest.ClusterURI()).Hosts
+		require.GreaterOrEqualf(mt, len(hosts), 2, "test cluster must have at least 2 mongos hosts")
+
+		// Reset the client with exactly 2 mongos hosts.
+		tpm := newTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetHosts(hosts[:2]).
+			SetPoolMonitor(tpm.PoolMonitor))
+
+		// Start 25 goroutines that each run 10 findOne operations. Run 25 goroutines instead of the
+		// 10 that the prose test specifies to reduce intermittent test failures caused by the
+		// random selections not being perfectly even over small numbers of operations.
+		var wg sync.WaitGroup
+		for i := 0; i < 25; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for i := 0; i < 10; i++ {
+					res := mt.Coll.FindOne(context.Background(), bson.D{})
+					assert.NoError(mt, res.Err(), "FindOne() error")
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Get all checkOut events and calculate the number of times each server was selected. The
+		// prose test spec says to use command monitoring events, but those don't include the server
+		// address, so use checkOut events instead.
+		checkOutEvents := tpm.Events(func(evt *event.PoolEvent) bool {
+			return evt.Type == event.GetStarted
+		})
+		counts := make(map[string]int)
+		for _, evt := range checkOutEvents {
+			counts[evt.Address]++
+		}
+		assert.Equal(mt, 2, len(counts), "expected exactly 2 server addresses")
+
+		// Calculate the frequency that each server was selected. Assert that each server was
+		// selected 50% (+/- 10%) of the time.
+		for addr, count := range counts {
+			frequency := float64(count) / float64(len(checkOutEvents))
+			assert.InDeltaf(mt,
+				0.5,
+				frequency,
+				0.1,
+				"expected server %q to be selected 50%% (+/- 10%%) of the time, but was selected %v%% of the time",
+				addr, frequency*100)
+		}
+	})
+}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -600,6 +600,10 @@ type Connection struct {
 	refCount      int
 	cleanupPoolFn func()
 
+	// cleanupServerFn resets the server state when a connection is returned to the connection pool
+	// via Close() or expired via Expire().
+	cleanupServerFn func()
+
 	mu sync.RWMutex
 }
 
@@ -700,6 +704,10 @@ func (c *Connection) cleanupReferences() error {
 	if c.cleanupPoolFn != nil {
 		c.cleanupPoolFn()
 		c.cleanupPoolFn = nil
+	}
+	if c.cleanupServerFn != nil {
+		c.cleanupServerFn()
+		c.cleanupServerFn = nil
 	}
 	c.connection = nil
 	return err

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -85,7 +85,6 @@ type pool struct {
 	nextID                       uint64 // nextID is the next pool ID for a new connection.
 	pinnedCursorConnections      uint64
 	pinnedTransactionConnections uint64
-	inUseConnections             int64
 
 	address       address.Address
 	minSize       uint64
@@ -452,8 +451,6 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 				ConnectionID: w.conn.poolID,
 			})
 		}
-
-		atomic.AddInt64(&p.inUseConnections, 1)
 		return w.conn, nil
 	}
 
@@ -483,8 +480,6 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 				ConnectionID: w.conn.poolID,
 			})
 		}
-
-		atomic.AddInt64(&p.inUseConnections, 1)
 		return w.conn, nil
 	case <-ctx.Done():
 		if p.monitor != nil {
@@ -587,13 +582,6 @@ func (p *pool) checkIn(conn *connection) error {
 			Address:      conn.addr.String(),
 		})
 	}
-
-	// Decrement the number of in-use connections once we know we have a non-nil connection that
-	// came from this pool. Do this in checkIn() instead of checkInNoEvent() because the latter is
-	// called by createConnections() and is not necessarily a check-in of an in-use connection. Use
-	// an int64 instead of a uint64 to mitigate the impact of any possible bugs that could cause the
-	// uint64 to underflow, which would effectively make the server unselectable.
-	atomic.AddInt64(&p.inUseConnections, -1)
 
 	return p.checkInNoEvent(conn)
 }
@@ -775,10 +763,6 @@ func (p *pool) availableConnectionCount() int {
 	defer p.idleMu.Unlock()
 
 	return len(p.idleConns)
-}
-
-func (p *pool) inUseConnectionCount() int64 {
-	return atomic.LoadInt64(&p.inUseConnections)
 }
 
 // createConnections creates connections for wantConn requests on the newConnWait queue.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -265,7 +265,7 @@ func (s *Server) Connection(ctx context.Context) (driver.Connection, error) {
 
 	// Increment the operation count before calling checkOut to make sure that all connection
 	// requests are included in the operation count, including those in the wait queue. If we got an
-	// error insted of a connection, immediately decrement the operation count.
+	// error instead of a connection, immediately decrement the operation count.
 	atomic.AddInt64(&s.operationCount, 1)
 	conn, err := s.pool.checkOut(ctx)
 	if err != nil {

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -448,7 +448,7 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 		// Of the two randomly selected suitable servers, pick the one with fewer in-use connections.
 		// We use in-use connections as an analog for in-progress operations because they are almost
 		// always the same value for a given server.
-		if server1.pool.inUseConnectionCount() < server2.pool.inUseConnectionCount() {
+		if server1.OperationCount() < server2.OperationCount() {
 			return server1, nil
 		}
 		return server2, nil
@@ -686,7 +686,6 @@ func (t *Topology) processSRVResults(parsedHosts []string) bool {
 	t.subLock.Unlock()
 
 	return true
-
 }
 
 // apply updates the Topology and its underlying FSM based on the provided server description and returns the server

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -13,13 +13,12 @@ package topology // import "go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
@@ -407,20 +406,71 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 			continue
 		}
 
-		selected := suitable[random.Intn(len(suitable))]
-		selectedS, err := t.FindServer(selected)
-		switch {
-		case err != nil:
-			return nil, err
-		case selectedS != nil:
-			return selectedS, nil
-		default:
-			// We don't have an actual server for the provided description.
-			// This could happen for a number of reasons, including that the
-			// server has since stopped being a part of this topology, or that
-			// the server selector returned no suitable servers.
+		// If there's only one suitable server description, try to find the associated server and
+		// return it. This is an optimization primarily for standalone and load-balanced deployments.
+		if len(suitable) == 1 {
+			server, err := t.FindServer(suitable[0])
+			if err != nil {
+				return nil, err
+			}
+			if server == nil {
+				continue
+			}
+			return server, nil
 		}
+
+		// Randomly select 2 suitable server descriptions and find servers for them. We select two
+		// so we can pick the one with the one with fewer in-progress operations below.
+		desc1, desc2 := pick2(suitable)
+		server1, err := t.FindServer(desc1)
+		if err != nil {
+			return nil, err
+		}
+		server2, err := t.FindServer(desc2)
+		if err != nil {
+			return nil, err
+		}
+
+		// If we don't have an actual server for one or both of the provided descriptions, either
+		// return the one server we have, or try again if they're both nil. This could happen for a
+		// number of reasons, including that the server has since stopped being a part of this
+		// topology.
+		if server1 == nil || server2 == nil {
+			if server1 == nil && server2 == nil {
+				continue
+			}
+			if server1 != nil {
+				return server1, nil
+			}
+			return server2, nil
+		}
+
+		// Of the two randomly selected suitable servers, pick the one with fewer in-use connections.
+		// We use in-use connections as an analog for in-progress operations because they are almost
+		// always the same value for a given server.
+		if server1.pool.inUseConnectionCount() < server2.pool.inUseConnectionCount() {
+			return server1, nil
+		}
+		return server2, nil
 	}
+}
+
+// pick2 returns 2 random server descriptions from the input slice of server descriptions,
+// guaranteeing that the same element from the slice is not picked twice. The order of server
+// descriptions in the input slice may be modified. If fewer than 2 server descriptions are
+// provided, pick2 will panic.
+func pick2(ds []description.Server) (description.Server, description.Server) {
+	// Select a random index from the input slice and keep the server description from that index.
+	idx := random.Intn(len(ds))
+	s1 := ds[idx]
+
+	// Swap the selected index to the end and reslice to remove it so we don't pick the same server
+	// description twice.
+	ds[idx], ds[len(ds)-1] = ds[len(ds)-1], ds[idx]
+	ds = ds[:len(ds)-1]
+
+	// Select another random index from the input slice and return both selected server descriptions.
+	return s1, ds[random.Intn(len(ds))]
 }
 
 // FindServer will attempt to find a server that fits the given server description.

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -8,16 +8,23 @@ package topology
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"path"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
@@ -628,4 +635,207 @@ func TestTopologyConstruction(t *testing.T) {
 			})
 		}
 	})
+}
+
+type inWindowServer struct {
+	Address  string `json:"address"`
+	Type     string `json:"type"`
+	AvgRTTMS int64  `json:"avg_rtt_ms"`
+}
+
+type inWindowTopology struct {
+	Type    string           `json:"type"`
+	Servers []inWindowServer `json:"servers"`
+}
+
+type inWindowOutcome struct {
+	Tolerance           float64            `json:"tolerance"`
+	ExpectedFrequencies map[string]float64 `json:"expected_frequencies"`
+}
+
+type inWindowTopologyState struct {
+	Address        string `json:"address"`
+	OperationCount int64  `json:"operation_count"`
+}
+
+type inWindowTestCase struct {
+	TopologyDescription inWindowTopology        `json:"topology_description"`
+	MockedTopologyState []inWindowTopologyState `json:"mocked_topology_state"`
+	Iterations          int                     `json:"iterations"`
+	Outcome             inWindowOutcome         `json:"outcome"`
+}
+
+// TestServerSelectionSpecInWindow runs the "in_window" server selection spec tests. This test is
+// in the "topology" package instead of the "description" package (where the rest of the server
+// selection spec tests are) because it primarily tests load-based server selection. Load-based
+// server selection is implemented in Topology.SelectServer() because it requires knowledge of the
+// current "operation count" (the number of currently running operations) for each server, so it
+// can't be effectively accomplished just with server descriptions like most other server selection
+// algorithms.
+func TestServerSelectionSpecInWindow(t *testing.T) {
+	const testsDir = "../../../../data/server-selection/in_window"
+
+	files := testhelpers.FindJSONFilesInDir(t, testsDir)
+
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			runInWindowTest(t, testsDir, file)
+		})
+	}
+}
+
+func runInWindowTest(t *testing.T, directory string, filename string) {
+	filepath := path.Join(directory, filename)
+	content, err := ioutil.ReadFile(filepath)
+	require.NoError(t, err)
+
+	var test inWindowTestCase
+	require.NoError(t, json.Unmarshal(content, &test))
+
+	// For each server described in the test's "topology_description", create both a *Server and
+	// description.Server, which are both required to run Topology.SelectServer().
+	servers := make(map[string]*Server, len(test.TopologyDescription.Servers))
+	descriptions := make([]description.Server, 0, len(test.TopologyDescription.Servers))
+	for _, testDesc := range test.TopologyDescription.Servers {
+		server, err := NewServer(
+			address.Address(testDesc.Address),
+			primitive.NilObjectID,
+			withMonitoringDisabled(func(bool) bool { return true }))
+		require.NoError(t, err, "error creating new server")
+		servers[testDesc.Address] = server
+
+		desc := description.Server{
+			Kind:          serverKindFromString(t, testDesc.Type),
+			Addr:          address.Address(testDesc.Address),
+			AverageRTT:    time.Duration(testDesc.AvgRTTMS) * time.Millisecond,
+			AverageRTTSet: true,
+		}
+
+		if testDesc.AvgRTTMS > 0 {
+			desc.AverageRTT = time.Duration(testDesc.AvgRTTMS) * time.Millisecond
+			desc.AverageRTTSet = true
+		}
+
+		descriptions = append(descriptions, desc)
+	}
+
+	// For each server state in the test's "mocked_topology_state", set the connection pool's
+	// in-use connections count to the test operation count value.
+	for _, state := range test.MockedTopologyState {
+		servers[state.Address].pool.inUseConnections = state.OperationCount
+	}
+
+	// Create a new Topology, set the state to "connected", store a topology description
+	// containing all server descriptions created from the test server descriptions, and copy
+	// all *Server instances to the Topology's servers list.
+	topology, err := New()
+	require.NoError(t, err, "error creating new Topology")
+	topology.connectionstate = connected
+	topology.desc.Store(description.Topology{
+		Kind:    topologyKindFromString(t, test.TopologyDescription.Type),
+		Servers: descriptions,
+	})
+	for addr, server := range servers {
+		topology.servers[address.Address(addr)] = server
+	}
+
+	// Run server selection the required number of times and record how many times each server
+	// address was selected.
+	counts := make(map[string]int, len(test.TopologyDescription.Servers))
+	for i := 0; i < test.Iterations; i++ {
+		selected, err := topology.SelectServer(
+			context.Background(),
+			description.ReadPrefSelector(readpref.Nearest()))
+		require.NoError(t, err, "error selecting server")
+		counts[string(selected.(*SelectedServer).address)]++
+	}
+
+	// Convert the server selection counts to selection frequencies by dividing the counts by
+	// the total number of server selection attempts.
+	frequencies := make(map[string]float64, len(counts))
+	for addr, count := range counts {
+		frequencies[addr] = float64(count) / float64(test.Iterations)
+	}
+
+	// Assert that the observed server selection frequency for each server address matches the
+	// expected server selection frequency.
+	for addr, expected := range test.Outcome.ExpectedFrequencies {
+		actual := frequencies[addr]
+
+		// If the expected frequency for a given server is 1 or 0, then the observed frequency
+		// MUST be exactly equal to the expected one.
+		if expected == 1 || expected == 0 {
+			assert.Equal(
+				t,
+				expected,
+				actual,
+				"expected frequency of %q to be equal to %f, but is %f",
+				addr, expected, actual)
+			continue
+		}
+
+		// Otherwise, check if the expected frequency is within the given tolerance range.
+		low := expected - test.Outcome.Tolerance
+		high := expected + test.Outcome.Tolerance
+		assert.True(
+			t,
+			actual >= low && actual <= high,
+			"expected frequency of %q to be in range [%f, %f], but is %f",
+			addr, low, high, actual)
+	}
+}
+
+func topologyKindFromString(t *testing.T, s string) description.TopologyKind {
+	t.Helper()
+
+	switch s {
+	case "Single":
+		return description.Single
+	case "ReplicaSet":
+		return description.ReplicaSet
+	case "ReplicaSetNoPrimary":
+		return description.ReplicaSetNoPrimary
+	case "ReplicaSetWithPrimary":
+		return description.ReplicaSetWithPrimary
+	case "Sharded":
+		return description.Sharded
+	case "LoadBalanced":
+		return description.LoadBalanced
+	case "Unknown":
+		return description.Unknown
+	default:
+		t.Fatalf("unrecognized topology kind: %q", s)
+	}
+
+	return description.Unknown
+}
+
+func serverKindFromString(t *testing.T, s string) description.ServerKind {
+	t.Helper()
+
+	switch s {
+	case "Standalone":
+		return description.Standalone
+	case "RSOther":
+		return description.RSMember
+	case "RSPrimary":
+		return description.RSPrimary
+	case "RSSecondary":
+		return description.RSSecondary
+	case "RSArbiter":
+		return description.RSArbiter
+	case "RSGhost":
+		return description.RSGhost
+	case "Mongos":
+		return description.Mongos
+	case "LoadBalancer":
+		return description.LoadBalancer
+	case "PossiblePrimary", "Unknown":
+		// Go does not have a PossiblePrimary server type and per the SDAM spec, this type is synonymous with Unknown.
+		return description.Unknown
+	default:
+		t.Fatalf("unrecognized server kind: %q", s)
+	}
+
+	return description.Unknown
 }

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -722,7 +722,7 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 	// For each server state in the test's "mocked_topology_state", set the connection pool's
 	// in-use connections count to the test operation count value.
 	for _, state := range test.MockedTopologyState {
-		servers[state.Address].pool.inUseConnections = state.OperationCount
+		servers[state.Address].operationCount = state.OperationCount
 	}
 
 	// Create a new Topology, set the state to "connected", store a topology description
@@ -730,7 +730,7 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 	// all *Server instances to the Topology's servers list.
 	topology, err := New()
 	require.NoError(t, err, "error creating new Topology")
-	topology.connectionstate = connected
+	topology.state = topologyConnected
 	topology.desc.Store(description.Topology{
 		Kind:    topologyKindFromString(t, test.TopologyDescription.Type),
 		Servers: descriptions,
@@ -775,6 +775,8 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 		}
 
 		// Otherwise, check if the expected frequency is within the given tolerance range.
+		// TODO(GODRIVER-2179): Use assert.Deltaf() when we migrate all test code to the
+		// "testify/assert" or an API-compatible library for assertions.
 		low := expected - test.Outcome.Tolerance
 		high := expected + test.Outcome.Tolerance
 		assert.True(


### PR DESCRIPTION
[GODRIVER-1825](https://jira.mongodb.org/browse/GODRIVER-1825)

Update `Topology.SelectServer()` to pick 2 random servers from the list of selectable servers, and return the one with fewer  in-progress operations to more evenly balance load across the selectable servers.

Changes:
* Add an `operationCount` counter in `Server` that keeps track of the number of requests for connections. Note that `operationCount` is not decremented while a connection is pinned to a transaction until the transaction is committed or aborted.
* Pick 2 random servers from the list of selectable servers in `Topology.SelectServer()` and return the one with fewer in-progress operations.
* Add a prose test for the one described in [operationCount-based Selection Within Latency Window](https://github.com/mongodb/specifications/blob/1028c348c86bb2c0ea313c30ed8320825048fe5d/source/server-selection/server-selection-tests.rst#prose-test).
* Add a test runner for the the [in_window](https://github.com/mongodb/specifications/tree/1028c348c86bb2c0ea313c30ed8320825048fe5d/source/server-selection/tests/in_window) server selection spec tests and sync all tests in that directory.