### PR TITLE
GODRIVER-2351 Add missing nil option checks

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -707,6 +707,9 @@ func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 
 	updateOptions := make([]*options.UpdateOptions, 0, len(opts))
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		uOpts := options.Update()
 		uOpts.BypassDocumentValidation = opt.BypassDocumentValidation
 		uOpts.Collation = opt.Collation
@@ -1311,6 +1314,9 @@ func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 
 	findOpts := make([]*options.FindOptions, 0, len(opts))
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		findOpts = append(findOpts, &options.FindOptions{
 			AllowPartialResults: opt.AllowPartialResults,
 			BatchSize:           opt.BatchSize,

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -389,6 +389,9 @@ func MergeIndexOptions(opts ...*IndexOptions) *IndexOptions {
 	i := Index()
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if opt.Background != nil {
 			i.Background = opt.Background
 		}

--- a/mongo/options/listdatabasesoptions.go
+++ b/mongo/options/listdatabasesoptions.go
@@ -40,7 +40,7 @@ func (ld *ListDatabasesOptions) SetAuthorizedDatabases(b bool) *ListDatabasesOpt
 func MergeListDatabasesOptions(opts ...*ListDatabasesOptions) *ListDatabasesOptions {
 	ld := ListDatabases()
 	for _, opt := range opts {
-		if opts == nil {
+		if opt == nil {
 			continue
 		}
 		if opt.NameOnly != nil {

--- a/mongo/readpref/readpref.go
+++ b/mongo/readpref/readpref.go
@@ -65,6 +65,9 @@ func New(mode Mode, opts ...Option) (*ReadPref, error) {
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		err := opt(rp)
 		if err != nil {
 			return nil, err

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -66,6 +66,9 @@ func newConnectionConfig(opts ...ConnectionOption) *connectionConfig {
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(cfg)
 	}
 

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -49,6 +49,9 @@ func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		err := opt(cfg)
 		if err != nil {
 			return nil, err

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -48,6 +48,9 @@ func newConfig(opts ...Option) (*config, error) {
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		err := opt(cfg)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
GODRIVER-2351

Adds missing `opt == nil { continue }` guards to option loops. When using patterns like `for _, opt := range opts`, we need to check that `opt != nil` before accessing its fields. Failure to do so can result in panics when users pass a single `nil` option to the potential slice of options in the variadic parameter.