### PR TITLE
Support 'let' option in BulkWriteOptions

### DIFF
--- a/data/crud/unified/bulkWrite-deleteMany-let.json
+++ b/data/crud/unified/bulkWrite-deleteMany-let.json
@@ -1,0 +1,200 @@
+{
+  "description": "BulkWrite deleteMany-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite deleteMany with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteMany": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "limit": 0
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite deleteMany with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "'delete.let' is an unknown field",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/bulkWrite-deleteMany-let.yml
+++ b/data/crud/unified/bulkWrite-deleteMany-let.yml
@@ -1,4 +1,4 @@
-description: "findOneAndDelete-let"
+description: "BulkWrite deleteMany-let"
 
 schemaVersion: "1.0"
 
@@ -15,7 +15,7 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData: &initialData
+initialData:
   - collectionName: *collection0Name
     databaseName: *database0Name
     documents:
@@ -23,64 +23,64 @@ initialData: &initialData
       - { _id: 2 }
 
 tests:
-  - description: "findOneAndDelete with let option"
+  - description: "BulkWrite deleteMany with let option"
     runOnRequirements:
       - minServerVersion: "5.0"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let0
+          requests:
+            - deleteMany:
+                filter: &filter
+                  $expr:
+                    $eq: [ "$_id", "$$id" ]
+          let: &let
             id: 1
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter
-                remove: true
-                let: *let0
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
           - { _id: 2 }
 
-  - description: "findOneAndDelete with let option unsupported (server-side error)"
+  - description: "BulkWrite deleteMany with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "4.2.0"
+      - minServerVersion: "3.6.0"
         maxServerVersion: "4.4.99"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter1
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let1
-            id: 1
+          requests:
+            - deleteOne:
+                filter: *filter
+          let: *let
         expectError:
-          # This error message is consistent between 4.2.x and 4.4.x servers.
-          # Older servers return a different error message.
-          errorContains: "field 'let' is an unknown field"
+          errorContains: "'delete.let' is an unknown field"
           isClientError: false
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter1
-                remove: true
-                let: *let1
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
           - { _id: 1 }
           - { _id: 2 }
-

--- a/data/crud/unified/bulkWrite-deleteOne-let.json
+++ b/data/crud/unified/bulkWrite-deleteOne-let.json
@@ -1,0 +1,200 @@
+{
+  "description": "BulkWrite deleteOne-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite deleteOne with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite deleteOne with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "'delete.let' is an unknown field",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/bulkWrite-deleteOne-let.yml
+++ b/data/crud/unified/bulkWrite-deleteOne-let.yml
@@ -1,4 +1,4 @@
-description: "findOneAndDelete-let"
+description: "BulkWrite deleteOne-let"
 
 schemaVersion: "1.0"
 
@@ -15,7 +15,7 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData: &initialData
+initialData:
   - collectionName: *collection0Name
     databaseName: *database0Name
     documents:
@@ -23,64 +23,64 @@ initialData: &initialData
       - { _id: 2 }
 
 tests:
-  - description: "findOneAndDelete with let option"
+  - description: "BulkWrite deleteOne with let option"
     runOnRequirements:
       - minServerVersion: "5.0"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let0
+          requests:
+            - deleteOne:
+                filter: &filter
+                  $expr:
+                    $eq: [ "$_id", "$$id" ]
+          let: &let
             id: 1
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter
-                remove: true
-                let: *let0
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
           - { _id: 2 }
 
-  - description: "findOneAndDelete with let option unsupported (server-side error)"
+  - description: "BulkWrite deleteOne with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "4.2.0"
-        maxServerVersion: "4.4.99"
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.9"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter1
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let1
-            id: 1
+          requests:
+            - deleteOne:
+                filter: *filter
+          let: *let
         expectError:
-          # This error message is consistent between 4.2.x and 4.4.x servers.
-          # Older servers return a different error message.
-          errorContains: "field 'let' is an unknown field"
+          errorContains: "'delete.let' is an unknown field"
           isClientError: false
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter1
-                remove: true
-                let: *let1
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
           - { _id: 1 }
           - { _id: 2 }
-

--- a/data/crud/unified/bulkWrite-replaceOne-let.json
+++ b/data/crud/unified/bulkWrite-replaceOne-let.json
@@ -1,0 +1,214 @@
+{
+  "description": "BulkWrite replaceOne-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "replacement": {
+                    "x": 3
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": {
+                        "x": 3
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 3
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite replaceOne with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "replacement": {
+                    "x": 3
+                  }
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "'update.let' is an unknown field",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": {
+                        "x": 3
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/bulkWrite-replaceOne-let.yml
+++ b/data/crud/unified/bulkWrite-replaceOne-let.yml
@@ -1,4 +1,4 @@
-description: "findOneAndDelete-let"
+description: "BulkWrite replaceOne-let"
 
 schemaVersion: "1.0"
 
@@ -15,7 +15,7 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData: &initialData
+initialData:
   - collectionName: *collection0Name
     databaseName: *database0Name
     documents:
@@ -23,64 +23,67 @@ initialData: &initialData
       - { _id: 2 }
 
 tests:
-  - description: "findOneAndDelete with let option"
+  - description: "BulkWrite replaceOne with let option"
     runOnRequirements:
       - minServerVersion: "5.0"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let0
+          requests:
+            - replaceOne:
+                filter: &filter
+                  $expr:
+                    $eq: [ "$_id", "$$id" ]
+                replacement: &replacement {"x": 3}
+          let: &let
             id: 1
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter
-                remove: true
-                let: *let0
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *replacement
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
+          - { _id: 1, x: 3 }
           - { _id: 2 }
 
-  - description: "findOneAndDelete with let option unsupported (server-side error)"
+  - description: "BulkWrite replaceOne with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "4.2.0"
-        maxServerVersion: "4.4.99"
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.9"
     operations:
-      - name: findOneAndDelete
-        object: *collection0
+      - object: *collection0
+        name: bulkWrite
         arguments:
-          filter: &filter1
-            $expr:
-              $eq: [ "$_id", "$$id" ]
-          let: &let1
-            id: 1
+          requests:
+            - replaceOne:
+                filter: *filter
+                replacement: *replacement
+          let: *let
         expectError:
-          # This error message is consistent between 4.2.x and 4.4.x servers.
-          # Older servers return a different error message.
-          errorContains: "field 'let' is an unknown field"
+          errorContains: "'update.let' is an unknown field"
           isClientError: false
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                findAndModify: *collection0Name
-                query: *filter1
-                remove: true
-                let: *let1
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *replacement
+                let: *let
     outcome:
       - collectionName: *collection0Name
         databaseName: *database0Name
         documents:
           - { _id: 1 }
           - { _id: 2 }
-

--- a/data/crud/unified/bulkWrite-updateMany-let.json
+++ b/data/crud/unified/bulkWrite-updateMany-let.json
@@ -1,0 +1,243 @@
+{
+  "description": "BulkWrite updateMany-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 20
+        },
+        {
+          "_id": 2,
+          "x": 21
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite updateMany with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 21
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 21
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 21
+            },
+            {
+              "_id": 2,
+              "x": 21
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateMany with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 21
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "'update.let' is an unknown field",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 21
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 20
+            },
+            {
+              "_id": 2,
+              "x": 21
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/bulkWrite-updateMany-let.yml
+++ b/data/crud/unified/bulkWrite-updateMany-let.yml
@@ -1,0 +1,97 @@
+description: "BulkWrite updateMany-let"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 20 }
+      - { _id: 2, x: 21 }
+
+tests:
+  - description: "BulkWrite updateMany with let option"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateMany:
+                filter: &filter
+                  $expr:
+                    $eq: [ "$_id", "$$id" ]
+                update: &update
+                  - $set:
+                      x: 21
+          let: &let
+            id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                let: *let
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 21 }
+          - { _id: 2, x: 21 }
+
+  - description: "BulkWrite updateMany with let option unsupported (server-side error)"
+    runOnRequirements:
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "4.9"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateMany:
+                filter: *filter
+                update: *update
+          let: *let
+        expectError:
+          errorContains: "'update.let' is an unknown field"
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: true
+                    upsert:
+                      $$unsetOrMatches: false
+                let: *let
+
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 20 }
+          - { _id: 2, x: 21 }

--- a/data/crud/unified/bulkWrite-updateOne-let.json
+++ b/data/crud/unified/bulkWrite-updateOne-let.json
@@ -1,0 +1,247 @@
+{
+  "description": "BulkWrite updateOne-let",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 20
+        },
+        {
+          "_id": 2,
+          "x": 21
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite updateOne with let option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 22
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 22
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 22
+            },
+            {
+              "_id": 2,
+              "x": 21
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateOne with let option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "$expr": {
+                      "$eq": [
+                        "$_id",
+                        "$$id"
+                      ]
+                    }
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 22
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "let": {
+              "id": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "'update.let' is an unknown field",
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "$expr": {
+                          "$eq": [
+                            "$_id",
+                            "$$id"
+                          ]
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 22
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "let": {
+                    "id": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 20
+            },
+            {
+              "_id": 2,
+              "x": 21
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/crud/unified/bulkWrite-updateOne-let.yml
+++ b/data/crud/unified/bulkWrite-updateOne-let.yml
@@ -1,0 +1,95 @@
+description: "BulkWrite updateOne-let"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 20 }
+      - { _id: 2, x: 21 }
+
+tests:
+  - description: "BulkWrite updateOne with let option"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: &filter
+                  $expr:
+                    $eq: [ "$_id", "$$id" ]
+                update: &update
+                  - $set:
+                      x: 22
+          let: &let
+            id: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                let: *let
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 22 }
+          - { _id: 2, x: 21 }
+
+  - description: "BulkWrite updateOne with let option unsupported (server-side error)"
+    runOnRequirements:
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "4.9"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: *filter
+                update: *update
+          let: *let
+        expectError:
+          errorContains: "'update.let' is an unknown field"
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                let: *let
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 20 }
+          - { _id: 2, x: 21 }

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -35,6 +35,7 @@ type bulkWrite struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	result                   BulkWriteResult
+	let                      interface{}
 }
 
 func (bw *bulkWrite) execute(ctx context.Context) error {
@@ -228,6 +229,13 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		Database(bw.collection.db.name).Collection(bw.collection.name).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ServerAPI(bw.collection.client.serverAPI)
+	if bw.let != nil {
+		let, err := transformBsoncoreDocument(bw.collection.registry, bw.let, true, "let")
+		if err != nil {
+			return operation.DeleteResult{}, err
+		}
+		op = op.Let(let)
+	}
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
 	}
@@ -309,6 +317,13 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		Database(bw.collection.db.name).Collection(bw.collection.name).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ArrayFilters(hasArrayFilters).ServerAPI(bw.collection.client.serverAPI)
+	if bw.let != nil {
+		let, err := transformBsoncoreDocument(bw.collection.registry, bw.let, true, "let")
+		if err != nil {
+			return operation.UpdateResult{}, err
+		}
+		op = op.Let(let)
+	}
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
 	}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -225,6 +225,7 @@ func (coll *Collection) BulkWrite(ctx context.Context, models []WriteModel,
 		collection:               coll,
 		selector:                 selector,
 		writeConcern:             wc,
+		let:                      bwo.Let,
 	}
 
 	err = op.execute(ctx)

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -115,6 +115,8 @@ func executeBulkWrite(ctx context.Context, operation *operation) (*operationResu
 			if err != nil {
 				return nil, fmt.Errorf("error creating write models: %v", err)
 			}
+		case "let":
+			opts.SetLet(val.Document())
 		default:
 			return nil, fmt.Errorf("unrecognized bulkWrite option %q", key)
 		}

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -19,6 +19,12 @@ type BulkWriteOptions struct {
 
 	// If true, no writes will be executed after one fails. The default value is true.
 	Ordered *bool
+
+	// Specifies parameters for all update and delete commands in the BulkWrite. This option is only valid for MongoDB
+	// versions >= 5.0. Older servers will report an error for using this option. This must be a document mapping
+	// parameter names to values. Values must be constant or closed expressions that do not reference document fields.
+	// Parameters can then be accessed as variables in an aggregate expression context (e.g. "$$var").
+	Let interface{}
 }
 
 // BulkWrite creates a new *BulkWriteOptions instance.
