### PR TITLE
GODRIVER-2218 Bump connection idle deadline on pool checkIn.

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -208,8 +208,6 @@ func (c *connection) connect(ctx context.Context) (err error) {
 		c.nc = tlsNc
 	}
 
-	c.bumpIdleDeadline()
-
 	// running hello and authentication is handled by a handshaker on the configuration instance.
 	handshaker := c.config.handshaker
 	if handshaker == nil {
@@ -364,7 +362,6 @@ func (c *connection) writeWireMessage(ctx context.Context, wm []byte) error {
 		}
 	}
 
-	c.bumpIdleDeadline()
 	return nil
 }
 
@@ -429,7 +426,6 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 		}
 	}
 
-	c.bumpIdleDeadline()
 	return dst, nil
 }
 

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -596,6 +596,8 @@ func (p *pool) checkInNoEvent(conn *connection) error {
 		return ErrWrongPool
 	}
 
+	conn.bumpIdleDeadline()
+
 	if reason, perished := connectionPerished(conn); perished {
 		_ = p.removeConnection(conn, reason)
 		go func() {

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -596,6 +596,12 @@ func (p *pool) checkInNoEvent(conn *connection) error {
 		return ErrWrongPool
 	}
 
+	// Bump the connection idle deadline here because we're about to make the connection "available".
+	// The idle deadline is used to determine when a connection has reached its max idle time and
+	// should be closed. A connection reaches its max idle time when it has been "available" in the
+	// idle connections stack for more than the configured duration (maxIdleTimeMS). Set it before
+	// we call connectionPerished(), which checks the idle deadline, because a newly "available"
+	// connection should never be perished due to max idle time.
 	conn.bumpIdleDeadline()
 
 	if reason, perished := connectionPerished(conn); perished {

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -853,7 +853,7 @@ func TestPool(t *testing.T) {
 			d := newdialer(&net.Dialer{})
 			p := newPool(poolConfig{
 				Address:     address.Address(addr.String()),
-				MaxIdleTime: 1 * time.Millisecond,
+				MaxIdleTime: 100 * time.Millisecond,
 			}, WithDialer(func(Dialer) Dialer { return d }))
 			err := p.ready()
 			noerr(t, err)
@@ -862,10 +862,10 @@ func TestPool(t *testing.T) {
 			c, err := p.checkOut(context.Background())
 			noerr(t, err)
 
-			// Sleep for 10ms, which will exceed the 1ms connection idle timeout. Then check the
+			// Sleep for 110ms, which will exceed the 100ms connection idle timeout. Then check the
 			// connection back in and expect that it is not closed because checkIn() should bump the
 			// connection idle deadline.
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(110 * time.Millisecond)
 			err = p.checkIn(c)
 			noerr(t, err)
 

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -840,6 +840,77 @@ func TestPool(t *testing.T) {
 			p1.close(context.Background())
 			p2.close(context.Background())
 		})
+		t.Run("bumps the connection idle deadline", func(t *testing.T) {
+			t.Parallel()
+
+			cleanup := make(chan struct{})
+			defer close(cleanup)
+			addr := bootstrapConnections(t, 1, func(nc net.Conn) {
+				<-cleanup
+				_ = nc.Close()
+			})
+
+			d := newdialer(&net.Dialer{})
+			p := newPool(poolConfig{
+				Address:     address.Address(addr.String()),
+				MaxIdleTime: 1 * time.Millisecond,
+			}, WithDialer(func(Dialer) Dialer { return d }))
+			err := p.ready()
+			noerr(t, err)
+
+			c, err := p.checkOut(context.Background())
+			noerr(t, err)
+
+			// Sleep for 10ms, which will exceed the 1ms connection idle timeout. Then check the
+			// connection back in and expect that it is not closed because checkIn() should bump the
+			// connection idle deadline.
+			time.Sleep(10 * time.Millisecond)
+			err = p.checkIn(c)
+			noerr(t, err)
+
+			assert.Equalf(t, 0, d.lenclosed(), "should have closed 0 connections")
+			assert.Equalf(t, 1, p.availableConnectionCount(), "should have 1 idle connections in pool")
+			assert.Equalf(t, 1, p.totalConnectionCount(), "should have 1 total connection in pool")
+
+			p.close(context.Background())
+		})
+		t.Run("sets minPoolSize connection idle deadline", func(t *testing.T) {
+			t.Parallel()
+
+			cleanup := make(chan struct{})
+			defer close(cleanup)
+			addr := bootstrapConnections(t, 4, func(nc net.Conn) {
+				<-cleanup
+				_ = nc.Close()
+			})
+
+			d := newdialer(&net.Dialer{})
+			p := newPool(poolConfig{
+				Address:     address.Address(addr.String()),
+				MinPoolSize: 3,
+				MaxIdleTime: 10 * time.Millisecond,
+			}, WithDialer(func(Dialer) Dialer { return d }))
+			err := p.ready()
+			noerr(t, err)
+
+			// Wait for maintain() to open 3 connections.
+			assertConnectionsOpened(t, d, 3)
+
+			// Sleep for 100ms, which will exceed the 10ms connection idle timeout, then try to check
+			// out a connection. Expect that all minPoolSize connections checked into the pool by
+			// maintain() have passed their idle deadline, so checkOut() close all 3 connections and
+			// try to create a new connection.
+			time.Sleep(100 * time.Millisecond)
+			_, err = p.checkOut(context.Background())
+			noerr(t, err)
+
+			assertConnectionsClosed(t, d, 3)
+			assert.Equalf(t, 4, d.lenopened(), "should have opened 4 connections")
+			assert.Equalf(t, 0, p.availableConnectionCount(), "should have 0 idle connections in pool")
+			assert.Equalf(t, 1, p.totalConnectionCount(), "should have 1 total connection in pool")
+
+			p.close(context.Background())
+		})
 	})
 	t.Run("maintain", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
[GODRIVER-2218](https://jira.mongodb.org/browse/GODRIVER-2218)

Currently a connection's "idle deadline" is increased in the Go driver only when [reading](https://github.com/mongodb/mongo-go-driver/blob/223854caf2932b7d9aa42d3255eea2cb13acf8f3/x/mongo/driver/topology/connection.go#L432) [writing](https://github.com/mongodb/mongo-go-driver/blob/223854caf2932b7d9aa42d3255eea2cb13acf8f3/x/mongo/driver/topology/connection.go#L367) to the connection. However, the [CMAP spec](https://github.com/mongodb/specifications/blob/5964c134a85707dcfa3c54b7f9f88d3451f4a175/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-1) defines "idle" as:

> Idle: The Connection is currently "available" (as defined below) and has been for longer than maxIdleTimeMS.

"Available" is defined as:

> The Connection has been established and is waiting in the pool to be checked out.

As a result, it's currently possible to check in a connection to the pool that has not been read from or written to for more than `maxIdleTimeMS` and it will be considered stale due to idle timeout. According to the definition of "idle" in the CMAP spec, that should be impossible.

Bump the connection idle deadline when checking connections into the pool.

Changes:
* Run `conn.bumpIdleDeadline()` in `pool.checkInNoEvent()`.
* Remove all other calls to `conn.bumpIdleDeadline()` because they are now unnecessary.
* Add a test that asserts checked-out but unused connections are not considered idle.
* Add a test that asserts connections checked in by `maintain()` have an idle deadline set.