### PR TITLE
GODRIVER-2349 Seed all pseudorandom number generators with a crypto-secure random number.

### DIFF
--- a/internal/randutil/randutil.go
+++ b/internal/randutil/randutil.go
@@ -2,6 +2,9 @@
 package randutil
 
 import (
+	crand "crypto/rand"
+	"fmt"
+	"io"
 	"math/rand"
 	"sync"
 )
@@ -51,4 +54,18 @@ func (lr *LockedRand) Shuffle(n int, swap func(i, j int)) {
 	lr.mu.Lock()
 	lr.r.Shuffle(n, swap)
 	lr.mu.Unlock()
+}
+
+// CryptoSeed returns a random int64 read from the "crypto/rand" random number generator. It is
+// intended to be used to seed pseudorandom number generators at package initialization. It panics
+// if it encounters any errors.
+func CryptoSeed() int64 {
+	var b [8]byte
+	_, err := io.ReadFull(crand.Reader, b[:])
+	if err != nil {
+		panic(fmt.Errorf("failed to read 8 bytes from a \"crypto/rand\".Reader: %v", err))
+	}
+
+	return (int64(b[0]) << 0) | (int64(b[1]) << 8) | (int64(b[2]) << 16) | (int64(b[3]) << 24) |
+		(int64(b[4]) << 32) | (int64(b[5]) << 40) | (int64(b[6]) << 48) | (int64(b[7]) << 56)
 }

--- a/internal/randutil/randutil.go
+++ b/internal/randutil/randutil.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 // Package randutil provides common random number utilities.
 package randutil
 

--- a/internal/randutil/randutil_test.go
+++ b/internal/randutil/randutil_test.go
@@ -1,0 +1,16 @@
+package randutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptoSeed(t *testing.T) {
+	seeds := make(map[int64]bool)
+	for i := 1; i < 1000000; i++ {
+		s := CryptoSeed()
+		require.False(t, seeds[s], "CryptoSeed returned a duplicate value %d", s)
+		seeds[s] = true
+	}
+}

