### PR TITLE
GODRIVER-2357 Inherited comment causes OperationFailure on MongoDB <4.4.0

### DIFF
--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -86,12 +86,11 @@ type valueReader struct {
 
 // NewBSONDocumentReader returns a ValueReader using b for the underlying BSON
 // representation. Parameter b must be a BSON Document.
-//
-// TODO(skriptble): There's a lack of symmetry between the reader and writer, since the reader takes
-// a []byte while the writer takes an io.Writer. We should have two versions of each, one that takes
-// a []byte and one that takes an io.Reader or io.Writer. The []byte version will need to return a
-// thing that can return the finished []byte since it might be reallocated when appended to.
 func NewBSONDocumentReader(b []byte) ValueReader {
+	// TODO(skriptble): There's a lack of symmetry between the reader and writer, since the reader takes a []byte while the
+	// TODO writer takes an io.Writer. We should have two versions of each, one that takes a []byte and one that takes an
+	// TODO io.Reader or io.Writer. The []byte version will need to return a thing that can return the finished []byte since
+	// TODO it might be reallocated when appended to.
 	return newValueReader(b)
 }
 

--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -165,7 +165,6 @@
     },
     {
       "description": "Test with document comment - pre 4.4",
-      "skipReason": "TODO(GODRIVER-2386): aggregate doesn't support document comments in any version",
       "runOnRequirements": [
         {
           "minServerVersion": "3.6.0",
@@ -253,7 +252,102 @@
       "description": "Test that comment is set on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0"
+          "minServerVersion": "4.4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "key": "value"
+            }
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": 1
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection0",
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test that comment is not set on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99",
+          "topologies": [
+            "replicaset"
+          ]
         }
       ],
       "operations": [
@@ -321,7 +415,9 @@
                     ]
                   },
                   "collection": "collection0",
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "database0"

--- a/data/change-streams/unified/change-streams.yml
+++ b/data/change-streams/unified/change-streams.yml
@@ -19,11 +19,11 @@ initialData:
   - collectionName: *collection0
     databaseName: *database0
     documents: []
+
 tests:
   - description: "Test array truncation"
     runOnRequirements:
       - minServerVersion: "4.7"
-        topologies: [replicaset]
     operations:
       - name: insertOne
         object: *collection0
@@ -139,7 +139,57 @@ tests:
 
   - description: "Test that comment is set on getMore"
     runOnRequirements:
+      - minServerVersion: "4.4.0"
+        # Topolgies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: &commentDoc
+            key: "value"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &new_document
+            _id: 1
+            a: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *commentDoc
+          - commandStartedEvent:
+              command:
+                insert: *collection0
+                documents:
+                  - *new_document
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0
+                comment: *commentDoc
+              commandName: getMore
+              databaseName: *database0
+
+  - description: "Test that comment is not set on getMore - pre 4.4"
+    runOnRequirements:
       - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
+        # Topolgies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -173,6 +223,6 @@ tests:
               command:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0
-                comment: "comment"
+                comment: { $$exists: false }
               commandName: getMore
               databaseName: *database0

--- a/data/crud/unified/aggregate.json
+++ b/data/crud/unified/aggregate.json
@@ -268,7 +268,6 @@
     },
     {
       "description": "aggregate with a document comment - pre 4.4",
-      "skipReason": "TODO(GODRIVER-2386): aggregate doesn't support document comments in any version",
       "runOnRequirements": [
         {
           "minServerVersion": "3.6.0",
@@ -331,7 +330,128 @@
       "description": "aggregate with comment sets comment on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0"
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "batchSize": 2,
+            "comment": {
+              "content": "test"
+            }
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "cursor": {
+                    "batchSize": 2
+                  },
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "content": "test"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "aggregate-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate with comment does not set comment on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -412,7 +532,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"
@@ -429,7 +551,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"

--- a/data/crud/unified/aggregate.yml
+++ b/data/crud/unified/aggregate.yml
@@ -67,104 +67,149 @@ tests:
               databaseName: *database0Name
 
   - description: "aggregate with a string comment"
-      runOnRequirements:
-        - minServerVersion: "3.6.0"
-      operations:
-        - name: aggregate
-          arguments:
-            pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-            comment: "comment"
-          object: *collection0
-      expectEvents:
-        - client: *client0
-          events:
-            - commandStartedEvent:
-                command:
-                  aggregate: *collection0Name
-                  pipeline: [ { $match: { _id: { $gt: 1 } } } ]
-                  comment: "comment"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: "comment"
+        object: *collection0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } } } ]
+                comment: "comment"
 
