### PR TITLE
GODRIVER-2336 Skip strict stable API count example

### DIFF
--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -51,11 +51,12 @@ func TestDocumentationExamples(t *testing.T) {
 	documentation_examples.StableAPIExamples()
 
 	// Because it uses RunCommand with an apiVersion, the strict count example can only be
-	// run on 5.0+ without auth.
+	// run on 5.0+ without auth. It also cannot be run on 6.0+ since the count command was
+	// added to API version 1 and no longer results in an error when strict is enabled.
 	ver, err := getServerVersion(ctx, client)
 	require.NoError(t, err, "getServerVersion error: %v", err)
 	auth := os.Getenv("AUTH") == "auth"
-	if testutil.CompareVersions(t, ver, "5.0") >= 0 && !auth {
+	if testutil.CompareVersions(t, ver, "5.0") >= 0 && testutil.CompareVersions(t, ver, "6.0") < 0 && !auth {
 		documentation_examples.StableAPIStrictCountExample(t)
 	} else {
 		t.Log("skipping stable API strict count example")


### PR DESCRIPTION
GODRIVER-2336

Skips the `StableAPIStrictCountExample` test when running against server version 6.0+. [DRIVERS-2228](https://jira.mongodb.org/browse/DRIVERS-2228) recently added the `count` command to API version 1, so enabling strict no longer results in the expected `count` error against the latest server versions.