### PR TITLE
GODRIVER-2181 Use dedicated state constants for each topology type.

### DIFF
--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -133,7 +133,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 			return &event.PoolMonitor{func(event *event.PoolEvent) { testInfo.originalEventChan <- event }}
 		}))
 	testHelpers.RequireNil(t, err, "error creating server: %v", err)
-	s.connectionstate = connected
+	s.state = serverConnected
 	testHelpers.RequireNil(t, err, "error connecting connection pool: %v", err)
 	defer s.pool.close(context.Background())
 

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -27,6 +27,13 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
+// Connection state constants.
+const (
+	connDisconnected int64 = iota
+	connConnected
+	connInitialized
+)
+
 var globalConnectionID uint64 = 1
 
 var (
@@ -38,10 +45,10 @@ var (
 func nextConnectionID() uint64 { return atomic.AddUint64(&globalConnectionID, 1) }
 
 type connection struct {
-	// connected must be accessed using the atomic package and should be at the beginning of the struct.
+	// state must be accessed using the atomic package and should be at the beginning of the struct.
 	// - atomic bug: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	// - suggested layout: https://go101.org/article/memory-layout.html
-	connected int64
+	state int64
 
 	id                   string
 	nc                   net.Conn // When nil, the connection is closed.
@@ -93,7 +100,7 @@ func newConnection(addr address.Address, opts ...ConnectionOption) *connection {
 	if !c.config.loadBalanced {
 		c.setGenerationNumber()
 	}
-	atomic.StoreInt64(&c.connected, initialized)
+	atomic.StoreInt64(&c.state, connInitialized)
 
 	return c
 }
@@ -123,7 +130,7 @@ func (c *connection) hasGenerationNumber() bool {
 // handshakes. All errors returned by connect are considered "before the handshake completes" and
 // must be handled by calling the appropriate SDAM handshake error handler.
 func (c *connection) connect(ctx context.Context) (err error) {
-	if !atomic.CompareAndSwapInt64(&c.connected, initialized, connected) {
+	if !atomic.CompareAndSwapInt64(&c.state, connInitialized, connConnected) {
 		return nil
 	}
 
@@ -133,7 +140,7 @@ func (c *connection) connect(ctx context.Context) (err error) {
 	// underlying net.Conn if it was created.
 	defer func() {
 		if err != nil {
-			atomic.StoreInt64(&c.connected, disconnected)
+			atomic.StoreInt64(&c.state, connDisconnected)
 
 			if c.nc != nil {
 				_ = c.nc.Close()
@@ -323,7 +330,7 @@ func (c *connection) cancellationListenerCallback() {
 
 func (c *connection) writeWireMessage(ctx context.Context, wm []byte) error {
 	var err error
-	if atomic.LoadInt64(&c.connected) != connected {
+	if atomic.LoadInt64(&c.state) != connConnected {
 		return ConnectionError{ConnectionID: c.id, message: "connection is closed"}
 	}
 	select {
@@ -380,7 +387,7 @@ func (c *connection) write(ctx context.Context, wm []byte) (err error) {
 
 // readWireMessage reads a wiremessage from the connection. The dst parameter will be overwritten.
 func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
-	if atomic.LoadInt64(&c.connected) != connected {
+	if atomic.LoadInt64(&c.state) != connConnected {
 		return dst, ConnectionError{ConnectionID: c.id, message: "connection is closed"}
 	}
 
@@ -483,7 +490,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 
 func (c *connection) close() error {
 	// Overwrite the connection state as the first step so only the first close call will execute.
-	if !atomic.CompareAndSwapInt64(&c.connected, connected, disconnected) {
+	if !atomic.CompareAndSwapInt64(&c.state, connConnected, connDisconnected) {
 		return nil
 	}
 
@@ -496,7 +503,7 @@ func (c *connection) close() error {
 }
 
 func (c *connection) closed() bool {
-	return atomic.LoadInt64(&c.connected) == disconnected
+	return atomic.LoadInt64(&c.state) == connDisconnected
 }
 
 func (c *connection) idleTimeoutExpired() bool {

--- a/x/mongo/driver/topology/connection_errors_test.go
+++ b/x/mongo/driver/topology/connection_errors_test.go
@@ -53,14 +53,14 @@ func TestConnectionErrors(t *testing.T) {
 		t.Run("write error", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			conn := &connection{id: "foobar", nc: &net.TCPConn{}, connected: connected}
+			conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
 			err := conn.writeWireMessage(ctx, []byte{})
 			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
 		})
 		t.Run("read error", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			conn := &connection{id: "foobar", nc: &net.TCPConn{}, connected: connected}
+			conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
 			_, err := conn.readWireMessage(ctx, []byte{})
 			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
 		})

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -505,7 +505,7 @@ func (p *pool) closeConnection(conn *connection) error {
 		return ErrWrongPool
 	}
 
-	if atomic.LoadInt64(&conn.connected) == connected {
+	if atomic.LoadInt64(&conn.state) == connConnected {
 		conn.closeConnectContext()
 		conn.wait() // Make sure that the connection has finished connecting.
 	}

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -232,7 +232,7 @@ func TestPool(t *testing.T) {
 					time.Sleep(time.Millisecond)
 				}
 				for _, c := range conns {
-					assert.Equalf(t, connected, c.connected, "expected conn to still be connected")
+					assert.Equalf(t, connConnected, c.state, "expected conn to still be connected")
 
 					err := p.checkIn(c)
 					noerr(t, err)

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -286,7 +286,7 @@ func TestServer(t *testing.T) {
 			require.NoError(t, err, "pool.ready() error")
 			defer s.pool.close(context.Background())
 
-			s.connectionstate = connected
+			s.state = serverConnected
 
 			// The internal connection pool resets the generation number once the number of connections in a generation
 			// reaches zero, which will cause some of these tests to fail because they assert that the generation
@@ -472,7 +472,7 @@ func TestServer(t *testing.T) {
 				return 1
 			}))
 		noerr(t, err)
-		s.connectionstate = connected
+		s.state = serverConnected
 		err = s.pool.ready()
 		noerr(t, err)
 		defer s.pool.close(context.Background())
@@ -606,7 +606,7 @@ func TestServer(t *testing.T) {
 				server, err := NewServer(address.Address("localhost"), primitive.NewObjectID())
 				assert.Nil(t, err, "NewServer error: %v", err)
 
-				server.connectionstate = connected
+				server.state = serverConnected
 				err = server.pool.ready()
 				assert.Nil(t, err, "pool.ready() error: %v", err)
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -30,6 +30,14 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/dns"
 )
 
+// Topology state constants.
+const (
+	topologyDisconnected int64 = iota
+	topologyDisconnecting
+	topologyConnected
+	topologyConnecting
+)
+
 // ErrSubscribeAfterClosed is returned when a user attempts to subscribe to a
 // closed Server or Topology.
 var ErrSubscribeAfterClosed = errors.New("cannot subscribe after closeConnection")
@@ -60,7 +68,7 @@ const (
 
 // Topology represents a MongoDB deployment.
 type Topology struct {
-	connectionstate int64
+	state int64
 
 	cfg *config
 
@@ -148,7 +156,7 @@ func New(opts ...Option) (*Topology, error) {
 // Connect initializes a Topology and starts the monitoring process. This function
 // must be called to properly monitor the topology.
 func (t *Topology) Connect() error {
-	if !atomic.CompareAndSwapInt64(&t.connectionstate, disconnected, connecting) {
+	if !atomic.CompareAndSwapInt64(&t.state, topologyDisconnected, topologyConnecting) {
 		return ErrTopologyConnected
 	}
 
@@ -230,14 +238,14 @@ func (t *Topology) Connect() error {
 
 	t.subscriptionsClosed = false // explicitly set in case topology was disconnected and then reconnected
 
-	atomic.StoreInt64(&t.connectionstate, connected)
+	atomic.StoreInt64(&t.state, topologyConnected)
 	return nil
 }
 
 // Disconnect closes the topology. It stops the monitoring thread and
 // closes all open subscriptions.
 func (t *Topology) Disconnect(ctx context.Context) error {
-	if !atomic.CompareAndSwapInt64(&t.connectionstate, connected, disconnecting) {
+	if !atomic.CompareAndSwapInt64(&t.state, topologyConnected, topologyDisconnecting) {
 		return ErrTopologyClosed
 	}
 
@@ -269,7 +277,7 @@ func (t *Topology) Disconnect(ctx context.Context) error {
 
 	t.desc.Store(description.Topology{})
 
-	atomic.StoreInt64(&t.connectionstate, disconnected)
+	atomic.StoreInt64(&t.state, topologyDisconnected)
 	t.publishTopologyClosedEvent()
 	return nil
 }
@@ -291,7 +299,7 @@ func (t *Topology) Kind() description.TopologyKind { return t.Description().Kind
 // and will be pre-populated with the current description.Topology.
 // Subscribe implements the driver.Subscriber interface.
 func (t *Topology) Subscribe() (*driver.Subscription, error) {
-	if atomic.LoadInt64(&t.connectionstate) != connected {
+	if atomic.LoadInt64(&t.state) != topologyConnected {
 		return nil, errors.New("cannot subscribe to Topology that is not connected")
 	}
 	ch := make(chan description.Topology, 1)
@@ -339,7 +347,7 @@ func (t *Topology) Unsubscribe(sub *driver.Subscription) error {
 // RequestImmediateCheck will send heartbeats to all the servers in the
 // topology right away, instead of waiting for the heartbeat timeout.
 func (t *Topology) RequestImmediateCheck() {
-	if atomic.LoadInt64(&t.connectionstate) != connected {
+	if atomic.LoadInt64(&t.state) != topologyConnected {
 		return
 	}
 	t.serversLock.Lock()
@@ -353,7 +361,7 @@ func (t *Topology) RequestImmediateCheck() {
 // server selection spec, and will time out after severSelectionTimeout or when the
 // parent context is done.
 func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelector) (driver.Server, error) {
-	if atomic.LoadInt64(&t.connectionstate) != connected {
+	if atomic.LoadInt64(&t.state) != topologyConnected {
 		return nil, ErrTopologyClosed
 	}
 	var ssTimeoutCh <-chan time.Time
@@ -418,7 +426,7 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 // FindServer will attempt to find a server that fits the given server description.
 // This method will return nil, nil if a matching server could not be found.
 func (t *Topology) FindServer(selected description.Server) (*SelectedServer, error) {
-	if atomic.LoadInt64(&t.connectionstate) != connected {
+	if atomic.LoadInt64(&t.state) != topologyConnected {
 		return nil, ErrTopologyClosed
 	}
 	t.serversLock.Lock()

--- a/x/mongo/driver/topology/topology_errors_test.go
+++ b/x/mongo/driver/topology/topology_errors_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build go1.13
 // +build go1.13
 
 package topology
@@ -30,7 +31,7 @@ func TestTopologyErrors(t *testing.T) {
 			noerr(t, err)
 
 			topo.cfg.cs.HeartbeatInterval = time.Minute
-			atomic.StoreInt64(&topo.connectionstate, connected)
+			atomic.StoreInt64(&topo.state, topologyConnected)
 			desc := description.Topology{
 				Servers: []description.Server{},
 			}

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -104,7 +104,7 @@ func TestServerSelection(t *testing.T) {
 			SupportedWireVersions.Max,
 		)
 		desc.CompatibilityErr = want
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
 		assert.Equal(t, err, want, "expected %v, got %v", want, err)
@@ -129,7 +129,7 @@ func TestServerSelection(t *testing.T) {
 			MinSupportedMongoDBVersion,
 		)
 		desc.CompatibilityErr = want
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 		topo.desc.Store(desc)
 		_, err = topo.SelectServer(context.Background(), selectFirst)
 		assert.Equal(t, err, want, "expected %v, got %v", want, err)
@@ -282,7 +282,7 @@ func TestServerSelection(t *testing.T) {
 	t.Run("findServer returns topology kind", func(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 		srvr, err := ConnectServer(address.Address("one"), topo.updateCallback, topo.id)
 		noerr(t, err)
 		topo.servers[address.Address("one")] = srvr
@@ -302,7 +302,7 @@ func TestServerSelection(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 
 		addr1 := address.Address("one")
 		addr2 := address.Address("two")
@@ -337,7 +337,7 @@ func TestServerSelection(t *testing.T) {
 		// send a not primary error to the server forcing an update
 		serv, err := topo.FindServer(desc.Servers[0])
 		noerr(t, err)
-		atomic.StoreInt64(&serv.connectionstate, connected)
+		atomic.StoreInt64(&serv.state, serverConnected)
 		_ = serv.ProcessError(driver.Error{Message: internal.LegacyNotPrimary}, initConnection{})
 
 		resp := make(chan []description.Server)
@@ -369,7 +369,7 @@ func TestServerSelection(t *testing.T) {
 		topo, err := New()
 		noerr(t, err)
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 
 		primaryAddr := address.Address("one")
 		desc := description.Topology{
@@ -399,7 +399,7 @@ func TestServerSelection(t *testing.T) {
 		noerr(t, err)
 
 		topo.cfg.cs.HeartbeatInterval = time.Minute
-		atomic.StoreInt64(&topo.connectionstate, connected)
+		atomic.StoreInt64(&topo.state, topologyConnected)
 		desc := description.Topology{
 			Servers: []description.Server{},
 		}


### PR DESCRIPTION
[GODRIVER-2181](https://jira.mongodb.org/browse/GODRIVER-2181)

Use dedicated constants for each of the `connection`, `pool`, `poolGenerationMap`, `Server`, and `Topology` types.

* Add new state constants for the `connection`, `poolGenerationMap`, `Server`, and `Topology` types following the existing naming pattern of the `pool` state constants.
* Remove any unused states for each type.
* Rename the "state" field in each of the above types to `state`.