### PR TITLE
GODRIVER-2010 Further clean up documentation examples

### DIFF
--- a/examples/documentation_examples/README
+++ b/examples/documentation_examples/README
@@ -1,0 +1,8 @@
+Go Driver Documentation Examples
+================================
+
+examples.go contains numerous documentation examples that are rendered in various locations on www.mongodb.com/docs.
+Each example is delineated with starting and ending comments (// Start/End Example #). All examples in examples.go
+are valid Go driver code. Each example is run as part of our CI with examples_test.go, so all code is up-to-date and
+accurate. We recommend using www.mongodb.com/docs to interact with these examples rather than viewing these files
+directly.

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -51,6 +51,7 @@ func parseDate(t *testing.T, dateString string) time.Time {
 }
 
 // InsertExamples contains examples for insert operations.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/insert-documents/.
 func InsertExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_insert")
 
@@ -140,6 +141,7 @@ func InsertExamples(t *testing.T, db *mongo.Database) {
 }
 
 // QueryToplevelFieldsExamples contains examples for querying top-level fields.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/query-documents/.
 func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_query_top")
 
@@ -308,6 +310,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 }
 
 // QueryEmbeddedDocumentsExamples contains examples for querying embedded document fields.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/query-embedded-documents/.
 func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_query_embedded")
 
@@ -469,6 +472,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 }
 
 // QueryArraysExamples contains examples for querying array fields.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/query-arrays/.
 func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_query_array")
 
@@ -655,6 +659,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 }
 
 // QueryArrayEmbeddedDocumentsExamples contains examples for querying fields with arrays and embedded documents.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/query-array-of-documents/.
 func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_query_array_embedded")
 
@@ -884,6 +889,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 }
 
 // QueryNullMissingFieldsExamples contains examples for querying fields that are null or missing.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/query-for-null-fields/.
 func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_query_null_missing")
 
@@ -962,6 +968,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 }
 
 // ProjectionExamples contains examples for specifying projections in find operations.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/project-fields-from-query-results/.
 func ProjectionExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_project")
 
@@ -1346,6 +1353,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 }
 
 // UpdateExamples contains examples of update operations.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/update-documents/.
 func UpdateExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_update")
 
@@ -1626,6 +1634,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 }
 
 // DeleteExamples contains examples of delete operations.
+// Appears at https://www.mongodb.com/docs/manual/tutorial/remove-documents/.
 func DeleteExamples(t *testing.T, db *mongo.Database) {
 	coll := db.Collection("inventory_delete")
 
@@ -1741,6 +1750,8 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 }
 
 var log = logger.New(ioutil.Discard, "", logger.LstdFlags)
+
+// Transactions examples below all appear at https://www.mongodb.com/docs/manual/core/transactions-in-applications/.
 
 // Start Transactions Intro Example 1
 
