### PR TITLE
GODRIVER-2311 Ensure unmarshaled BSON values always use distinct underlying byte arrays.

### DIFF
--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -748,7 +748,11 @@ func (vr *valueReader) readBytes(length int32) ([]byte, error) {
 
 	start := vr.offset
 	vr.offset += int64(length)
-	return vr.d[start : start+int64(length)], nil
+
+	b := make([]byte, length)
+	copy(b, vr.d[start:start+int64(length)])
+
+	return b, nil
 }
 
 func (vr *valueReader) appendBytes(dst []byte, length int32) ([]byte, error) {

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -7,22 +7,36 @@
 package bson
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestUnmarshal(t *testing.T) {
 	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy of the test data so we can modify it later.
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+
+			// Assert that unmarshaling the input data results in the expected value.
 			got := reflect.New(tc.sType).Interface()
-			err := Unmarshal(tc.data, got)
+			err := Unmarshal(data, got)
 			noerr(t, err)
 			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
+
+			// Fill the input data slice with random bytes and then assert that the result still
+			// matches the expected value.
+			_, err = rand.Read(data)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match expected after modifying the input bytes")
 		})
 	}
 }
@@ -30,10 +44,21 @@ func TestUnmarshal(t *testing.T) {
 func TestUnmarshalWithRegistry(t *testing.T) {
 	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy of the test data so we can modify it later.
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+
+			// Assert that unmarshaling the input data results in the expected value.
 			got := reflect.New(tc.sType).Interface()
-			err := UnmarshalWithRegistry(DefaultRegistry, tc.data, got)
+			err := UnmarshalWithRegistry(DefaultRegistry, data, got)
 			noerr(t, err)
 			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
+
+			// Fill the input data slice with random bytes and then assert that the result still
+			// matches the expected value.
+			_, err = rand.Read(data)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match expected after modifying the input bytes")
 		})
 	}
 }
@@ -41,11 +66,22 @@ func TestUnmarshalWithRegistry(t *testing.T) {
 func TestUnmarshalWithContext(t *testing.T) {
 	for _, tc := range unmarshalingTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy of the test data so we can modify it later.
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+
+			// Assert that unmarshaling the input data results in the expected value.
 			dc := bsoncodec.DecodeContext{Registry: DefaultRegistry}
 			got := reflect.New(tc.sType).Interface()
-			err := UnmarshalWithContext(dc, tc.data, got)
+			err := UnmarshalWithContext(dc, data, got)
 			noerr(t, err)
 			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
+
+			// Fill the input data slice with random bytes and then assert that the result still
+			// matches the expected value.
+			_, err = rand.Read(data)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match expected after modifying the input bytes")
 		})
 	}
 }
@@ -77,6 +113,10 @@ func TestUnmarshalExtJSONWithContext(t *testing.T) {
 
 	type fooString struct {
 		Foo string
+	}
+
+	type fooBytes struct {
+		Foo []byte
 	}
 
 	var cases = []struct {
@@ -133,15 +173,44 @@ func TestUnmarshalExtJSONWithContext(t *testing.T) {
 			data:  []byte(`{"foo":"\uD834\u00BF"}`),
 			want:  &fooString{Foo: "�¿"},
 		},
+		// GODRIVER-2311
+		// Test that ExtJSON-encoded binary unmarshals correctly to a bson.D and that the
+		// unmarshaled value does not reference the same underlying byte array as the input.
+		{
+			name:  "bson.D with binary",
+			sType: reflect.TypeOf(D{}),
+			data:  []byte(`{"foo": {"$binary": {"subType": "0", "base64": "AAECAwQF"}}}`),
+			want:  &D{{"foo", primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}}}},
+		},
+		// GODRIVER-2311
+		// Test that ExtJSON-encoded binary unmarshals correctly to a struct and that the
+		// unmarshaled value does not reference thesame  underlying byte array as the input.
+		{
+			name:  "struct with binary",
+			sType: reflect.TypeOf(fooBytes{}),
+			data:  []byte(`{"foo": {"$binary": {"subType": "0", "base64": "AAECAwQF"}}}`),
+			want:  &fooBytes{Foo: []byte{0, 1, 2, 3, 4, 5}},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy of the test data so we can modify it later.
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+
+			// Assert that unmarshaling the input data results in the expected value.
 			got := reflect.New(tc.sType).Interface()
 			dc := bsoncodec.DecodeContext{Registry: DefaultRegistry}
-			err := UnmarshalExtJSONWithContext(dc, tc.data, true, got)
+			err := UnmarshalExtJSONWithContext(dc, data, true, got)
 			noerr(t, err)
 			assert.Equal(t, tc.want, got, "Did not unmarshal as expected.")
+
+			// Fill the input data slice with random bytes and then assert that the result still
+			// matches the expected value.
+			_, err = rand.Read(data)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match expected after modifying the input bytes")
 		})
 	}
 }