-    - description: "aggregate with a document comment"
-      runOnRequirements:
-        - minServerVersion: "4.4"
-      operations:
-        - name: aggregate
-          arguments:
-            pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-            comment: &comment0 { content: "test" }
-          object: *collection0
-      expectEvents:
-        - client: *client0
-          events:
-            - commandStartedEvent:
-                command:
-                  aggregate: *collection0Name
-                  pipeline: [ { $match: { _id: { $gt: 1 } } } ]
-                  comment: *comment0
+  - description: "aggregate with a document comment"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: &comment0 { content: "test" }
+        object: *collection0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } } } ]
+                comment: *comment0
 
-    - description: "aggregate with a document comment - pre 4.4"
-      runOnRequirements:
-        - minServerVersion: "3.6.0"
-          maxServerVersion: "4.2.99"
-      operations:
-        - name: aggregate
-          object: *collection0
-          arguments:
-            pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-            comment: *comment0
-          expectError:
-            isClientError: false
-      expectEvents:
-        - client: *client0
-          events:
-            - commandStartedEvent:
-                command:
-                  aggregate: *collection0Name
-                  pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-                  comment: *comment0
-                commandName: aggregate
-                databaseName: *database0Name
+  - description: "aggregate with a document comment - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.2.99"
+    operations:
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          comment: *comment0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                comment: *comment0
+              commandName: aggregate
+              databaseName: *database0Name
 
-    - description: "aggregate with comment sets comment on getMore"
-      runOnRequirements:
-        - minServerVersion: "3.6.0"
-      operations:
-        - name: aggregate
-          arguments:
-            pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-            batchSize: 2
-            comment: "comment"
-          object: *collection0
-          expectResult:
-            - { _id: 2, x: 22 }
-            - { _id: 3, x: 33 }
-            - { _id: 4, x: 44 }
-            - { _id: 5, x: 55 }
-            - { _id: 6, x: 66 }
-      expectEvents:
-        - client: *client0
-          events:
-            - commandStartedEvent:
-                command:
-                  aggregate: *collection0Name
-                  pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-                  cursor: { batchSize: 2 }
-                  comment: "comment"
-                commandName: aggregate
-                databaseName: *database0Name
-            - commandStartedEvent:
-                command:
-                  comment: "comment"
-                  collection: *collection0Name
-                  batchSize: 2
-                  comment: { $$exists: false }
-                commandName: getMore
-                databaseName: *database0Name
-            - commandStartedEvent:
-                command:
-                  getMore: { $$type: [ int, long ] }
-                  collection: *collection0Name
-                  batchSize: 2
-                  comment: "comment"
-                commandName: getMore
-                databaseName: *database0Name
+  - description: "aggregate with comment sets comment on getMore"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          batchSize: 2
+          comment: *comment0
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                cursor: { batchSize: 2 }
+                comment: *comment0
+              commandName: aggregate
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment0
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: *comment0
+              commandName: getMore
+              databaseName: *database0Name
+
+  - description: "aggregate with comment does not set comment on getMore - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          batchSize: 2
+          comment: "comment"
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                cursor: { batchSize: 2 }
+                comment: "comment"
+              commandName: aggregate
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+              commandName: getMore
+              databaseName: *database0Name

