### PR TITLE
GODRIVER-2362 Add spec test for presence of "to" field in change stream event

### DIFF
--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -1,10 +1,22 @@
 {
   "description": "change-streams",
   "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
       }
     },
     {
@@ -34,10 +46,7 @@
       "description": "Test array truncation",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.7",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.7"
         }
       ],
       "operations": [
@@ -107,6 +116,53 @@
                   "newSize": 2
                 }
               ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "to field is set in a rename change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "collection1"
+          }
+        },
+        {
+          "name": "rename",
+          "object": "collection0",
+          "arguments": {
+            "to": "collection1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "rename",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "to": {
+              "db": "database0",
+              "coll": "collection1"
             }
           }
         }

--- a/data/change-streams/unified/change-streams.yml
+++ b/data/change-streams/unified/change-streams.yml
@@ -1,8 +1,13 @@
 description: "change-streams"
 schemaVersion: "1.0"
+runOnRequirements:
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded-replicaset ]
 createEntities:
   - client:
       id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
   - database:
       id: &database0 database0
       client: *client0
@@ -15,11 +20,11 @@ initialData:
   - collectionName: *collection0
     databaseName: *database0
     documents: []
+
 tests:
   - description: "Test array truncation"
     runOnRequirements:
       - minServerVersion: "4.7"
-        topologies: [replicaset]
     operations:
       - name: insertOne
         object: *collection0
@@ -70,3 +75,31 @@ tests:
             ]
           }
         }
+
+  - description: "to field is set in a rename change event"
+    runOnRequirements:
+      - minServerVersion: "4.0.1"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: &collection1 collection1
+      - name: rename
+        object: *collection0
+        arguments:
+          to: *collection1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: rename
+          ns:
+            db: *database0
+            coll: *collection0
+          to:
+            db: *database0
+            coll: *collection1

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -798,6 +798,36 @@ func executeListIndexes(ctx context.Context, operation *operation) (*operationRe
 	return newCursorResult(docs), nil
 }
 
+func executeRenameCollection(ctx context.Context, operation *operation) (*operationResult, error) {
+	coll, err := entities(ctx).collection(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var toName string
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "to":
+			toName = val.StringValue()
+		default:
+			return nil, fmt.Errorf("unrecognized rename option %q", key)
+		}
+	}
+
+	renameCmd := bson.D{
+		{"renameCollection", coll.Database().Name() + "." + coll.Name()},
+		{"to", coll.Database().Name() + "." + toName},
+	}
+	// rename can only be run on the 'admin' database.
+	admin := coll.Database().Client().Database("admin")
+	res, err := admin.RunCommand(context.Background(), renameCmd).DecodeBytes()
+	return newDocumentResult(res, err), nil
+}
+
 func executeReplaceOne(ctx context.Context, operation *operation) (*operationResult, error) {
 	coll, err := entities(ctx).collection(operation.Object)
 	if err != nil {

--- a/mongo/integration/unified/database_operation_execution.go
+++ b/mongo/integration/unified/database_operation_execution.go
@@ -143,40 +143,6 @@ func executeListCollectionNames(ctx context.Context, operation *operation) (*ope
 	return newValueResult(bsontype.Array, data, nil), nil
 }
 
-func executeRenameCollection(ctx context.Context, operation *operation) (*operationResult, error) {
-	// rename can only be run on the 'admin' database.
-	admin, err := entities(ctx).database("admin")
-	if err != nil {
-		return nil, err
-	}
-
-	coll, err := entities(ctx).collection(operation.Object)
-	if err != nil {
-		return nil, err
-	}
-
-	var toName string
-	elems, _ := operation.Arguments.Elements()
-	for _, elem := range elems {
-		key := elem.Key()
-		val := elem.Value()
-
-		switch key {
-		case "to":
-			toName = val.StringValue()
-		default:
-			return nil, fmt.Errorf("unrecognized rename option %q", key)
-		}
-	}
-
-	renameCmd := bson.D{
-		{"renameCollection", coll.Database().Name() + "." + coll.Name()},
-		{"to", coll.Database().Name() + "." + toName},
-	}
-	res, err := admin.RunCommand(context.Background(), renameCmd).DecodeBytes()
-	return newDocumentResult(res, err), nil
-}
-
 func executeRunCommand(ctx context.Context, operation *operation) (*operationResult, error) {
 	db, err := entities(ctx).database(operation.Object)
 	if err != nil {

--- a/mongo/integration/unified/operation.go
+++ b/mongo/integration/unified/operation.go
@@ -97,6 +97,8 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 		return executeListCollections(ctx, op)
 	case "listCollectionNames":
 		return executeListCollectionNames(ctx, op)
+	case "rename":
+		return executeRenameCollection(ctx, op)
 	case "runCommand":
 		return executeRunCommand(ctx, op)
 

--- a/mongo/integration/unified/operation.go
+++ b/mongo/integration/unified/operation.go
@@ -97,8 +97,6 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 		return executeListCollections(ctx, op)
 	case "listCollectionNames":
 		return executeListCollectionNames(ctx, op)
-	case "rename":
-		return executeRenameCollection(ctx, op)
 	case "runCommand":
 		return executeRunCommand(ctx, op)
 
@@ -135,6 +133,8 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 		return executeInsertOne(ctx, op)
 	case "listIndexes":
 		return executeListIndexes(ctx, op)
+	case "rename":
+		return executeRenameCollection(ctx, op)
 	case "replaceOne":
 		return executeReplaceOne(ctx, op)
 	case "updateOne":

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -262,6 +262,17 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 			}
 		}
 	}
+	// Add 'admin' database as entity for use in rename operations if a client entity is specified.
+	if tc.entities != nil && tc.entities.clientEntities != nil {
+		eo := entityOptions{
+			ID:           "admin",
+			DatabaseName: "admin",
+			ClientID:     "client0",
+		}
+		if err := tc.entities.addEntity(testCtx, "database", &eo); err != nil {
+			return fmt.Errorf("error creating 'admin' database entity: %v", err)
+		}
+	}
 
 	// Work around SERVER-39704.
 	if mtest.ClusterTopologyKind() == mtest.Sharded && tc.performsDistinct() {

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -262,16 +262,18 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 			}
 		}
 	}
