### PR TITLE
[mtest package] Create function to get current mock responses

### DIFF
--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -261,6 +261,11 @@ func (t *T) AddMockResponses(responses ...bson.D) {
 	t.mockDeployment.addResponses(responses...)
 }
 
+// GetMockResponses get a list of the current responses.
+func (t *T) GetMockResponses(responses ...bson.D) []bson.D {
+	return t.mockDeployment.conn.responses
+}
+
 // ClearMockResponses clears all responses in the mock deployment.
 func (t *T) ClearMockResponses() {
 	t.mockDeployment.clearResponses()


### PR DESCRIPTION
Hi guys, for testing purposes I need to somehow get the current mock responses added to `*mtest.T` so that I can assert all started event matched with how much data added to the responses.

Thank you