### PR TITLE
GODRIVER-2409 Add spec test for unsupported operation.

### DIFF
--- a/data/unified-test-format/valid-fail/operation-unsupported.json
+++ b/data/unified-test-format/valid-fail/operation-unsupported.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-unsupported",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported operation",
+      "operations": [
+        {
+          "name": "unsupportedOperation",
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/data/unified-test-format/valid-fail/operation-unsupported.yml
+++ b/data/unified-test-format/valid-fail/operation-unsupported.yml
@@ -1,0 +1,13 @@
+description: "operation-unsupported"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: "Unsupported operation"
+    operations:
+      - name: unsupportedOperation
+        object: *client0


### PR DESCRIPTION
GODRIVER-2409

Syncs a simple spec tests that ensures that the unified test runner fails when it encounters an unsupported operation `unsupportedOperation`.