### PR TITLE
GODRIVER-2068 Use monitor.TestPoolMonitor to replace most connection pool monitors in tests.

### DIFF
--- a/internal/testutil/monitor/monitor.go
+++ b/internal/testutil/monitor/monitor.go
@@ -1,0 +1,78 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package monitor provides test types that are used to monitor client state and actions via the
+// various monitor types supported by the driver.
+package monitor
+
+import (
+	"sync"
+
+	"go.mongodb.org/mongo-driver/event"
+)
+
+// TestPoolMonitor exposes an *event.TestPoolMonitor and collects all events logged to that
+// *event.TestPoolMonitor. It is safe to use from multiple concurrent goroutines.
+type TestPoolMonitor struct {
+	*event.PoolMonitor
+
+	events []*event.PoolEvent
+	mu     sync.RWMutex
+}
+
+func NewTestPoolMonitor() *TestPoolMonitor {
+	tpm := &TestPoolMonitor{
+		events: make([]*event.PoolEvent, 0),
+	}
+	tpm.PoolMonitor = &event.PoolMonitor{
+		Event: func(evt *event.PoolEvent) {
+			tpm.mu.Lock()
+			defer tpm.mu.Unlock()
+			tpm.events = append(tpm.events, evt)
+		},
+	}
+	return tpm
+}
+
+// Events returns a copy of the events collected by the testPoolMonitor. Filters can optionally be
+// applied to the returned events set and are applied using AND logic (i.e. all filters must return
+// true to include the event in the result).
+func (tpm *TestPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*event.PoolEvent {
+	filtered := make([]*event.PoolEvent, 0, len(tpm.events))
+	tpm.mu.RLock()
+	defer tpm.mu.RUnlock()
+
+	for _, evt := range tpm.events {
+		keep := true
+		for _, filter := range filters {
+			if !filter(evt) {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			filtered = append(filtered, evt)
+		}
+	}
+
+	return filtered
+}
+
+// ClearEvents will reset the events collected by the testPoolMonitor.
+func (tpm *TestPoolMonitor) ClearEvents() {
+	tpm.mu.Lock()
+	defer tpm.mu.Unlock()
+	tpm.events = tpm.events[:0]
+}
+
+// IsPoolCleared returns true if there are any events of type "event.PoolCleared" in the events
+// recorded by the testPoolMonitor.
+func (tpm *TestPoolMonitor) IsPoolCleared() bool {
+	poolClearedEvents := tpm.Events(func(evt *event.PoolEvent) bool {
+		return evt.Type == event.PoolCleared
+	})
+	return len(poolClearedEvents) > 0
+}

--- a/internal/testutil/ops.go
+++ b/internal/testutil/ops.go
@@ -9,7 +9,6 @@ package testutil // import "go.mongodb.org/mongo-driver/internal/testutil"
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,30 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
-
-// AutoCreateIndexes creates an index in the test cluster.
-func AutoCreateIndexes(t *testing.T, keys []string) {
-	elems := make([][]byte, 0, len(keys))
-	for _, k := range keys {
-		elems = append(elems, bsoncore.AppendInt32Element(nil, k, 1))
-	}
-	name := strings.Join(keys, "_")
-	indexes := bsoncore.BuildDocumentFromElements(nil,
-		bsoncore.AppendDocumentElement(nil, "key", bsoncore.BuildDocumentFromElements(nil,
-			elems...)),
-		bsoncore.AppendStringElement(nil, "name", name),
-	)
-	err := operation.NewCreateIndexes(indexes).Collection(ColName(t)).Database(DBName(t)).
-		Deployment(Topology(t)).ServerSelector(description.WriteSelector()).Execute(context.Background())
-	require.NoError(t, err)
-}
-
-// AutoDropCollection drops the collection in the test cluster.
-func AutoDropCollection(t *testing.T) {
-	DropCollection(t, DBName(t), ColName(t))
-}
 
 // DropCollection drops the collection in the test cluster.
 func DropCollection(t *testing.T, dbname, colname string) {
@@ -64,28 +40,6 @@ func InsertDocs(t *testing.T, dbname, colname string, writeConcern *writeconcern
 	err := operation.NewInsert(docs...).Collection(colname).Database(dbname).
 		Deployment(Topology(t)).ServerSelector(description.WriteSelector()).Execute(context.Background())
 	require.NoError(t, err)
-}
-
-// EnableMaxTimeFailPoint turns on the max time fail point in the test cluster.
-func EnableMaxTimeFailPoint(t *testing.T, s *topology.Server) error {
-	cmd := bsoncore.BuildDocumentFromElements(nil,
-		bsoncore.AppendStringElement(nil, "configureFailPoint", "maxTimeAlwaysTimeOut"),
-		bsoncore.AppendStringElement(nil, "mode", "alwaysOn"),
-	)
-	return operation.NewCommand(cmd).
-		Database("admin").Deployment(driver.SingleServerDeployment{Server: s}).
-		Execute(context.Background())
-}
-
-// DisableMaxTimeFailPoint turns off the max time fail point in the test cluster.
-func DisableMaxTimeFailPoint(t *testing.T, s *topology.Server) {
-	cmd := bsoncore.BuildDocumentFromElements(nil,
-		bsoncore.AppendStringElement(nil, "configureFailPoint", "maxTimeAlwaysTimeOut"),
-		bsoncore.AppendStringElement(nil, "mode", "off"),
-	)
-	_ = operation.NewCommand(cmd).
-		Database("admin").Deployment(driver.SingleServerDeployment{Server: s}).
-		Execute(context.Background())
 }
 
 // RunCommand runs an arbitrary command on a given database of target server

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -503,15 +504,9 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		})
 	})
 