--- a/data/crud/unified/find-comment.json
+++ b/data/crud/unified/find-comment.json
@@ -150,7 +150,6 @@
     },
     {
       "description": "find with document comment - pre 4.4",
-      "skipReason": "TODO(GODRIVER-2386): aggregate doesn't support document comments in any version",
       "runOnRequirements": [
         {
           "maxServerVersion": "4.2.99",
@@ -199,7 +198,112 @@
       "description": "find with comment sets comment on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0"
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "batchSize": 2,
+            "comment": {
+              "key": "value"
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2,
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "find with comment does not set comment on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -268,7 +372,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 }
               }
             },
@@ -283,7 +389,9 @@
                   },
                   "collection": "coll0",
                   "batchSize": 2,
-                  "comment": "comment"
+                  "comment": {
+                    "$$exists": false
+                  }
                 }
               }
             }

--- a/data/crud/unified/find-comment.yml
+++ b/data/crud/unified/find-comment.yml
@@ -1,82 +1,110 @@
-description: "find-comment"
-
+description: "change-streams"
 schemaVersion: "1.0"
-
+runOnRequirements:
+  - topologies: [ replicaset, sharded-replicaset ]
 createEntities:
   - client:
       id: &client0 client0
-      observeEvents: [ commandStartedEvent ]
+      observeEvents:
+        - commandStartedEvent
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: &database0Name crud-tests
+      databaseName: *database0
   - collection:
       id: &collection0 collection0
       database: *database0
-      collectionName: &collection0Name coll0
-
-initialData: &initialData
-  - collectionName: *collection0Name
-    databaseName: *database0Name
-    documents:
-      - { _id: 1, x: 11 }
-      - { _id: 2, x: 22 }
-      - { _id: 3, x: 33 }
-      - { _id: 4, x: 44 }
-      - { _id: 5, x: 55 }
-      - { _id: 6, x: 66 }
+      collectionName: *collection0
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
 
 tests:
-  - description: "find with string comment"
+  - description: "Test array truncation"
     runOnRequirements:
-      - minServerVersion: "3.6"
+      - minServerVersion: "4.7"
     operations:
-      - name: find
+      - name: insertOne
         object: *collection0
         arguments:
-          filter: &filter
-            _id: 1
-          comment: "comment"
-        expectResult: &expect_result
-          - { _id: 1 }
-    expectEvents:
-      - client: *client0
-        events:
-          - commandStartedEvent:
-              command:
-                find: *collection0Name
-                filter: *filter
-                comment: "comment"
+          document: {
+            "_id": 1,
+            "a": 1,
+            "array": ["foo", {"a": "bar"}, 1, 2, 3]
+          }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: {
+            "_id": 1
+          }
+          update: [
+            {
+              "$set": {
+                "array": ["foo", {"a": "bar"}]
+              }
+            }
+          ]
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult: {
+          "operationType": "update",
+          "ns": {
+            "db": "database0",
+            "coll": "collection0"
+          },
+          # It is up to the MongoDB server to decide how to report a change.
+          # This expectation is based on the current MongoDB server behavior.
+          # Alternatively, we could have used a set of possible expectations of which only one
+          # must be satisfied, but the unified test format does not support this.
+          "updateDescription": {
+            "updatedFields": {},
+            "removedFields": [],
+            "truncatedArrays": [
+              {
+                "field": "array",
+                "newSize": 2
+              }
+            ]
+          }
+        }
 
-  - description: "find with document comment"
+  - description: "Test with document comment"
     runOnRequirements:
       - minServerVersion: "4.4"
     operations:
-      - name: find
+      - name: createChangeStream
         object: *collection0
         arguments:
-          filter: *filter
-          comment: &comment { key: "value"}
-        expectResult: *expect_result
+          pipeline: []
+          comment: &comment0 { name: "test1" }
+        saveResultAsEntity: &changeStream0 changeStream0
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                find: *collection0Name
-                filter: *filter
-                comment: *comment
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *comment0
 