@@ -495,4 +564,255 @@ func TestUnmarshalBSONWithUndefinedField(t *testing.T) {
 			assert.Equal(t, "value", responseDoc.DefinedField, "expected DefinedField to be 'value', got %q", responseDoc.DefinedField)
 		})
 	}
+}
+
+// GODRIVER-2311
+// Assert that unmarshaled values containing byte slices do not reference the same underlying byte
+// array as the BSON input data byte slice.
+func TestUnmarshalByteSlicesUseDistinctArrays(t *testing.T) {
+	type fooBytes struct {
+		Foo []byte
+	}
+
+	type myBytes []byte
+	type fooMyBytes struct {
+		Foo myBytes
+	}
+
+	type fooBinary struct {
+		Foo primitive.Binary
+	}
+
+	type fooObjectID struct {
+		Foo primitive.ObjectID
+	}
+
+	type fooDBPointer struct {
+		Foo primitive.DBPointer
+	}
+
+	testCases := []struct {
+		description string
+		data        []byte
+		sType       reflect.Type
+		want        interface{}
+
+		// getByteSlice returns the byte slice from the unmarshaled value, allowing the test to
+		// inspect the addresses of the underlying byte array.
+		getByteSlice func(interface{}) []byte
+	}{
+		{
+			description: "struct with byte slice",
+			data: docToBytes(fooBytes{
+				Foo: []byte{0, 1, 2, 3, 4, 5},
+			}),
+			sType: reflect.TypeOf(fooBytes{}),
+			want: &fooBytes{
+				Foo: []byte{0, 1, 2, 3, 4, 5},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*fooBytes))).Foo
+			},
+		},
+		{
+			description: "bson.D with byte slice",
+			data: docToBytes(D{
+				{"foo", []byte{0, 1, 2, 3, 4, 5}},
+			}),
+			sType: reflect.TypeOf(D{}),
+			want: &D{
+				{"foo", primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*D)))[0].Value.(primitive.Binary).Data
+			},
+		},
+		{
+			description: "struct with custom byte slice type",
+			data: docToBytes(fooMyBytes{
+				Foo: myBytes{0, 1, 2, 3, 4, 5},
+			}),
+			sType: reflect.TypeOf(fooMyBytes{}),
+			want: &fooMyBytes{
+				Foo: myBytes{0, 1, 2, 3, 4, 5},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*fooMyBytes))).Foo
+			},
+		},
+		{
+			description: "bson.D with custom byte slice type",
+			data: docToBytes(D{
+				{"foo", myBytes{0, 1, 2, 3, 4, 5}},
+			}),
+			sType: reflect.TypeOf(D{}),
+			want: &D{
+				{"foo", primitive.Binary{Subtype: 0, Data: myBytes{0, 1, 2, 3, 4, 5}}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*D)))[0].Value.(primitive.Binary).Data
+			},
+		},
+		{
+			description: "struct with primitive.Binary",
+			data: docToBytes(fooBinary{
+				Foo: primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}},
+			}),
+			sType: reflect.TypeOf(fooBinary{}),
+			want: &fooBinary{
+				Foo: primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*fooBinary))).Foo.Data
+			},
+		},
+		{
+			description: "bson.D with primitive.Binary",
+			data: docToBytes(D{
+				{"foo", primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}}},
+			}),
+			sType: reflect.TypeOf(D{}),
+			want: &D{
+				{"foo", primitive.Binary{Subtype: 0, Data: []byte{0, 1, 2, 3, 4, 5}}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*D)))[0].Value.(primitive.Binary).Data
+			},
+		},
+		{
+			description: "struct with primitive.ObjectID",
+			data: docToBytes(fooObjectID{
+				Foo: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+			}),
+			sType: reflect.TypeOf(fooObjectID{}),
+			want: &fooObjectID{
+				Foo: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*fooObjectID))).Foo[:]
+			},
+		},
+		{
+			description: "bson.D with primitive.ObjectID",
+			data: docToBytes(D{
+				{"foo", primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+			}),
+			sType: reflect.TypeOf(D{}),
+			want: &D{
+				{"foo", primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				oid := (*(val.(*D)))[0].Value.(primitive.ObjectID)
+				return oid[:]
+			},
+		},
+		{
+			description: "struct with primitive.DBPointer",
+			data: docToBytes(fooDBPointer{
+				Foo: primitive.DBPointer{
+					DB:      "test",
+					Pointer: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+				},
+			}),
+			sType: reflect.TypeOf(fooDBPointer{}),
+			want: &fooDBPointer{
+				Foo: primitive.DBPointer{
+					DB:      "test",
+					Pointer: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+				},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				return (*(val.(*fooDBPointer))).Foo.Pointer[:]
+			},
+		},
+		{
+			description: "bson.D with primitive.DBPointer",
+			data: docToBytes(D{
+				{"foo", primitive.DBPointer{
+					DB:      "test",
+					Pointer: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+				}},
+			}),
+			sType: reflect.TypeOf(D{}),
+			want: &D{
+				{"foo", primitive.DBPointer{
+					DB:      "test",
+					Pointer: primitive.ObjectID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+				}},
+			},
+			getByteSlice: func(val interface{}) []byte {
+				oid := (*(val.(*D)))[0].Value.(primitive.DBPointer).Pointer
+				return oid[:]
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			// Make a copy of the test data so we can modify it later.
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+
+			// Assert that unmarshaling the input data results in the expected value.
+			got := reflect.New(tc.sType).Interface()
+			err := Unmarshal(data, got)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match the expected value")
+
+			// Fill the input data slice with random bytes and then assert that the result still
+			// matches the expected value.
+			_, err = rand.Read(data)
+			noerr(t, err)
+			assert.Equal(t, tc.want, got, "unmarshaled value does not match expected after modifying the input bytes")
+
+			// Assert that the byte slice in the unmarshaled value does not share any memory
+			// addresses with the input byte slice.
+			assertDifferentArrays(t, data, tc.getByteSlice(got))
+		})
+	}
+}
+
+// assertDifferentArrays asserts that two byte slices reference distinct memory ranges, meaning
+// they reference different underlying byte arrays.
+func assertDifferentArrays(t *testing.T, a, b []byte) {
+	// Find the start and end memory addresses for the underlying byte array for each input byte
+	// slice.
+	sliceAddrRange := func(b []byte) (uintptr, uintptr) {
+		sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+		return sh.Data, sh.Data + uintptr(sh.Cap-1)
+	}
+	aStart, aEnd := sliceAddrRange(a)
+	bStart, bEnd := sliceAddrRange(b)
+
+	// If "b" starts after "a" ends or "a" starts after "b" ends, there is no overlap.
+	if bStart > aEnd || aStart > bEnd {
+		return
+	}
+
+	// Otherwise, calculate the overlap start and end and print the memory overlap error message.
+	min := func(a, b uintptr) uintptr {
+		if a < b {
+			return a
+		}
+		return b
+	}
+	max := func(a, b uintptr) uintptr {
+		if a > b {
+			return a
+		}
+		return b
+	}
+	overlapLow := max(aStart, bStart)
+	overlapHigh := min(aEnd, bEnd)
+
+	t.Errorf("Byte slices point to the same the same underlying byte array:\n"+
+		"\ta addresses:\t%d ... %d\n"+
+		"\tb addresses:\t%d ... %d\n"+
+		"\toverlap:\t%d ... %d",
+		aStart, aEnd,
+		bStart, bEnd,
+		overlapLow, overlapHigh)
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -39,6 +39,10 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 		valPtrStruct = unmarshalerPtrStruct{I: &i, M: &m, B: &b, S: &s}
 	}
 