-	customDeploymentClientOpts := options.Client().
-		SetPoolMonitor(poolMonitor).
-		SetWriteConcern(mtest.MajorityWc).
-		SetReadConcern(mtest.MajorityRc).
-		SetRetryReads(false)
 	customDeploymentOpts := mtest.NewOptions().
 		Topologies(mtest.ReplicaSet). // Avoid complexity of sharded fail points.
 		MinServerVersion("4.0").      // 4.0 is needed to use replica set fail points.
-		ClientOptions(customDeploymentClientOpts).
 		CreateClient(false)
 	mt.RunOpts("custom deployment", customDeploymentOpts, func(mt *mtest.T) {
 		// Tests for the changeStreamDeployment type. These are written as integration tests for ChangeStream rather
@@ -519,7 +514,13 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		// by ChangeStream when executing an aggregate.
 
 		mt.Run("errors are processed for SDAM on initial aggregate", func(mt *mtest.T) {
-			clearPoolChan()
+			tpm := monitor.NewTestPoolMonitor()
+			mt.ResetClient(options.Client().
+				SetPoolMonitor(tpm.PoolMonitor).
+				SetWriteConcern(mtest.MajorityWc).
+				SetReadConcern(mtest.MajorityRc).
+				SetRetryReads(false))
+
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
 				Mode: mtest.FailPointMode{
@@ -533,10 +534,16 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 			_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.NotNil(mt, err, "expected Watch error, got nil")
-			assert.True(mt, isPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
+			assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
 		})
 		mt.Run("errors are processed for SDAM on getMore", func(mt *mtest.T) {
-			clearPoolChan()
+			tpm := monitor.NewTestPoolMonitor()
+			mt.ResetClient(options.Client().
+				SetPoolMonitor(tpm.PoolMonitor).
+				SetWriteConcern(mtest.MajorityWc).
+				SetReadConcern(mtest.MajorityRc).
+				SetRetryReads(false))
+
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
 				Mode: mtest.FailPointMode{
@@ -557,12 +564,13 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 			assert.True(mt, cs.Next(context.Background()), "expected Next to return true, got false (iteration error %v)",
 				cs.Err())
-			assert.True(mt, isPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
+			assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared after non-timeout network error but was not")
 		})
-		retryAggClientOpts := options.Client().SetRetryReads(true).SetPoolMonitor(poolMonitor)
-		retryAggMtOpts := mtest.NewOptions().ClientOptions(retryAggClientOpts)
-		mt.RunOpts("errors are processed for SDAM on retried aggregate", retryAggMtOpts, func(mt *mtest.T) {
-			clearPoolChan()
+		mt.Run("errors are processed for SDAM on retried aggregate", func(mt *mtest.T) {
+			tpm := monitor.NewTestPoolMonitor()
+			mt.ResetClient(options.Client().
+				SetPoolMonitor(tpm.PoolMonitor).
+				SetRetryReads(true))
 
 			mt.SetFailPoint(mtest.FailPoint{
 				ConfigureFailPoint: "failCommand",
@@ -578,14 +586,10 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
 			assert.NotNil(mt, err, "expected Watch error, got nil")
 
-			var numClearedEvents int
-			for len(poolChan) > 0 {
-				curr := <-poolChan
-				if curr.Type == event.PoolCleared {
-					numClearedEvents++
-				}
-			}
-			assert.Equal(mt, 2, numClearedEvents, "expected two PoolCleared events, got %d", numClearedEvents)
+			clearedEvents := tpm.Events(func(evt *event.PoolEvent) bool {
+				return evt.Type == event.PoolCleared
+			})
+			assert.Equal(mt, 2, len(clearedEvents), "expected two PoolCleared events, got %d", len(clearedEvents))
 		})
 	})
 	// Setting min server version as 4.0 since v3.6 does not send a "dropEvent"

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -24,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -558,7 +559,7 @@ func TestClient(t *testing.T) {
 
 		// Reset the client with a dialer that delays all network round trips by 300ms and set the
 		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples.
-		tpm := newTestPoolMonitor()
+		tpm := monitor.NewTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
 			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
@@ -733,7 +734,7 @@ func TestClientStress(t *testing.T) {
 		// pool configurations.
 		maxPoolSizes := []uint64{1, 10, 100}
 		for _, maxPoolSize := range maxPoolSizes {
-			tpm := newTestPoolMonitor()
+			tpm := monitor.NewTestPoolMonitor()
 			maxPoolSizeOpt := mtest.NewOptions().ClientOptions(
 				options.Client().
 					SetPoolMonitor(tpm.PoolMonitor).

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func TestRetryableReadsProse(t *testing.T) {
-	tpm := newTestPoolMonitor()
+	tpm := monitor.NewTestPoolMonitor()
 
 	// Client options with MaxPoolSize of 1 and RetryReads used per the test description.
 	// Lower HeartbeatInterval used to speed the test up for any server that uses streaming

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -16,6 +16,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -141,7 +142,7 @@ func TestRetryableWritesProse(t *testing.T) {
 		})
 	})
 
-	tpm := newTestPoolMonitor()
+	tpm := monitor.NewTestPoolMonitor()
 	// Client options with MaxPoolSize of 1 and RetryWrites used per the test description.
 	// Lower HeartbeatInterval used to speed the test up for any server that uses streaming
 	// heartbeats. Only connect to first host in list for sharded clusters.

--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -18,6 +18,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -70,7 +71,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				})
 
 				// Reset the client with the appName specified in the failpoint and the pool monitor.
-				tpm := newTestPoolMonitor()
+				tpm := monitor.NewTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().
 					SetAppName(appName).
 					SetPoolMonitor(tpm.PoolMonitor).
@@ -106,7 +107,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 					})
 
 					// Reset the client with the appName specified in the failpoint.
-					tpm := newTestPoolMonitor()
+					tpm := monitor.NewTestPoolMonitor()
 					mt.ResetClient(baseClientOpts().
 						SetAppName(appName).
 						SetPoolMonitor(tpm.PoolMonitor).
@@ -136,7 +137,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 					})
 
 					// Reset the client with the appName specified in the failpoint.
-					tpm := newTestPoolMonitor()
+					tpm := monitor.NewTestPoolMonitor()
 					mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
 					_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
@@ -165,7 +166,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				})
 
 				// Reset the client with the appName specified in the failpoint.
-				tpm := newTestPoolMonitor()
+				tpm := monitor.NewTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
 				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"test", 1}})
