### PR TITLE
GODRIVER-2294 Support PIT pre- and post-images for change streams

### DIFF
--- a/data/change-streams/unified/change-streams-pre_and_post_images.json
+++ b/data/change-streams/unified/change-streams-pre_and_post_images.json
@@ -1,0 +1,826 @@
+{
+  "description": "change-streams-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "collMod",
+          "insert",
+          "update",
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/change-streams/unified/change-streams-pre_and_post_images.yml
+++ b/data/change-streams/unified/change-streams-pre_and_post_images.yml
@@ -1,0 +1,350 @@
+description: "change-streams-pre_and_post_images"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "6.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ collMod, insert, update, getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &enablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: true }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &disablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: false }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -395,7 +395,16 @@ func (cs *ChangeStream) createPipelineOptionsDoc() bsoncore.Document {
 	}
 
 	if cs.options.FullDocument != nil {
-		plDoc = bsoncore.AppendStringElement(plDoc, "fullDocument", string(*cs.options.FullDocument))
+		// Only append a default "fullDocument" field if wire version is less than 6 (3.6). Otherwise,
+		// the server will assume users want the default behavior, and "fullDocument" does not need to be
+		// specified.
+		if *cs.options.FullDocument != options.Default || (cs.wireVersion != nil && cs.wireVersion.Max < 6) {
+			plDoc = bsoncore.AppendStringElement(plDoc, "fullDocument", string(*cs.options.FullDocument))
+		}
+	}
+
+	if cs.options.FullDocumentBeforeChange != nil {
+		plDoc = bsoncore.AppendStringElement(plDoc, "fullDocumentBeforeChange", string(*cs.options.FullDocumentBeforeChange))
 	}
 
 	if cs.options.ResumeAfter != nil {

--- a/mongo/integration/unified/client_operation_execution.go
+++ b/mongo/integration/unified/client_operation_execution.go
@@ -58,10 +58,23 @@ func executeCreateChangeStream(ctx context.Context, operation *operation) (*oper
 			switch fd := val.StringValue(); fd {
 			case "default":
 				opts.SetFullDocument(options.Default)
+			case "required":
+				opts.SetFullDocument(options.Required)
 			case "updateLookup":
 				opts.SetFullDocument(options.UpdateLookup)
+			case "whenAvailable":
+				opts.SetFullDocument(options.WhenAvailable)
 			default:
 				return nil, fmt.Errorf("unrecognized fullDocument value %q", fd)
+			}
+		case "fullDocumentBeforeChange":
+			switch fdbc := val.StringValue(); fdbc {
+			case "off":
+				opts.SetFullDocumentBeforeChange(options.Off)
+			case "required":
+				opts.SetFullDocumentBeforeChange(options.Required)
+			case "whenAvailable":
+				opts.SetFullDocumentBeforeChange(options.WhenAvailable)
 			}
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -23,10 +23,13 @@ type ChangeStreamOptions struct {
 	// default value is nil, which means the default collation of the collection will be used.
 	Collation *Collation
 
-	// Specifies whether the updated document should be returned in change notifications for update operations along
-	// with the deltas describing the changes made to the document. The default is options.Default, which means that
-	// the updated document will not be included in the change notification.
+	// Specifies how the updated document should be returned in change notifications for update operations. The default
+	// is options.Default, which means that only partial update deltas will be included in the change notification.
 	FullDocument *FullDocument
+
+	// Specifies how the pre-update document should be returned in change notifications for update operations. The default
+	// is options.Off, which means that the pre-update document will not be included in the change notification.
+	FullDocumentBeforeChange *FullDocument
 
 	// The maximum amount of time that the server should wait for new documents to satisfy a tailable cursor query.
 	MaxAwaitTime *time.Duration
@@ -81,6 +84,12 @@ func (cso *ChangeStreamOptions) SetCollation(c Collation) *ChangeStreamOptions {
 // SetFullDocument sets the value for the FullDocument field.
 func (cso *ChangeStreamOptions) SetFullDocument(fd FullDocument) *ChangeStreamOptions {
 	cso.FullDocument = &fd
+	return cso
+}
+
+// SetFullDocumentBeforeChange sets the value for the FullDocumentBeforeChange field.
+func (cso *ChangeStreamOptions) SetFullDocumentBeforeChange(fdbc FullDocument) *ChangeStreamOptions {
+	cso.FullDocumentBeforeChange = &fdbc
 	return cso
 }
 
@@ -141,6 +150,9 @@ func MergeChangeStreamOptions(opts ...*ChangeStreamOptions) *ChangeStreamOptions
 		}
 		if cso.FullDocument != nil {
 			csOpts.FullDocument = cso.FullDocument
+		}
+		if cso.FullDocumentBeforeChange != nil {
+			csOpts.FullDocumentBeforeChange = cso.FullDocumentBeforeChange
 		}
 		if cso.MaxAwaitTime != nil {
 			csOpts.MaxAwaitTime = cso.MaxAwaitTime

--- a/mongo/options/mongooptions.go
+++ b/mongo/options/mongooptions.go
@@ -89,16 +89,22 @@ const (
 	After
 )
 
-// FullDocument specifies whether a change stream should include a copy of the entire document that was changed from
-// some time after the change occurred.
+// FullDocument specifies how a change stream should return the modified document.
 type FullDocument string
 
 const (
-	// Default does not include a document copy
+	// Default does not include a document copy.
 	Default FullDocument = "default"
+	// Off is the same as sending no value for fullDocumentBeforeChange.
+	Off FullDocument = "off"
+	// Required is the same as WhenAvailable but raises a server-side error if the post-image is not available.
+	Required FullDocument = "required"
 	// UpdateLookup includes a delta describing the changes to the document and a copy of the entire document that
-	// was changed
+	// was changed.
 	UpdateLookup FullDocument = "updateLookup"
+	// WhenAvailable includes a post-image of the the modified document for replace and update change events
+	// if the post-image for this event is available.
+	WhenAvailable FullDocument = "whenAvailable"
 )
 
 // ArrayFilters is used to hold filters for the array filters CRUD option. If a registry is nil, bson.DefaultRegistry


### PR DESCRIPTION
GODRIVER-2294
GODRIVER-2329

Syncs change stream unified spec tests to add tests for the new `fullDocument` values and `fullDocumentBeforeChange` (first commit). Adds `FullDocumentBeforeChange` to `ChangeStreamOptions`. Adds new `FullDocument` values: `Required`, `WhenAvailable` and `Off`.