### PR TITLE
Add missing licences and update license script

### DIFF
--- a/bson/bsoncodec/doc.go
+++ b/bson/bsoncodec/doc.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 // Package bsoncodec provides a system for encoding values to BSON representations and decoding
 // values from BSON representations. This package considers both binary BSON and ExtendedJSON as
 // BSON representations. The types in this package enable a flexible system for handling this

--- a/bson/mgocompat/doc.go
+++ b/bson/mgocompat/doc.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 // Package mgocompat provides Registry, a BSON registry compatible with globalsign/mgo's BSON,
 // with some remaining differences. It also provides RegistryRespectNilValues for compatibility
 // with mgo's BSON with RespectNilValues set to true. A registry can be configured on a

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package primitive
 
 import (

--- a/bson/truncation_test.go
+++ b/bson/truncation_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bson
 
 import (

--- a/cmd/docbuilder/main.go
+++ b/cmd/docbuilder/main.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package main
 
 import (

--- a/etc/add-license.sh
+++ b/etc/add-license.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-copyright=$'// Copyright (C) MongoDB, Inc. 2017-present.
+copyright=$'// Copyright (C) MongoDB, Inc. 2022-present.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License. You may obtain
@@ -8,8 +8,9 @@ copyright=$'// Copyright (C) MongoDB, Inc. 2017-present.
 '
 
 add_copyright() {
-    local line=$(head -n 1 $1)
-    if [ "$line" == "// Copyright (C) MongoDB, Inc. 2017-present." ]; then
+    # Check if first 24 bytes match first 24 bytes of copyright notice.
+    local line=$(head -c 24 $1)
+    if [ "$line" == "// Copyright (C) MongoDB" ]; then
         echo "$1 already has copyright notice" >&2
         return
     fi

--- a/mongo/batch_cursor.go
+++ b/mongo/batch_cursor.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package mongo
 
 import (

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package mongo
 
 import (

--- a/mongo/integration/sessions_prose_test.go
+++ b/mongo/integration/sessions_prose_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package options
 
 import (

--- a/mongo/options/collation_test.go
+++ b/mongo/options/collation_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package options
 
 import (

--- a/x/bsonx/bsoncore/document_sequence.go
+++ b/x/bsonx/bsoncore/document_sequence.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bsoncore
 
 import (

--- a/x/bsonx/bsoncore/document_sequence_test.go
+++ b/x/bsonx/bsoncore/document_sequence_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bsoncore
 
 import (

--- a/x/bsonx/primitive_codecs_test.go
+++ b/x/bsonx/primitive_codecs_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bsonx
 
 import (

--- a/x/bsonx/reflectionfree_d_codec_test.go
+++ b/x/bsonx/reflectionfree_d_codec_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bsonx
 
 import (

--- a/x/bsonx/registry.go
+++ b/x/bsonx/registry.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bsonx
 
 import (

--- a/x/mongo/driver/auth/internal/gssapi/gss_wrapper.c
+++ b/x/mongo/driver/auth/internal/gssapi/gss_wrapper.c
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 //+build gssapi
 //+build linux darwin
 

--- a/x/mongo/driver/auth/internal/gssapi/gss_wrapper.h
+++ b/x/mongo/driver/auth/internal/gssapi/gss_wrapper.h
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 //+build gssapi
 //+build linux darwin
 #ifndef GSS_WRAPPER_H

--- a/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
+++ b/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.c
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 //+build gssapi,windows
 
 #include "sspi_wrapper.h"

--- a/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.h
+++ b/x/mongo/driver/auth/internal/gssapi/sspi_wrapper.h
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 //+build gssapi,windows
 
 #ifndef SSPI_WRAPPER_H

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/batch_cursor_test.go
+++ b/x/mongo/driver/batch_cursor_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/batches.go
+++ b/x/mongo/driver/batches.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/batches_test.go
+++ b/x/mongo/driver/batches_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver // import "go.mongodb.org/mongo-driver/x/mongo/driver"
 
 import (

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/integration/aggregate_test.go
+++ b/x/mongo/driver/integration/aggregate_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/x/mongo/driver/integration/compressor_test.go
+++ b/x/mongo/driver/integration/compressor_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/x/mongo/driver/integration/insert_test.go
+++ b/x/mongo/driver/integration/insert_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/x/mongo/driver/integration/integration.go
+++ b/x/mongo/driver/integration/integration.go
@@ -1,1 +1,7 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration

--- a/x/mongo/driver/integration/main_test.go
+++ b/x/mongo/driver/integration/main_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/x/mongo/driver/integration/scram_test.go
+++ b/x/mongo/driver/integration/scram_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package integration
 
 import (

--- a/x/mongo/driver/legacy.go
+++ b/x/mongo/driver/legacy.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 // LegacyOperationKind indicates if an operation is a legacy find, getMore, or killCursors. This is used

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package driver
 
 import (

--- a/x/mongo/driver/topology/connection_legacy.go
+++ b/x/mongo/driver/topology/connection_legacy.go
@@ -1,1 +1,7 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology
 
 import (

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology
 
 import (

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology
 
 import (

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package topology
 
 import (

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package wiremessage
 
 import (


### PR DESCRIPTION
Updates the `add-license.sh` script under `etc` and adds a 2022 copyright notice to all `*.go` files not under `vendor` that were missing it.