### PR TITLE
Remove unused ServerOption error.

### DIFF
--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -209,8 +209,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 		}))
 	}
 
-	s, err := NewServer(address.Address(l.Addr().String()), primitive.NewObjectID(), sOpts...)
-	testHelpers.RequireNil(t, err, "error creating server: %v", err)
+	s := NewServer(address.Address(l.Addr().String()), primitive.NewObjectID(), sOpts...)
 	s.state = serverConnected
 	testHelpers.RequireNil(t, err, "error connecting connection pool: %v", err)
 	defer s.pool.close(context.Background())

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -130,11 +130,8 @@ type updateTopologyCallback func(description.Server) description.Server
 // ConnectServer creates a new Server and then initializes it using the
 // Connect method.
 func ConnectServer(addr address.Address, updateCallback updateTopologyCallback, topologyID primitive.ObjectID, opts ...ServerOption) (*Server, error) {
-	srvr, err := NewServer(addr, topologyID, opts...)
-	if err != nil {
-		return nil, err
-	}
-	err = srvr.Connect(updateCallback)
+	srvr := NewServer(addr, topologyID, opts...)
+	err := srvr.Connect(updateCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -143,12 +140,8 @@ func ConnectServer(addr address.Address, updateCallback updateTopologyCallback, 
 
 // NewServer creates a new server. The mongodb server at the address will be monitored
 // on an internal monitoring goroutine.
-func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...ServerOption) (*Server, error) {
-	cfg, err := newServerConfig(opts...)
-	if err != nil {
-		return nil, err
-	}
-
+func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...ServerOption) *Server {
+	cfg := newServerConfig(opts...)
 	globalCtx, globalCtxCancel := context.WithCancel(context.Background())
 	s := &Server{
 		state: serverDisconnected,
@@ -190,7 +183,7 @@ func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...Serv
 	s.pool = newPool(pc, connectionOpts...)
 	s.publishServerOpeningEvent(s.address)
 
-	return s, nil
+	return s
 }
 
 // Connect initializes the Server by starting background monitoring goroutines.

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -40,7 +40,7 @@ type serverConfig struct {
 	poolMaintainInterval time.Duration
 }
 
-func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
+func newServerConfig(opts ...ServerOption) *serverConfig {
 	cfg := &serverConfig{
 		heartbeatInterval: 10 * time.Second,
 		heartbeatTimeout:  10 * time.Second,
@@ -52,72 +52,62 @@ func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
 		if opt == nil {
 			continue
 		}
-		err := opt(cfg)
-		if err != nil {
-			return nil, err
-		}
+		opt(cfg)
 	}
 
-	return cfg, nil
+	return cfg
 }
 
 // ServerOption configures a server.
-type ServerOption func(*serverConfig) error
+type ServerOption func(*serverConfig)
 
 func withMonitoringDisabled(fn func(bool) bool) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.monitoringDisabled = fn(cfg.monitoringDisabled)
-		return nil
 	}
 }
 
 // WithConnectionOptions configures the server's connections.
 func WithConnectionOptions(fn func(...ConnectionOption) []ConnectionOption) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.connectionOpts = fn(cfg.connectionOpts...)
-		return nil
 	}
 }
 
 // WithCompressionOptions configures the server's compressors.
 func WithCompressionOptions(fn func(...string) []string) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.compressionOpts = fn(cfg.compressionOpts...)
-		return nil
 	}
 }
 
 // WithServerAppName configures the server's application name.
 func WithServerAppName(fn func(string) string) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.appname = fn(cfg.appname)
-		return nil
 	}
 }
 
 // WithHeartbeatInterval configures a server's heartbeat interval.
 func WithHeartbeatInterval(fn func(time.Duration) time.Duration) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.heartbeatInterval = fn(cfg.heartbeatInterval)
-		return nil
 	}
 }
 
 // WithHeartbeatTimeout configures how long to wait for a heartbeat socket to
 // connection.
 func WithHeartbeatTimeout(fn func(time.Duration) time.Duration) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.heartbeatTimeout = fn(cfg.heartbeatTimeout)
-		return nil
 	}
 }
 
 // WithMaxConnections configures the maximum number of connections to allow for
 // a given server. If max is 0, then maximum connection pool size is not limited.
 func WithMaxConnections(fn func(uint64) uint64) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.maxConns = fn(cfg.maxConns)
-		return nil
 	}
 }
 
@@ -125,9 +115,8 @@ func WithMaxConnections(fn func(uint64) uint64) ServerOption {
 // a given server. If min is 0, then there is no lower limit to the number of
 // connections.
 func WithMinConnections(fn func(uint64) uint64) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.minConns = fn(cfg.minConns)
-		return nil
 	}
 }
 
@@ -135,9 +124,8 @@ func WithMinConnections(fn func(uint64) uint64) ServerOption {
 // pool may establish simultaneously. If maxConnecting is 0, the default value
 // of 2 is used.
 func WithMaxConnecting(fn func(uint64) uint64) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.maxConnecting = fn(cfg.maxConnecting)
-		return nil
 	}
 }
 