--- a/internal/randutil/randutil_test.go
+++ b/internal/randutil/randutil_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package randutil
 
 import (

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -24,7 +24,7 @@ import (
 )
 
 // random is a package-global pseudo-random number generator.
-var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
+var random = randutil.NewLockedRand(rand.NewSource(randutil.CryptoSeed()))
 
 // ParseAndValidate parses the provided URI into a ConnString object.
 // It check that all values are valid.

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -57,7 +57,7 @@ var ErrServerSelectionTimeout = errors.New("server selection timeout")
 type MonitorMode uint8
 
 // random is a package-global pseudo-random number generator.
-var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
+var random = randutil.NewLockedRand(rand.NewSource(randutil.CryptoSeed()))
 
 // These constants are the available monitoring modes.
 const (

--- a/x/mongo/driver/uuid/uuid.go
+++ b/x/mongo/driver/uuid/uuid.go
@@ -16,17 +16,17 @@ import (
 // UUID represents a UUID.
 type UUID [16]byte
 
-// random is a package-global pseudo-random number generator.
-var random = randutil.NewLockedRand(rand.NewSource(randutil.CryptoSeed()))
+// A source is a UUID generator that reads random values from a randutil.LockedRand.
+// It is safe to use from multiple goroutines.
+type source struct {
+	random *randutil.LockedRand
+}
 
-// New returns a random UUIDv4. It uses a "math/rand" pseudo-random number generator seeded with a
-// cryptographically-secure random number at package initialization.
-//
-// New should not be used to generate cryptographically-secure random UUIDs.
-func New() (UUID, error) {
+// new returns a random UUIDv4 with bytes read from the source's random number generator.
+func (s *source) new() (UUID, error) {
 	var uuid [16]byte
 
-	_, err := io.ReadFull(random, uuid[:])
+	_, err := io.ReadFull(s.random, uuid[:])
 	if err != nil {
 		return [16]byte{}, err
 	}
@@ -34,6 +34,26 @@ func New() (UUID, error) {
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
 
 	return uuid, nil
+}
+
+// newGlobalSource returns a source that uses a "math/rand" pseudo-random number generator seeded
+// with a cryptographically-secure random number. It is intended to be used to initialize the
+// package-global UUID generator.
+func newGlobalSource() *source {
+	return &source{
+		random: randutil.NewLockedRand(rand.NewSource(randutil.CryptoSeed())),
+	}
+}
+
+// globalSource is a package-global pseudo-random UUID generator.
+var globalSource = newGlobalSource()
+
+// New returns a random UUIDv4. It uses a "math/rand" pseudo-random number generator seeded with a
+// cryptographically-secure random number at package initialization.
+//
+// New should not be used to generate cryptographically-secure random UUIDs.
+func New() (UUID, error) {
+	return globalSource.new()
 }
 
 // Equal returns true if two UUIDs are equal.

--- a/x/mongo/driver/uuid/uuid.go
+++ b/x/mongo/driver/uuid/uuid.go
@@ -9,7 +9,6 @@ package uuid // import "go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 import (
 	"io"
 	"math/rand"
-	"time"
 
 	"go.mongodb.org/mongo-driver/internal/randutil"
 )
@@ -18,10 +17,10 @@ import (
 type UUID [16]byte
 
 // random is a package-global pseudo-random number generator.
-var random = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
+var random = randutil.NewLockedRand(rand.NewSource(randutil.CryptoSeed()))
 
-// New returns a random UUIDv4. It uses a "math/rand" pseudo-random number generator seeded with the
-// package initialization time.
+// New returns a random UUIDv4. It uses a "math/rand" pseudo-random number generator seeded with a
+// cryptographically-secure random number at package initialization.
 //
 // New should not be used to generate cryptographically-secure random UUIDs.
 func New() (UUID, error) {

--- a/x/mongo/driver/uuid/uuid_test.go
+++ b/x/mongo/driver/uuid/uuid_test.go
@@ -1,17 +1,50 @@
 package uuid
 
 import (
+	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	m := make(map[UUID]bool)
-	for i := 1; i < 100; i++ {
+	for i := 1; i < 1000000; i++ {
 		uuid, err := New()
-		assert.NoError(t, err, "New error")
-		assert.False(t, m[uuid], "New returned a duplicate UUID %v", uuid)
+		require.NoError(t, err, "New error")
+		require.False(t, m[uuid], "New returned a duplicate UUID %v", uuid)
 		m[uuid] = true
+	}
+}
+
+// GODRIVER-2349
+// Test that initializing many package-global UUID sources concurrently never leads to any duplicate
+// UUIDs being generated.
+func TestGlobalSource(t *testing.T) {
+	// Create a slice of 1,000 sources and initialize them in 1,000 separate goroutines. The goal is
+	// to emulate many separate Go driver processes starting at the same time and initializing the
+	// uuid package at the same time.
+	sources := make([]*source, 1000)
+	var wg sync.WaitGroup
+	for i := range sources {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sources[i] = newGlobalSource()
+		}(i)
+	}
+	wg.Wait()
+
+	// Read 1,000 UUIDs from each source and assert that there is never a duplicate value, either
+	// from the same source or from separate sources.
+	const iterations = 1000
+	uuids := make(map[UUID]bool, len(sources)*iterations)
+	for i := 0; i < iterations; i++ {
+		for j, s := range sources {
+			uuid, err := s.new()
+			require.NoError(t, err, "new() error")
+			require.Falsef(t, uuids[uuid], "source %d returned a duplicate UUID on iteration %d: %v", j, i, uuid)
+			uuids[uuid] = true
+		}
 	}
 }

--- a/x/mongo/driver/uuid/uuid_test.go
+++ b/x/mongo/driver/uuid/uuid_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package uuid
 
 import (


### PR DESCRIPTION
[GODRIVER-2349](https://jira.mongodb.org/browse/GODRIVER-2349)

On some versions of Go and on some operating systems, `time.Now()` returns a time with lower-than-expected resolution (updates every 500μs to 15ms). The Go driver uses `time.Now().UnixNano()` to seed some pseudo-random number generators, including the one for generating session IDs [here](https://github.com/mongodb/mongo-go-driver/blob/630ff7cbfd2363b49bfa48968b80ce287e70ae85/x/mongo/driver/uuid/uuid.go#L21). Due to that, it's possible, under the right conditions, to start two processes that reproduce the same sequence of session IDs if they are started at almost the same time.

To remove that possibility, read an `int64` value from the `"crypto/rand".Reader` and use it to seed all pseudo-random number generators in the driver.