### PR TITLE
GODRIVER-2323 Support int64 for 'n' field in insert, update, and delete ops.

### DIFF
--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -114,7 +114,7 @@ func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWr
 			batchErr.Labels = writeErr.Labels
 			batchErr.WriteConcernError = convertDriverWriteConcernError(writeErr.WriteConcernError)
 		}
-		batchRes.InsertedCount = int64(res.N)
+		batchRes.InsertedCount = res.N
 	case *DeleteOneModel, *DeleteManyModel:
 		res, err := bw.runDelete(ctx, batch)
 		if err != nil {
@@ -126,7 +126,7 @@ func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWr
 			batchErr.Labels = writeErr.Labels
 			batchErr.WriteConcernError = convertDriverWriteConcernError(writeErr.WriteConcernError)
 		}
-		batchRes.DeletedCount = int64(res.N)
+		batchRes.DeletedCount = res.N
 	case *ReplaceOneModel, *UpdateOneModel, *UpdateManyModel:
 		res, err := bw.runUpdate(ctx, batch)
 		if err != nil {
@@ -138,8 +138,8 @@ func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWr
 			batchErr.Labels = writeErr.Labels
 			batchErr.WriteConcernError = convertDriverWriteConcernError(writeErr.WriteConcernError)
 		}