-  - description: "find with document comment - pre 4.4"
+  - description: "Test with document comment - pre 4.4"
     runOnRequirements:
-      - maxServerVersion: "4.2.99"
-        minServerVersion: "3.6"
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.2.99"
     operations:
-      - name: find
+      - name: createChangeStream
         object: *collection0
         arguments:
-          filter: *filter
-          comment: *comment
+          pipeline: []
+          comment: &comment0 { name: "test1" }
         expectError:
           isClientError: false
     expectEvents:
@@ -84,45 +112,117 @@ tests:
         events:
           - commandStartedEvent:
               command:
-                find: *collection0Name
-                filter: *filter
-                comment: *comment
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *comment0
 
-  - description: "find with comment does not set comment on getMore - pre 4.4"
+  - description: "Test with string comment"
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        maxServerVersion: "4.3.99"
     operations:
-      - name: find
+      - name: createChangeStream
         object: *collection0
         arguments:
-          filter: &filter_get_more { _id: { $gt: 1 } }
-          batchSize: 2
+          pipeline: []
           comment: "comment"
-        expectResult:
-          - { _id: 2, x: 22 }
-          - { _id: 3, x: 33 }
-          - { _id: 4, x: 44 }
-          - { _id: 5, x: 55 }
-          - { _id: 6, x: 66 }
+        saveResultAsEntity: &changeStream0 changeStream0
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                find: *collection0Name
-                filter: { _id: { $gt: 1 } }
-                batchSize: 2
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: "comment"
+
+  - description: "Test that comment is set on getMore"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+        # Topolgies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: &commentDoc
+            key: "value"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &new_document
+            _id: 1
+            a: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
+                comment: *commentDoc
+          - commandStartedEvent:
+              command:
+                insert: *collection0
+                documents:
+                  - *new_document
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0
+                comment: *commentDoc
+              commandName: getMore
+              databaseName: *database0
+
+  - description: "Test that comment is not set on getMore - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
+        # Topolgies are limited because of potentially empty getMore responses
+        # on sharded clusters.
+        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          comment: "comment"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &new_document
+            _id: 1
+            a: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $changeStream: {}
                 comment: "comment"
           - commandStartedEvent:
               command:
-                getMore: { $$type: [ int, long ] }
-                collection: *collection0Name
-                batchSize: 2
-                comment: { $$exists: false }
+                insert: *collection0
+                documents:
+                  - *new_document
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                collection: *collection0Name
-                batchSize: 2
+                collection: *collection0
                 comment: { $$exists: false }