-	// Add 'admin' database as entity for use in rename operations if a client entity is specified.
-	if tc.entities != nil && tc.entities.clientEntities != nil {
-		eo := entityOptions{
-			ID:           "admin",
-			DatabaseName: "admin",
-			ClientID:     "client0",
-		}
-		if err := tc.entities.addEntity(testCtx, "database", &eo); err != nil {
-			return fmt.Errorf("error creating 'admin' database entity: %v", err)
-		}
+
+	// Add 'adminClient' client and 'admin' database as entities for use in rename operations.
+	if err := tc.entities.addEntity(testCtx, "client", &entityOptions{ID: "adminClient"}); err != nil {
+		return fmt.Errorf("error creating 'adminClient' client entity: %v", err)
+	}
+	eo := entityOptions{
+		ID:           "admin",
+		DatabaseName: "admin",
+		ClientID:     "adminClient",
+	}
+	if err := tc.entities.addEntity(testCtx, "database", &eo); err != nil {
+		return fmt.Errorf("error creating 'admin' database entity: %v", err)
 	}
 
 	// Work around SERVER-39704.

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -262,20 +262,6 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 			}
 		}
 	}
-
-	// Add 'adminClient' client and 'admin' database as entities for use in rename operations.
-	if err := tc.entities.addEntity(testCtx, "client", &entityOptions{ID: "adminClient"}); err != nil {
-		return fmt.Errorf("error creating 'adminClient' client entity: %v", err)
-	}
-	eo := entityOptions{
-		ID:           "admin",
-		DatabaseName: "admin",
-		ClientID:     "adminClient",
-	}
-	if err := tc.entities.addEntity(testCtx, "database", &eo); err != nil {
-		return fmt.Errorf("error creating 'admin' database entity: %v", err)
-	}
-
 	// Work around SERVER-39704.
 	if mtest.ClusterTopologyKind() == mtest.Sharded && tc.performsDistinct() {
 		if err := performDistinctWorkaround(testCtx); err != nil {


### PR DESCRIPTION
GODRIVER-2362

Adds a new spec test that verifies that `to` is set in a change stream event document after the `rename` operation has been run. The Go driver has no concrete type for change stream event documents, but I did have to add support for the `rename` operation in the unified test runner.