### PR TITLE
GODRIVER-2264 Fix PATH on Windows Evergreen tasks to work with Cygwin/Bash shell.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -73,12 +73,19 @@ functions:
           fi
 
           # Set actual PATH. PATH should contain binaries from GOROOT, GOPATH, GCC_PATH and mongodb.
-          # Adding GOROOT's bin to PATH on Windows requires a cygpath conversion.
           export GOROOTBIN="$GOROOT/bin"
+          export GOPATHBIN="$GOPATH/bin"
           if [ "Windows_NT" = "$OS" ]; then
-             export GOROOTBIN=$(cygpath -m $GOROOTBIN)
+             # Convert all Windows-style paths (e.g. C:/) to Bash-style Cygwin paths
+             # (e.g. /cygdrive/c/...) because PATH is interpreted by Bash, which uses ":" as a
+             # separator so doesn't support Windows-style paths. Other scripts or binaries that
+             # aren't part of Cygwin still need the environment variables to use Windows-style
+             # paths, so only convert them when setting PATH. Note that GCC_PATH is already a
+             # Bash-style Cygwin path for all Windows tasks.
+             export PATH="$(cygpath $GOROOTBIN):$(cygpath $GOPATHBIN):${GCC_PATH}:$(cygpath $MONGODB_BINARIES):$PATH"
+          else
+             export PATH="$GOROOTBIN:$GOPATHBIN:${GCC_PATH}:$MONGODB_BINARIES:$PATH"
           fi
-          export PATH="$GOROOTBIN:$GOPATH/bin:${GCC_PATH}:$MONGODB_BINARIES:$PATH"
 
           # Check Go installation.
           go version


### PR DESCRIPTION
Currently Go builds fail or use the wrong version of Go on Windows Evergreen tasks. The issue is that the `PATH` environment variable contains a mixture of Windows-style paths (e.g. `C:/...`) and Bash-style Cygwin paths (e.g. `/cygdrive/c/...`), but is being interpreted by the Bash shell in Cygwin, which doesn't support Windows-style paths (the `PATH` separator and the Windows drive separator are both a colon ":"). To fix it, convert all Windows-style paths to Bash-style Cygwin paths when building the `PATH` environment variable. Note that other scripts and binaries expect Windows-style paths, so keep the Windows-style paths for all other exported environment variables (e.g. `GOROOT`).