+              commandName: getMore
+              databaseName: *database0

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -137,8 +137,8 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, want2, res.InsertedIDs[2], "expected inserted ID %v, got %v", want2, res.InsertedIDs[2])
 		})
 		mt.Run("batches", func(mt *mtest.T) {
-			// TODO(GODRIVER-425): remove this as part a larger project to
-			// refactor integration and other longrunning tasks.
+			// TODO(GODRIVER-425): remove this as part a larger project to refactor integration and other longrunning
+			// TODO tasks.
 			if os.Getenv("EVR_TASK_ID") == "" {
 				mt.Skip("skipping long running integration test outside of evergreen")
 			}
@@ -167,8 +167,8 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, numDocs, len(res.InsertedIDs), "expected %v inserted IDs, got %v", numDocs, len(res.InsertedIDs))
 		})
 		mt.Run("large document batches", func(mt *mtest.T) {
-			// TODO(GODRIVER-425): remove this as part a larger project to
-			// refactor integration and other longrunning tasks.
+			// TODO(GODRIVER-425): remove this as part a larger project to refactor integration and other longrunning
+			// TODO tasks.
 			if os.Getenv("EVR_TASK_ID") == "" {
 				mt.Skip("skipping long running integration test outside of evergreen")
 			}
@@ -249,8 +249,8 @@ func TestCollection(t *testing.T) {
 			}
 		})
 		mt.Run("writeError index", func(mt *mtest.T) {
-			// TODO(GODRIVER-425): remove this as part a larger project to
-			// refactor integration and other longrunning tasks.
+			// TODO(GODRIVER-425): remove this as part a larger project to refactor integration and other longrunning
+			// TODO tasks.
 			if os.Getenv("EVR_TASK_ID") == "" {
 				mt.Skip("skipping long running integration test outside of evergreen")
 			}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -268,9 +268,9 @@ func (t *T) ClearMockResponses() {
 
 // GetStartedEvent returns the most recent CommandStartedEvent, or nil if one is not present.
 // This can only be called once per event.
-// TODO(GODRIVER-2075): GetStartedEvent documents that it returns the most recent event, but
-// actually returns the first event. Update either the documentation or implementation.
 func (t *T) GetStartedEvent() *event.CommandStartedEvent {
+	// TODO(GODRIVER-2075): GetStartedEvent documents that it returns the most recent event, but actually returns the first
+	// TODO event. Update either the documentation or implementation.
 	if len(t.started) == 0 {
 		return nil
 	}
@@ -281,9 +281,9 @@ func (t *T) GetStartedEvent() *event.CommandStartedEvent {
 
 // GetSucceededEvent returns the most recent CommandSucceededEvent, or nil if one is not present.
 // This can only be called once per event.
-// TODO(GODRIVER-2075): GetSucceededEvent documents that it returns the most recent event, but
-// actually returns the first event. Update either the documentation or implementation.
 func (t *T) GetSucceededEvent() *event.CommandSucceededEvent {
+	// TODO(GODRIVER-2075): GetSucceededEvent documents that it returns the most recent event, but actually returns the
+	// TODO first event. Update either the documentation or implementation.
 	if len(t.succeeded) == 0 {
 		return nil
 	}
@@ -294,9 +294,9 @@ func (t *T) GetSucceededEvent() *event.CommandSucceededEvent {
 
 // GetFailedEvent returns the most recent CommandFailedEvent, or nil if one is not present.
 // This can only be called once per event.
-// TODO(GODRIVER-2075): GetFailedEvent documents that it returns the most recent event, but actually
-// returns the first event. Update either the documentation or implementation.
 func (t *T) GetFailedEvent() *event.CommandFailedEvent {
+	// TODO(GODRIVER-2075): GetFailedEvent documents that it returns the most recent event, but actually  returns the first
+	// TODO event. Update either the documentation or implementation.
 	if len(t.failed) == 0 {
 		return nil
 	}

--- a/mongo/integration/unified/testrunner_operation.go
+++ b/mongo/integration/unified/testrunner_operation.go
@@ -236,8 +236,8 @@ func executeLoop(ctx context.Context, args *loopArgs, loopDone <-chan struct{}) 
 					case !args.failuresStored(): // store failures as errors if storeFailuressAsEntity isn't specified
 						appendErr = entityMap.appendBSONArrayEntity(args.ErrorsEntityID, errDoc)
 					// errors are test runner errors
-					// TODO GODRIVER-1950: use error types to determine error vs failure instead of depending on the fact that
-					// operation.execute prepends "execution failed" to test runner errors
+					// TODO GODRIVER-1950: use error types to determine error vs failure instead of depending on the
+					// TODO fact that operation.execute prepends "execution failed" to test runner errors
 					case strings.Contains(loopErr.Error(), "execution failed: "):
 						appendErr = entityMap.appendBSONArrayEntity(args.ErrorsEntityID, errDoc)
 					// failures are if an operation returns an incorrect result or error

--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -65,8 +65,7 @@ func AppendHeader(dst []byte, t bsontype.Type, key string) []byte {
 	// return append(AppendType(dst, t), key+string(0x00)...)
 }
 
-// TODO(skriptble): All of the Read* functions should return src resliced to start just after what
-// was read.
+// TODO(skriptble): All of the Read* functions should return src resliced to start just after what was read.
 
 // ReadType will return the first byte of the provided []byte as a type. If
 // there is no available byte, false is returned.
@@ -197,12 +196,13 @@ func ReadString(src []byte) (string, []byte, bool) {
 
 // AppendDocumentStart reserves a document's length and returns the index where the length begins.
 // This index can later be used to write the length of the document.
-//
-// TODO(skriptble): We really need AppendDocumentStart and AppendDocumentEnd.
-// AppendDocumentStart would handle calling ReserveLength and providing the index of the start of
-// the document. AppendDocumentEnd would handle taking that start index, adding the null byte,
-// calculating the length, and filling in the length at the start of the document.
-func AppendDocumentStart(dst []byte) (index int32, b []byte) { return ReserveLength(dst) }
+func AppendDocumentStart(dst []byte) (index int32, b []byte) {
+	// TODO(skriptble): We really need AppendDocumentStart and AppendDocumentEnd.  AppendDocumentStart would handle calling
+	// TODO ReserveLength and providing the index of the start of the document. AppendDocumentEnd would handle taking that
+	// TODO start index, adding the null byte, calculating the length, and filling in the length at the start of the
+	// TODO document.
+	return ReserveLength(dst)
+}
 
 // AppendDocumentStartInline functions the same as AppendDocumentStart but takes a pointer to the
 // index int32 which allows this function to be used inline.

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -214,11 +214,11 @@ func (ssd SingleConnectionDeployment) MinRTT() time.Duration {
 	return 0
 }
 
-// TODO(GODRIVER-617): We can likely use 1 type for both the Type and the RetryMode by using
-// 2 bits for the mode and 1 bit for the type. Although in the practical sense, we might not want to
-// do that since the type of retryability is tied to the operation itself and isn't going change,
-// e.g. and insert operation will always be a write, however some operations are both reads and
-// writes, for instance aggregate is a read but with a $out parameter it's a write.
+// TODO(GODRIVER-617): We can likely use 1 type for both the Type and the RetryMode by using 2 bits for the mode and 1
+// TODO bit for the type. Although in the practical sense, we might not want to do that since the type of retryability
+// TODO is tied to the operation itself and isn't going change, e.g. and insert operation will always be a write,
+// TODO however some operations are both reads and  writes, for instance aggregate is a read but with a $out parameter
+// TODO it's a write.
 
 // Type specifies whether an operation is a read, write, or unknown.
 type Type uint

--- a/x/mongo/driver/mongocrypt/mongocrypt_test.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_test.go
@@ -127,8 +127,8 @@ func testKmsCtx(t *testing.T, ctx *Context, keyAltName bool) {
 	hostname, err := kmsCtx.HostName()
 	noerr(t, err)
 
-	// TODO GODRIVER-2217: Simply check if hostname != expectedHost once all OSes build the latest
-	// libmongocrypt versions.
+	// TODO GODRIVER-2217: Simply check if hostname != expectedHost once all OSes build the latest libmongocrypt
+	// TODO versions.
 	//
 	// Only check for the hostname. libmongocrypt versions that do not include MONGOCRYPT-352 will not
 	// include the default port "443".

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1265,8 +1265,8 @@ func (op Operation) getReadPrefBasedOnTransaction() (*readpref.ReadPref, error) 
 }
 
 func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bool) (bsoncore.Document, error) {
-	// TODO(GODRIVER-2231): Instead of checking if isOutputAggregate and desc.Server.WireVersion.Max < 13,
-	// somehow check if supplied readPreference was "overwritten" with primary in description.selectForReplicaSet.
+	// TODO(GODRIVER-2231): Instead of checking if isOutputAggregate and desc.Server.WireVersion.Max < 13, somehow check
+	// TODO if supplied readPreference was "overwritten" with primary in description.selectForReplicaSet.
 	if desc.Server.Kind == description.Standalone || (isOpQuery && desc.Server.Kind != description.Mongos) ||
 		op.Type == Write || (op.IsOutputAggregate && desc.Server.WireVersion.Max < 13) {
 		// Don't send read preference for:

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -39,8 +39,8 @@ var skippedTestDescriptions = map[string]string{
 	// asserts that handshake errors trigger events "connection closed" then "pool cleared". The Go
 	// driver uses the same code path for creating all application connections, so those opposing
 	// event orders cannot be satisfied simultaneously.
-	// TODO(DRIVERS-1785): Re-enable this test once the spec test is updated to use the same event
-	// order as the "errors during authentication are processed" load-balancer SDAM spec test.
+	// TODO(DRIVERS-1785): Re-enable this test once the spec test is updated to use the same event order as the "errors
+	// TODO during authentication are processed" load-balancer SDAM spec test.
 	"error during minPoolSize population clears pool": "event ordering is incompatible with load-balancer SDAM spec test (DRIVERS-1785)",
 	// GODRIVER-1826: The Go connection pool does not currently always deliver connections created
 	// by maintain() to waiting check-outs. There is a race condition between the goroutine started
@@ -48,16 +48,15 @@ var skippedTestDescriptions = map[string]string{
 	// wantConn created by the waiting check-outs. Most of the time, createConnections() wins and
 	// starts creating new connections. That is not a problem for general use cases, but it prevents
 	// the "threads blocked by maxConnecting check out minPoolSize connections" test from passing.
-	// TODO(DRIVERS-2225): Re-enable this test once the spec test is updated to support the Go pool
-	// minPoolSize maintain() behavior.
+	// TODO(DRIVERS-2225): Re-enable this test once the spec test is updated to support the Go pool minPoolSize
+	// TODO maintain() behavior.
 	"threads blocked by maxConnecting check out minPoolSize connections": "test requires that connections established by minPoolSize are immediately used to satisfy check-out requests (DRIVERS-2225)",
 	// GODRIVER-1826: The Go connection pool currently delivers any available connection to the
 	// earliest waiting check-out request, independent of if that check-out request already
 	// requested a new connection. That behavior is currently incompatible with the "threads blocked
 	// by maxConnecting check out returned connections" test, which expects that check-out requests
 	// that request a new connection cannot be satisfied by a check-in.
-	// TODO(DRIVERS-2223): Re-enable this test once the spec test is updated to support the Go pool
-	// check-in behavior.
+	// TODO(DRIVERS-2223): Re-enable this test once the spec test is updated to support the Go pool check-in behavior.
 	"threads blocked by maxConnecting check out returned connections": "test requires a checked-in connections cannot satisfy a check-out waiting on a new connection (DRIVERS-2223)",
 }
 

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -774,8 +774,8 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 		}
 
 		// Otherwise, check if the expected frequency is within the given tolerance range.
-		// TODO(GODRIVER-2179): Use assert.Deltaf() when we migrate all test code to the
-		// "testify/assert" or an API-compatible library for assertions.
+		// TODO(GODRIVER-2179): Use assert.Deltaf() when we migrate all test code to the "testify/assert" or an
+		// TODO API-compatible library for assertions.
 		low := expected - test.Outcome.Tolerance
 		high := expected + test.Outcome.Tolerance
 		assert.True(


### PR DESCRIPTION
GODRIVER-2357

Sync unified CRUD & Change-Stream tests with https://github.com/mongodb/specifications/commit/97c54e21828877aa1534f05324ec6bb7aea5df89 .

The path here is

[GODRIVER-2199](https://github.com/mongodb/mongo-go-driver/pull/922) <- [GODRIVER-2303](https://github.com/mongodb/mongo-go-driver/pull/928) <- GODRIVER-2357