### PR TITLE
GODRIVER-2376 Partially sync CRUD unified spec tests

### DIFF
--- a/data/crud/unified/aggregate-write-readPreference.yml
+++ b/data/crud/unified/aggregate-write-readPreference.yml
@@ -87,9 +87,9 @@ tests:
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
-        # MongoDB 4.2 introduced support for read concerns and write stages.
-        # Pre-4.2 servers may allow a "local" read concern anyway, but some
-        # drivers may avoid inheriting a client-level read concern for pre-4.2.
+      # MongoDB 4.2 introduced support for read concerns and write stages.
+      # Pre-4.2 servers may allow a "local" read concern anyway, but some
+      # drivers may avoid inheriting a client-level read concern for pre-4.2.
       - minServerVersion: "4.2"
         maxServerVersion: "4.4.99"
         serverless: "forbid"

--- a/data/crud/unified/bulkWrite-replaceOne-let.json
+++ b/data/crud/unified/bulkWrite-replaceOne-let.json
@@ -95,6 +95,12 @@
                       },
                       "u": {
                         "x": 3
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -183,6 +189,12 @@
                       },
                       "u": {
                         "x": 3
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/data/crud/unified/bulkWrite-replaceOne-let.yml
+++ b/data/crud/unified/bulkWrite-replaceOne-let.yml
@@ -47,6 +47,8 @@ tests:
                 updates:
                   - q: *filter
                     u: *replacement
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let
     outcome:
       - collectionName: *collection0Name
@@ -80,6 +82,8 @@ tests:
                 updates:
                   - q: *filter
                     u: *replacement
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let
     outcome:
       - collectionName: *collection0Name

--- a/data/crud/unified/bulkWrite-update-hint-serverError.yml
+++ b/data/crud/unified/bulkWrite-update-hint-serverError.yml
@@ -79,18 +79,14 @@ tests:
                     q: *updateOne_filter
                     u: *updateOne_update
                     hint: *hint_string
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                   -
                     q: *updateOne_filter
                     u: *updateOne_update
                     hint: *hint_doc
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 ordered: true
     outcome:
       -
@@ -148,15 +144,13 @@ tests:
                     u: *updateMany_update
                     multi: true
                     hint: *hint_string
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
                   -
                     q: *updateMany_filter
                     u: *updateMany_update
                     multi: true
                     hint: *hint_doc
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
                 ordered: true
     outcome:
       -
@@ -215,20 +209,16 @@ tests:
                     u:
                       x: 333
                     hint: *hint_string
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                   -
                     q:
                       _id: 4
                     u:
                       x: 444
                     hint: *hint_doc
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 ordered: true
     outcome:
       -

--- a/data/crud/unified/bulkWrite-updateMany-let.yml
+++ b/data/crud/unified/bulkWrite-updateMany-let.yml
@@ -85,8 +85,7 @@ tests:
                   - q: *filter
                     u: *update
                     multi: true
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
                 let: *let
 
     outcome:

--- a/data/crud/unified/replaceOne-hint.yml
+++ b/data/crud/unified/replaceOne-hint.yml
@@ -64,10 +64,8 @@ tests:
                     q: *filter
                     u: *replacement
                     hint: _id_
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: &outcome
       -
         collectionName: *collection_name
@@ -105,8 +103,6 @@ tests:
                     u: *replacement
                     hint:
                       _id: 1
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: *outcome

--- a/data/crud/unified/replaceOne-let.json
+++ b/data/crud/unified/replaceOne-let.json
@@ -94,6 +94,12 @@
                       },
                       "u": {
                         "x": "foo"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -176,6 +182,12 @@
                       },
                       "u": {
                         "x": "foo"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/data/crud/unified/replaceOne-let.yml
+++ b/data/crud/unified/replaceOne-let.yml
@@ -51,6 +51,8 @@ tests:
                   -
                     q: *filter
                     u: *replacement
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let
     outcome:
       -
@@ -84,6 +86,8 @@ tests:
                   -
                     q: *filter
                     u: *replacement
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let
     outcome:
       -

--- a/data/crud/unified/updateMany-hint-serverError.yml
+++ b/data/crud/unified/updateMany-hint-serverError.yml
@@ -68,8 +68,7 @@ tests:
                     u: *update
                     multi: true
                     hint: _id_
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
     outcome: &outcome
       -
         collectionName: *collection_name
@@ -112,6 +111,5 @@ tests:
                     multi: true
                     hint:
                       _id: 1
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
     outcome: *outcome

--- a/data/crud/unified/updateMany-hint.yml
+++ b/data/crud/unified/updateMany-hint.yml
@@ -69,8 +69,7 @@ tests:
                     u: *update
                     multi: true
                     hint: _id_
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
     outcome: &outcome
       -
         collectionName: *collection_name
@@ -112,6 +111,5 @@ tests:
                     multi: true
                     hint:
                       _id: 1
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
     outcome: *outcome

--- a/data/crud/unified/updateMany-let.json
+++ b/data/crud/unified/updateMany-let.json
@@ -114,7 +114,10 @@
                           }
                         }
                       ],
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {
@@ -158,7 +161,7 @@
       "description": "updateMany with let option unsupported (server-side error)",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
+          "minServerVersion": "4.2.0",
           "maxServerVersion": "4.4.99"
         }
       ],
