### PR TITLE
GODRIVER-2352 Add clientEncryption entity to unified test format

### DIFF
--- a/data/unified-test-format/valid-fail/clientEncryptionOpts-missing-kms-credentials.json
+++ b/data/unified-test-format/valid-fail/clientEncryptionOpts-missing-kms-credentials.json
@@ -1,0 +1,37 @@
+{
+  "description": "clientEncryptionOpts-missing-kms-credentials",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "encryptedClient": {
+        "id": "encryptedClient0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId"
+            },
+            "azure": {
+              "tenantId": "tenantId"
+            },
+            "gcp": {
+              "email": "email"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/clientEncryptionOpts-missing-kms-credentials.yml
+++ b/data/unified-test-format/valid-fail/clientEncryptionOpts-missing-kms-credentials.yml
@@ -1,0 +1,20 @@
+description: clientEncryptionOpts-missing-kms-credentials
+
+schemaVersion: "1.8"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - encryptedClient:
+      id: &encryptedClient0 encryptedClient0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: { accessKeyId: "accessKeyId" }
+          azure: { tenantId: "tenantId" }
+          gcp: { email: "email" }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-fail/clientEncryptionOpts-no-kms.json
+++ b/data/unified-test-format/valid-fail/clientEncryptionOpts-no-kms.json
@@ -1,0 +1,27 @@
+{
+  "description": "clientEncryptionOpts-no-kms",
+  "schemaVersion": "1.8",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "encryptedClient": {
+        "id": "encryptedClient0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {}
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/clientEncryptionOpts-no-kms.yml
+++ b/data/unified-test-format/valid-fail/clientEncryptionOpts-no-kms.yml
@@ -1,0 +1,17 @@
+description: clientEncryptionOpts-no-kms
+
+schemaVersion: "1.8"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - encryptedClient:
+      id: &encryptedClient0 encryptedClient0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders: {}
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_aws_kms_credentials.json
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_aws_kms_credentials.json
@@ -1,0 +1,36 @@
+{
+  "description": "kmsProviders-missing_aws_kms_credentials",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_aws_kms_credentials.yml
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_aws_kms_credentials.yml
@@ -1,0 +1,22 @@
+# Missing required KMS credentials should lead to clientEncryption initialization failure.
+description: kmsProviders-missing_aws_kms_credentials
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: { accessKeyId: "accessKeyId" }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_azure_kms_credentials.json
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_azure_kms_credentials.json
@@ -1,0 +1,36 @@
+{
+  "description": "kmsProviders-missing_azure_kms_credentials",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "azure": {
+              "tenantId": "tenantId"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_azure_kms_credentials.yml
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_azure_kms_credentials.yml
@@ -1,0 +1,22 @@
+# Missing required KMS credentials should lead to clientEncryption initialization failure.
+description: kmsProviders-missing_azure_kms_credentials
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          azure: { tenantId: "tenantId" }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_gcp_kms_credentials.json
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_gcp_kms_credentials.json
@@ -1,0 +1,36 @@
+{
+  "description": "kmsProviders-missing_gcp_kms_credentials",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "gcp": {
+              "email": "email"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/kmsProviders-missing_gcp_kms_credentials.yml
+++ b/data/unified-test-format/valid-fail/kmsProviders-missing_gcp_kms_credentials.yml
@@ -1,0 +1,22 @@
+# Missing required KMS credentials should lead to clientEncryption initialization failure.
+description: kmsProviders-missing_gcp_kms_credentials
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          gcp: { email: "email" }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-fail/kmsProviders-no_kms.json
+++ b/data/unified-test-format/valid-fail/kmsProviders-no_kms.json
@@ -1,0 +1,32 @@
+{
+  "description": "clientEncryptionOpts-no_kms",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {}
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/kmsProviders-no_kms.yml
+++ b/data/unified-test-format/valid-fail/kmsProviders-no_kms.yml
@@ -1,0 +1,21 @@
+# No configured KMS providers should lead to clientEncryption initialization failure.
+description: clientEncryptionOpts-no_kms
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders: {}
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-pass/kmsProviders-explicit_kms_credentials.json
+++ b/data/unified-test-format/valid-pass/kmsProviders-explicit_kms_credentials.json
@@ -1,0 +1,52 @@
+{
+  "description": "kmsProviders-explicit_kms_credentials",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId",
+              "secretAccessKey": "secretAccessKey"
+            },
+            "azure": {
+              "tenantId": "tenantId",
+              "clientId": "clientId",
+              "clientSecret": "clientSecret"
+            },
+            "gcp": {
+              "email": "email",
+              "privateKey": "cHJpdmF0ZUtleQo="
+            },
+            "kmip": {
+              "endpoint": "endpoint"
+            },
+            "local": {
+              "key": "a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/kmsProviders-explicit_kms_credentials.yml
+++ b/data/unified-test-format/valid-pass/kmsProviders-explicit_kms_credentials.yml
@@ -1,0 +1,26 @@
+# kmsProviders should support explicit credentials.
+description: kmsProviders-explicit_kms_credentials
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: { accessKeyId: "accessKeyId", secretAccessKey: "secretAccessKey" }
+          azure: { tenantId: "tenantId", clientId: "clientId", clientSecret: "clientSecret" }
+          gcp: { email: "email", privateKey: "cHJpdmF0ZUtleQo=" }
+          kmip: { endpoint: "endpoint" }
+          local: { key: "a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5a2V5" }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-pass/kmsProviders-mixed_kms_credential_fields.json
+++ b/data/unified-test-format/valid-pass/kmsProviders-mixed_kms_credential_fields.json
@@ -1,0 +1,54 @@
+{
+  "description": "kmsProviders-mixed_kms_credential_fields",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": "accessKeyId",
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure": {
+              "tenantId": "tenantId",
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp": {
+              "email": "email",
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/kmsProviders-mixed_kms_credential_fields.yml
+++ b/data/unified-test-format/valid-pass/kmsProviders-mixed_kms_credential_fields.yml
@@ -1,0 +1,24 @@
+# kmsProviders should support both explicit and placeholder credential fields.
+description: kmsProviders-mixed_kms_credential_fields
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: { accessKeyId: "accessKeyId", secretAccessKey: { $$placeholder: 1 } }
+          azure: { tenantId: "tenantId", clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          gcp: { email: "email", privateKey: { $$placeholder: 1 } }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-pass/kmsProviders-placeholder_kms_credentials.json
+++ b/data/unified-test-format/valid-pass/kmsProviders-placeholder_kms_credentials.json
@@ -1,0 +1,70 @@
+{
+  "description": "kmsProviders-placeholder_kms_credentials",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            },
+            "azure": {
+              "tenantId": {
+                "$$placeholder": 1
+              },
+              "clientId": {
+                "$$placeholder": 1
+              },
+              "clientSecret": {
+                "$$placeholder": 1
+              }
+            },
+            "gcp": {
+              "email": {
+                "$$placeholder": 1
+              },
+              "privateKey": {
+                "$$placeholder": 1
+              }
+            },
+            "kmip": {
+              "endpoint": {
+                "$$placeholder": 1
+              }
+            },
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/kmsProviders-placeholder_kms_credentials.yml
+++ b/data/unified-test-format/valid-pass/kmsProviders-placeholder_kms_credentials.yml
@@ -1,0 +1,26 @@
+# kmsProviders should support loading credentials at runtime.
+description: kmsProviders-placeholder_kms_credentials
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+          azure: { tenantId: { $$placeholder: 1 }, clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          gcp: { email: { $$placeholder: 1 }, privateKey: { $$placeholder: 1 } }
+          kmip: { endpoint: { $$placeholder: 1 } }
+          local: { key: { $$placeholder: 1 } }
+
+tests:
+  - description: ""
+    operations: []

--- a/data/unified-test-format/valid-pass/kmsProviders-unconfigured_kms.json
+++ b/data/unified-test-format/valid-pass/kmsProviders-unconfigured_kms.json
@@ -1,0 +1,38 @@
+{
+  "description": "kmsProviders-unconfigured_kms",
+  "schemaVersion": "1.8",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws": {},
+            "azure": {},
+            "gcp": {},
+            "kmip": {},
+            "local": {}
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/data/unified-test-format/valid-pass/kmsProviders-unconfigured_kms.yml
+++ b/data/unified-test-format/valid-pass/kmsProviders-unconfigured_kms.yml
@@ -1,0 +1,26 @@
+# kmsProviders should support request for on-demand KMS credentials.
+description: kmsProviders-unconfigured_kms
+
+schemaVersion: "1.8"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          aws: {}
+          azure: {}
+          gcp: {}
+          kmip: {}
+          local: {}
+
+tests:
+  - description: ""
+    operations: []

--- a/mongo/integration/mtest/csfle_enabled.go
+++ b/mongo/integration/mtest/csfle_enabled.go
@@ -9,6 +9,8 @@
 
 package mtest
 
+// CSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
+// Client Side Field Level Encryption support is enabled with the cse build tag.
 func CSFLEEnabled() bool {
 	return true
 }

--- a/mongo/integration/mtest/csfle_enabled.go
+++ b/mongo/integration/mtest/csfle_enabled.go
@@ -1,0 +1,14 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build cse
+// +build cse
+
+package mtest
+
+func CSFLEEnabled() bool {
+	return true
+}

--- a/mongo/integration/mtest/csfle_enabled.go
+++ b/mongo/integration/mtest/csfle_enabled.go
@@ -9,8 +9,8 @@
 
 package mtest
 
-// CSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
+// IsCSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
 // Client Side Field Level Encryption support is enabled with the cse build tag.
-func CSFLEEnabled() bool {
+func IsCSFLEEnabled() bool {
 	return true
 }

--- a/mongo/integration/mtest/csfle_not_enabled.go
+++ b/mongo/integration/mtest/csfle_not_enabled.go
@@ -9,8 +9,8 @@
 
 package mtest
 
-// CSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
+// IsCSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
 // Client Side Field Level Encryption support is enabled with the cse build tag.
-func CSFLEEnabled() bool {
+func IsCSFLEEnabled() bool {
 	return false
 }

--- a/mongo/integration/mtest/csfle_not_enabled.go
+++ b/mongo/integration/mtest/csfle_not_enabled.go
@@ -9,6 +9,8 @@
 
 package mtest
 
+// CSFLEEnabled returns true if driver is built with Client Side Field Level Encryption support.
+// Client Side Field Level Encryption support is enabled with the cse build tag.
 func CSFLEEnabled() bool {
 	return false
 }

--- a/mongo/integration/mtest/csfle_not_enabled.go
+++ b/mongo/integration/mtest/csfle_not_enabled.go
@@ -1,0 +1,14 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build !cse
+// +build !cse
+
+package mtest
+
+func CSFLEEnabled() bool {
+	return false
+}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -758,7 +758,7 @@ func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 	}
 
 	if rob.CSFLE != nil {
-		if *rob.CSFLE != CSFLEEnabled() {
+		if *rob.CSFLE != IsCSFLEEnabled() {
 			if *rob.CSFLE {
 				return fmt.Errorf("runOnBlock requires CSFLE to be enabled. Build with the cse tag to enable")
 			}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -758,10 +758,9 @@ func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 	}
 
 	if rob.CSFLE != nil {
-		if *rob.CSFLE != IsCSFLEEnabled() {
-			if *rob.CSFLE {
-				return fmt.Errorf("runOnBlock requires CSFLE to be enabled. Build with the cse tag to enable")
-			}
+		if *rob.CSFLE && !IsCSFLEEnabled() {
+			return fmt.Errorf("runOnBlock requires CSFLE to be enabled. Build with the cse tag to enable")
+		} else if !*rob.CSFLE && IsCSFLEEnabled() {
 			return fmt.Errorf("runOnBlock requires CSFLE to be disabled. Build without the cse tag to disable")
 		}
 	}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -753,7 +753,19 @@ func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 	if err := verifyServerlessConstraint(rob.Serverless); err != nil {
 		return err
 	}
-	return verifyServerParametersConstraints(rob.ServerParameters)
+	if err := verifyServerParametersConstraints(rob.ServerParameters); err != nil {
+		return err
+	}
+
+	if rob.CSFLE != nil {
+		if *rob.CSFLE != CSFLEEnabled() {
+			if *rob.CSFLE {
+				return fmt.Errorf("runOnBlock requires CSFLE to be enabled. Build with the cse tag to enable")
+			}
+			return fmt.Errorf("runOnBlock requires CSFLE to be disabled. Build without the cse tag to disable")
+		}
+	}
+	return nil
 }
 
 // verifyConstraints returns an error if the current environment does not match the constraints specified for the test.

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -58,6 +58,7 @@ type RunOnBlock struct {
 	ServerParameters map[string]bson.RawValue `bson:"serverParameters"`
 	Auth             *bool                    `bson:"auth"`
 	AuthEnabled      *bool                    `bson:"authEnabled"`
+	CSFLE            *bool                    `bson:"csfle"`
 }
 
 // UnmarshalBSON implements custom BSON unmarshalling behavior for RunOnBlock because some test formats use the
@@ -72,6 +73,7 @@ func (r *RunOnBlock) UnmarshalBSON(data []byte) error {
 		ServerParameters map[string]bson.RawValue `bson:"serverParameters"`
 		Auth             *bool                    `bson:"auth"`
 		AuthEnabled      *bool                    `bson:"authEnabled"`
+		CSFLE            *bool                    `bson:"csfle"`
 		Extra            map[string]interface{}   `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
@@ -87,6 +89,7 @@ func (r *RunOnBlock) UnmarshalBSON(data []byte) error {
 	r.ServerParameters = temp.ServerParameters
 	r.Auth = temp.Auth
 	r.AuthEnabled = temp.AuthEnabled
+	r.CSFLE = temp.CSFLE
 
 	if temp.Topology != nil {
 		r.Topology = temp.Topology

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -237,7 +237,7 @@ func (em *EntityMap) addEntity(ctx context.Context, entityType string, entityOpt
 		err = em.addSessionEntity(entityOptions)
 	case "bucket":
 		err = em.addGridFSBucketEntity(entityOptions)
-	case "encryptedClient":
+	case "clientEncryption":
 		err = em.addClientEncryptionEntity(entityOptions)
 	default:
 		return fmt.Errorf("unrecognized entity type %q", entityType)

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -429,19 +429,6 @@ func (em *EntityMap) addDatabaseEntity(entityOptions *entityOptions) error {
 	return nil
 }
 
-var (
-	envVarAwsAccessKeyID         = "AWS_ACCESS_KEY_ID"
-	envVarAwsSecretAccessKey     = "AWS_SECRET_ACCESS_KEY"
-	envVarAwsTempAccessKeyID     = "CSFLE_AWS_TEMP_ACCESS_KEY_ID"
-	envVarAwsTempSecretAccessKey = "CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
-	envVarAwsTempSessionToken    = "CSFLE_AWS_TEMP_SESSION_TOKEN"
-	envVarAzureTenantID          = "AZURE_TENANT_ID"
-	envVarAzureClientID          = "AZURE_CLIENT_ID"
-	envVarAzureClientSecret      = "AZURE_CLIENT_SECRET"
-	envVarGcpEmail               = "GCP_EMAIL"
-	envVarGcpPrivateKey          = "GCP_PRIVATE_KEY"
-)
-
 // getKmsCredential processes a value of an input KMS provider credential.
 // An empty document returns from the environment.
 // A string is returned as-is.
@@ -485,14 +472,14 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	if aws, ok := ceo.KmsProviders["aws"]; ok {
 		kmsProviders["aws"] = make(map[string]interface{})
 
-		awsSessionToken, err := getKmsCredential(aws, "sessionToken", envVarAwsTempSessionToken, "")
+		awsSessionToken, err := getKmsCredential(aws, "sessionToken", "CSFLE_AWS_TEMP_SESSION_TOKEN", "")
 		if err != nil {
 			return err
 		}
 		if awsSessionToken != "" {
 			// Get temporary AWS credentials.
 			kmsProviders["aws"]["sessionToken"] = awsSessionToken
-			awsAccessKeyID, err := getKmsCredential(aws, "accessKeyId", envVarAwsTempAccessKeyID, "")
+			awsAccessKeyID, err := getKmsCredential(aws, "accessKeyId", "CSFLE_AWS_TEMP_ACCESS_KEY_ID", "")
 			if err != nil {
 				return err
 			}
@@ -500,7 +487,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 				kmsProviders["aws"]["accessKeyId"] = awsAccessKeyID
 			}
 
-			awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", envVarAwsTempSecretAccessKey, "")
+			awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", "CSFLE_AWS_TEMP_SECRET_ACCESS_KEY", "")
 			if err != nil {
 				return err
 			}
@@ -508,7 +495,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 				kmsProviders["aws"]["secretAccessKey"] = awsSecretAccessKey
 			}
 		} else {
-			awsAccessKeyID, err := getKmsCredential(aws, "accessKeyId", envVarAwsAccessKeyID, "")
+			awsAccessKeyID, err := getKmsCredential(aws, "accessKeyId", "AWS_ACCESS_KEY_ID", "")
 			if err != nil {
 				return err
 			}
@@ -516,7 +503,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 				kmsProviders["aws"]["accessKeyId"] = awsAccessKeyID
 			}
 
-			awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", envVarAwsSecretAccessKey, "")
+			awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", "AWS_SECRET_ACCESS_KEY", "")
 			if err != nil {
 				return err
 			}
@@ -530,7 +517,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	if azure, ok := ceo.KmsProviders["azure"]; ok {
 		kmsProviders["azure"] = make(map[string]interface{})
 
-		azureTenantID, err := getKmsCredential(azure, "tenantId", envVarAzureTenantID, "")
+		azureTenantID, err := getKmsCredential(azure, "tenantId", "AZURE_TENANT_ID", "")
 		if err != nil {
 			return err
 		}
@@ -538,7 +525,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 			kmsProviders["azure"]["tenantId"] = azureTenantID
 		}
 
-		azureClientID, err := getKmsCredential(azure, "clientId", envVarAzureClientID, "")
+		azureClientID, err := getKmsCredential(azure, "clientId", "AZURE_CLIENT_ID", "")
 		if err != nil {
 			return err
 		}
@@ -546,7 +533,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 			kmsProviders["azure"]["clientId"] = azureClientID
 		}
 
-		azureClientSecret, err := getKmsCredential(azure, "clientSecret", envVarAzureClientSecret, "")
+		azureClientSecret, err := getKmsCredential(azure, "clientSecret", "AZURE_CLIENT_SECRET", "")
 		if err != nil {
 			return err
 		}
@@ -558,7 +545,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	if gcp, ok := ceo.KmsProviders["gcp"]; ok {
 		kmsProviders["gcp"] = make(map[string]interface{})
 
-		gcpEmail, err := getKmsCredential(gcp, "email", envVarGcpEmail, "")
+		gcpEmail, err := getKmsCredential(gcp, "email", "GCP_EMAIL", "")
 		if err != nil {
 			return err
 		}
@@ -566,7 +553,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 			kmsProviders["gcp"]["email"] = gcpEmail
 		}
 
-		gcpPrivateKey, err := getKmsCredential(gcp, "privateKey", envVarGcpPrivateKey, "")
+		gcpPrivateKey, err := getKmsCredential(gcp, "privateKey", "GCP_PRIVATE_KEY", "")
 		if err != nil {
 			return err
 		}

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -591,7 +591,11 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		return newEntityNotFoundError("client", ceo.KeyVaultClient)
 	}
 
-	ce, err := mongo.NewClientEncryption(keyVaultClient.Client, options.ClientEncryption().SetKeyVaultNamespace(ceo.KeyVaultNamespace).SetKmsProviders(kmsProviders))
+	ce, err := mongo.NewClientEncryption(
+		keyVaultClient.Client,
+		options.ClientEncryption().
+			SetKeyVaultNamespace(ceo.KeyVaultNamespace).
+			SetKmsProviders(kmsProviders))
 	if err != nil {
 		return err
 	}

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -374,7 +374,7 @@ func (em *EntityMap) close(ctx context.Context) []error {
 	}
 
 	for id, client := range em.clientEntities {
-		if ok, _ := em.keyVaultClientIDs[id]; ok {
+		if ok := em.keyVaultClientIDs[id]; ok {
 			// Client will be closed in clientEncryption.Close()
 			continue
 		}
@@ -456,7 +456,7 @@ func getKmsCredential(kmsDocument bson.Raw, credentialName string, defaultValue 
 			placeholderDoc := bsoncore.NewDocumentBuilder().AppendInt32("$$placeholder", 1).Build()
 
 			// Check if document is a placeholder.
-			if bytes.Compare(doc, placeholderDoc) != 0 {
+			if !bytes.Equal(doc, placeholderDoc) {
 				return nil, fmt.Errorf("unexpected non-empty document for %v: %v", credentialName, doc)
 			}
 			if defaultValue == "" {
@@ -487,20 +487,20 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 			kmsProviders["aws"]["sessionToken"] = *awsSessionToken
 		}
 
-		defaultAccessKeyId := envAwsAccessKeyID
+		defaultAccessKeyID := envAwsAccessKeyID
 		defaultSecretAccessKey := envAwsSecretAccessKey
 
 		if awsSessionToken != nil {
-			defaultAccessKeyId = envAwsTempAccessKeyID
+			defaultAccessKeyID = envAwsTempAccessKeyID
 			defaultSecretAccessKey = envAwsTempSecretAccessKey
 		}
 
-		awsAccessKeyId, err := getKmsCredential(aws, "accessKeyId", defaultAccessKeyId)
+		awsAccessKeyID, err := getKmsCredential(aws, "accessKeyId", defaultAccessKeyID)
 		if err != nil {
 			return err
 		}
-		if awsAccessKeyId != nil {
-			kmsProviders["aws"]["accessKeyId"] = *awsAccessKeyId
+		if awsAccessKeyID != nil {
+			kmsProviders["aws"]["accessKeyId"] = *awsAccessKeyID
 		}
 
 		awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", defaultSecretAccessKey)
@@ -515,20 +515,20 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	if azure, ok := ceo.KmsProviders["azure"]; ok {
 		kmsProviders["azure"] = make(map[string]interface{})
 
-		azureTenantId, err := getKmsCredential(azure, "tenantId", envAzureTenantID)
+		azureTenantID, err := getKmsCredential(azure, "tenantId", envAzureTenantID)
 		if err != nil {
 			return err
 		}
-		if azureTenantId != nil {
-			kmsProviders["azure"]["tenantId"] = *azureTenantId
+		if azureTenantID != nil {
+			kmsProviders["azure"]["tenantId"] = *azureTenantID
 		}
 
-		azureClientId, err := getKmsCredential(azure, "clientId", envAzureClientID)
+		azureClientID, err := getKmsCredential(azure, "clientId", envAzureClientID)
 		if err != nil {
 			return err
 		}
-		if azureClientId != nil {
-			kmsProviders["azure"]["clientId"] = *azureClientId
+		if azureClientID != nil {
+			kmsProviders["azure"]["clientId"] = *azureClientID
 		}
 
 		azureClientSecret, err := getKmsCredential(azure, "clientSecret", envAzureClientSecret)

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -445,11 +445,11 @@ var (
 // getKmsCredential processes a value of an input KMS provider credential.
 // An empty document returns from the environment.
 // A string is returned as-is.
-func getKmsCredential(kmsDocument bson.Raw, credentialName string, defaultValue string) (*string, error) {
+func getKmsCredential(kmsDocument bson.Raw, credentialName string, defaultValue string) (string, error) {
 	credentialVal, err := kmsDocument.LookupErr(credentialName)
 	if err == nil {
 		if str, ok := credentialVal.StringValueOK(); ok {
-			return &str, nil
+			return str, nil
 		}
 
 		if doc, ok := credentialVal.DocumentOK(); ok {
@@ -457,19 +457,19 @@ func getKmsCredential(kmsDocument bson.Raw, credentialName string, defaultValue 
 
 			// Check if document is a placeholder.
 			if !bytes.Equal(doc, placeholderDoc) {
-				return nil, fmt.Errorf("unexpected non-empty document for %v: %v", credentialName, doc)
+				return "", fmt.Errorf("unexpected non-empty document for %v: %v", credentialName, doc)
 			}
 			if defaultValue == "" {
-				return nil, fmt.Errorf("unable to get default value for %v. Please set CSFLE environment variables", credentialName)
+				return "", fmt.Errorf("unable to get default value for %v. Please set CSFLE environment variables", credentialName)
 			}
-			return &defaultValue, nil
+			return defaultValue, nil
 		}
 
-		return nil, fmt.Errorf("expected String or Document for %v, got: %v", credentialName, credentialVal)
+		return "", fmt.Errorf("expected String or Document for %v, got: %v", credentialName, credentialVal)
 	} else if err == bsoncore.ErrElementNotFound {
-		return nil, nil
+		return "", nil
 	}
-	return nil, err
+	return "", err
 }
 
 func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) error {
@@ -483,14 +483,14 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if awsSessionToken != nil {
-			kmsProviders["aws"]["sessionToken"] = *awsSessionToken
+		if awsSessionToken != "" {
+			kmsProviders["aws"]["sessionToken"] = awsSessionToken
 		}
 
 		defaultAccessKeyID := envAwsAccessKeyID
 		defaultSecretAccessKey := envAwsSecretAccessKey
 
-		if awsSessionToken != nil {
+		if awsSessionToken != "" {
 			defaultAccessKeyID = envAwsTempAccessKeyID
 			defaultSecretAccessKey = envAwsTempSecretAccessKey
 		}
@@ -499,16 +499,16 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if awsAccessKeyID != nil {
-			kmsProviders["aws"]["accessKeyId"] = *awsAccessKeyID
+		if awsAccessKeyID != "" {
+			kmsProviders["aws"]["accessKeyId"] = awsAccessKeyID
 		}
 
 		awsSecretAccessKey, err := getKmsCredential(aws, "secretAccessKey", defaultSecretAccessKey)
 		if err != nil {
 			return err
 		}
-		if awsSecretAccessKey != nil {
-			kmsProviders["aws"]["secretAccessKey"] = *awsSecretAccessKey
+		if awsSecretAccessKey != "" {
+			kmsProviders["aws"]["secretAccessKey"] = awsSecretAccessKey
 		}
 	}
 
@@ -519,24 +519,24 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if azureTenantID != nil {
-			kmsProviders["azure"]["tenantId"] = *azureTenantID
+		if azureTenantID != "" {
+			kmsProviders["azure"]["tenantId"] = azureTenantID
 		}
 
 		azureClientID, err := getKmsCredential(azure, "clientId", envAzureClientID)
 		if err != nil {
 			return err
 		}
-		if azureClientID != nil {
-			kmsProviders["azure"]["clientId"] = *azureClientID
+		if azureClientID != "" {
+			kmsProviders["azure"]["clientId"] = azureClientID
 		}
 
 		azureClientSecret, err := getKmsCredential(azure, "clientSecret", envAzureClientSecret)
 		if err != nil {
 			return err
 		}
-		if azureClientSecret != nil {
-			kmsProviders["azure"]["clientSecret"] = *azureClientSecret
+		if azureClientSecret != "" {
+			kmsProviders["azure"]["clientSecret"] = azureClientSecret
 		}
 	}
 
@@ -547,16 +547,16 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if gcpEmail != nil {
-			kmsProviders["gcp"]["email"] = *gcpEmail
+		if gcpEmail != "" {
+			kmsProviders["gcp"]["email"] = gcpEmail
 		}
 
 		gcpPrivateKey, err := getKmsCredential(gcp, "privateKey", envGcpPrivateKey)
 		if err != nil {
 			return err
 		}
-		if gcpPrivateKey != nil {
-			kmsProviders["gcp"]["privateKey"] = *gcpPrivateKey
+		if gcpPrivateKey != "" {
+			kmsProviders["gcp"]["privateKey"] = gcpPrivateKey
 		}
 	}
 
@@ -567,8 +567,8 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if kmipEndpoint != nil {
-			kmsProviders["kmip"]["endpoint"] = *kmipEndpoint
+		if kmipEndpoint != "" {
+			kmsProviders["kmip"]["endpoint"] = kmipEndpoint
 		}
 	}
 
@@ -580,8 +580,8 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		if err != nil {
 			return err
 		}
-		if localKey != nil {
-			kmsProviders["local"]["key"] = *localKey
+		if localKey != "" {
+			kmsProviders["local"]["key"] = localKey
 		}
 	}
 

--- a/mongo/integration/unified/entity.go
+++ b/mongo/integration/unified/entity.go
@@ -7,6 +7,7 @@
 package unified
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -452,8 +453,10 @@ func getKmsCredential(kmsDocument bson.Raw, credentialName string, defaultValue 
 		}
 
 		if doc, ok := credentialVal.DocumentOK(); ok {
-			// Check if document is empty.
-			if len(doc) != 5 {
+			placeholderDoc := bsoncore.NewDocumentBuilder().AppendInt32("$$placeholder", 1).Build()
+
+			// Check if document is a placeholder.
+			if bytes.Compare(doc, placeholderDoc) != 0 {
 				return nil, fmt.Errorf("unexpected non-empty document for %v: %v", credentialName, doc)
 			}
 			if defaultValue == "" {

--- a/mongo/integration/unified/schema_version.go
+++ b/mongo/integration/unified/schema_version.go
@@ -16,7 +16,9 @@ import (
 
 var (
 	supportedSchemaVersions = map[int]string{
-		1: "1.6",
+		// TODO: 1.7 support will be added in GODRIVER-1986.
+		// TODO: Claim to support 1.8 to run tests added in GODRIVER-2352.
+		1: "1.8",
 	}
 )
 


### PR DESCRIPTION
GODRIVER-2352

Add Unified Test Format support for 1.8. This is a prerequisite for the Go implementation of the CSFLE Key Management API.

# Background & Motivation

See https://github.com/mongodb/specifications/commit/e91f0ec558d8d6c3213126fd63aa3d111771f49d and https://github.com/mongodb/specifications/commit/0f65908778188a8d6eeb22571c7791a2b1674234 for the Unified Test Format changes.

# Notes

`ClientEncryption.Close()` calls `Disconnect` on the keyVaultClient. [Client entities used as keyVaultClients are tracked](https://github.com/mongodb/mongo-go-driver/pull/920/commits/9b1b9c2e5093d8303727bb80de402fa3d6ed4622) to prevent the test runner from calling `Disconnect` twice.