### PR TITLE
GODRIVER-2315 Further restrict tests that expect errors with capped collection deletes.

### DIFF
--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -308,8 +308,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
@@ -377,8 +377,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
 		})
-		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{
@@ -1526,8 +1526,8 @@ func TestCollection(t *testing.T) {
 				})
 			}
 		})
-		mt.RunOpts("delete write errors", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+		mt.RunOpts("delete write errors", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
 			doc := mongo.NewDeleteOneModel().SetFilter(bson.D{{"x", 1}})
 			models := []mongo.WriteModel{doc, doc}
@@ -1625,8 +1625,8 @@ func TestCollection(t *testing.T) {
 			assert.Equal(mt, expectedModel, actualModel, "expected model %v in BulkWriteException, got %v",
 				expectedModel, actualModel)
 		})
-		mt.RunOpts("unordered writeError index", mtest.NewOptions().MaxServerVersion("5.2"), func(mt *mtest.T) {
-			// Deletes are not allowed on capped collections on MongoDB 5.2-. We use this
+		mt.RunOpts("unordered writeError index", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
+			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
 			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
 			capped := mt.CreateCollection(mtest.Collection{


### PR DESCRIPTION
GODRIVER-2315

[SERVER-63201](https://jira.mongodb.org/browse/SERVER-63201)  recently allowed deletes on capped collections in the latest server versions. That ticket was backported to server version 5.0.7. Some of our tests in `integration/collection_test.go` expect server-side write errors when running a delete operation against a capped collection. Updates these tests to only run against 5.0.6- (previously ran on 5.2.99-).