### PR TITLE
GODRIVER-2283 Remove innacurate comment about AdvanceCluster/OperationTime

### DIFF
--- a/mongo/session.go
+++ b/mongo/session.go
@@ -106,7 +106,10 @@ func SessionFromContext(ctx context.Context) Session {
 //
 // EndSession method should abort any existing transactions and close the session.
 //
-// AdvanceClusterTime and AdvanceOperationTime are for internal use only and must not be called.
+// AdvanceClusterTime advances the cluster time for a session. This method will return an error if the session has ended.
+//
+// AdvanceOperationTime advances the operation time for a session. This method will return an error if the session has
+// ended.
 type Session interface {
 	// Functions to modify session state.
 	StartTransaction(...*options.TransactionOptions) error


### PR DESCRIPTION
GODRIVER-2283

Removes comment stating that `AdvanceClusterTime` and `AdvanceOperationTime` are for internal use only. Explains the functions of the methods in documentation instead.

`AdvanceClusterTime` and `AdvanceOperationTime` are part of the drivers specifications for [sessions](https://github.com/mongodb/specifications/blob/b995503e975af1ea661fdd1fb83cc4f4ac2254a9/source/sessions/driver-sessions.rst#advanceclustertime) and [causal consistency](https://github.com/mongodb/specifications/blob/b995503e975af1ea661fdd1fb83cc4f4ac2254a9/source/causal-consistency/causal-consistency.rst#advanceoperationtime) respectively. They are expected to be used by applications wishing to manually plumb/persist a causal token for use across different logical sessions.