### PR TITLE
GODRIVER-1953 Remove bsonx from production code paths.

### DIFF
--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -17,13 +17,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/examples/documentation_examples"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
@@ -174,7 +174,7 @@ func TestCausalConsistencyExamples(t *testing.T) {
 func getServerVersion(ctx context.Context, client *mongo.Client) (string, error) {
 	serverStatus, err := client.Database("admin").RunCommand(
 		ctx,
-		bsonx.Doc{{"serverStatus", bsonx.Int32(1)}},
+		bson.D{{"serverStatus", 1}},
 	).DecodeBytes()
 	if err != nil {
 		return "", err

--- a/mongo/client_options_test.go
+++ b/mongo/client_options_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/x/bsonx"
 )
 
 func TestClientOptions_CustomDialer(t *testing.T) {
@@ -27,7 +27,7 @@ func TestClientOptions_CustomDialer(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Connect(context.Background())
 	require.NoError(t, err)
-	_, err = client.ListDatabases(context.Background(), bsonx.Doc{})
+	_, err = client.ListDatabases(context.Background(), bson.D{})
 	require.NoError(t, err)
 	got := atomic.LoadInt32(&td.called)
 	if got < 1 {

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -18,7 +18,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
@@ -439,7 +438,7 @@ func (db *Database) ListCollectionNames(ctx context.Context, filter interface{},
 
 	names := make([]string, 0)
 	for res.Next(ctx) {
-		next := &bsonx.Doc{}
+		next := &bsoncore.Document{}
 		err = res.Decode(next)
 		if err != nil {
 			return nil, err
@@ -450,8 +449,8 @@ func (db *Database) ListCollectionNames(ctx context.Context, filter interface{},
 			return nil, err
 		}
 
-		if elem.Type() != bson.TypeString {
-			return nil, fmt.Errorf("incorrect type for 'name'. got %v. want %v", elem.Type(), bson.TypeString)
+		if elem.Type != bson.TypeString {
+			return nil, fmt.Errorf("incorrect type for 'name'. got %v. want %v", elem.Type, bson.TypeString)
 		}
 
 		elemName := elem.StringValue()

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -438,13 +438,7 @@ func (db *Database) ListCollectionNames(ctx context.Context, filter interface{},
 
 	names := make([]string, 0)
 	for res.Next(ctx) {
-		next := &bsoncore.Document{}
-		err = res.Decode(next)
-		if err != nil {
-			return nil, err
-		}
-
-		elem, err := next.LookupErr("name")
+		elem, err := res.Current.LookupErr("name")
 		if err != nil {
 			return nil, err
 		}

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -596,12 +596,12 @@ func (b *Bucket) parseUploadOptions(opts ...*options.UploadOptions) (*Upload, er
 		if err != nil {
 			return nil, err
 		}
-		doc := &bson.D{}
-		unMarErr := bson.UnmarshalWithRegistry(uo.Registry, raw, doc)
+		var doc bson.D
+		unMarErr := bson.UnmarshalWithRegistry(uo.Registry, raw, &doc)
 		if unMarErr != nil {
 			return nil, unMarErr
 		}
-		upload.metadata = *doc
+		upload.metadata = doc
 	}
 
 	return upload, nil

--- a/mongo/main_test.go
+++ b/mongo/main_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestMain(m *testing.M) {
@@ -32,8 +33,8 @@ func TestMain(m *testing.M) {
 	assert.RegisterOpts(reflect.TypeOf(&readconcern.ReadConcern{}), cmp.AllowUnexported(readconcern.ReadConcern{}))
 	assert.RegisterOpts(reflect.TypeOf(&writeconcern.WriteConcern{}), cmp.AllowUnexported(writeconcern.WriteConcern{}))
 	assert.RegisterOpts(reflect.TypeOf(&readpref.ReadPref{}), cmp.AllowUnexported(readpref.ReadPref{}))
-	assert.RegisterOpts(reflect.TypeOf(bsonx.Doc{}), cmp.AllowUnexported(bsonx.Elem{}, bsonx.Val{}))
-	assert.RegisterOpts(reflect.TypeOf(bsonx.Arr{}), cmp.AllowUnexported(bsonx.Val{}))
+	assert.RegisterOpts(reflect.TypeOf(bson.D{}), cmp.AllowUnexported(bson.E{}, bsoncore.Value{}))
+	assert.RegisterOpts(reflect.TypeOf(bson.A{}), cmp.AllowUnexported(bsoncore.Value{}))
 
 	os.Exit(m.Run())
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -81,8 +80,6 @@ func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsonco
 	switch tt := val.(type) {
 	case nil:
 		return nil, nil, ErrNilDocument
-	case bsonx.Doc:
-		val = tt.Copy()
 	case []byte:
 		// Slight optimization so we'll just use MarshalBSON and not go through the codec machinery.
 		val = bson.Raw(tt)
@@ -123,16 +120,16 @@ func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsonco
 	return doc, id, nil
 }
 
-func transformDocument(registry *bsoncodec.Registry, val interface{}) (bsonx.Doc, error) {
-	if doc, ok := val.(bsonx.Doc); ok {
-		return doc.Copy(), nil
-	}
-	b, err := transformBsoncoreDocument(registry, val, true, "document")
-	if err != nil {
-		return nil, err
-	}
-	return bsonx.ReadDoc(b)
-}
+// func transformDocument(registry *bsoncodec.Registry, val interface{}) (bsoncore.Document, error) {
+// 	// if doc, ok := val.(bsonx.Doc); ok {
+// 	// 	return doc.Copy(), nil
+// 	// }
+// 	b, err := transformBsoncoreDocument(registry, val, true, "document")
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return b, nil
+// }
 
 func transformBsoncoreDocument(registry *bsoncodec.Registry, val interface{}, mapAllowed bool, paramName string) (bsoncore.Document, error) {
 	if registry == nil {
@@ -276,7 +273,7 @@ func transformUpdateValue(registry *bsoncodec.Registry, update interface{}, doll
 	switch t := update.(type) {
 	case nil:
 		return u, ErrNilDocument
-	case primitive.D, bsonx.Doc:
+	case primitive.D:
 		u.Type = bsontype.EmbeddedDocument
 		u.Data, err = transformBsoncoreDocument(registry, update, true, "update")
 		if err != nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -80,6 +81,8 @@ func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsonco
 	switch tt := val.(type) {
 	case nil:
 		return nil, nil, ErrNilDocument
+	case bsonx.Doc:
+		val = tt.Copy()
 	case []byte:
 		// Slight optimization so we'll just use MarshalBSON and not go through the codec machinery.
 		val = bson.Raw(tt)
@@ -119,17 +122,6 @@ func transformAndEnsureID(registry *bsoncodec.Registry, val interface{}) (bsonco
 
 	return doc, id, nil
 }
-
-// func transformDocument(registry *bsoncodec.Registry, val interface{}) (bsoncore.Document, error) {
-// 	// if doc, ok := val.(bsonx.Doc); ok {
-// 	// 	return doc.Copy(), nil
-// 	// }
-// 	b, err := transformBsoncoreDocument(registry, val, true, "document")
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return b, nil
-// }
 
 func transformBsoncoreDocument(registry *bsoncodec.Registry, val interface{}, mapAllowed bool, paramName string) (bsoncore.Document, error) {
 	if registry == nil {
@@ -273,7 +265,7 @@ func transformUpdateValue(registry *bsoncodec.Registry, update interface{}, doll
 	switch t := update.(type) {
 	case nil:
 		return u, ErrNilDocument
-	case primitive.D:
+	case primitive.D, bsonx.Doc:
 		u.Type = bsontype.EmbeddedDocument
 		u.Data, err = transformBsoncoreDocument(registry, update, true, "update")
 		if err != nil {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -16,59 +16,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestMongoHelpers(t *testing.T) {
-	t.Run("transform document", func(t *testing.T) {
-		testCases := []struct {
-			name     string
-			document interface{}
-			want     bsonx.Doc
-			err      error
-		}{
-			{
-				"bson.Marshaler",
-				bMarsh{bsonx.Doc{{"foo", bsonx.String("bar")}}},
-				bsonx.Doc{{"foo", bsonx.String("bar")}},
-				nil,
-			},
-			{
-				"reflection",
-				reflectStruct{Foo: "bar"},
-				bsonx.Doc{{"foo", bsonx.String("bar")}},
-				nil,
-			},
-			{
-				"reflection pointer",
-				&reflectStruct{Foo: "bar"},
-				bsonx.Doc{{"foo", bsonx.String("bar")}},
-				nil,
-			},
-			{
-				"unsupported type",
-				[]string{"foo", "bar"},
-				nil,
-				MarshalError{
-					Value: []string{"foo", "bar"},
-					Err:   errors.New("WriteArray can only write a Array while positioned on a Element or Value but is positioned on a TopLevel")},
-			},
-			{
-				"nil",
-				nil,
-				nil,
-				ErrNilDocument,
-			},
-		}
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				got, err := transformDocument(bson.NewRegistryBuilder().Build(), tc.document)
-				assert.Equal(t, tc.err, err, "expected error %v, got %v", tc.err, err)
-				assert.Equal(t, tc.want, got, "expected document %v, got %v", tc.want, got)
-			})
-		}
-	})
 	t.Run("transform and ensure ID", func(t *testing.T) {
 		t.Run("newly added _id should be first element", func(t *testing.T) {
 			doc := bson.D{{"foo", "bar"}, {"baz", "qux"}, {"hello", "world"}}
@@ -511,11 +462,11 @@ func TestMongoHelpers(t *testing.T) {
 var _ bson.Marshaler = bMarsh{}
 
 type bMarsh struct {
-	bsonx.Doc
+	bson.D
 }
 
 func (b bMarsh) MarshalBSON() ([]byte, error) {
-	return b.Doc.MarshalBSON()
+	return bson.Marshal(b)
 }
 
 type reflectStruct struct {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -459,20 +459,6 @@ func TestMongoHelpers(t *testing.T) {
 	})
 }
 
-var _ bson.Marshaler = bMarsh{}
-
-type bMarsh struct {
-	bson.D
-}
-
-func (b bMarsh) MarshalBSON() ([]byte, error) {
-	return bson.Marshal(b)
-}
-
-type reflectStruct struct {
-	Foo string
-}
-
 var _ bsoncodec.ValueMarshaler = bvMarsh{}
 
 type bvMarsh struct {


### PR DESCRIPTION
[GODRIVER-1953](https://jira.mongodb.org/browse/GODRIVER-1953)

Stop using types and functions from the `bsonx` package in "production" code paths. Leave references in (most) tests and non-production code (e.g. benchmarks) to make reviewing easier and ensure backward compatibility of the changes. We can remove those additional `bsonx` references (and maybe the `bsonx` package) in a later change.

Based on https://github.com/mongodb/mongo-go-driver/pull/692 by [RammasEchor](https://github.com/RammasEchor)