### PR TITLE
GODRIVER-2321 Fix getMore with comment specs

### DIFF
--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -255,6 +255,7 @@
         {
           "minServerVersion": "4.4.0",
           "topologies": [
+            "single",
             "replicaset"
           ]
         }

--- a/data/change-streams/unified/change-streams.yml
+++ b/data/change-streams/unified/change-streams.yml
@@ -141,10 +141,7 @@ tests:
   - description: "Test that comment is set on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        # Topolgies are limited because of potentially empty getMore responses
-        # on sharded clusters.
-        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
-        topologies: [ replicaset ]
+        topologies: [ single, replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0

--- a/data/crud/unified/aggregate.json
+++ b/data/crud/unified/aggregate.json
@@ -332,7 +332,11 @@
       "skipReason": "aggregate comments are string-only",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0"
+          "minServerVersion": "4.4.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
         }
       ],
       "operations": [

--- a/data/crud/unified/aggregate.yml
+++ b/data/crud/unified/aggregate.yml
@@ -129,6 +129,7 @@ tests:
   - description: "aggregate with comment sets comment on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
+        topologies: [ single, replicaset ]
     operations:
       - name: aggregate
         arguments:

--- a/data/crud/unified/find-comment.json
+++ b/data/crud/unified/find-comment.json
@@ -199,7 +199,11 @@
       "description": "find with comment sets comment on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0"
+          "minServerVersion": "4.4.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
         }
       ],
       "operations": [

--- a/data/crud/unified/find-comment.yml
+++ b/data/crud/unified/find-comment.yml
@@ -1,111 +1,82 @@
-description: "change-streams"
+description: "find-comment"
+
 schemaVersion: "1.0"
-runOnRequirements:
-  - topologies: [ replicaset, sharded-replicaset ]
+
 createEntities:
   - client:
       id: &client0 client0
-      observeEvents:
-        - commandStartedEvent
+      observeEvents: [ commandStartedEvent ]
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: *database0
+      databaseName: &database0Name crud-tests
   - collection:
       id: &collection0 collection0
       database: *database0
-      collectionName: *collection0
-initialData:
-  - collectionName: *collection0
-    databaseName: *database0
-    documents: []
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+      - { _id: 6, x: 66 }
 
 tests:
-  - description: "Test array truncation"
+  - description: "find with string comment"
     runOnRequirements:
-      - minServerVersion: "4.7"
+      - minServerVersion: "3.6"
     operations:
-      - name: insertOne
+      - name: find
         object: *collection0
         arguments:
-          document: {
-            "_id": 1,
-            "a": 1,
-            "array": ["foo", {"a": "bar"}, 1, 2, 3]
-          }
-      - name: createChangeStream
-        object: *collection0
-        arguments:
-          pipeline: []
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: updateOne
-        object: *collection0
-        arguments:
-          filter: {
-            "_id": 1
-          }
-          update: [
-            {
-              "$set": {
-                "array": ["foo", {"a": "bar"}]
-              }
-            }
-          ]
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
-        expectResult: {
-          "operationType": "update",
-          "ns": {
-            "db": "database0",
-            "coll": "collection0"
-          },
-          # It is up to the MongoDB server to decide how to report a change.
-          # This expectation is based on the current MongoDB server behavior.
-          # Alternatively, we could have used a set of possible expectations of which only one
-          # must be satisfied, but the unified test format does not support this.
-          "updateDescription": {
-            "updatedFields": {},
-            "removedFields": [],
-            "truncatedArrays": [
-              {
-                "field": "array",
-                "newSize": 2
-              }
-            ]
-          }
-        }
-
-  - description: "Test with document comment"
-    runOnRequirements:
-      - minServerVersion: "4.4"
-    operations:
-      - name: createChangeStream
-        object: *collection0
-        arguments:
-          pipeline: []
-          comment: &comment0 { name: "test1" }
-        saveResultAsEntity: &changeStream0 changeStream0
+          filter: &filter
+            _id: 1
+          comment: "comment"
+        expectResult: &expect_result
+          - { _id: 1 }
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                aggregate: *collection0
-                pipeline:
-                  - $changeStream: {}
-                comment: *comment0
+                find: *collection0Name
+                filter: *filter
+                comment: "comment"
 
-  - description: "Test with document comment - pre 4.4"
-    skipReason: "TODO(GODRIVER-2386): aggregate only supports string comments"
+  - description: "find with document comment"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
-        maxServerVersion: "4.2.99"
+      - minServerVersion: "4.4"
     operations:
-      - name: createChangeStream
+      - name: find
         object: *collection0
         arguments:
-          pipeline: []
-          comment: &comment0 { name: "test1" }
+          filter: *filter
+          comment: &comment { key: "value"}
+        expectResult: *expect_result
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: *filter
+                comment: *comment
+
+  - description: "find with document comment - pre 4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+        minServerVersion: "3.6"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: *filter
+          comment: &comment { key: "value"}
         expectError:
           isClientError: false
     expectEvents:
@@ -113,117 +84,45 @@ tests:
         events:
           - commandStartedEvent:
               command:
-                aggregate: *collection0
-                pipeline:
-                  - $changeStream: {}
-                comment: *comment0
+                find: *collection0Name
+                filter: *filter
+                comment: *comment
 
-  - description: "Test with string comment"
-    runOnRequirements:
-      - minServerVersion: "3.6.0"
-    operations:
-      - name: createChangeStream
-        object: *collection0
-        arguments:
-          pipeline: []
-          comment: "comment"
-        saveResultAsEntity: &changeStream0 changeStream0
-    expectEvents:
-      - client: *client0
-        events:
-          - commandStartedEvent:
-              command:
-                aggregate: *collection0
-                pipeline:
-                  - $changeStream: {}
-                comment: "comment"
-
-  - description: "Test that comment is set on getMore"
+  - description: "find with comment sets comment on getMore"
     runOnRequirements:
       - minServerVersion: "4.4.0"
-        # Topolgies are limited because of potentially empty getMore responses
-        # on sharded clusters.
-        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
-        topologies: [ replicaset ]
+        topologies: [ single, replicaset ]
     operations:
-      - name: createChangeStream
+      - name: find
         object: *collection0
         arguments:
-          pipeline: []
-          comment: &commentDoc
-            key: "value"
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: insertOne
-        object: *collection0
-        arguments:
-          document: &new_document
-            _id: 1
-            a: 1
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
-    expectEvents:
-      - client: *client0
-        events:
-          - commandStartedEvent:
-              command:
-                aggregate: *collection0
-                pipeline:
-                  - $changeStream: {}
-                comment: *commentDoc
-          - commandStartedEvent:
-              command:
-                insert: *collection0
-                documents:
-                  - *new_document
-          - commandStartedEvent:
-              command:
-                getMore: { $$type: [ int, long ] }
-                collection: *collection0
-                comment: *commentDoc
-              commandName: getMore
-              databaseName: *database0
-
-  - description: "Test that comment is not set on getMore - pre 4.4"
-    runOnRequirements:
-      - minServerVersion: "3.6.0"
-        maxServerVersion: "4.3.99"
-        # Topolgies are limited because of potentially empty getMore responses
-        # on sharded clusters.
-        # See https://jira.mongodb.org/browse/DRIVERS-2248 for more details.
-        topologies: [ replicaset ]
-    operations:
-      - name: createChangeStream
-        object: *collection0
-        arguments:
-          pipeline: []
+          filter: &filter_get_more { _id: { $gt: 1 } }
+          batchSize: 2
           comment: "comment"
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: insertOne
-        object: *collection0
-        arguments:
-          document: &new_document
-            _id: 1
-            a: 1
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
     expectEvents:
       - client: *client0
         events:
           - commandStartedEvent:
               command:
-                aggregate: *collection0
-                pipeline:
-                  - $changeStream: {}
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+                batchSize: 2
                 comment: "comment"
           - commandStartedEvent:
               command:
-                insert: *collection0
-                documents:
-                  - *new_document
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: "comment"
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                collection: *collection0
-                comment: { $$exists: false }
-              commandName: getMore
-              databaseName: *database0
+                collection: *collection0Name
+                batchSize: 2
+                comment: "comment"

--- a/data/crud/unified/find-comment.yml
+++ b/data/crud/unified/find-comment.yml
@@ -126,3 +126,42 @@ tests:
                 collection: *collection0Name
                 batchSize: 2
                 comment: "comment"
+
+  - description: "find with comment does not set comment on getMore - pre 4.4"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+        maxServerVersion: "4.3.99"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: &filter_get_more { _id: { $gt: 1 } }
+          batchSize: 2
+          comment: "comment"
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+                batchSize: 2
+                comment: "comment"
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 2
+                comment: { $$exists: false }


### PR DESCRIPTION
GODRIVER-2321

Sync `change-streams`, `aggregate`, and `find-comment` unified spec tests from [mongodb/specifications@ad1ee9b](https://github.com/mongodb/specifications/commit/ad1ee9b764f7d9ff193fe485d31feca536e6a2d7).  

Include [missing test](https://github.com/mongodb/specifications/blob/ad1ee9b764f7d9ff193fe485d31feca536e6a2d7/source/crud/tests/unified/find-comment.yml#L91) to `find-comment.yml`.