### PR TITLE
GODRIVER-2380 Sync CRUD spec tests for allowDiskUse

### DIFF
--- a/data/crud/unified/aggregate-allowdiskuse.json
+++ b/data/crud/unified/aggregate-allowdiskuse.json
@@ -1,11 +1,6 @@
 {
-  "description": "find-allowdiskuse",
+  "description": "aggregate-allowdiskuse",
   "schemaVersion": "1.0",
-  "runOnRequirements": [
-    {
-      "minServerVersion": "4.3.1"
-    }
-  ],
   "createEntities": [
     {
       "client": {
@@ -19,26 +14,37 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "test_find_allowdiskuse"
+        "collectionName": "coll0"
       }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
     }
   ],
   "tests": [
     {
-      "description": "Find does not send allowDiskUse when value is not specified",
+      "description": "Aggregate does not send allowDiskUse when value is not specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {}
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ]
           }
         }
       ],
@@ -49,11 +55,18 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": {
                     "$$exists": false
                   }
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]
@@ -61,13 +74,17 @@
       ]
     },
     {
-      "description": "Find sends allowDiskUse false when false is specified",
+      "description": "Aggregate sends allowDiskUse false when false is specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {},
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
             "allowDiskUse": false
           }
         }
@@ -79,9 +96,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": false
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]
@@ -89,13 +113,17 @@
       ]
     },
     {
-      "description": "Find sends allowDiskUse true when true is specified",
+      "description": "Aggregate sends allowDiskUse true when true is specified",
       "operations": [
         {
           "object": "collection0",
-          "name": "find",
+          "name": "aggregate",
           "arguments": {
-            "filter": {},
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
             "allowDiskUse": true
           }
         }
@@ -107,9 +135,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "find": "test_find_allowdiskuse",
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
                   "allowDiskUse": true
-                }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
               }
             }
           ]

--- a/data/crud/unified/aggregate-allowdiskuse.yml
+++ b/data/crud/unified/aggregate-allowdiskuse.yml
@@ -1,0 +1,75 @@
+description: aggregate-allowdiskuse
+
+schemaVersion: '1.0'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: 'Aggregate does not send allowDiskUse when value is not specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: &pipeline [ { $match: {} } ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: { $$exists: false }
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: 'Aggregate sends allowDiskUse false when false is specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *pipeline
+          allowDiskUse: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: false
+              commandName: aggregate
+              databaseName: *database0Name
+
+  - description: 'Aggregate sends allowDiskUse true when true is specified'
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: *pipeline
+          allowDiskUse: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline
+                allowDiskUse: true
+              commandName: aggregate
+              databaseName: *database0Name

--- a/data/crud/unified/find-allowdiskuse.yml
+++ b/data/crud/unified/find-allowdiskuse.yml
@@ -24,7 +24,7 @@ createEntities:
       collectionName: &collection_name test_find_allowdiskuse
 tests:
   -
-    description: 'Find does not send allowDiskuse when value is not specified'
+    description: 'Find does not send allowDiskUse when value is not specified'
     operations:
       -
         object: *collection0
@@ -42,7 +42,7 @@ tests:
                 allowDiskUse:
                   $$exists: false
   -
-    description: 'Find sends allowDiskuse false when false is specified'
+    description: 'Find sends allowDiskUse false when false is specified'
     operations:
       -
         object: *collection0


### PR DESCRIPTION
GODRIVER-2380

Adds tests to ensure that `allowDiskUse` is sent correctly in `aggregate` and `find` operations when it is unset, false and true (we already have the correct behavior).