### PR TITLE
GODRIVER-2365 Update docs links in source and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <a href="https://goreportcard.com/report/go.mongodb.org/mongo-driver"><img src="https://goreportcard.com/badge/go.mongodb.org/mongo-driver"></a>
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo"><img src="etc/assets/godev-mongo-blue.svg" alt="docs"></a>
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/bson"><img src="etc/assets/godev-bson-blue.svg" alt="docs"></a>
-  <a href="https://docs.mongodb.com/drivers/go/current/"><img src="etc/assets/docs-mongodb-green.svg"></a>
+  <a href="https://www.mongodb.com/docs/drivers/go/current/"><img src="etc/assets/docs-mongodb-green.svg"></a>
 </p>
 
 # MongoDB Go Driver
@@ -153,7 +153,7 @@ if err == mongo.ErrNoDocuments {
 // Do something with result...
 ```
 
-Additional examples and documentation can be found under the examples directory and [on the MongoDB Documentation website](https://docs.mongodb.com/drivers/go/current/).
+Additional examples and documentation can be found under the examples directory and [on the MongoDB Documentation website](https://www.mongodb.com/docs/drivers/go/current/).
 
 -------------------------
 ## Feedback
@@ -222,7 +222,7 @@ The MongoDB Go Driver supports wire protocol compression using Snappy, zLib, or 
 MONGO_GO_DRIVER_COMPRESSOR=snappy make
 ```
 
-Ensure the [`--networkMessageCompressors` flag](https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-networkmessagecompressors) on mongod or mongos includes `zlib` if testing zLib compression.
+Ensure the [`--networkMessageCompressors` flag](https://www.mongodb.com/docs/manual/reference/program/mongod/#cmdoption-mongod-networkmessagecompressors) on mongod or mongos includes `zlib` if testing zLib compression.
 
 -------------------------
 ## Contribution

--- a/data/atlas-data-lake-testing/README.rst
+++ b/data/atlas-data-lake-testing/README.rst
@@ -10,7 +10,7 @@ Introduction
 ============
 
 The YAML and JSON files in this directory tree are platform-independent tests
-that drivers can use to assert compatibility with `Atlas Data Lake <https://docs.mongodb.com/datalake>`_.
+that drivers can use to assert compatibility with `Atlas Data Lake <https://www.mongodb.com/docs/datalake>`_.
 
 Running these integration tests will require a running ``mongohoused``
 with data available in its ``test.driverdata`` collection. See the
@@ -42,7 +42,7 @@ The following tests MUST be implemented to fully test compatibility with
 Atlas Data Lake.
 
 #. Test that the driver properly constructs and issues a
-   `killCursors <https://docs.mongodb.com/manual/reference/command/killCursors/>`_
+   `killCursors <https://www.mongodb.com/docs/manual/reference/command/killCursors/>`_
    command to Atlas Data Lake. For this test, configure an APM listener on a
    client and execute a query on the ``test.driverdata`` collection that will
    leave a cursor open on the server (e.g. specify ``batchSize=2`` for a query

--- a/data/client-side-encryption/README.rst
+++ b/data/client-side-encryption/README.rst
@@ -43,7 +43,7 @@ For example, the following matches a command_started_event for an insert of a do
       command_name: insert
 
 
-The values of `$$type` correspond to `these documented string representations of BSON types <https://docs.mongodb.com/manual/reference/bson-types/>`_.
+The values of `$$type` correspond to `these documented string representations of BSON types <https://www.mongodb.com/docs/manual/reference/bson-types/>`_.
 
 
 Each YAML file has the following keys:
@@ -548,7 +548,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 5. Load `corpus/corpus.json <../corpus/corpus.json>`_ to a variable named ``corpus``. The corpus contains subdocuments with the following fields:
 
    - ``kms`` is either ``aws``, ``azure``, ``gcp``, or ``local``
-   - ``type`` is a BSON type string `names coming from here <https://docs.mongodb.com/manual/reference/operator/query/type/>`_)
+   - ``type`` is a BSON type string `names coming from here <https://www.mongodb.com/docs/manual/reference/operator/query/type/>`_)
    - ``algo`` is either ``rand`` or ``det`` for random or deterministic encryption
    - ``method`` is either ``auto``, for automatic encryption or ``explicit`` for  explicit encryption
    - ``identifier`` is either ``id`` or ``altname`` for the key identifier

--- a/data/crud/README.rst
+++ b/data/crud/README.rst
@@ -255,7 +255,7 @@ Test that ``writeErrors[].errInfo`` in a command response is propagated as
 ``WriteError.details`` (or equivalent) in the driver.
 
 Using a 5.0+ server, create a collection with
-`document validation <https://docs.mongodb.com/manual/core/schema-validation/>`_
+`document validation <https://www.mongodb.com/docs/manual/core/schema-validation/>`_
 like so:
 
 .. code:: javascript

--- a/data/crud/v1/read/aggregate-collation.yml
+++ b/data/crud/v1/read/aggregate-collation.yml
@@ -12,7 +12,7 @@ tests:
                 pipeline:
                     - $match:
                         x: 'PING'
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
         outcome:
             result:
                 - {_id: 1, x: 'ping'}

--- a/data/crud/v1/read/count-collation.yml
+++ b/data/crud/v1/read/count-collation.yml
@@ -10,7 +10,7 @@ tests:
             name: countDocuments
             arguments:
                 filter: { x: 'ping' }
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: 1

--- a/data/crud/v1/read/distinct-collation.yml
+++ b/data/crud/v1/read/distinct-collation.yml
@@ -11,7 +11,7 @@ tests:
             name: distinct
             arguments:
                 fieldName: "string"
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/data/crud/v1/read/find-collation.yml
+++ b/data/crud/v1/read/find-collation.yml
@@ -10,7 +10,7 @@ tests:
             name: "find"
             arguments:
                 filter: {x: 'PING'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
         outcome:
             result:
                 - {_id: 1, x: 'ping'}

--- a/data/crud/v1/write/bulkWrite-collation.yml
+++ b/data/crud/v1/write/bulkWrite-collation.yml
@@ -8,7 +8,7 @@ data:
 minServerVersion: '3.4'
 serverless: 'forbid'
 
-# See: https://docs.mongodb.com/manual/reference/collation/#collation-document
+# See: https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 tests:
     -
         description: "BulkWrite with delete operations and collation"

--- a/data/crud/v1/write/deleteMany-collation.yml
+++ b/data/crud/v1/write/deleteMany-collation.yml
@@ -13,7 +13,7 @@ tests:
             arguments:
                 filter:
                     x: 'PING'
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/data/crud/v1/write/deleteOne-collation.yml
+++ b/data/crud/v1/write/deleteOne-collation.yml
@@ -12,7 +12,7 @@ tests:
             name: "deleteOne"
             arguments:
                 filter: {x: 'PING'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/data/crud/v1/write/findOneAndDelete-collation.yml
+++ b/data/crud/v1/write/findOneAndDelete-collation.yml
@@ -14,7 +14,7 @@ tests:
                 filter: {_id: 2, x: 'PING'}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'ping'}

--- a/data/crud/v1/write/findOneAndReplace-collation.yml
+++ b/data/crud/v1/write/findOneAndReplace-collation.yml
@@ -15,7 +15,7 @@ tests:
                 projection: {x: 1, _id: 0}
                 returnDocument: After
                 sort: {x: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'pong'}

--- a/data/crud/v1/write/findOneAndUpdate-collation.yml
+++ b/data/crud/v1/write/findOneAndUpdate-collation.yml
@@ -17,7 +17,7 @@ tests:
                     $set: {x: 'pong'}
                 projection: {x: 1, _id: 0}
                 sort: {_id: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'ping'}

--- a/data/crud/v1/write/replaceOne-collation.yml
+++ b/data/crud/v1/write/replaceOne-collation.yml
@@ -12,7 +12,7 @@ tests:
             arguments:
                 filter: {x: 'PING'}
                 replacement: {_id: 2, x: 'pong'}
-                collation: {locale: 'en_US', strength: 2} # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: {locale: 'en_US', strength: 2} # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/data/crud/v1/write/updateMany-collation.yml
+++ b/data/crud/v1/write/updateMany-collation.yml
@@ -15,7 +15,7 @@ tests:
                     x: 'ping'
                 update:
                     $set: {x: 'pong'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/data/crud/v1/write/updateOne-collation.yml
+++ b/data/crud/v1/write/updateOne-collation.yml
@@ -13,7 +13,7 @@ tests:
                 filter: {x: 'PING'}
                 update:
                     $set: {x: 'pong'}
-                collation: { locale: 'en_US', strength: 2} # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2} # https://www.mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/etc/check_fmt.sh
+++ b/etc/check_fmt.sh
@@ -13,7 +13,7 @@ fi
 # Ignore long lines that are comments containing URI-like strings.
 # E.g ignored lines:
 #     // "mongodb://ldap-user:ldap-pwd@localhost:27017/?authMechanism=PLAIN"
-#     // (https://docs.mongodb.com/manual/core/authentication-mechanisms-enterprise/#security-auth-ldap).
+#     // (https://www.mongodb.com/docs/manual/core/authentication-mechanisms-enterprise/#security-auth-ldap).
 lll_out="$(find "$@" -type f -name "*_examples_test.go" | lll -w 4 -l 80 -e '^\s*\/\/.+:\/\/' --files)"
 
 if [[ $lll_out ]]; then

--- a/mongo/bulk_write_models.go
+++ b/mongo/bulk_write_models.go
@@ -152,7 +152,7 @@ func (rom *ReplaceOneModel) SetFilter(filter interface{}) *ReplaceOneModel {
 }
 
 // SetReplacement specifies a document that will be used to replace the selected document. It cannot be nil and cannot
-// contain any update operators (https://docs.mongodb.com/manual/reference/operator/update/).
+// contain any update operators (https://www.mongodb.com/docs/manual/reference/operator/update/).
 func (rom *ReplaceOneModel) SetReplacement(rep interface{}) *ReplaceOneModel {
 	rom.Replacement = rep
 	return rom
@@ -210,7 +210,7 @@ func (uom *UpdateOneModel) SetFilter(filter interface{}) *UpdateOneModel {
 }
 
 // SetUpdate specifies the modifications to be made to the selected document. The value must be a document containing
-// update operators (https://docs.mongodb.com/manual/reference/operator/update/). It cannot be nil or empty.
+// update operators (https://www.mongodb.com/docs/manual/reference/operator/update/). It cannot be nil or empty.
 func (uom *UpdateOneModel) SetUpdate(update interface{}) *UpdateOneModel {
 	uom.Update = update
 	return uom
@@ -274,7 +274,7 @@ func (umm *UpdateManyModel) SetFilter(filter interface{}) *UpdateManyModel {
 }
 
 // SetUpdate specifies the modifications to be made to the selected documents. The value must be a document containing
-// update operators (https://docs.mongodb.com/manual/reference/operator/update/). It cannot be nil or empty.
+// update operators (https://www.mongodb.com/docs/manual/reference/operator/update/). It cannot be nil or empty.
 func (umm *UpdateManyModel) SetUpdate(update interface{}) *UpdateManyModel {
 	umm.Update = update
 	return umm

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -63,7 +63,7 @@ var (
 // ChangeStream is used to iterate over a stream of events. Each event can be decoded into a Go type via the Decode
 // method or accessed as raw BSON via the Current field. This type is not goroutine safe and must not be used
 // concurrently by multiple goroutines. For more information about change streams, see
-// https://docs.mongodb.com/manual/changeStreams/.
+// https://www.mongodb.com/docs/manual/changeStreams/.
 type ChangeStream struct {
 	// Current is the BSON bytes of the current event. This property is only valid until the next call to Next or
 	// TryNext. If continued access is required, a copy must be made.

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -845,7 +845,7 @@ func (c *Client) Database(name string, opts ...*options.DatabaseOptions) *Databa
 //
 // The opts parameter can be used to specify options for this operation (see the options.ListDatabasesOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listDatabases/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listDatabases/.
 func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...*options.ListDatabasesOptions) (ListDatabasesResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -918,7 +918,7 @@ func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...
 // The opts parameter can be used to specify options for this operation (see the options.ListDatabasesOptions
 // documentation.)
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listDatabases/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listDatabases/.
 func (c *Client) ListDatabaseNames(ctx context.Context, filter interface{}, opts ...*options.ListDatabasesOptions) ([]string, error) {
 	opts = append(opts, options.ListDatabases().SetNameOnly(true))
 
@@ -970,13 +970,13 @@ func (c *Client) UseSessionWithOptions(ctx context.Context, opts *options.Sessio
 }
 
 // Watch returns a change stream for all changes on the deployment. See
-// https://docs.mongodb.com/manual/changeStreams/ for more information about change streams.
+// https://www.mongodb.com/docs/manual/changeStreams/ for more information about change streams.
 //
 // The client must be configured with read concern majority or no read concern for a change stream to be created
 // successfully.
 //
 // The pipeline parameter must be an array of documents, each representing a pipeline stage. The pipeline cannot be
-// nil or empty. The stage documents must all be non-nil. See https://docs.mongodb.com/manual/changeStreams/ for a list
+// nil or empty. The stage documents must all be non-nil. See https://www.mongodb.com/docs/manual/changeStreams/ for a list
 // of pipeline stages that can be used with change streams. For a pipeline of bson.D documents, the mongo.Pipeline{}
 // type can be used.
 //

--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -101,7 +101,7 @@ func ExampleConnect_sRV() {
 	// list of host names. The driver will resolve SRV records prefixed with
 	// "_mongodb_tcp" and use the returned host names to build its view of the
 	// deployment.
-	// See https://docs.mongodb.com/manual/reference/connection-string/ for more
+	// See https://www.mongodb.com/docs/manual/reference/connection-string/ for more
 	// information about SRV. Full support for SRV records with sharded clusters
 	// requires driver version 1.1.0 or higher.
 
@@ -129,7 +129,7 @@ func ExampleConnect_direct() {
 
 func ExampleConnect_sCRAM() {
 	// Configure a Client with SCRAM authentication
-	// (https://docs.mongodb.com/manual/core/security-scram/).
+	// (https://www.mongodb.com/docs/manual/core/security-scram/).
 	// The default authentication database for SCRAM is "admin". This can be
 	// configured via the authSource query parameter in the URI or the
 	// AuthSource field in the options.Credential struct. SCRAM is the default
@@ -152,7 +152,7 @@ func ExampleConnect_sCRAM() {
 
 func ExampleConnect_x509() {
 	// Configure a Client with X509 authentication
-	// (https://docs.mongodb.com/manual/core/security-x.509/).
+	// (https://www.mongodb.com/docs/manual/core/security-x.509/).
 
 	// X509 can be configured with different sets of options in the connection
 	// string:
@@ -188,7 +188,7 @@ func ExampleConnect_x509() {
 
 func ExampleConnect_pLAIN() {
 	// Configure a Client with LDAP authentication
-	// (https://docs.mongodb.com/manual/core/authentication-mechanisms-enterprise/#security-auth-ldap).
+	// (https://www.mongodb.com/docs/manual/core/authentication-mechanisms-enterprise/#security-auth-ldap).
 	// MongoDB Enterprise supports proxy authentication through an LDAP service
 	// that can be used through the PLAIN authentication mechanism.
 	// This auth mechanism sends the password in plaintext and therefore should
@@ -212,7 +212,7 @@ func ExampleConnect_pLAIN() {
 }
 
 func ExampleConnect_kerberos() {
-	// Configure a Client with GSSAPI/SSPI authentication (https://docs.mongodb.com/manual/core/kerberos/).
+	// Configure a Client with GSSAPI/SSPI authentication (https://www.mongodb.com/docs/manual/core/kerberos/).
 	// MongoDB Enterprise supports proxy authentication through a Kerberos
 	// service. Using Kerberos authentication requires the "gssapi" build tag
 	// and cgo support during compilation. The default service name for Kerberos

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -166,7 +166,7 @@ func (coll *Collection) Database() *Database {
 	return coll.db
 }
 
-// BulkWrite performs a bulk write operation (https://docs.mongodb.com/manual/core/bulk-write-operations/).
+// BulkWrite performs a bulk write operation (https://www.mongodb.com/docs/manual/core/bulk-write-operations/).
 //
 // The models parameter must be a slice of operations to be executed in this bulk write. It cannot be nil or empty.
 // All of the models must be non-nil. See the mongo.WriteModel documentation for a list of valid model types and
@@ -324,7 +324,7 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 //
 // The opts parameter can be used to specify options for the operation (see the options.InsertOneOptions documentation.)
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/insert/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/insert/.
 func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 	opts ...*options.InsertOneOptions) (*InsertOneResult, error) {
 
@@ -353,7 +353,7 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 //
 // The opts parameter can be used to specify options for the operation (see the options.InsertManyOptions documentation.)
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/insert/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/insert/.
 func (coll *Collection) InsertMany(ctx context.Context, documents []interface{},
 	opts ...*options.InsertManyOptions) (*InsertManyResult, error) {
 
@@ -485,7 +485,7 @@ func (coll *Collection) delete(ctx context.Context, filter interface{}, deleteOn
 //
 // The opts parameter can be used to specify options for the operation (see the options.DeleteOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/delete/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/delete/.
 func (coll *Collection) DeleteOne(ctx context.Context, filter interface{},
 	opts ...*options.DeleteOptions) (*DeleteResult, error) {
 
@@ -501,7 +501,7 @@ func (coll *Collection) DeleteOne(ctx context.Context, filter interface{},
 //
 // The opts parameter can be used to specify options for the operation (see the options.DeleteOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/delete/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/delete/.
 func (coll *Collection) DeleteMany(ctx context.Context, filter interface{},
 	opts ...*options.DeleteOptions) (*DeleteResult, error) {
 
@@ -601,12 +601,12 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 // the operation will succeed and an UpdateResult with a MatchedCount of 0 will be returned.
 //
 // The update parameter must be a document containing update operators
-// (https://docs.mongodb.com/manual/reference/operator/update/) and can be used to specify the modifications to be
+// (https://www.mongodb.com/docs/manual/reference/operator/update/) and can be used to specify the modifications to be
 // made to the selected document. It cannot be nil or empty.
 //
 // The opts parameter can be used to specify options for the operation (see the options.UpdateOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/update/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/update/.
 func (coll *Collection) UpdateByID(ctx context.Context, id interface{}, update interface{},
 	opts ...*options.UpdateOptions) (*UpdateResult, error) {
 	if id == nil {
@@ -623,12 +623,12 @@ func (coll *Collection) UpdateByID(ctx context.Context, id interface{}, update i
 // matched set and MatchedCount will equal 1.
 //
 // The update parameter must be a document containing update operators
-// (https://docs.mongodb.com/manual/reference/operator/update/) and can be used to specify the modifications to be
+// (https://www.mongodb.com/docs/manual/reference/operator/update/) and can be used to specify the modifications to be
 // made to the selected document. It cannot be nil or empty.
 //
 // The opts parameter can be used to specify options for the operation (see the options.UpdateOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/update/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/update/.
 func (coll *Collection) UpdateOne(ctx context.Context, filter interface{}, update interface{},
 	opts ...*options.UpdateOptions) (*UpdateResult, error) {
 
@@ -651,12 +651,12 @@ func (coll *Collection) UpdateOne(ctx context.Context, filter interface{}, updat
 // with a MatchedCount of 0 will be returned.
 //
 // The update parameter must be a document containing update operators
-// (https://docs.mongodb.com/manual/reference/operator/update/) and can be used to specify the modifications to be made
+// (https://www.mongodb.com/docs/manual/reference/operator/update/) and can be used to specify the modifications to be made
 // to the selected documents. It cannot be nil or empty.
 //
 // The opts parameter can be used to specify options for the operation (see the options.UpdateOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/update/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/update/.
 func (coll *Collection) UpdateMany(ctx context.Context, filter interface{}, update interface{},
 	opts ...*options.UpdateOptions) (*UpdateResult, error) {
 
@@ -680,11 +680,11 @@ func (coll *Collection) UpdateMany(ctx context.Context, filter interface{}, upda
 // selected from the matched set and MatchedCount will equal 1.
 //
 // The replacement parameter must be a document that will be used to replace the selected document. It cannot be nil
-// and cannot contain any update operators (https://docs.mongodb.com/manual/reference/operator/update/).
+// and cannot contain any update operators (https://www.mongodb.com/docs/manual/reference/operator/update/).
 //
 // The opts parameter can be used to specify options for the operation (see the options.ReplaceOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/update/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/update/.
 func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 	replacement interface{}, opts ...*options.ReplaceOptions) (*UpdateResult, error) {
 
@@ -728,12 +728,12 @@ func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 // The pipeline parameter must be an array of documents, each representing an aggregation stage. The pipeline cannot
 // be nil but can be empty. The stage documents must all be non-nil. For a pipeline of bson.D documents, the
 // mongo.Pipeline type can be used. See
-// https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/#db-collection-aggregate-stages for a list of
+// https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/#db-collection-aggregate-stages for a list of
 // valid stages in aggregations.
 //
 // The opts parameter can be used to specify options for the operation (see the options.AggregateOptions documentation.)
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/aggregate/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/aggregate/.
 func (coll *Collection) Aggregate(ctx context.Context, pipeline interface{},
 	opts ...*options.AggregateOptions) (*Cursor, error) {
 	a := aggregateParams{
@@ -984,7 +984,7 @@ func (coll *Collection) CountDocuments(ctx context.Context, filter interface{},
 // The opts parameter can be used to specify options for the operation (see the options.EstimatedDocumentCountOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/count/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/count/.
 func (coll *Collection) EstimatedDocumentCount(ctx context.Context,
 	opts ...*options.EstimatedDocumentCountOptions) (int64, error) {
 
@@ -1043,7 +1043,7 @@ func (coll *Collection) EstimatedDocumentCount(ctx context.Context,
 //
 // The opts parameter can be used to specify options for the operation (see the options.DistinctOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/distinct/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/distinct/.
 func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter interface{},
 	opts ...*options.DistinctOptions) ([]interface{}, error) {
 
@@ -1132,7 +1132,7 @@ func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter i
 //
 // The opts parameter can be used to specify options for the operation (see the options.FindOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/find/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/find/.
 func (coll *Collection) Find(ctx context.Context, filter interface{},
 	opts ...*options.FindOptions) (cur *Cursor, err error) {
 
@@ -1305,7 +1305,7 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 //
 // The opts parameter can be used to specify options for this operation (see the options.FindOneOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/find/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/find/.
 func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 	opts ...*options.FindOneOptions) *SingleResult {
 
@@ -1411,7 +1411,7 @@ func (coll *Collection) findAndModify(ctx context.Context, op *operation.FindAnd
 // The opts parameter can be used to specify options for the operation (see the options.FindOneAndDeleteOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/findAndModify/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/findAndModify/.
 func (coll *Collection) FindOneAndDelete(ctx context.Context, filter interface{},
 	opts ...*options.FindOneAndDeleteOptions) *SingleResult {
 
@@ -1467,12 +1467,12 @@ func (coll *Collection) FindOneAndDelete(ctx context.Context, filter interface{}
 // ErrNoDocuments wil be returned. If the filter matches multiple documents, one will be selected from the matched set.
 //
 // The replacement parameter must be a document that will be used to replace the selected document. It cannot be nil
-// and cannot contain any update operators (https://docs.mongodb.com/manual/reference/operator/update/).
+// and cannot contain any update operators (https://www.mongodb.com/docs/manual/reference/operator/update/).
 //
 // The opts parameter can be used to specify options for the operation (see the options.FindOneAndReplaceOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/findAndModify/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/findAndModify/.
 func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{},
 	replacement interface{}, opts ...*options.FindOneAndReplaceOptions) *SingleResult {
 
@@ -1546,13 +1546,13 @@ func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{
 // ErrNoDocuments wil be returned. If the filter matches multiple documents, one will be selected from the matched set.
 //
 // The update parameter must be a document containing update operators
-// (https://docs.mongodb.com/manual/reference/operator/update/) and can be used to specify the modifications to be made
+// (https://www.mongodb.com/docs/manual/reference/operator/update/) and can be used to specify the modifications to be made
 // to the selected document. It cannot be nil or empty.
 //
 // The opts parameter can be used to specify options for the operation (see the options.FindOneAndUpdateOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/findAndModify/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/findAndModify/.
 func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{},
 	update interface{}, opts ...*options.FindOneAndUpdateOptions) *SingleResult {
 
@@ -1629,13 +1629,13 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 }
 
 // Watch returns a change stream for all changes on the corresponding collection. See
-// https://docs.mongodb.com/manual/changeStreams/ for more information about change streams.
+// https://www.mongodb.com/docs/manual/changeStreams/ for more information about change streams.
 //
 // The Collection must be configured with read concern majority or no read concern for a change stream to be created
 // successfully.
 //
 // The pipeline parameter must be an array of documents, each representing a pipeline stage. The pipeline cannot be
-// nil but can be empty. The stage documents must all be non-nil. See https://docs.mongodb.com/manual/changeStreams/ for
+// nil but can be empty. The stage documents must all be non-nil. See https://www.mongodb.com/docs/manual/changeStreams/ for
 // a list of pipeline stages that can be used with change streams. For a pipeline of bson.D documents, the
 // mongo.Pipeline{} type can be used.
 //

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -125,7 +125,7 @@ func (c *Cursor) Next(ctx context.Context) bool {
 
 // TryNext attempts to get the next document for this cursor. It returns true if there were no errors and the next
 // document is available. This is only recommended for use with tailable cursors as a non-blocking alternative to
-// Next. See https://docs.mongodb.com/manual/core/tailable-cursors/ for more information about tailable cursors.
+// Next. See https://www.mongodb.com/docs/manual/core/tailable-cursors/ for more information about tailable cursors.
 //
 // TryNext returns false if the cursor is exhausted, an error occurs when getting results from the server, the next
 // document is not yet available, or ctx expires. If ctx expires, the error will be set to ctx.Err().

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -106,12 +106,12 @@ func (db *Database) Collection(name string, opts ...*options.CollectionOptions) 
 // The pipeline parameter must be a slice of documents, each representing an aggregation stage. The pipeline
 // cannot be nil but can be empty. The stage documents must all be non-nil. For a pipeline of bson.D documents, the
 // mongo.Pipeline type can be used. See
-// https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/#db-aggregate-stages for a list of valid
+// https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/#db-aggregate-stages for a list of valid
 // stages in database-level aggregations.
 //
 // The opts parameter can be used to specify options for this operation (see the options.AggregateOptions documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/aggregate/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/aggregate/.
 func (db *Database) Aggregate(ctx context.Context, pipeline interface{},
 	opts ...*options.AggregateOptions) (*Cursor, error) {
 	a := aggregateParams{
@@ -301,7 +301,7 @@ func (db *Database) Drop(ctx context.Context) error {
 // The opts parameter can be used to specify options for the operation (see the options.ListCollectionsOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listCollections/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listCollections/.
 //
 // BUG(benjirewis): ListCollectionSpecifications prevents listing more than 100 collections per database when running
 // against MongoDB version 2.6.
@@ -338,7 +338,7 @@ func (db *Database) ListCollectionSpecifications(ctx context.Context, filter int
 // The opts parameter can be used to specify options for the operation (see the options.ListCollectionsOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listCollections/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listCollections/.
 //
 // BUG(benjirewis): ListCollections prevents listing more than 100 collections per database when running against
 // MongoDB version 2.6.
@@ -422,7 +422,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 // The opts parameter can be used to specify options for the operation (see the options.ListCollectionsOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listCollections/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listCollections/.
 //
 // BUG(benjirewis): ListCollectionNames prevents listing more than 100 collections per database when running against
 // MongoDB version 2.6.
@@ -471,13 +471,13 @@ func (db *Database) WriteConcern() *writeconcern.WriteConcern {
 }
 
 // Watch returns a change stream for all changes to the corresponding database. See
-// https://docs.mongodb.com/manual/changeStreams/ for more information about change streams.
+// https://www.mongodb.com/docs/manual/changeStreams/ for more information about change streams.
 //
 // The Database must be configured with read concern majority or no read concern for a change stream to be created
 // successfully.
 //
 // The pipeline parameter must be a slice of documents, each representing a pipeline stage. The pipeline cannot be
-// nil but can be empty. The stage documents must all be non-nil. See https://docs.mongodb.com/manual/changeStreams/ for
+// nil but can be empty. The stage documents must all be non-nil. See https://www.mongodb.com/docs/manual/changeStreams/ for
 // a list of pipeline stages that can be used with change streams. For a pipeline of bson.D documents, the
 // mongo.Pipeline{} type can be used.
 //
@@ -505,7 +505,7 @@ func (db *Database) Watch(ctx context.Context, pipeline interface{},
 // The opts parameter can be used to specify options for the operation (see the options.CreateCollectionOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/create/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/create/.
 func (db *Database) CreateCollection(ctx context.Context, name string, opts ...*options.CreateCollectionOptions) error {
 	cco := options.MergeCreateCollectionOptions(opts...)
 	op := operation.NewCreate(name).ServerAPI(db.client.serverAPI)
@@ -585,7 +585,7 @@ func (db *Database) CreateCollection(ctx context.Context, name string, opts ...*
 }
 
 // CreateView executes a create command to explicitly create a view on the server. See
-// https://docs.mongodb.com/manual/core/views/ for more information about views. This method requires driver version >=
+// https://www.mongodb.com/docs/manual/core/views/ for more information about views. This method requires driver version >=
 // 1.4.0 and MongoDB version >= 3.4.
 //
 // The viewName parameter specifies the name of the view to create.

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -141,5 +141,5 @@
 // See the ClientSideEncryption and ClientSideEncryptionCreateKey examples below for code samples about using this
 // feature.
 //
-// [1] See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+// [1] See https://www.mongodb.com/docs/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo

--- a/mongo/gridfs/doc.go
+++ b/mongo/gridfs/doc.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-// Package gridfs provides a MongoDB GridFS API. See https://docs.mongodb.com/manual/core/gridfs/ for more
+// Package gridfs provides a MongoDB GridFS API. See https://www.mongodb.com/docs/manual/core/gridfs/ for more
 // information about GridFS and its use cases.
 //
 // Buckets

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -45,7 +45,7 @@ type IndexView struct {
 // IndexModel represents a new index to be created.
 type IndexModel struct {
 	// A document describing which keys should be used for the index. It cannot be nil. This must be an order-preserving
-	// type such as bson.D. Map types such as bson.M are not valid. See https://docs.mongodb.com/manual/indexes/#indexes
+	// type such as bson.D. Map types such as bson.M are not valid. See https://www.mongodb.com/docs/manual/indexes/#indexes
 	// for examples of valid documents.
 	Keys interface{}
 
@@ -65,7 +65,7 @@ func isNamespaceNotFoundError(err error) bool {
 // The opts parameter can be used to specify options for this operation (see the options.ListIndexesOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/listIndexes/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listIndexes/.
 func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOptions) (*Cursor, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -175,7 +175,7 @@ func (iv IndexView) CreateOne(ctx context.Context, model IndexModel, opts ...*op
 // The opts parameter can be used to specify options for this operation (see the options.CreateIndexesOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/createIndexes/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/createIndexes/.
 func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ...*options.CreateIndexesOptions) ([]string, error) {
 	names := make([]string, 0, len(models))
 
@@ -427,7 +427,7 @@ func (iv IndexView) drop(ctx context.Context, name string, opts ...*options.Drop
 // The opts parameter can be used to specify options for this operation (see the options.DropIndexesOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/dropIndexes/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/dropIndexes/.
 func (iv IndexView) DropOne(ctx context.Context, name string, opts ...*options.DropIndexesOptions) (bson.Raw, error) {
 	if name == "*" {
 		return nil, ErrMultipleIndexDrop
@@ -443,7 +443,7 @@ func (iv IndexView) DropOne(ctx context.Context, name string, opts ...*options.D
 // The opts parameter can be used to specify options for this operation (see the options.DropIndexesOptions
 // documentation).
 //
-// For more information about the command, see https://docs.mongodb.com/manual/reference/command/dropIndexes/.
+// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/dropIndexes/.
 func (iv IndexView) DropAll(ctx context.Context, opts ...*options.DropIndexesOptions) (bson.Raw, error) {
 	return iv.drop(ctx, "*", opts...)
 }

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -434,7 +434,7 @@ func TestDatabase(t *testing.T) {
 
 			// All possible options except collation. The collation is omitted here and tested below because the
 			// collation document reported by listCollections fills in extra fields and includes a "version" field
-			// that's not described in https://docs.mongodb.com/manual/reference/collation/.
+			// that's not described in https://www.mongodb.com/docs/manual/reference/collation/.
 			storageEngine := bson.M{
 				"wiredTiger": bson.M{
 					"configString": "block_compressor=zlib",

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -23,7 +23,7 @@ type AggregateOptions struct {
 
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -13,7 +13,7 @@ var DefaultOrdered = true
 type BulkWriteOptions struct {
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -45,7 +45,7 @@ type ContextDialer interface {
 // AuthMechanism: the mechanism to use for authentication. Supported values include "SCRAM-SHA-256", "SCRAM-SHA-1",
 // "MONGODB-CR", "PLAIN", "GSSAPI", "MONGODB-X509", and "MONGODB-AWS". This can also be set through the "authMechanism"
 // URI option. (e.g. "authMechanism=PLAIN"). For more information, see
-// https://docs.mongodb.com/manual/core/authentication-mechanisms/.
+// https://www.mongodb.com/docs/manual/core/authentication-mechanisms/.
 //
 // AuthMechanismProperties can be used to specify additional configuration options for certain mechanisms. They can also
 // be set through the "authMechanismProperites" URI option
@@ -231,7 +231,7 @@ func (c *ClientOptions) GetURI() string {
 // If the URI format is incorrect or there are conflicting options specified in the URI an error will be recorded and
 // can be retrieved by calling Validate.
 //
-// For more information about the URI format, see https://docs.mongodb.com/manual/reference/connection-string/. See
+// For more information about the URI format, see https://www.mongodb.com/docs/manual/reference/connection-string/. See
 // mongo.Connect documentation for examples of using URIs for different Client configurations.
 func (c *ClientOptions) ApplyURI(uri string) *ClientOptions {
 	if c.err != nil {
@@ -475,7 +475,7 @@ func (c *ClientOptions) SetAuth(auth Credential) *ClientOptions {
 //
 // If this option is specified, the driver will perform a negotiation with the server to determine a common list of of
 // compressors and will use the first one in that list when performing operations. See
-// https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-networkmessagecompressors for more
+// https://www.mongodb.com/docs/manual/reference/program/mongod/#cmdoption-mongod-networkmessagecompressors for more
 // information about configuring compression on the server and the server-side defaults.
 //
 // This can also be set through the "compressors" URI option (e.g. "compressors=zstd,zlib,snappy"). The default is
@@ -636,7 +636,7 @@ func (c *ClientOptions) SetReadConcern(rc *readconcern.ReadConcern) *ClientOptio
 // 3. "maxStalenessSeconds" (or "maxStaleness"): Specify a maximum replication lag for reads from secondaries in a
 // replica set (e.g. "maxStalenessSeconds=10").
 //
-// The default is readpref.Primary(). See https://docs.mongodb.com/manual/core/read-preference/#read-preference for
+// The default is readpref.Primary(). See https://www.mongodb.com/docs/manual/core/read-preference/#read-preference for
 // more information about read preferences.
 func (c *ClientOptions) SetReadPreference(rp *readpref.ReadPref) *ClientOptions {
 	c.ReadPreference = rp

--- a/mongo/options/createcollectionoptions.go
+++ b/mongo/options/createcollectionoptions.go
@@ -67,7 +67,7 @@ func (tso *TimeSeriesOptions) SetGranularity(granularity string) *TimeSeriesOpti
 
 // CreateCollectionOptions represents options that can be used to configure a CreateCollection operation.
 type CreateCollectionOptions struct {
-	// Specifies if the collection is capped (see https://docs.mongodb.com/manual/core/capped-collections/). If true,
+	// Specifies if the collection is capped (see https://www.mongodb.com/docs/manual/core/capped-collections/). If true,
 	// the SizeInBytes option must also be specified. The default value is false.
 	Capped *bool
 
@@ -94,33 +94,33 @@ type CreateCollectionOptions struct {
 	StorageEngine interface{}
 
 	// Specifies what should happen if a document being inserted does not pass validation. Valid values are "error" and
-	// "warn". See https://docs.mongodb.com/manual/core/schema-validation/#accept-or-reject-invalid-documents for more
+	// "warn". See https://www.mongodb.com/docs/manual/core/schema-validation/#accept-or-reject-invalid-documents for more
 	// information. This option is only valid for MongoDB versions >= 3.2. The default value is "error".
 	ValidationAction *string
 
 	// Specifies how strictly the server applies validation rules to existing documents in the collection during update
 	// operations. Valid values are "off", "strict", and "moderate". See
-	// https://docs.mongodb.com/manual/core/schema-validation/#existing-documents for more information. This option is
+	// https://www.mongodb.com/docs/manual/core/schema-validation/#existing-documents for more information. This option is
 	// only valid for MongoDB versions >= 3.2. The default value is "strict".
 	ValidationLevel *string
 
 	// A document specifying validation rules for the collection. See
-	// https://docs.mongodb.com/manual/core/schema-validation/ for more information about schema validation. This option
+	// https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about schema validation. This option
 	// is only valid for MongoDB versions >= 3.2. The default value is nil, meaning no validator will be used for the
 	// collection.
 	Validator interface{}
 
 	// Value indicating after how many seconds old time-series data should be deleted. See
-	// https://docs.mongodb.com/manual/reference/command/create/ for supported options, and
-	// https://docs.mongodb.com/manual/core/timeseries-collections/ for more information on time-series
+	// https://www.mongodb.com/docs/manual/reference/command/create/ for supported options, and
+	// https://www.mongodb.com/docs/manual/core/timeseries-collections/ for more information on time-series
 	// collections.
 	//
 	// This option is only valid for MongoDB versions >= 5.0
 	ExpireAfterSeconds *int64
 
 	// Options for specifying a time-series collection. See
-	// https://docs.mongodb.com/manual/reference/command/create/ for supported options, and
-	// https://docs.mongodb.com/manual/core/timeseries-collections/ for more information on time-series
+	// https://www.mongodb.com/docs/manual/reference/command/create/ for supported options, and
+	// https://www.mongodb.com/docs/manual/core/timeseries-collections/ for more information on time-series
 	// collections.
 	//
 	// This option is only valid for MongoDB versions >= 5.0

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -602,7 +602,7 @@ func MergeFindOneOptions(opts ...*FindOneOptions) *FindOneOptions {
 type FindOneAndReplaceOptions struct {
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 
@@ -755,7 +755,7 @@ type FindOneAndUpdateOptions struct {
 
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -210,7 +210,7 @@ type IndexOptions struct {
 	// of the DefaultLanguage option.
 	LanguageOverride *string
 
-	// The index version number for a text index. See https://docs.mongodb.com/manual/core/index-text/#text-versions for
+	// The index version number for a text index. See https://www.mongodb.com/docs/manual/core/index-text/#text-versions for
 	// information about different version numbers.
 	TextVersion *int32
 
@@ -220,7 +220,7 @@ type IndexOptions struct {
 	// that every field will have a weight of 1.
 	Weights interface{}
 
-	// The index version number for a 2D sphere index. See https://docs.mongodb.com/manual/core/2dsphere/#dsphere-v2 for
+	// The index version number for a 2D sphere index. See https://www.mongodb.com/docs/manual/core/2dsphere/#dsphere-v2 for
 	// information about different version numbers.
 	SphereVersion *int32
 

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -10,7 +10,7 @@ package options
 type InsertOneOptions struct {
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 }
@@ -46,7 +46,7 @@ func MergeInsertOneOptions(opts ...*InsertOneOptions) *InsertOneOptions {
 type InsertManyOptions struct {
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/options/listdatabasesoptions.go
+++ b/mongo/options/listdatabasesoptions.go
@@ -13,7 +13,7 @@ type ListDatabasesOptions struct {
 	NameOnly *bool
 
 	// If true, only the databases which the user is authorized to see will be returned. For more information about
-	// the behavior of this option, see https://docs.mongodb.com/manual/reference/privilege-actions/#find. The default
+	// the behavior of this option, see https://www.mongodb.com/docs/manual/reference/privilege-actions/#find. The default
 	// value is true.
 	AuthorizedDatabases *bool
 }

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -10,7 +10,7 @@ package options
 type ReplaceOptions struct {
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -21,7 +21,7 @@ var DefaultCausalConsistency = true
 type SessionOptions struct {
 	// If true, causal consistency will be enabled for the session. This option cannot be set to true if Snapshot is
 	// set to true. The default value is true unless Snapshot is set to true. See
-	// https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#sessions for more information.
+	// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#sessions for more information.
 	CausalConsistency *bool
 
 	// The default read concern for transactions started in the session. The default value is nil, which means that

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -15,7 +15,7 @@ type UpdateOptions struct {
 
 	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
 	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
-	// false. See https://docs.mongodb.com/manual/core/schema-validation/ for more information about document
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 	// validation.
 	BypassDocumentValidation *bool
 

--- a/mongo/readpref/options.go
+++ b/mongo/readpref/options.go
@@ -61,7 +61,7 @@ func WithTagSets(tagSets ...tag.Set) Option {
 
 // WithHedgeEnabled specifies whether or not hedged reads should be enabled in the server. This feature requires MongoDB
 // server version 4.4 or higher. For more information about hedged reads, see
-// https://docs.mongodb.com/manual/core/sharded-cluster-query-router/#mongos-hedged-reads. If not specified, the default
+// https://www.mongodb.com/docs/manual/core/sharded-cluster-query-router/#mongos-hedged-reads. If not specified, the default
 // is to not send a value to the server, which will result in the server defaults being used.
 func WithHedgeEnabled(hedgeEnabled bool) Option {
 	return func(rp *ReadPref) error {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -77,9 +77,9 @@ func SessionFromContext(ctx context.Context) Session {
 // for a group of operations or to execute operations in an ACID transaction. A new Session can be created from a Client
 // instance. A Session created from a Client must only be used to execute operations using that Client or a Database or
 // Collection created from that Client. Custom implementations of this interface should not be used in production. For
-// more information about sessions, and their use cases, see https://docs.mongodb.com/manual/reference/server-sessions/,
-// https://docs.mongodb.com/manual/core/read-isolation-consistency-recency/#causal-consistency, and
-// https://docs.mongodb.com/manual/core/transactions/.
+// more information about sessions, and their use cases, see https://www.mongodb.com/docs/manual/reference/server-sessions/,
+// https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency, and
+// https://www.mongodb.com/docs/manual/core/transactions/.
 //
 // StartTransaction starts a new transaction, configured with the given options, on this session. This method will
 // return an error if there is already a transaction in-progress for this session.


### PR DESCRIPTION
GODRIVER-2365

Updates all occurrences of `docs.mongodb.com` to `www.mongodb.com/docs` in code and documentation within the Go driver. 