### PR TITLE
Fix two data races in test code.

### DIFF
--- a/internal/testutil/monitor/monitor.go
+++ b/internal/testutil/monitor/monitor.go
@@ -41,10 +41,10 @@ func NewTestPoolMonitor() *TestPoolMonitor {
 // applied to the returned events set and are applied using AND logic (i.e. all filters must return
 // true to include the event in the result).
 func (tpm *TestPoolMonitor) Events(filters ...func(*event.PoolEvent) bool) []*event.PoolEvent {
-	filtered := make([]*event.PoolEvent, 0, len(tpm.events))
 	tpm.mu.RLock()
 	defer tpm.mu.RUnlock()
 
+	filtered := make([]*event.PoolEvent, 0, len(tpm.events))
 	for _, evt := range tpm.events {
 		keep := true
 		for _, filter := range filters {

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,30 +33,33 @@ var _ net.Conn = &mockSlowConn{}
 type mockSlowConn struct {
 	reader *bytes.Reader
 	delay  time.Duration
-	closed bool
+	closed atomic.Value
 }
 
 // newMockSlowConn returns a net.Conn that reads from the specified response after blocking for a
 // delay duration. Calls to Write() reset the read buffer, so subsequent Read() calls read from the
 // beginning of the provided response.
 func newMockSlowConn(response []byte, delay time.Duration) *mockSlowConn {
+	var closed atomic.Value
+	closed.Store(false)
+
 	return &mockSlowConn{
 		reader: bytes.NewReader(response),
 		delay:  delay,
-		closed: false,
+		closed: closed,
 	}
 }
 
 func (msc *mockSlowConn) Read(b []byte) (int, error) {
 	time.Sleep(msc.delay)
-	if msc.closed {
+	if msc.closed.Load().(bool) {
 		return 0, io.ErrUnexpectedEOF
 	}
 	return msc.reader.Read(b)
 }
 
 func (msc *mockSlowConn) Write(b []byte) (int, error) {
-	if msc.closed {
+	if msc.closed.Load().(bool) {
 		return 0, io.ErrUnexpectedEOF
 	}
 	_, err := msc.reader.Seek(0, io.SeekStart)
@@ -65,7 +69,7 @@ func (msc *mockSlowConn) Write(b []byte) (int, error) {
 // Close closes the mock connection. All subsequent calls to Read or Write return error
 // io.ErrUnexpectedEOF. It is not safe to call Close concurrently with Read or Write.
 func (msc *mockSlowConn) Close() error {
-	msc.closed = true
+	msc.closed.Store(true)
 	return nil
 }
 


### PR DESCRIPTION
Running various `topology` package tests with the data race detector reveals two data races in the test code:
```
❯ go test -timeout 120s -run 'TestCMAP|TestPool|TestServer|TestConnection' go.mongodb.org/mongo-driver/x/mongo/driver/topology -count=1 -race
==================
WARNING: DATA RACE
Read at 0x00c00000f4e0 by goroutine 17:
  go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*mockSlowConn).Read()
      ./mongo-go-driver/x/mongo/driver/topology/rtt_monitor_test.go:51 +0x6e
  ...

Previous write at 0x00c00000f4e0 by goroutine 24:
  go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*mockSlowConn).Close()
      ./mongo-go-driver/x/mongo/driver/topology/rtt_monitor_test.go:68 +0x34
  ...

==================
WARNING: DATA RACE
Read at 0x00c0004c4088 by goroutine 25:
  go.mongodb.org/mongo-driver/internal/testutil/monitor.(*TestPoolMonitor).Events()
      ./mongo-go-driver/internal/testutil/monitor/monitor.go:44 +0x7a
  ...

Previous write at 0x00c0004c4088 by goroutine 201:
  go.mongodb.org/mongo-driver/internal/testutil/monitor.NewTestPoolMonitor.func1()
      ./mongo-go-driver/internal/testutil/monitor/monitor.go:34 +0x176
  ...
```

Fix those two data races.