+	type fooBytes struct {
+		Foo []byte
+	}
+
 	return []unmarshalingTestCase{
 		{
 			name: "small struct",
@@ -118,6 +122,19 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			sType: reflect.TypeOf(unmarshalerPtrStruct{}),
 			want:  &valPtrStruct,
 			data:  docToBytes(valPtrStruct),
+		},
+		// GODRIVER-2311
+		// Test that an unmarshaled struct that has a byte slice value does not reference the same
+		// underlying as the input.
+		{
+			name:  "struct with byte slice",
+			sType: reflect.TypeOf(fooBytes{}),
+			want: &fooBytes{
+				Foo: []byte{0, 1, 2, 3, 4, 5},
+			},
+			data: docToBytes(fooBytes{
+				Foo: []byte{0, 1, 2, 3, 4, 5},
+			}),
 		},
 	}
 }


### PR DESCRIPTION
[GODRIVER-2311](https://jira.mongodb.org/browse/GODRIVER-2311)

Currently unmarshaling BSON to a Go value containing byte slice can result in the unmarshaled byte slice pointing to the same underlying array as the input BSON byte slice. As a result, in those circumstances it is possible to corrupt the unmarshaled value by modifying the input BSON byte slice. Fix the problem by always returning a copy when unmarshaling byte slices.

Changes:
* Always return a copy of the byte slice from `valueReader.readBytes()`.
* Add tests that try to detect byte slices in unmarshaled values that point to the same underlying array as the input byte slice.