### PR TITLE
GODRIVER-2384 Unified test runner changes for CSOT.

### DIFF
--- a/data/unified-test-format/valid-pass/entity-cursor-iterateOnce.json
+++ b/data/unified-test-format/valid-pass/entity-cursor-iterateOnce.json
@@ -1,0 +1,108 @@
+{
+  "description": "entity-cursor-iterateOnce",
+  "schemaVersion": "1.5",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "database0",
+      "collectionName": "coll0",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "iterateOnce",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateOnce",
+          "object": "cursor0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find",
+                "databaseName": "database0"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/entity-cursor-iterateOnce.yml
+++ b/data/unified-test-format/valid-pass/entity-cursor-iterateOnce.yml
@@ -1,0 +1,58 @@
+description: entity-cursor-iterateOnce
+
+schemaVersion: '1.5'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - _id: 1
+      - _id: 2
+      - _id: 3
+
+tests:
+  - description: iterateOnce
+    operations:
+      - name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 2 }
+      # This operation could be iterateUntilDocumentOrError, but we use iterateOne to ensure that drivers support it.
+      - name: iterateOnce
+        object: *cursor0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                batchSize: 2
+              commandName: find
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: long }
+                collection: *collection0Name
+              commandName: getMore

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
@@ -1,0 +1,63 @@
+{
+  "description": "initialCollectionData-collectionOptions",
+  "schemaVersion": "1.5",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0",
+      "collectionOptions": {
+        "capped": true,
+        "size": 512
+      },
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "collection is created with the correct options",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collStats",
+            "command": {
+              "collStats": "coll0",
+              "scale": 1
+            }
+          },
+          "expectResult": {
+            "capped": true,
+            "maxSize": 512
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
@@ -41,6 +41,11 @@
   "tests": [
     {
       "description": "collection is created with the correct options",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
@@ -1,0 +1,39 @@
+description: initialCollectionData-collectionOptions
+
+schemaVersion: '1.5'
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    collectionOptions:
+      capped: true
+      size: &cappedSize 512
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: collection is created with the correct options
+    operations:
+      # Execute a collStats command to ensure the collection was created with the correct options.
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: collStats
+          command:
+            collStats: *collection0Name
+            scale: 1
+        expectResult:
+          capped: true
+          maxSize: *cappedSize

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
@@ -25,6 +25,8 @@ initialData:
 
 tests:
   - description: collection is created with the correct options
+    runOnRequirements:
+      - minServerVersion: "3.6"
     operations:
       # Execute a collStats command to ensure the collection was created with the correct options.
       - name: runCommand

--- a/data/unified-test-format/valid-pass/matches-lte-operator.json
+++ b/data/unified-test-format/valid-pass/matches-lte-operator.json
@@ -1,0 +1,78 @@
+{
+  "description": "matches-lte-operator",
+  "schemaVersion": "1.5",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "special lte matching operator",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "y": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$lte": 1
+                      },
+                      "y": {
+                        "$$lte": 2
+                      }
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "database0Name"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/matches-lte-operator.yml
+++ b/data/unified-test-format/valid-pass/matches-lte-operator.yml
@@ -1,0 +1,40 @@
+description: matches-lte-operator
+
+schemaVersion: '1.5'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: special lte matching operator
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id : 1, y: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  # We can make exact assertions here but we use the $$lte operator to ensure drivers support it.
+                  - { _id: { $$lte: 1 }, y: { $$lte: 2 } }
+              commandName: insert
+              databaseName: *database0Name

--- a/mongo/integration/unified/collection_data.go
+++ b/mongo/integration/unified/collection_data.go
@@ -34,8 +34,8 @@ type collectionDataOptions struct {
 // createCollection configures the collection represented by the receiver using the internal client. This function
 // first drops the collection and then creates it with specified options (if any) and inserts the seed data if needed.
 func (c *collectionData) createCollection(ctx context.Context) error {
-	db := mtest.GlobalClient().Database(c.DatabaseName)
-	coll := db.Collection(c.CollectionName, options.Collection().SetWriteConcern(mtest.MajorityWc))
+	db := mtest.GlobalClient().Database(c.DatabaseName, options.Database().SetWriteConcern(mtest.MajorityWc))
+	coll := db.Collection(c.CollectionName)
 	if err := coll.Drop(ctx); err != nil {
 		return fmt.Errorf("error dropping collection: %v", err)
 	}
@@ -55,8 +55,8 @@ func (c *collectionData) createCollection(ctx context.Context) error {
 		}
 	}
 
-	// If no data is given, create the collection with write concern "majority".
-	if len(c.Documents) == 0 {
+	// If neither documents nor options are provided, still create the collection with write concern "majority".
+	if len(c.Documents) == 0 && c.Options == nil {
 		// The write concern has to be manually specified in the command document because RunCommand does not honor
 		// the database's write concern.
 		create := bson.D{

--- a/mongo/integration/unified/matches.go
+++ b/mongo/integration/unified/matches.go
@@ -233,11 +233,11 @@ func evaluateSpecialComparison(ctx context.Context, assertionDoc bson.Raw, actua
 			return fmt.Errorf("expected lsid %v, got %v", expectedID, actualID)
 		}
 	case "$$lte":
-		if !assertionVal.IsNumber() {
-			return fmt.Errorf("expected assertionVal to be a number but got a %s", assertionVal.Type)
+		if assertionVal.Type != bsontype.Int32 && assertionVal.Type != bsontype.Int64 {
+			return fmt.Errorf("expected assertionVal to be an Int32 or Int64 but got a %s", assertionVal.Type)
 		}
-		if !actual.IsNumber() {
-			return fmt.Errorf("expected value to be a number but got a %s", actual.Type)
+		if actual.Type != bsontype.Int32 && actual.Type != bsontype.Int64 {
+			return fmt.Errorf("expected value to be an Int32 or Int64 but got a %s", actual.Type)
 		}
 
 		// Numeric values can be compared even if their types are different (e.g. if expected is an int32 and actual

--- a/mongo/integration/unified/matches.go
+++ b/mongo/integration/unified/matches.go
@@ -233,21 +233,21 @@ func evaluateSpecialComparison(ctx context.Context, assertionDoc bson.Raw, actua
 			return fmt.Errorf("expected lsid %v, got %v", expectedID, actualID)
 		}
 	case "$$lte":
+		if !assertionVal.IsNumber() {
+			return fmt.Errorf("expected assertionVal to be a number but got a %s", assertionVal.Type)
+		}
+		if !actual.IsNumber() {
+			return fmt.Errorf("expected value to be a number but got a %s", actual.Type)
+		}
+
 		// Numeric values can be compared even if their types are different (e.g. if expected is an int32 and actual
 		// is an int64).
-		if assertionVal.IsNumber() {
-			if !actual.IsNumber() {
-				return fmt.Errorf("expected value to be a number but got a %s", actual.Type)
-			}
-
-			actualInt64 := actual.AsInt64()
-			expectedInt64 := assertionVal.AsInt64()
-			if actualInt64 > expectedInt64 {
-				return fmt.Errorf("expected numeric value %d to be less than or equal %d", actualInt64, expectedInt64)
-			}
-			return nil
+		expectedInt64 := assertionVal.AsInt64()
+		actualInt64 := actual.AsInt64()
+		if actualInt64 > expectedInt64 {
+			return fmt.Errorf("expected numeric value %d to be less than or equal %d", actualInt64, expectedInt64)
 		}
-		return fmt.Errorf("expected assertionVal to be a number but got a %s", assertionVal.Type)
+		return nil
 	default:
 		return fmt.Errorf("unrecognized special matching assertion %q", assertion)
 	}

--- a/mongo/integration/unified/matches.go
+++ b/mongo/integration/unified/matches.go
@@ -232,6 +232,22 @@ func evaluateSpecialComparison(ctx context.Context, assertionDoc bson.Raw, actua
 		if !bytes.Equal(expectedID, actualID) {
 			return fmt.Errorf("expected lsid %v, got %v", expectedID, actualID)
 		}
+	case "$$lte":
+		// Numeric values can be compared even if their types are different (e.g. if expected is an int32 and actual
+		// is an int64).
+		if assertionVal.IsNumber() {
+			if !actual.IsNumber() {
+				return fmt.Errorf("expected value to be a number but got a %s", actual.Type)
+			}
+
+			actualInt64 := actual.AsInt64()
+			expectedInt64 := assertionVal.AsInt64()
+			if actualInt64 > expectedInt64 {
+				return fmt.Errorf("expected numeric value %d to be less than or equal %d", actualInt64, expectedInt64)
+			}
+			return nil
+		}
+		return fmt.Errorf("expected assertionVal to be a number but got a %s", assertionVal.Type)
 	default:
 		return fmt.Errorf("unrecognized special matching assertion %q", assertion)
 	}

--- a/mongo/integration/unified/operation.go
+++ b/mongo/integration/unified/operation.go
@@ -151,6 +151,8 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 	// Cursor operations
 	case "close":
 		return newEmptyResult(), executeClose(ctx, op)
+	case "iterateOnce":
+		return executeIterateOnce(ctx, op)
 	case "iterateUntilDocumentOrError":
 		return executeIterateUntilDocumentOrError(ctx, op)
 	default:

--- a/mongo/integration/unified/testrunner_operation.go
+++ b/mongo/integration/unified/testrunner_operation.go
@@ -156,6 +156,23 @@ func executeTestRunnerOperation(ctx context.Context, operation *operation, loopD
 			return fmt.Errorf("expected %d connections to be checked out, got %d", expected, actual)
 		}
 		return nil
+	case "createEntities":
+		entitiesRaw, err := args.LookupErr("entities")
+		if err != nil {
+			return fmt.Errorf("'entities' argument not found in createEntities operation")
+		}
+
+		var createEntities map[string]*entityOptions
+		if err := bson.Unmarshal(entitiesRaw.Value, &createEntities); err != nil {
+			return fmt.Errorf("error unmarshalling 'entities' argument to entityOptions: %v", err)
+		}
+
+		for entityType, entityOptions := range createEntities {
+			if err := entities(ctx).addEntity(ctx, entityType, entityOptions); err != nil {
+				return fmt.Errorf("error creating entity: %v", err)
+			}
+		}
+		return nil
 	default:
 		return fmt.Errorf("unrecognized testRunner operation %q", operation.Name)
 	}


### PR DESCRIPTION
GODRIVER-2384

Updates the unified test runner to support functionality that will be introduced with the merging of [this PR](https://github.com/mongodb/specifications/pull/959). These test runner updates should allow me to start running the CSOT spec tests in subsequent PRs. 

Syncs valid-pass tests (POC tests that should pass in the unified test runner). Adds support for specifying `collectionOptions` in `initialData`, using the `iterateOnce` operation on cursor entities, using `$$lte` as a special matching operator, and using the `createEntities` operation on the test runner.

I did not sync the `invalid` tests, as we don't currently have a way of running those in the Go driver. I also did not add the new [`isTimeoutError`](https://github.com/mongodb/specifications/pull/959/files#diff-f718c246f51e05b3731a7b03b176a0d4b0c381a9261810742d2677823f963f98R935-R939) assertion, as that relies on CSOT changes not yet in the driver. 