@@ -40,6 +46,12 @@ func (b *BulkWriteOptions) SetBypassDocumentValidation(bypass bool) *BulkWriteOp
 	return b
 }
 
+// SetLet sets the value for the Let field.
+func (b *BulkWriteOptions) SetLet(let interface{}) *BulkWriteOptions {
+	b.Let = &let
+	return b
+}
+
 // MergeBulkWriteOptions combines the given BulkWriteOptions instances into a single BulkWriteOptions in a last-one-wins
 // fashion.
 func MergeBulkWriteOptions(opts ...*BulkWriteOptions) *BulkWriteOptions {
@@ -53,6 +65,9 @@ func MergeBulkWriteOptions(opts ...*BulkWriteOptions) *BulkWriteOptions {
 		}
 		if opt.BypassDocumentValidation != nil {
 			b.BypassDocumentValidation = opt.BypassDocumentValidation
+		}
+		if opt.Let != nil {
+			b.Let = opt.Let
 		}
 	}
 

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -46,7 +46,10 @@ func (b *BulkWriteOptions) SetBypassDocumentValidation(bypass bool) *BulkWriteOp
 	return b
 }
 
-// SetLet sets the value for the Let field.
+// SetLet sets the value for the Let field. Let specifies parameters for all update and delete commands in the BulkWrite.
+// This option is only valid for MongoDB versions >= 5.0. Older servers will report an error for using this option.
+// This must be a document mapping parameter names to values. Values must be constant or closed expressions that do not
+// reference document fields. Parameters can then be accessed as variables in an aggregate expression context (e.g. "$$var").
 func (b *BulkWriteOptions) SetLet(let interface{}) *BulkWriteOptions {
 	b.Let = &let
 	return b


### PR DESCRIPTION
GODRIVER-2314
GODRIVER-2327
GODRIVER-2313

Syncs CRUD bulkWrite spec tests. (first commit). Adds a new `let` option to `BulkWriteOptions` to be passed down to any `update` or `delete` commands within the `BulkWrite` (second commit).