### PR TITLE
GODRIVER-2394 No error raised for bulkWrite with comment on <= 3.2

### DIFF
--- a/data/crud/unified/bulkWrite-comment.json
+++ b/data/crud/unified/bulkWrite-comment.json
@@ -412,6 +412,7 @@
       "description": "BulkWrite with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/bulkWrite-comment.yml
+++ b/data/crud/unified/bulkWrite-comment.yml
@@ -154,7 +154,8 @@ tests:
 
   - description: 'BulkWrite with comment - pre 4.4'
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - object: *collection0
         name: bulkWrite

--- a/data/crud/unified/deleteMany-comment.json
+++ b/data/crud/unified/deleteMany-comment.json
@@ -175,6 +175,7 @@
       "description": "deleteMany with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/deleteMany-comment.yml
+++ b/data/crud/unified/deleteMany-comment.yml
@@ -74,7 +74,8 @@ tests:
 
   - description: "deleteMany with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: deleteMany
         object: *collection0

--- a/data/crud/unified/deleteOne-comment.json
+++ b/data/crud/unified/deleteOne-comment.json
@@ -177,6 +177,7 @@
       "description": "deleteOne with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/deleteOne-comment.yml
+++ b/data/crud/unified/deleteOne-comment.yml
@@ -75,7 +75,8 @@ tests:
 
   - description: "deleteOne with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: deleteOne
         object: *collection0

--- a/data/crud/unified/insertMany-comment.json
+++ b/data/crud/unified/insertMany-comment.json
@@ -166,6 +166,7 @@
       "description": "insertMany with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/insertMany-comment.yml
+++ b/data/crud/unified/insertMany-comment.yml
@@ -70,7 +70,8 @@ tests:
 
   - description: "insertMany with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: insertMany
         object: *collection0

--- a/data/crud/unified/insertOne-comment.json
+++ b/data/crud/unified/insertOne-comment.json
@@ -162,6 +162,7 @@
       "description": "insertOne with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/insertOne-comment.yml
+++ b/data/crud/unified/insertOne-comment.yml
@@ -70,7 +70,8 @@ tests:
 
   - description: "insertOne with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: insertOne
         object: *collection0

--- a/data/crud/unified/replaceOne-comment.json
+++ b/data/crud/unified/replaceOne-comment.json
@@ -166,6 +166,7 @@
       "description": "ReplaceOne with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/replaceOne-comment.yml
+++ b/data/crud/unified/replaceOne-comment.yml
@@ -74,7 +74,8 @@ tests:
 
   - description: "ReplaceOne with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: replaceOne
         object: *collection0

--- a/data/crud/unified/updateMany-comment.json
+++ b/data/crud/unified/updateMany-comment.json
@@ -182,6 +182,7 @@
       "description": "UpdateMany with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/updateMany-comment.yml
+++ b/data/crud/unified/updateMany-comment.yml
@@ -77,7 +77,8 @@ tests:
 
   - description: "UpdateMany with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: updateMany
         object: *collection0

--- a/data/crud/unified/updateOne-comment.json
+++ b/data/crud/unified/updateOne-comment.json
@@ -186,6 +186,7 @@
       "description": "UpdateOne with comment - pre 4.4",
       "runOnRequirements": [
         {
+          "minServerVersion": "3.4.0",
           "maxServerVersion": "4.2.99"
         }
       ],

--- a/data/crud/unified/updateOne-comment.yml
+++ b/data/crud/unified/updateOne-comment.yml
@@ -77,7 +77,8 @@ tests:
 
   - description: "UpdateOne with comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
+      - minServerVersion: "3.4.0"
+        maxServerVersion: "4.2.99"
     operations:
       - name: updateOne
         object: *collection0


### PR DESCRIPTION
[GODRIVER-2394](https://jira.mongodb.org/browse/GODRIVER-2394)

Sync the unified CRUD tests with https://github.com/mongodb/specifications/commit/b8371eac99679f072672fa9c7c3ecafb279e13f1 .  Merging this into GODRIVER-2330, which is the branch that needs it directly.  It will eventually be merged into master through GODRIVER-2199 branch.

The path here is 

[GODRIVER-2199](https://github.com/mongodb/mongo-go-driver/pull/922) <- [GODRIVER-2330](https://github.com/mongodb/mongo-go-driver/pull/923) <- GODRIVER-2394