@@ -1997,6 +2008,7 @@ func WithTransactionExample(ctx context.Context) error {
 // End Transactions withTxn API Example 1
 
 // ChangeStreamExamples contains examples of changestream operations.
+// Appears at https://www.mongodb.com/docs/manual/changeStreams/.
 func ChangeStreamExamples(t *testing.T, db *mongo.Database) {
 	ctx := context.Background()
 
@@ -2103,6 +2115,7 @@ func ChangeStreamExamples(t *testing.T, db *mongo.Database) {
 }
 
 // AggregationExamples contains examples of aggregation operations.
+// Appears at https://www.mongodb.com/docs/manual/aggregation/.
 func AggregationExamples(t *testing.T, db *mongo.Database) {
 	ctx := context.Background()
 
@@ -2523,6 +2536,7 @@ func AggregationExamples(t *testing.T, db *mongo.Database) {
 }
 
 // CausalConsistencyExamples contains examples of causal consistency usage.
+// Appears at https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/.
 func CausalConsistencyExamples(client *mongo.Client) error {
 	ctx := context.Background()
 	coll := client.Database("test").Collection("items")
@@ -2611,6 +2625,7 @@ func CausalConsistencyExamples(client *mongo.Client) error {
 }
 
 // RunCommandExamples contains examples of RunCommand operations.
+// Appears at https://www.mongodb.com/docs/manual/reference/command/collStats/.
 func RunCommandExamples(t *testing.T, db *mongo.Database) {
 	ctx := context.Background()
 
@@ -2680,6 +2695,7 @@ func RunCommandExamples(t *testing.T, db *mongo.Database) {
 }
 
 // IndexExamples contains examples of Index operations.
+// Appears at https://www.mongodb.com/docs/manual/indexes/.
 func IndexExamples(t *testing.T, db *mongo.Database) {
 	ctx := context.Background()
 
@@ -2945,6 +2961,7 @@ func StableAPIStrictCountExample(t *testing.T) {
 }
 
 // StableAPIExamples runs all stable API examples.
+// These appear at https://www.mongodb.com/docs/manual/reference/stable-api/.
 func StableAPIExamples() {
 	StableAPIExample()
 	StableAPIStrictExample()
@@ -3121,6 +3138,8 @@ func snapshotQueryRetailExample(mt *mtest.T) error {
 	return nil
 }
 
+// SnapshotQuery examples runs examples of using sessions with Snapshot enabled.
+// These appear at https://www.mongodb.com/docs/manual/tutorial/long-running-queries/.
 func SnapshotQueryExamples(mt *mtest.T) {
 	insertSnapshotQueryTestData(mt)
 	require.NoError(mt, snapshotQueryPetExample(mt))

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -1948,18 +1948,17 @@ func TransactionsExamples(ctx context.Context, client *mongo.Client) error {
 // Start Transactions withTxn API Example 1
 
 // WithTransactionExample is an example of using the Session.WithTransaction function.
-func WithTransactionExample() {
-	ctx := context.TODO()
+func WithTransactionExample(ctx context.Context) error {
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
 	// uri := "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/"
-	var uri string
+	uri := mtest.ClusterURI()
 
 	clientOpts := options.Client().ApplyURI(uri)
 	client, err := mongo.Connect(ctx, clientOpts)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer func() { _ = client.Disconnect(ctx) }()
 
@@ -1986,15 +1985,16 @@ func WithTransactionExample() {
 	// Step 2: Start a session and run the callback using WithTransaction.
 	session, err := client.StartSession()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer session.EndSession(ctx)
 
 	result, err := session.WithTransaction(ctx, callback)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	fmt.Printf("result: %v\n", result)
+	log.Printf("result: %v\n", result)
+	return nil
 }
 
 // End Transactions withTxn API Example 1
@@ -2809,7 +2809,7 @@ func StableAPIExample() {
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
 	// uri := "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/"
-	uri := "mongodb://localhost:27017"
+	uri := mtest.ClusterURI()
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
@@ -2831,7 +2831,7 @@ func StableAPIStrictExample() {
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
 	// uri := "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/"
-	uri := "mongodb://localhost:27017"
+	uri := mtest.ClusterURI()
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
@@ -2853,7 +2853,7 @@ func StableAPINonStrictExample() {
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
 	// uri := "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/"
-	uri := "mongodb://localhost:27017"
+	uri := mtest.ClusterURI()
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(false)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
@@ -2876,7 +2876,7 @@ func StableAPIDeprecationErrorsExample() {
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
 	// uri := "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/"
-	uri := "mongodb://localhost:27017"
+	uri := mtest.ClusterURI()
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetDeprecationErrors(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -4,9 +4,6 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-// NOTE: Any time this file is modified, a WEBSITE ticket should be opened to sync the changes with
-// the "What is MongoDB" webpage, which the example was originally added to as part of WEBSITE-5148.
-
 package documentation_examples
 
 import (

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -42,10 +42,7 @@ func requireCursorLength(t *testing.T, cursor *mongo.Cursor, length int) {
 
 func containsKey(doc bson.Raw, key ...string) bool {
 	_, err := doc.LookupErr(key...)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func parseDate(t *testing.T, dateString string) time.Time {
@@ -67,7 +64,7 @@ func InsertExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 1
 
 		result, err := coll.InsertOne(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", "canvas"},
 				{"qty", 100},
@@ -89,7 +86,7 @@ func InsertExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 2
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"item", "canvas"}},
 		)
 
@@ -104,7 +101,7 @@ func InsertExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 3
 
 		result, err := coll.InsertMany(
-			context.Background(),
+			context.TODO(),
 			[]interface{}{
 				bson.D{
 					{"item", "journal"},
@@ -208,7 +205,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 6
 
@@ -220,7 +217,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 7
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{},
 		)
 
@@ -234,7 +231,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 9
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"status", "D"}},
 		)
 
@@ -248,7 +245,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 10
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"status", bson.D{{"$in", bson.A{"A", "D"}}}}})
 
 		// End Example 10
@@ -261,7 +258,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 11
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 				{"qty", bson.D{{"$lt", 30}}},
@@ -277,7 +274,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 12
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"$or",
 					bson.A{
@@ -296,7 +293,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 13
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 				{"$or", bson.A{
@@ -376,7 +373,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 14
 
@@ -388,7 +385,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 15
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"size", bson.D{
 					{"h", 14},
@@ -407,7 +404,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 16
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"size", bson.D{
 					{"w", 21},
@@ -426,7 +423,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 17
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"size.uom", "in"}},
 		)
 
@@ -440,7 +437,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 18
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"size.h", bson.D{
 					{"$lt", 15},
@@ -457,7 +454,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 19
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"size.h", bson.D{
 					{"$lt", 15},
@@ -517,7 +514,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 20
 
@@ -529,7 +526,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 21
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"tags", bson.A{"red", "blank"}}},
 		)
 
@@ -543,7 +540,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 22
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"tags", bson.D{{"$all", bson.A{"red", "blank"}}}},
 			})
@@ -558,7 +555,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 23
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"tags", "red"},
 			})
@@ -573,7 +570,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 24
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"dim_cm", bson.D{
 					{"$gt", 25},
@@ -590,7 +587,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 25
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"dim_cm", bson.D{
 					{"$gt", 15},
@@ -608,7 +605,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 26
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"dim_cm", bson.D{
 					{"$elemMatch", bson.D{
@@ -628,7 +625,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 27
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"dim_cm.1", bson.D{
 					{"$gt", 25},
@@ -645,7 +642,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 28
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"tags", bson.D{
 					{"$size", 3},
@@ -734,7 +731,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 29
 
@@ -746,7 +743,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 30
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock", bson.D{
 					{"warehouse", "A"},
@@ -764,7 +761,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 31
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock", bson.D{
 					{"qty", 5},
@@ -782,7 +779,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 32
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock.0.qty", bson.D{
 					{"$lte", 20},
@@ -799,7 +796,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 33
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock.qty", bson.D{
 					{"$lte", 20},
@@ -816,7 +813,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 34
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock", bson.D{
 					{"$elemMatch", bson.D{
@@ -836,7 +833,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 35
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock", bson.D{
 					{"$elemMatch", bson.D{
@@ -858,7 +855,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 36
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock.qty", bson.D{
 					{"$gt", 10},
@@ -876,7 +873,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 37
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"instock.qty", 5},
 				{"instock.warehouse", "A"},
@@ -909,7 +906,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 38
 
@@ -921,7 +918,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 39
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", nil},
 			})
@@ -936,7 +933,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 40
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", bson.D{
 					{"$type", 10},
@@ -953,7 +950,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 41
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", bson.D{
 					{"$exists", false},
@@ -1059,7 +1056,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 42
 
@@ -1071,7 +1068,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 43
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{{"status", "A"}},
 		)
 
@@ -1090,7 +1087,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1124,7 +1121,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1157,7 +1154,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1191,7 +1188,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1228,7 +1225,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1267,7 +1264,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1320,7 +1317,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 		}
 
 		cursor, err := coll.Find(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1464,7 +1461,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 51
 
@@ -1476,7 +1473,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 52
 
 		result, err := coll.UpdateOne(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", "paper"},
 			},
@@ -1526,7 +1523,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 53
 
 		result, err := coll.UpdateMany(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"qty", bson.D{
 					{"$lt", 50},
@@ -1580,7 +1577,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 54
 
 		result, err := coll.ReplaceOne(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"item", "paper"},
 			},
@@ -1693,7 +1690,7 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 			},
 		}
 
-		result, err := coll.InsertMany(context.Background(), docs)
+		result, err := coll.InsertMany(context.TODO(), docs)
 
 		// End Example 55
 
@@ -1705,7 +1702,7 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 57
 
 		result, err := coll.DeleteMany(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "A"},
 			},
@@ -1721,7 +1718,7 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 		// Start Example 58
 
 		result, err := coll.DeleteOne(
-			context.Background(),
+			context.TODO(),
 			bson.D{
 				{"status", "D"},
 			},
@@ -1737,7 +1734,7 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 56
 
-		result, err := coll.DeleteMany(context.Background(), bson.D{})
+		result, err := coll.DeleteMany(context.TODO(), bson.D{})
 
 		// End Example 56
 
@@ -1952,7 +1949,7 @@ func TransactionsExamples(ctx context.Context, client *mongo.Client) error {
 
 // WithTransactionExample is an example of using the Session.WithTransaction function.
 func WithTransactionExample() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2807,7 +2804,7 @@ func IndexExamples(t *testing.T, db *mongo.Database) {
 
 // StableAPIExample is an example of creating a client with stable API.
 func StableAPIExample() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2829,7 +2826,7 @@ func StableAPIExample() {
 
 // StableAPIStrictExample is an example of creating a client with strict stable API.
 func StableAPIStrictExample() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2851,7 +2848,7 @@ func StableAPIStrictExample() {
 
 // StableAPINonStrictExample is an example of creating a client with non-strict stable API.
 func StableAPINonStrictExample() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2874,7 +2871,7 @@ func StableAPINonStrictExample() {
 // StableAPIDeprecationErrorsExample is an example of creating a client with stable API
 // with deprecation errors.
 func StableAPIDeprecationErrorsExample() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -2554,10 +2554,10 @@ func CausalConsistencyExamples(client *mongo.Client) error {
 	opts := options.Session().SetDefaultReadConcern(readconcern.Majority()).SetDefaultWriteConcern(
 		writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(1000)))
 	session1, err := client.StartSession(opts)
-
 	if err != nil {
 		return err
 	}
+	defer session1.EndSession(context.TODO())
 
 	err = client.UseSessionWithOptions(context.TODO(), opts, func(sctx mongo.SessionContext) error {
 		// Run an update with our causally-consistent session
@@ -2588,10 +2588,10 @@ func CausalConsistencyExamples(client *mongo.Client) error {
 		readconcern.Majority()).SetDefaultWriteConcern(writeconcern.New(writeconcern.WMajority(),
 		writeconcern.WTimeout(1000)))
 	session2, err := client.StartSession(opts)
-
 	if err != nil {
 		return err
 	}
+	defer session2.EndSession(context.TODO())
 
 	err = client.UseSessionWithOptions(context.TODO(), opts, func(sctx mongo.SessionContext) error {
 		// Set cluster time of session2 to session1's cluster time

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -133,7 +133,11 @@ func TestTransactionExamples(t *testing.T) {
 	if err != nil || testutil.CompareVersions(t, ver, "4.0") < 0 || topo.Kind() != description.ReplicaSet {
 		t.Skip("server does not support transactions")
 	}
+
 	err = documentation_examples.TransactionsExamples(ctx, client)
+	require.NoError(t, err)
+
+	err = documentation_examples.WithTransactionExample(ctx)
 	require.NoError(t, err)
 }
 

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -4,9 +4,6 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-// NOTE: Any time this file is modified, a WEBSITE ticket should be opened to sync the changes with
-// the "What is MongoDB" webpage, which the example was originally added to as part of WEBSITE-5148.
-
 package documentation_examples_test
 
 import (
@@ -17,11 +14,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/examples/documentation_examples"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
@@ -42,8 +37,7 @@ func TestDocumentationExamples(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cs := testutil.ConnString(t)
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(cs.String()))
+	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(mtest.ClusterURI()))
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 
@@ -93,103 +87,49 @@ func TestDocumentationExamples(t *testing.T) {
 	// run on 5.0+ without auth. It also cannot be run on 6.0+ since the count command was
 	// added to API version 1 and no longer results in an error when strict is enabled.
 	mtOpts := mtest.NewOptions().MinServerVersion("5.0").MaxServerVersion("5.3")
-	mt.RunOpts("StableAPIStrictCountExample", mtOpts, func(t *mtest.T) {
+	mt.RunOpts("StableAPIStrictCountExample", mtOpts, func(mt *mtest.T) {
 		documentation_examples.StableAPIStrictCountExample(mt.T)
 	})
 
+	// Snapshot queries can only run on 5.0+ non-sharded and sharded replicasets.
 	mtOpts = mtest.NewOptions().MinServerVersion("5.0").Topologies(mtest.ReplicaSet, mtest.Sharded)
-	mt.RunOpts("SnapshotQueryExamples", mtOpts, func(t *mtest.T) {
-		documentation_examples.SnapshotQueryExamples(t)
+	mt.RunOpts("SnapshotQueryExamples", mtOpts, func(mt *mtest.T) {
+		documentation_examples.SnapshotQueryExamples(mt)
 	})
-}
 
-func TestAggregationExamples(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	// Only 3.6+ supports $lookup in aggregations as is used in aggregation examples.
+	mtOpts = mtest.NewOptions().MinServerVersion("3.6")
+	mt.RunOpts("AggregationExamples", mtOpts, func(mt *mtest.T) {
+		documentation_examples.AggregationExamples(mt.T, db)
+	})
 
-	cs := testutil.ConnString(t)
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(cs.String()))
-	require.NoError(t, err)
-	defer client.Disconnect(ctx)
+	// Transaction examples can only run on replica sets on 4.0+.
+	cliOpts := options.ClientOptions{Deployment: createTopology(t)}
+	mtOpts = mtest.NewOptions().ClientOptions(&cliOpts).MinServerVersion("4.0").Topologies(mtest.ReplicaSet)
+	mt.RunOpts("TransactionsExamples", mtOpts, func(mt *mtest.T) {
+		documentation_examples.TransactionsExamples(ctx, mt.Client)
+	})
+	mt.RunOpts("WithTransactionExample", mtOpts, func(mt *mtest.T) {
+		documentation_examples.WithTransactionExample(ctx)
+	})
 
-	db := client.Database("documentation_examples")
+	// Change stream examples can only run on replica sets on 3.6+.
+	mtOpts = mtest.NewOptions().ClientOptions(&cliOpts).MinServerVersion("3.6").Topologies(mtest.ReplicaSet)
+	mt.RunOpts("ChangeStreamExamples", mtOpts, func(mt *mtest.T) {
+		csdb := client.Database("changestream_examples")
+		documentation_examples.ChangeStreamExamples(mt.T, csdb)
+	})
 
-	ver, err := getServerVersion(ctx, client)
-	if err != nil || testutil.CompareVersions(t, ver, "3.6") < 0 {
-		t.Skip("server does not support let in $lookup in aggregations")
-	}
-	documentation_examples.AggregationExamples(t, db)
-}
-
-func TestTransactionExamples(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	topo := createTopology(t)
-	client, err := mongo.Connect(context.Background(), &options.ClientOptions{Deployment: topo})
-	require.NoError(t, err)
-	defer client.Disconnect(ctx)
-
-	ver, err := getServerVersion(ctx, client)
-	if err != nil || testutil.CompareVersions(t, ver, "4.0") < 0 || topo.Kind() != description.ReplicaSet {
-		t.Skip("server does not support transactions")
-	}
-
-	err = documentation_examples.TransactionsExamples(ctx, client)
-	require.NoError(t, err)
-
-	err = documentation_examples.WithTransactionExample(ctx)
-	require.NoError(t, err)
-}
-
-func TestChangeStreamExamples(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	topo := createTopology(t)
-	client, err := mongo.Connect(context.Background(), &options.ClientOptions{Deployment: topo})
-	require.NoError(t, err)
-	defer client.Disconnect(ctx)
-
-	db := client.Database("changestream_examples")
-	ver, err := getServerVersion(ctx, client)
-	if err != nil || testutil.CompareVersions(t, ver, "3.6") < 0 || topo.Kind() != description.ReplicaSet {
-		t.Skip("server does not support changestreams")
-	}
-	documentation_examples.ChangeStreamExamples(t, db)
-}
-
-func TestCausalConsistencyExamples(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	cs := testutil.ConnString(t)
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(cs.String()))
-	require.NoError(t, err)
-	defer client.Disconnect(ctx)
-
-	// TODO(GODRIVER-2238): Remove skip once failures on MongoDB v4.0 sharded clusters are fixed.
-	ver, err := getServerVersion(ctx, client)
-	if err != nil || testutil.CompareVersions(t, ver, "4.0") == 0 {
-		t.Skip("TODO(GODRIVER-2238): Skip until failures on MongoDB v4.0 sharded clusters are fixed")
-	}
-
-	err = documentation_examples.CausalConsistencyExamples(client)
-	require.NoError(t, err)
-}
-
-func getServerVersion(ctx context.Context, client *mongo.Client) (string, error) {
-	serverStatus, err := client.Database("admin").RunCommand(
-		ctx,
-		bson.D{{"serverStatus", 1}},
-	).DecodeBytes()
-	if err != nil {
-		return "", err
-	}
-
-	version, err := serverStatus.LookupErr("version")
-	if err != nil {
-		return "", err
-	}
-
-	return version.StringValue(), nil
+	// Causal consistency examples cannot run on 4.0.
+	// TODO(GODRIVER-2238): Remove version filtering once failures on 4.0 sharded clusters are fixed.
+	mtOpts = mtest.NewOptions().ClientOptions(&cliOpts).MinServerVersion("4.2").Topologies(mtest.ReplicaSet)
+	mt.RunOpts("CausalConsistencyExamples/post4.2", mtOpts, func(mt *mtest.T) {
+		documentation_examples.CausalConsistencyExamples(mt.Client)
+	})
+	mtOpts = mtest.NewOptions().ClientOptions(&cliOpts).MaxServerVersion("4.0").Topologies(mtest.ReplicaSet)
+	mt.RunOpts("CausalConsistencyExamples/pre4.0", mtOpts, func(mt *mtest.T) {
+		documentation_examples.CausalConsistencyExamples(mt.Client)
+	})
 }
 
 func createTopology(t *testing.T) *topology.Topology {

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -96,8 +96,10 @@ func TestDocumentationExamples(t *testing.T) {
 		documentation_examples.SnapshotQueryExamples(mt)
 	})
 
-	// Only 3.6+ supports $lookup in aggregations as is used in aggregation examples.
-	mtOpts = mtest.NewOptions().MinServerVersion("3.6")
+	// Only 3.6+ supports $lookup in aggregations as is used in aggregation examples. No
+	// collection needs to be created, and collection creation can sometimes cause failures
+	// on sharded clusters.
+	mtOpts = mtest.NewOptions().MinServerVersion("3.6").CreateCollection(false)
 	mt.RunOpts("AggregationExamples", mtOpts, func(mt *mtest.T) {
 		documentation_examples.AggregationExamples(mt.T, db)
 	})


### PR DESCRIPTION
GODRIVER-2010

Adds a README to `examples/documentation_examples` explaining the purpose of `examples.go` and `examples_test.go`. Replaces `context.Background()` with `context.TODO()` is actual example code. Actually runs `WithTransactionExample`. Uses `mtest.ClusterURI()` instead of hard-coding URIs. Reorganizes `examples_test.go` to use `mtest` for server version/topology logic. Adds links to examples pointing to where they appear/will appear on www.mongodb.com/docs.