@@ -145,66 +133,58 @@ func WithMaxConnecting(fn func(uint64) uint64) ServerOption {
 // before being removed. If connectionPoolMaxIdleTime is 0, then no idle time is set and connections will not be removed
 // because of their age
 func WithConnectionPoolMaxIdleTime(fn func(time.Duration) time.Duration) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.poolMaxIdleTime = fn(cfg.poolMaxIdleTime)
-		return nil
 	}
 }
 
 // WithConnectionPoolMaintainInterval configures the interval that the background connection pool
 // maintenance goroutine runs.
 func WithConnectionPoolMaintainInterval(fn func(time.Duration) time.Duration) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.poolMaintainInterval = fn(cfg.poolMaintainInterval)
-		return nil
 	}
 }
 
 // WithConnectionPoolMonitor configures the monitor for all connection pool actions
 func WithConnectionPoolMonitor(fn func(*event.PoolMonitor) *event.PoolMonitor) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.poolMonitor = fn(cfg.poolMonitor)
-		return nil
 	}
 }
 
 // WithServerMonitor configures the monitor for all SDAM events for a server
 func WithServerMonitor(fn func(*event.ServerMonitor) *event.ServerMonitor) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.serverMonitor = fn(cfg.serverMonitor)
-		return nil
 	}
 }
 
 // WithClock configures the ClusterClock for the server to use.
 func WithClock(fn func(clock *session.ClusterClock) *session.ClusterClock) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.clock = fn(cfg.clock)
-		return nil
 	}
 }
 
 // WithRegistry configures the registry for the server to use when creating
 // cursors.
 func WithRegistry(fn func(*bsoncodec.Registry) *bsoncodec.Registry) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.registry = fn(cfg.registry)
-		return nil
 	}
 }
 
 // WithServerAPI configures the server API options for the server to use.
 func WithServerAPI(fn func(serverAPI *driver.ServerAPIOptions) *driver.ServerAPIOptions) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.serverAPI = fn(cfg.serverAPI)
-		return nil
 	}
 }
 
 // WithServerLoadBalanced specifies whether or not the server is behind a load balancer.
 func WithServerLoadBalanced(fn func(bool) bool) ServerOption {
-	return func(cfg *serverConfig) error {
+	return func(cfg *serverConfig) {
 		cfg.loadBalanced = fn(cfg.loadBalanced)
-		return nil
 	}
 }

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -556,7 +556,7 @@ func (t *Topology) selectServerFromDescription(desc description.Topology,
 func (t *Topology) pollSRVRecords() {
 	defer t.pollingwg.Done()
 
-	serverConfig, _ := newServerConfig(t.cfg.serverOpts...)
+	serverConfig := newServerConfig(t.cfg.serverOpts...)
 	heartbeatInterval := serverConfig.heartbeatInterval
 
 	pollTicker := time.NewTicker(t.rescanSRVInterval)

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -34,8 +34,7 @@ func TestOptionsSetting(t *testing.T) {
 
 	assert.Equal(t, ssts, conf.serverSelectionTimeout)
 
-	serverConf, err := newServerConfig(conf.serverOpts...)
-	assert.Nil(t, err, "error from newServerConfig: %v", err)
+	serverConf := newServerConfig(conf.serverOpts...)
 	assert.Equal(t, name, serverConf.appname, "expected appname to be: %v, got: %v", name, serverConf.appname)
 }
 
@@ -98,8 +97,7 @@ func TestLoadBalancedFromConnString(t *testing.T) {
 			assert.Nil(t, err, "topology.New error: %v", err)
 			assert.Equal(t, tc.loadBalanced, topo.cfg.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, topo.cfg.loadBalanced)
 
-			srvr, err := NewServer("", topo.id, topo.cfg.serverOpts...)
-			assert.Nil(t, err, "NewServer error: %v", err)
+			srvr := NewServer("", topo.id, topo.cfg.serverOpts...)
 			assert.Equal(t, tc.loadBalanced, srvr.cfg.loadBalanced, "expected loadBalanced %v, got %v", tc.loadBalanced, srvr.cfg.loadBalanced)
 
 			conn := newConnection("", srvr.cfg.connectionOpts...)

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -697,11 +697,10 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 	servers := make(map[string]*Server, len(test.TopologyDescription.Servers))
 	descriptions := make([]description.Server, 0, len(test.TopologyDescription.Servers))
 	for _, testDesc := range test.TopologyDescription.Servers {
-		server, err := NewServer(
+		server := NewServer(
 			address.Address(testDesc.Address),
 			primitive.NilObjectID,
 			withMonitoringDisabled(func(bool) bool { return true }))
-		require.NoError(t, err, "error creating new server")
 		servers[testDesc.Address] = server
 
 		desc := description.Server{


### PR DESCRIPTION
Type `ServerOption` is currently a `func(*serverConfig) error`. However, no `ServerOption` functions return an error. Remove the error returned by the `ServerOption` type (now `func(*serverConfig)`) and remove all of the now-unnecessary error handling logic.

Follow up to previous similar PR https://github.com/mongodb/mongo-go-driver/pull/859