### PR TITLE
Update CONTRIBUTING with current information and stop ignoring *.md files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ driver-test-data.tar.gz
 perf
 **mongocryptd.pid
 *.test
-**.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,30 @@
 # Contributing to the MongoDB Go Driver
 
-Thank you for your interest in contributing to the MongoDB Go driver.
+Thank you for your interest in contributing to the MongoDB Go Driver!
 
-We are building this software together and strongly encourage contributions from the community that are within the guidelines set forth
-below.
+We are building this software together and strongly encourage contributions from the community that are within the guidelines set forth below.
 
 ## Bug Fixes and New Features
 
-Before starting to write code, look for existing [tickets](https://jira.mongodb.org/browse/GODRIVER) or
-[create one](https://jira.mongodb.org/secure/CreateIssue!default.jspa) for your bug, issue, or feature request. This helps the community
-avoid working on something that might not be of interest or which has already been addressed.
+Before starting to write code, look for existing [tickets](https://jira.mongodb.org/browse/GODRIVER) or [create one](https://jira.mongodb.org/secure/CreateIssue!default.jspa) for your bug, issue, or feature request. This helps the community avoid working on something that might not be of interest or which has already been addressed.
 
 ## Pull Requests & Patches
 
-The Go Driver team is experimenting with GerritHub for contributions. GerritHub uses GitHub for authentication and uses a patch based
-workflow. Since GerritHub supports importing of Pull Requests we will also accept Pull Requests, but Code Review will be done in
-GerritHub.
+The Go Driver team uses GitHub to manage and review all code changes. Patches should generally be made against the master (default) branch and include relevant tests, if
+applicable.
 
-Patches should generally be made against the master (default) branch and include relevant tests, if applicable.
+Code should compile and tests should pass under all Go versions which the driver currently supports. Currently the Go Driver supports a minimum version of Go 1.10 and requires Go 1.16 for development. Please run the following Make targets to validate your changes:
+- `make fmt`
+- `make lint` (requires [golangci-lint](https://github.com/golangci/golangci-lint) and [lll](https://github.com/walle/lll) to be installed and available in the `PATH`)
+- `make test`
+- `make test-race`
 
-Code should compile and tests should pass under all go versions which the driver currently supports.  Currently the driver
-supports a minimum version of go 1.7. Please ensure the following tools have been run on the code: gofmt, golint, errcheck,
-go test (with coverage and with the race detector), and go vet. For convenience, you can run 'make' to run all these tools.
-**By default, running the tests requires that you have a mongod server running on localhost, listening on the default port.**
-At minimum, please test against the latest release version of the MongoDB server.
+**Running the tests requires that you have a `mongod` server running on localhost, listening on the default port (27017). At minimum, please test against the latest release version of the MongoDB server.**
 
 If any tests do not pass, or relevant tests are not included, the patch will not be considered.
 
-If you are working on a bug or feature listed in Jira, please include the ticket number prefixed with GODRIVER in the commit,
-e.g. GODRIVER-123. For the patch commit message itself, please follow the [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) guide.
+If you are working on a bug or feature listed in Jira, please include the ticket number prefixed with GODRIVER in the commit message and GitHub pull request title, (e.g. GODRIVER-123). For the patch commit message itself, please follow the [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) guide.
 
 ## Talk To Us
 
-If you want to work on the driver, write documentation, or have questions/complaints, please reach out to use either via [MongoDB Community Forums](https://community.mongodb.com/tags/c/drivers-odms-connectors/7/go-driver) or by creating a Question
-issue at (https://jira.mongodb.org/secure/CreateIssue!default.jspa).
+If you want to work on the driver, write documentation, or have questions/complaints, please reach out to us either via [MongoDB Community Forums](https://community.mongodb.com/tags/c/drivers-odms-connectors/7/go-driver) or by creating a Question issue in [Jira](https://jira.mongodb.org/secure/CreateIssue!default.jspa).

--- a/vendor/github.com/xdg-go/pbkdf2/README.md
+++ b/vendor/github.com/xdg-go/pbkdf2/README.md
@@ -1,0 +1,17 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/xdg-go/pbkdf2.svg)](https://pkg.go.dev/github.com/xdg-go/pbkdf2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xdg-go/pbkdf2)](https://goreportcard.com/report/github.com/xdg-go/pbkdf2)
+[![Github Actions](https://github.com/xdg-go/pbkdf2/actions/workflows/test.yml/badge.svg)](https://github.com/xdg-go/pbkdf2/actions/workflows/test.yml)
+
+# pbkdf2 – Go implementation of PBKDF2
+
+## Description
+
+Package pbkdf2 provides password-based key derivation based on
+[RFC 8018](https://tools.ietf.org/html/rfc8018).
+
+## Copyright and License
+
+Copyright 2021 by David A. Golden. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vendor/github.com/xdg-go/scram/CHANGELOG.md
+++ b/vendor/github.com/xdg-go/scram/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## v1.0.2 - 2021-03-28
+
+- Switch PBKDF2 dependency to github.com/xdg-go/pbkdf2 to
+  minimize transitive dependencies and support Go 1.9+.
+
+## v1.0.1 - 2021-03-27
+
+- Bump stringprep dependency to v1.0.2 for Go 1.11 support.
+
+## v1.0.0 - 2021-03-27
+
+- First release as a Go module

--- a/vendor/github.com/xdg-go/scram/README.md
+++ b/vendor/github.com/xdg-go/scram/README.md
@@ -1,0 +1,72 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/xdg-go/scram.svg)](https://pkg.go.dev/github.com/xdg-go/scram)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xdg-go/scram)](https://goreportcard.com/report/github.com/xdg-go/scram)
+[![Github Actions](https://github.com/xdg-go/scram/actions/workflows/test.yml/badge.svg)](https://github.com/xdg-go/scram/actions/workflows/test.yml)
+
+# scram – Go implementation of RFC-5802
+
+## Description
+
+Package scram provides client and server implementations of the Salted
+Challenge Response Authentication Mechanism (SCRAM) described in
+[RFC-5802](https://tools.ietf.org/html/rfc5802) and
+[RFC-7677](https://tools.ietf.org/html/rfc7677).
+
+It includes both client and server side support.
+
+Channel binding and extensions are not (yet) supported.
+
+## Examples
+
+### Client side
+
+    package main
+
+    import "github.com/xdg-go/scram"
+
+    func main() {
+        // Get Client with username, password and (optional) authorization ID.
+        clientSHA1, err := scram.SHA1.NewClient("mulder", "trustno1", "")
+        if err != nil {
+            panic(err)
+        }
+
+        // Prepare the authentication conversation. Use the empty string as the
+        // initial server message argument to start the conversation.
+        conv := clientSHA1.NewConversation()
+        var serverMsg string
+
+        // Get the first message, send it and read the response.
+        firstMsg, err := conv.Step(serverMsg)
+        if err != nil {
+            panic(err)
+        }
+        serverMsg = sendClientMsg(firstMsg)
+
+        // Get the second message, send it, and read the response.
+        secondMsg, err := conv.Step(serverMsg)
+        if err != nil {
+            panic(err)
+        }
+        serverMsg = sendClientMsg(secondMsg)
+
+        // Validate the server's final message.  We have no further message to
+        // send so ignore that return value.
+        _, err = conv.Step(serverMsg)
+        if err != nil {
+            panic(err)
+        }
+
+        return
+    }
+
+    func sendClientMsg(s string) string {
+        // A real implementation would send this to a server and read a reply.
+        return ""
+    }
+
+## Copyright and License
+
+Copyright 2018 by David A. Golden. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vendor/github.com/xdg-go/stringprep/CHANGELOG.md
+++ b/vendor/github.com/xdg-go/stringprep/CHANGELOG.md
@@ -1,0 +1,22 @@
+# CHANGELOG
+
+<a name="v1.0.2"></a>
+## [v1.0.2] - 2021-03-27
+
+### Maintenance
+
+- Change minimum Go version to 1.11
+
+<a name="v1.0.1"></a>
+## [v1.0.1] - 2021-03-24
+
+### Bug Fixes
+
+- Add go.mod file
+
+<a name="v1.0.0"></a>
+## [v1.0.0] - 2018-02-21
+
+[v1.0.2]: https://github.com/xdg-go/stringprep/releases/tag/v1.0.2
+[v1.0.1]: https://github.com/xdg-go/stringprep/releases/tag/v1.0.1
+[v1.0.0]: https://github.com/xdg-go/stringprep/releases/tag/v1.0.0

--- a/vendor/github.com/xdg-go/stringprep/README.md
+++ b/vendor/github.com/xdg-go/stringprep/README.md
@@ -1,0 +1,28 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/xdg-go/stringprep.svg)](https://pkg.go.dev/github.com/xdg-go/stringprep)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xdg-go/stringprep)](https://goreportcard.com/report/github.com/xdg-go/stringprep)
+[![Github Actions](https://github.com/xdg-go/stringprep/actions/workflows/test.yml/badge.svg)](https://github.com/xdg-go/stringprep/actions/workflows/test.yml)
+
+# stringprep – Go implementation of RFC-3454 stringprep and RFC-4013 SASLprep
+
+## Synopsis
+
+```
+    import "github.com/xdg-go/stringprep"
+
+    prepped := stringprep.SASLprep.Prepare("TrustNô1")
+
+```
+
+## Description
+
+This library provides an implementation of the stringprep algorithm
+(RFC-3454) in Go, including all data tables.
+
+A pre-built SASLprep (RFC-4013) profile is provided as well.
+
+## Copyright and License
+
+Copyright 2018 by David A. Golden. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vendor/github.com/youmark/pkcs8/README.md
+++ b/vendor/github.com/youmark/pkcs8/README.md
@@ -1,0 +1,21 @@
+pkcs8
+===
+OpenSSL can generate private keys in both "traditional format" and PKCS#8 format. Newer applications are advised to use more secure PKCS#8 format. Go standard crypto package provides a [function](http://golang.org/pkg/crypto/x509/#ParsePKCS8PrivateKey) to parse private key in PKCS#8 format. There is a limitation to this function. It can only handle unencrypted PKCS#8 private keys. To use this function, the user has to save the private key in file without encryption, which is a bad practice to leave private keys unprotected on file systems. In addition, Go standard package lacks the functions to convert RSA/ECDSA private keys into PKCS#8 format.
+
+pkcs8 package fills the gap here. It implements functions to process private keys in PKCS#8 format, as defined in [RFC5208](https://tools.ietf.org/html/rfc5208) and [RFC5958](https://tools.ietf.org/html/rfc5958). It can handle both unencrypted PKCS#8 PrivateKeyInfo format and EncryptedPrivateKeyInfo format with PKCS#5 (v2.0) algorithms.
+
+
+[**Godoc**](http://godoc.org/github.com/youmark/pkcs8)
+
+## Installation
+Supports Go 1.9+
+
+```text
+go get github.com/youmark/pkcs8
+```
+## dependency
+This package depends on golang.org/x/crypto/pbkdf2 package. Use the following command to retrive pbkdf2 package
+```text
+go get golang.org/x/crypto/pbkdf2
+```
+

--- a/vendor/gopkg.in/yaml.v3/README.md
+++ b/vendor/gopkg.in/yaml.v3/README.md
@@ -1,0 +1,150 @@
+# YAML support for the Go language
+
+Introduction
+------------
+
+The yaml package enables Go programs to comfortably encode and decode YAML
+values. It was developed within [Canonical](https://www.canonical.com) as
+part of the [juju](https://juju.ubuntu.com) project, and is based on a
+pure Go port of the well-known [libyaml](http://pyyaml.org/wiki/LibYAML)
+C library to parse and generate YAML data quickly and reliably.
+
+Compatibility
+-------------
+
+The yaml package supports most of YAML 1.2, but preserves some behavior
+from 1.1 for backwards compatibility.
+
+Specifically, as of v3 of the yaml package:
+
+ - YAML 1.1 bools (_yes/no, on/off_) are supported as long as they are being
+   decoded into a typed bool value. Otherwise they behave as a string. Booleans
+   in YAML 1.2 are _true/false_ only.
+ - Octals encode and decode as _0777_ per YAML 1.1, rather than _0o777_
+   as specified in YAML 1.2, because most parsers still use the old format.
+   Octals in the  _0o777_ format are supported though, so new files work.
+ - Does not support base-60 floats. These are gone from YAML 1.2, and were
+   actually never supported by this package as it's clearly a poor choice.
+
+and offers backwards
+compatibility with YAML 1.1 in some cases.
+1.2, including support for
+anchors, tags, map merging, etc. Multi-document unmarshalling is not yet
+implemented, and base-60 floats from YAML 1.1 are purposefully not
+supported since they're a poor design and are gone in YAML 1.2.
+
+Installation and usage
+----------------------
+
+The import path for the package is *gopkg.in/yaml.v3*.
+
+To install it, run:
+
+    go get gopkg.in/yaml.v3
+
+API documentation
+-----------------
+
+If opened in a browser, the import path itself leads to the API documentation:
+
+  - [https://gopkg.in/yaml.v3](https://gopkg.in/yaml.v3)
+
+API stability
+-------------
+
+The package API for yaml v3 will remain stable as described in [gopkg.in](https://gopkg.in).
+
+
+License
+-------
+
+The yaml package is licensed under the MIT and Apache License 2.0 licenses.
+Please see the LICENSE file for details.
+
+
+Example
+-------
+
+```Go
+package main
+
+import (
+        "fmt"
+        "log"
+
+        "gopkg.in/yaml.v3"
+)
+
+var data = `
+a: Easy!
+b:
+  c: 2
+  d: [3, 4]
+`
+
+// Note: struct fields must be public in order for unmarshal to
+// correctly populate the data.
+type T struct {
+        A string
+        B struct {
+                RenamedC int   `yaml:"c"`
+                D        []int `yaml:",flow"`
+        }
+}
+
+func main() {
+        t := T{}
+    
+        err := yaml.Unmarshal([]byte(data), &t)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- t:\n%v\n\n", t)
+    
+        d, err := yaml.Marshal(&t)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- t dump:\n%s\n\n", string(d))
+    
+        m := make(map[interface{}]interface{})
+    
+        err = yaml.Unmarshal([]byte(data), &m)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- m:\n%v\n\n", m)
+    
+        d, err = yaml.Marshal(&m)
+        if err != nil {
+                log.Fatalf("error: %v", err)
+        }
+        fmt.Printf("--- m dump:\n%s\n\n", string(d))
+}
+```
+
+This example will generate the following output:
+
+```
+--- t:
+{Easy! {2 [3 4]}}
+
+--- t dump:
+a: Easy!
+b:
+  c: 2
+  d: [3, 4]
+
+
+--- m:
+map[a:Easy! b:map[c:2 d:[3 4]]]
+
+--- m dump:
+a: Easy!
+b:
+  c: 2
+  d:
+  - 3
+  - 4
+```
+


### PR DESCRIPTION
Some information in CONTRIBUTING.md is out-of-date and some Markdown files are missing from the vendor directory.

Changes:
* Update CONTRIBUTING.md with current information on contributing to the Go Driver.
* Remove `**.md` from .gitignore so git picks up all changes to Markdown files.
* Commit all previously ignored *.md files from the vendor directory.