-		batchRes.MatchedCount = int64(res.N)
-		batchRes.ModifiedCount = int64(res.NModified)
+		batchRes.MatchedCount = res.N
+		batchRes.ModifiedCount = res.NModified
 		batchRes.UpsertedCount = int64(len(res.Upserted))
 		for _, upsert := range res.Upserted {
 			batchRes.UpsertedIDs[int64(batch.indexes[upsert.Index])] = upsert.ID

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -473,7 +473,7 @@ func (coll *Collection) delete(ctx context.Context, filter interface{}, deleteOn
 	if rr&expectedRr == 0 {
 		return nil, err
 	}
-	return &DeleteResult{DeletedCount: int64(op.Result().N)}, err
+	return &DeleteResult{DeletedCount: op.Result().N}, err
 }
 
 // DeleteOne executes a delete command to delete at most one document from the collection.

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -582,8 +582,8 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 
 	opRes := op.Result()
 	res := &UpdateResult{
-		MatchedCount:  int64(opRes.N),
-		ModifiedCount: int64(opRes.NModified),
+		MatchedCount:  opRes.N,
+		ModifiedCount: opRes.NModified,
 		UpsertedCount: int64(len(opRes.Upserted)),
 	}
 	if len(opRes.Upserted) > 0 {

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
@@ -54,9 +55,12 @@ func buildCountResult(response bsoncore.Document) (CountResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "n": // for count using original command
-			var ok bool
-			cr.N, ok = element.Value().AsInt64OK()
-			if !ok {
+			switch element.Value().Type {
+			case bson.TypeInt32:
+				cr.N = int64(element.Value().Int32())
+			case bson.TypeInt64:
+				cr.N = element.Value().Int64()
+			default:
 				return cr, fmt.Errorf("response field 'n' is type int64, but received BSON type %s",
 					element.Value().Type)
 			}

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
@@ -55,12 +54,9 @@ func buildCountResult(response bsoncore.Document) (CountResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "n": // for count using original command
-			switch element.Value().Type {
-			case bson.TypeInt32:
-				cr.N = int64(element.Value().Int32())
-			case bson.TypeInt64:
-				cr.N = element.Value().Int64()
-			default:
+			var ok bool
+			cr.N, ok = element.Value().AsInt64OK()
+			if !ok {
 				return cr, fmt.Errorf("response field 'n' is type int64, but received BSON type %s",
 					element.Value().Type)
 			}

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
@@ -55,12 +54,9 @@ func buildDeleteResult(response bsoncore.Document) (DeleteResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "n":
-			switch element.Value().Type {
-			case bson.TypeInt32:
-				dr.N = int64(element.Value().Int32())
-			case bson.TypeInt64:
-				dr.N = element.Value().Int64()
-			default:
+			var ok bool
+			dr.N, ok = element.Value().AsInt64OK()
+			if !ok {
 				return dr, fmt.Errorf("response field 'n' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		}

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
@@ -41,7 +42,7 @@ type Insert struct {
 // InsertResult represents an insert result returned by the server.
 type InsertResult struct {
 	// Number of documents successfully inserted.
-	N int32
+	N int64
 }
 
 func buildInsertResult(response bsoncore.Document) (InsertResult, error) {
@@ -53,10 +54,13 @@ func buildInsertResult(response bsoncore.Document) (InsertResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "n":
-			var ok bool
-			ir.N, ok = element.Value().AsInt32OK()
-			if !ok {
-				return ir, fmt.Errorf("response field 'n' is type int32, but received BSON type %s", element.Value().Type)
+			switch element.Value().Type {
+			case bson.TypeInt32:
+				ir.N = int64(element.Value().Int32())
+			case bson.TypeInt64:
+				ir.N = element.Value().Int64()
+			default:
+				return ir, fmt.Errorf("response field 'n' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		}
 	}

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
@@ -54,12 +53,9 @@ func buildInsertResult(response bsoncore.Document) (InsertResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "n":
-			switch element.Value().Type {
-			case bson.TypeInt32:
-				ir.N = int64(element.Value().Int32())
-			case bson.TypeInt64:
-				ir.N = element.Value().Int64()
-			default:
+			var ok bool
+			ir.N, ok = element.Value().AsInt64OK()
+			if !ok {
 				return ir, fmt.Errorf("response field 'n' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		}

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -51,9 +51,9 @@ type Upsert struct {
 // UpdateResult contains information for the result of an Update operation.
 type UpdateResult struct {
 	// Number of documents matched.
-	N int32
+	N int64
 	// Number of documents modified.
-	NModified int32
+	NModified int64
 	// Information about upserted documents.
 	Upserted []Upsert
 }
@@ -67,16 +67,22 @@ func buildUpdateResult(response bsoncore.Document) (UpdateResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "nModified":
-			var ok bool
-			ur.NModified, ok = element.Value().Int32OK()
-			if !ok {
-				return ur, fmt.Errorf("response field 'nModified' is type int32, but received BSON type %s", element.Value().Type)
+			switch element.Value().Type {
+			case bson.TypeInt32:
+				ur.NModified = int64(element.Value().Int32())
+			case bson.TypeInt64:
+				ur.NModified = element.Value().Int64()
+			default:
+				return ur, fmt.Errorf("response field 'nModified' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		case "n":
-			var ok bool
-			ur.N, ok = element.Value().Int32OK()
-			if !ok {
-				return ur, fmt.Errorf("response field 'n' is type int32, but received BSON type %s", element.Value().Type)
+			switch element.Value().Type {
+			case bson.TypeInt32:
+				ur.N = int64(element.Value().Int32())
+			case bson.TypeInt64:
+				ur.N = element.Value().Int64()
+			default:
+				return ur, fmt.Errorf("response field 'n' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		case "upserted":
 			arr, ok := element.Value().ArrayOK()

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -67,21 +67,15 @@ func buildUpdateResult(response bsoncore.Document) (UpdateResult, error) {
 	for _, element := range elements {
 		switch element.Key() {
 		case "nModified":
-			switch element.Value().Type {
-			case bson.TypeInt32:
-				ur.NModified = int64(element.Value().Int32())
-			case bson.TypeInt64:
-				ur.NModified = element.Value().Int64()
-			default:
+			var ok bool
+			ur.NModified, ok = element.Value().AsInt64OK()
+			if !ok {
 				return ur, fmt.Errorf("response field 'nModified' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		case "n":
-			switch element.Value().Type {
-			case bson.TypeInt32:
-				ur.N = int64(element.Value().Int32())
-			case bson.TypeInt64:
-				ur.N = element.Value().Int64()
-			default:
+			var ok bool
+			ur.N, ok = element.Value().AsInt64OK()
+			if !ok {
 				return ur, fmt.Errorf("response field 'n' is type int32 or int64, but received BSON type %s", element.Value().Type)
 			}
 		case "upserted":


### PR DESCRIPTION
[GODRIVER-2323](https://jira.mongodb.org/browse/GODRIVER-2323)

Add support for int32 and int64 types in the `"n"` and `"nModified"` fields in various server CRUD responses.