@@ -174,7 +175,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
 			})
 			mt.Run("pool not cleared on timeout network error", func(mt *mtest.T) {
-				tpm := newTestPoolMonitor()
+				tpm := monitor.NewTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetPoolMonitor(tpm.PoolMonitor))
 
 				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
@@ -191,7 +192,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 				assert.False(mt, tpm.IsPoolCleared(), "expected pool to not be cleared but was")
 			})
 			mt.Run("pool not cleared on context cancellation", func(mt *mtest.T) {
-				tpm := newTestPoolMonitor()
+				tpm := monitor.NewTestPoolMonitor()
 				mt.ResetClient(baseClientOpts().SetPoolMonitor(tpm.PoolMonitor))
 
 				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
@@ -264,7 +265,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 					})
 
 					// Reset the client with the appName specified in the failpoint.
-					tpm := newTestPoolMonitor()
+					tpm := monitor.NewTestPoolMonitor()
 					mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
 					runServerErrorsTest(mt, tc.isShutdownError, tpm)
@@ -288,7 +289,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 					})
 
 					// Reset the client with the appName specified in the failpoint.
-					tpm := newTestPoolMonitor()
+					tpm := monitor.NewTestPoolMonitor()
 					mt.ResetClient(baseClientOpts().SetAppName(appName).SetPoolMonitor(tpm.PoolMonitor))
 
 					runServerErrorsTest(mt, tc.isShutdownError, tpm)
