### PR TITLE
Fix "func (c *Client) Ping" comment

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -244,7 +244,7 @@ func (c *Client) Disconnect(ctx context.Context) error {
 // If it is nil, the client's read preference is used.
 //
 // If the server is down, Ping will try to select a server until the client's server selection timeout expires.
-// This can be configured through the ClientOptions.SetServerSelectionTimeout option when creating a new Client.
+// This can be configured through the ClientOptions.ServerSelectionTimeout option when creating a new Client.
 // After the timeout expires, a server selection error is returned.
 //
 // Using Ping reduces application resilience because applications starting up will error if the server is temporarily


### PR DESCRIPTION
I read comment of this, I tried to set `ClientOptions.SetServerSelectionTimeout` but it not exist.
https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.9.0/mongo#Client.Ping

I think it change the function name `SetServerSelectionTimeout` to `SeverSelectionTimeout`
