### PR TITLE
Godriver 2370.update err msg csfle

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build cse
 // +build cse
 
 package integration
@@ -687,7 +688,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			{"aws success with endpoint", "aws", awsSuccessWithEndpoint, "", false},
 			{"aws success with https endpoint", "aws", awsSuccessWithHTTPSEndpoint, "", false},
 			{"aws failure with connection error", "aws", awsFailureConnectionError, "connection refused", false},
-			{"aws failure with wrong endpoint", "aws", awsFailureInvalidEndpoint, "us-east-1", false},
+			{"aws failure with wrong endpoint", "aws", awsFailureInvalidEndpoint, "mongocrypt", false},
 			{"aws failure with parse error", "aws", awsFailureParseError, "parse error", false},
 			{"azure success", "azure", azure, "", true},
 			{"gcp success", "gcp", gcpSuccess, "", true},


### PR DESCRIPTION
[GODRIVER-2370](https://jira.mongodb.org/browse/GODRIVER-2370)

Can't cherry-pick https://github.com/mongodb/mongo-go-driver/commit/f48a833c0e8fc25447ce8a2b156ca25684c10560 because the case structure is different, so made the change directly.