@@ -298,7 +299,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 	})
 }
 
-func runServerErrorsTest(mt *mtest.T, isShutdownError bool, tpm *testPoolMonitor) {
+func runServerErrorsTest(mt *mtest.T, isShutdownError bool, tpm *monitor.TestPoolMonitor) {
 	mt.Helper()
 
 	_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})

--- a/mongo/integration/server_selection_prose_test.go
+++ b/mongo/integration/server_selection_prose_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/internal/testutil/monitor"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -62,7 +63,7 @@ func TestServerSelectionProse(t *testing.T) {
 		// Reset the client with exactly 2 mongos hosts. Use a ServerMonitor to wait for both mongos
 		// host descriptions to move from kind "Unknown" to kind "Mongos".
 		topologyEvents := make(chan *event.TopologyDescriptionChangedEvent, 10)
-		tpm := newTestPoolMonitor()
+		tpm := monitor.NewTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetHosts(hosts[:2]).
 			SetPoolMonitor(tpm.PoolMonitor).
@@ -127,7 +128,7 @@ func TestServerSelectionProse(t *testing.T) {
 		// Reset the client with exactly 2 mongos hosts. Use a ServerMonitor to wait for both mongos
 		// host descriptions to move from kind "Unknown" to kind "Mongos".
 		topologyEvents := make(chan *event.TopologyDescriptionChangedEvent, 10)
-		tpm := newTestPoolMonitor()
+		tpm := monitor.NewTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetHosts(hosts[:2]).
 			SetPoolMonitor(tpm.PoolMonitor).


### PR DESCRIPTION
[GODRIVER-2068](https://jira.mongodb.org/browse/GODRIVER-2068)

There are various test types that are used as an `*event.PoolMonitor` and all work slightly differently with different levels of isolation between tests. The existing `testPoolMonitor` in the `mongo/integration` package tests can satisfy the use cases of all pool monitors used in tests and is intended to be instantiated per-test to prevent interaction between tests. Move the existing `testPoolMonitor` into a new test utility package `internal/testutil/monitor` and use it in most tests that require a connection pool monitor.

Making the new test pool monitor available to all tests also allows us to improve the flaky `TestServerConnectionTimeout` test by replacing the test-specific pool monitor with a `monitor.TestPoolMonitor`.

Changes:
* Remove the various test types that are used as an `*event.PoolMonitor` and replace them with the new `monitor.TestPoolMonitor` type.
* Remove unused code from the `internal/testutil` package.