### PR TITLE
Fix serverless task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -530,12 +530,10 @@ functions:
           export GOFLAGS=-mod=vendor
           AUTH="auth" \
           SSL="ssl" \
-          MONGODB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}" \
+          MONGODB_URI="${SERVERLESS_URI}" \
           SERVERLESS="serverless" \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
-          SINGLE_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}" \
-          MULTI_MONGOS_LB_URI="${MULTI_ATLASPROXY_SERVERLESS_URI}" \
           MONGO_GO_DRIVER_COMPRESSOR=${MONGO_GO_DRIVER_COMPRESSOR} \
           make evg-test-serverless
 

--- a/data/change-streams/unified/change-streams-pre_and_post_images.json
+++ b/data/change-streams/unified/change-streams-pre_and_post_images.json
@@ -1,6 +1,6 @@
 {
   "description": "change-streams-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "6.0.0",
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded-replicaset",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/data/change-streams/unified/change-streams-pre_and_post_images.yml
+++ b/data/change-streams/unified/change-streams-pre_and_post_images.yml
@@ -1,10 +1,11 @@
 description: "change-streams-pre_and_post_images"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0.0"
     topologies: [ replicaset, sharded-replicaset, load-balanced ]
+    serverless: forbid
 
 createEntities:
   - client:

--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -1,12 +1,14 @@
 {
   "description": "change-streams",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
   "runOnRequirements": [
     {
+      "minServerVersion": "3.6",
       "topologies": [
         "replicaset",
         "sharded-replicaset"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/data/change-streams/unified/change-streams.json
+++ b/data/change-streams/unified/change-streams.json
@@ -1,6 +1,6 @@
 {
   "description": "change-streams",
-  "schemaVersion": "1.7",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",

--- a/data/change-streams/unified/change-streams.yml
+++ b/data/change-streams/unified/change-streams.yml
@@ -1,6 +1,6 @@
 description: "change-streams"
 
-schemaVersion: "1.7"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "3.6"

--- a/data/change-streams/unified/change-streams.yml
+++ b/data/change-streams/unified/change-streams.yml
@@ -1,7 +1,12 @@
 description: "change-streams"
-schemaVersion: "1.0"
+
+schemaVersion: "1.7"
+
 runOnRequirements:
-  - topologies: [ replicaset, sharded-replicaset ]
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded-replicaset ]
+    serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0

--- a/data/unified-test-format/valid-pass/poc-change-streams.json
+++ b/data/unified-test-format/valid-pass/poc-change-streams.json
@@ -1,6 +1,11 @@
 {
   "description": "poc-change-streams",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "serverless": "forbid"
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/data/unified-test-format/valid-pass/poc-change-streams.yml
+++ b/data/unified-test-format/valid-pass/poc-change-streams.yml
@@ -1,6 +1,9 @@
 description: "poc-change-streams"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - serverless: forbid
 
 createEntities:
   # Entities for creating changeStreams

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -36,18 +36,6 @@ func ClusterURI() string {
 	return testContext.connString.Original
 }
 
-// SingleMongosLoadBalancerURI returns the URI for a load balancer fronting a single mongos. This will only be set
-// if the cluster is load balanced.
-func SingleMongosLoadBalancerURI() string {
-	return testContext.singleMongosLoadBalancerURI
-}
-
-// MultiMongosLoadBalancerURI returns the URI for a load balancer fronting multiple mongoses. This will only be set
-// if the cluster is load balanced.
-func MultiMongosLoadBalancerURI() string {
-	return testContext.multiMongosLoadBalancerURI
-}
-
 // ClusterConnString returns the parsed ConnString for the cluster.
 func ClusterConnString() connstring.ConnString {
 	return testContext.connString

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -36,6 +36,11 @@ func ClusterURI() string {
 	return testContext.connString.Original
 }
 
+// Serverless returns whether the test is running against a serverless instance.
+func Serverless() bool {
+	return testContext.serverless
+}
+
 // SingleMongosLoadBalancerURI returns the URI for a load balancer fronting a single mongos. This will only be set
 // if the cluster is load balanced.
 func SingleMongosLoadBalancerURI() string {

--- a/mongo/integration/mtest/global_state.go
+++ b/mongo/integration/mtest/global_state.go
@@ -36,6 +36,18 @@ func ClusterURI() string {
 	return testContext.connString.Original
 }
 
+// SingleMongosLoadBalancerURI returns the URI for a load balancer fronting a single mongos. This will only be set
+// if the cluster is load balanced.
+func SingleMongosLoadBalancerURI() string {
+	return testContext.singleMongosLoadBalancerURI
+}
+
+// MultiMongosLoadBalancerURI returns the URI for a load balancer fronting multiple mongoses. This will only be set
+// if the cluster is load balanced.
+func MultiMongosLoadBalancerURI() string {
+	return testContext.multiMongosLoadBalancerURI
+}
+
 // ClusterConnString returns the parsed ConnString for the cluster.
 func ClusterConnString() connstring.ConnString {
 	return testContext.connString

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -43,18 +43,16 @@ var testContext struct {
 	// shardedReplicaSet will be true if we're connected to a sharded cluster and each shard is backed by a replica set.
 	// We track this as a separate boolean rather than setting topoKind to ShardedReplicaSet because a general
 	// "Sharded" constraint in a test should match both Sharded and ShardedReplicaSet.
-	shardedReplicaSet           bool
-	client                      *mongo.Client // client used for setup and teardown
-	serverVersion               string
-	authEnabled                 bool
-	sslEnabled                  bool
-	enterpriseServer            bool
-	dataLake                    bool
-	requireAPIVersion           bool
-	serverParameters            bson.Raw
-	singleMongosLoadBalancerURI string
-	multiMongosLoadBalancerURI  string
-	serverless                  bool
+	shardedReplicaSet bool
+	client            *mongo.Client // client used for setup and teardown
+	serverVersion     string
+	authEnabled       bool
+	sslEnabled        bool
+	enterpriseServer  bool
+	dataLake          bool
+	requireAPIVersion bool
+	serverParameters  bson.Raw
+	serverless        bool
 }
 
 func setupClient(cs connstring.ConnString, opts *options.ClientOptions) (*mongo.Client, error) {
@@ -176,28 +174,6 @@ func Setup(setupOpts ...*SetupOptions) error {
 		}
 		if !foundStandalone {
 			testContext.shardedReplicaSet = true
-		}
-	}
-
-	// For load balanced clusters, retrieve the required LB URIs and add additional information (e.g. TLS options) to
-	// them if necessary.
-	if testContext.topoKind == LoadBalanced {
-		singleMongosURI := os.Getenv("SINGLE_MONGOS_LB_URI")
-		if singleMongosURI == "" {
-			return errors.New("SINGLE_MONGOS_LB_URI must be set when running against load balanced clusters")
-		}
-		testContext.singleMongosLoadBalancerURI, err = addNecessaryParamsToURI(singleMongosURI)
-		if err != nil {
-			return fmt.Errorf("error getting single mongos load balancer uri: %v", err)
-		}
-
-		multiMongosURI := os.Getenv("MULTI_MONGOS_LB_URI")
-		if multiMongosURI == "" {
-			return errors.New("MULTI_MONGOS_LB_URI must be set when running against load balanced clusters")
-		}
-		testContext.multiMongosLoadBalancerURI, err = addNecessaryParamsToURI(multiMongosURI)
-		if err != nil {
-			return fmt.Errorf("error getting multi mongos load balancer uri: %v", err)
 		}
 	}
 

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -43,16 +43,18 @@ var testContext struct {
 	// shardedReplicaSet will be true if we're connected to a sharded cluster and each shard is backed by a replica set.
 	// We track this as a separate boolean rather than setting topoKind to ShardedReplicaSet because a general
 	// "Sharded" constraint in a test should match both Sharded and ShardedReplicaSet.
-	shardedReplicaSet bool
-	client            *mongo.Client // client used for setup and teardown
-	serverVersion     string
-	authEnabled       bool
-	sslEnabled        bool
-	enterpriseServer  bool
-	dataLake          bool
-	requireAPIVersion bool
-	serverParameters  bson.Raw
-	serverless        bool
+	shardedReplicaSet           bool
+	client                      *mongo.Client // client used for setup and teardown
+	serverVersion               string
+	authEnabled                 bool
+	sslEnabled                  bool
+	enterpriseServer            bool
+	dataLake                    bool
+	requireAPIVersion           bool
+	serverParameters            bson.Raw
+	singleMongosLoadBalancerURI string
+	multiMongosLoadBalancerURI  string
+	serverless                  bool
 }
 
 func setupClient(cs connstring.ConnString, opts *options.ClientOptions) (*mongo.Client, error) {
@@ -174,6 +176,28 @@ func Setup(setupOpts ...*SetupOptions) error {
 		}
 		if !foundStandalone {
 			testContext.shardedReplicaSet = true
+		}
+	}
+
+	// For load balanced clusters, retrieve the required LB URIs and add additional information (e.g. TLS options) to
+	// them if necessary.
+	if testContext.topoKind == LoadBalanced {
+		singleMongosURI := os.Getenv("SINGLE_MONGOS_LB_URI")
+		if singleMongosURI == "" {
+			return errors.New("SINGLE_MONGOS_LB_URI must be set when running against load balanced clusters")
+		}
+		testContext.singleMongosLoadBalancerURI, err = addNecessaryParamsToURI(singleMongosURI)
+		if err != nil {
+			return fmt.Errorf("error getting single mongos load balancer uri: %v", err)
+		}
+
+		multiMongosURI := os.Getenv("MULTI_MONGOS_LB_URI")
+		if multiMongosURI == "" {
+			return errors.New("MULTI_MONGOS_LB_URI must be set when running against load balanced clusters")
+		}
+		testContext.multiMongosLoadBalancerURI, err = addNecessaryParamsToURI(multiMongosURI)
+		if err != nil {
+			return fmt.Errorf("error getting multi mongos load balancer uri: %v", err)
 		}
 	}
 

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -179,9 +179,10 @@ func Setup(setupOpts ...*SetupOptions) error {
 		}
 	}
 
-	// For load balanced clusters, retrieve the required LB URIs and add additional information (e.g. TLS options) to
+	// For non-serverless, load balanced clusters, retrieve the required LB URIs and add additional information (e.g. TLS options) to
 	// them if necessary.
-	if testContext.topoKind == LoadBalanced {
+	testContext.serverless = os.Getenv("SERVERLESS") == "serverless"
+	if !testContext.serverless && testContext.topoKind == LoadBalanced {
 		singleMongosURI := os.Getenv("SINGLE_MONGOS_LB_URI")
 		if singleMongosURI == "" {
 			return errors.New("SINGLE_MONGOS_LB_URI must be set when running against load balanced clusters")
@@ -203,7 +204,6 @@ func Setup(setupOpts ...*SetupOptions) error {
 
 	testContext.authEnabled = os.Getenv("AUTH") == "auth"
 	testContext.sslEnabled = os.Getenv("SSL") == "ssl"
-	testContext.serverless = os.Getenv("SERVERLESS") == "serverless"
 	biRes, err := testContext.client.Database("admin").RunCommand(context.Background(), bson.D{{"buildInfo", 1}}).DecodeBytes()
 	if err != nil {
 		return fmt.Errorf("buildInfo error: %v", err)

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -142,11 +142,11 @@ func newClientEntity(ctx context.Context, em *EntityMap, entityOptions *entityOp
 }
 
 func getURIForClient(opts *entityOptions) string {
-	if mtest.ClusterTopologyKind() != mtest.LoadBalanced {
+	if mtest.Serverless() || mtest.ClusterTopologyKind() != mtest.LoadBalanced {
 		return mtest.ClusterURI()
 	}
 
-	// For load-balanced deployments, UseMultipleMongoses is used to determine the load balancer URI. If set to false,
+	// For non-serverless load-balanced deployments, UseMultipleMongoses is used to determine the load balancer URI. If set to false,
 	// the LB fronts a single server. If unset or explicitly true, the LB fronts multiple mongos servers.
 	switch {
 	case opts.UseMultipleMongoses != nil && !*opts.UseMultipleMongoses:

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -72,7 +72,7 @@ func newClientEntity(ctx context.Context, em *EntityMap, entityOptions *entityOp
 
 	// Construct a ClientOptions instance by first applying the cluster URI and then the URIOptions map to ensure that
 	// the options specified in the test file take precedence.
-	uri := getURIForClient(entityOptions)
+	uri := mtest.ClusterURI()
 	clientOpts := options.Client().ApplyURI(uri)
 	if entityOptions.URIOptions != nil {
 		if err := setClientOptionsFromURIOptions(clientOpts, entityOptions.URIOptions); err != nil {
@@ -139,21 +139,6 @@ func newClientEntity(ctx context.Context, em *EntityMap, entityOptions *entityOp
 
 	entity.Client = client
 	return entity, nil
-}
-
-func getURIForClient(opts *entityOptions) string {
-	if mtest.ClusterTopologyKind() != mtest.LoadBalanced {
-		return mtest.ClusterURI()
-	}
-
-	// For load-balanced deployments, UseMultipleMongoses is used to determine the load balancer URI. If set to false,
-	// the LB fronts a single server. If unset or explicitly true, the LB fronts multiple mongos servers.
-	switch {
-	case opts.UseMultipleMongoses != nil && !*opts.UseMultipleMongoses:
-		return mtest.SingleMongosLoadBalancerURI()
-	default:
-		return mtest.MultiMongosLoadBalancerURI()
-	}
 }
 
 func (c *clientEntity) stopListeningForEvents() {


### PR DESCRIPTION
GODRIVER-2389
GODRIVER-2214

Syncs unified change streams tests to not run against serverless topologies (they are not supported). Updates serverless testing to use the new `SERVERLESS_URI` as a testing URI.

I've linked the serverless task to this PR manually to show it passing and will also add the serverless task to the set of tasks run on every GH Evergreen patch.