@@ -207,7 +210,10 @@
                           }
                         }
                       ],
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {

--- a/data/crud/unified/updateMany-let.yml
+++ b/data/crud/unified/updateMany-let.yml
@@ -56,6 +56,7 @@ tests:
                     q: *filter
                     u: *update
                     multi: true
+                    upsert: { $$unsetOrMatches: false }
                 let: *let0
     outcome:
       -
@@ -68,7 +69,7 @@ tests:
 
   - description: "updateMany with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
+      - minServerVersion: "4.2.0"
         maxServerVersion: "4.4.99"
     operations:
       - name: updateMany
@@ -94,6 +95,7 @@ tests:
                     q: *filter1
                     u: *update1
                     multi: true
+                    upsert: { $$unsetOrMatches: false }
                 let: *let1
     outcome:
       -

--- a/data/crud/unified/updateOne-hint-serverError.yml
+++ b/data/crud/unified/updateOne-hint-serverError.yml
@@ -64,10 +64,8 @@ tests:
                     q: *filter
                     u: *update
                     hint: _id_
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: &outcome
       -
         collectionName: *collection_name
@@ -106,8 +104,6 @@ tests:
                     u: *update
                     hint:
                       _id: 1
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: *outcome

--- a/data/crud/unified/updateOne-hint.yml
+++ b/data/crud/unified/updateOne-hint.yml
@@ -65,10 +65,8 @@ tests:
                     q: *filter
                     u: *update
                     hint: _id_
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: &outcome
       -
         collectionName: *collection_name
@@ -106,8 +104,6 @@ tests:
                     u: *update
                     hint:
                       _id: 1
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
     outcome: *outcome

--- a/data/crud/unified/updateOne-let.json
+++ b/data/crud/unified/updateOne-let.json
@@ -103,7 +103,13 @@
                             "x": "$$x"
                           }
                         }
-                      ]
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {
@@ -136,7 +142,7 @@
       "description": "UpdateOne with let option unsupported (server-side error)",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
+          "minServerVersion": "4.2.0",
           "maxServerVersion": "4.4.99"
         }
       ],
@@ -184,7 +190,13 @@
                             "x": "$$x"
                           }
                         }
-                      ]
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {

--- a/data/crud/unified/updateOne-let.yml
+++ b/data/crud/unified/updateOne-let.yml
@@ -52,6 +52,8 @@ tests:
                   -
                     q: *filter
                     u: *update
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let0
     outcome:
       -
@@ -63,7 +65,7 @@ tests:
 
   - description: "UpdateOne with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
+      - minServerVersion: "4.2.0"
         maxServerVersion: "4.4.99"
     operations:
       - name: updateOne
@@ -88,6 +90,8 @@ tests:
                   -
                     q: *filter1
                     u: *update1
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 let: *let1
     outcome:
       -

--- a/data/crud/unified/updateWithPipelines.yml
+++ b/data/crud/unified/updateWithPipelines.yml
@@ -74,10 +74,8 @@ tests:
                     u:
                       - { $replaceRoot: { newRoot: $t } }
                       - { $addFields: { foo: 1 } }
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
               commandName: update
               databaseName: *database_name
     outcome:
@@ -128,8 +126,7 @@ tests:
                       - { $project: { x: 1 } }
                       - { $addFields: { foo: 1 } }
                     multi: true
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
               commandName: update
               databaseName: *database_name
     outcome:
@@ -229,10 +226,8 @@ tests:
                     u:
                       - { $replaceRoot: { newRoot: $t } }
                       - { $addFields: { foo: 1 } }
-                    multi:
-                      $$unsetOrMatches: false
-                    upsert:
-                      $$unsetOrMatches: false
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
               commandName: update
               databaseName: *database_name
     outcome:
@@ -286,8 +281,7 @@ tests:
                       - { $project: { x: 1 } }
                       - { $addFields: { foo: 1 } }
                     multi: true
-                    upsert:
-                      $$unsetOrMatches: false
+                    upsert: { $$unsetOrMatches: false }
               commandName: update
               databaseName: *database_name
     outcome:


### PR DESCRIPTION
GODRIVER-2376

Partially syncs the CRUD unified spec tests (we still can't sync fully until we add `comment` support for CRUD operations in GODRIVER-2318). Mostly adds `$$unsetOrMatches` for `multi` and `upsert` for `update` operations. Some drivers besides the Go driver explicitly send `multi: false` or `upsert: false` and were failing spec tests as those fields were not specified in the expected events.