### PR TITLE
GODRIVER-2407 Implement POC for SkipAncestors

### DIFF
--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -123,6 +123,20 @@ type DecodeContext struct {
 	// Ancestor is a bson.M, BSON embedded document values being decoded into an empty interface
 	// will be decoded into a bson.M.
 	Ancestor reflect.Type
+
+	// SkipAncestors is a set of types for which the decoder should avoid applying ancestor logic.  This field is
+	// required because the value of the context's ancestor could potentially change multiple times in it's lifecycle.
+	SkipAncestors map[reflect.Type]bool
+}
+
+// HasValidAncestor will return `true` if the ancestor type is valid and can be used with ancestor logic, and `false`
+// otherwise.  This will help us decode data with user-defined precision.
+func (dc DecodeContext) HasValidAncestor() bool {
+	skip := false
+	if skipSet := dc.SkipAncestors; skipSet != nil {
+		skip = skipSet[dc.Ancestor]
+	}
+	return dc.Ancestor != nil && !skip
 }
 
 // ValueCodec is the interface that groups the methods to encode and decode

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -124,19 +124,26 @@ type DecodeContext struct {
 	// will be decoded into a bson.M.
 	Ancestor reflect.Type
 
-	// SkipAncestors is a set of types for which the decoder should avoid applying ancestor logic.  This field is
-	// required because the value of the context's ancestor could potentially change multiple times in it's lifecycle.
-	SkipAncestors map[reflect.Type]bool
+	// TypeMap is a set of types for which the decoder should avoid applying ancestor logic.  These types will also
+	// be used as override for the principle types in decoding empty interfaces.
+	EmptyInterfaceTypeMap map[reflect.Type]reflect.Type
 }
 
 // HasValidAncestor will return `true` if the ancestor type is valid and can be used with ancestor logic, and `false`
 // otherwise.  This will help us decode data with user-defined precision.
 func (dc DecodeContext) HasValidAncestor() bool {
 	skip := false
-	if skipSet := dc.SkipAncestors; skipSet != nil {
-		skip = skipSet[dc.Ancestor]
+	if eiTypes := dc.EmptyInterfaceTypeMap; eiTypes != nil {
+		skip = eiTypes[dc.Ancestor] != nil
 	}
 	return dc.Ancestor != nil && !skip
+}
+
+func (dc DecodeContext) ForceType() reflect.Type {
+	if eiTypes := dc.EmptyInterfaceTypeMap; eiTypes != nil {
+		return eiTypes[dc.Ancestor]
+	}
+	return nil
 }
 
 // ValueCodec is the interface that groups the methods to encode and decode

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -64,6 +64,10 @@ func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, val
 		return dc.Ancestor, nil
 	}
 
+	// If the context has a foreced type defined, then use that type.  Otherwise, use the type map.
+	if ft := dc.ForceType(); ft != nil {
+		return ft, nil
+	}
 	rtype, err := dc.LookupTypeMapEntry(valueType)
 	if err == nil {
 		return rtype, nil
@@ -80,7 +84,7 @@ func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, val
 			lookupType = bsontype.Type(0)
 		}
 
-		rtype, err = dc.LookupTypeMapEntry(lookupType)
+		rtype, err := dc.LookupTypeMapEntry(lookupType)
 		if err == nil {
 			return rtype, nil
 		}

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -57,7 +57,7 @@ func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWrit
 
 func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, valueType bsontype.Type) (reflect.Type, error) {
 	isDocument := valueType == bsontype.Type(0) || valueType == bsontype.EmbeddedDocument
-	if isDocument && dc.Ancestor != nil {
+	if isDocument && dc.HasValidAncestor() {
 		// Using ancestor information rather than looking up the type map entry forces consistent decoding.
 		// If we're decoding into a bson.D, subdocuments should also be decoded as bson.D, even if a type map entry
 		// has been registered.

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -251,7 +251,9 @@ func TestDecoderv2(t *testing.T) {
 		var bsonOut someMap
 		dec, _ := NewDecoderWithContext(
 			bsoncodec.DecodeContext{
-				SkipAncestors: map[reflect.Type]bool{reflect.TypeOf(someMap{}): true},
+				EmptyInterfaceTypeMap: map[reflect.Type]reflect.Type{
+					reflect.TypeOf(someMap{}): reflect.TypeOf(map[string]interface{}{}),
+				},
 			},
 			bsonrw.NewBSONDocumentReader(bytes))
 		dec.Decode(&bsonOut)
@@ -260,7 +262,7 @@ func TestDecoderv2(t *testing.T) {
 		assert.Equal(t, inType, bsonOutType, "expected '%s' to equal '%s'", inType, bsonOutType)
 
 		bsonFooOutType := reflect.TypeOf(bsonOut["foo"]).String()
-		documentType := reflect.TypeOf(D{}).String()
+		documentType := reflect.TypeOf(map[string]interface{}{}).String()
 		assert.Equal(t, documentType, bsonFooOutType, "expected '%s' to equal '%s'", inFooType, bsonFooOutType)
 	})
 }

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -199,12 +199,12 @@ func TestDecoderv2(t *testing.T) {
 		dc2 := bsoncodec.DecodeContext{Registry: NewRegistryBuilder().Build()}
 		dec, err := NewDecoderWithContext(dc1, bsonrw.NewBSONDocumentReader([]byte{}))
 		noerr(t, err)
-		if dec.dc != dc1 {
+		if !reflect.DeepEqual(dec.dc, dc1) {
 			t.Errorf("Decoder should use the Registry provided. got %v; want %v", dec.dc, dc1)
 		}
 		err = dec.SetContext(dc2)
 		noerr(t, err)
-		if dec.dc != dc2 {
+		if !reflect.DeepEqual(dec.dc, dc2) {
 			t.Errorf("Decoder should use the Registry provided. got %v; want %v", dec.dc, dc2)
 		}
 	})
@@ -214,12 +214,12 @@ func TestDecoderv2(t *testing.T) {
 		dc2 := bsoncodec.DecodeContext{Registry: r2}
 		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader([]byte{}))
 		noerr(t, err)
-		if dec.dc != dc1 {
+		if !reflect.DeepEqual(dec.dc, dc1) {
 			t.Errorf("Decoder should use the Registry provided. got %v; want %v", dec.dc, dc1)
 		}
 		err = dec.SetRegistry(r2)
 		noerr(t, err)
-		if dec.dc != dc2 {
+		if !reflect.DeepEqual(dec.dc, dc2) {
 			t.Errorf("Decoder should use the Registry provided. got %v; want %v", dec.dc, dc2)
 		}
 	})
@@ -234,6 +234,34 @@ func TestDecoderv2(t *testing.T) {
 		if err != ErrDecodeToNil {
 			t.Fatalf("Decode error mismatch; expected %v, got %v", ErrDecodeToNil, err)
 		}
+	})
+	t.Run("DecodeWithSkipAncestor", func(t *testing.T) {
+		type someMap map[string]interface{}
+
+		in := make(someMap)
+		in["foo"] = map[string]interface{}{"bar": "baz"}
+		inType := reflect.TypeOf(in).String()
+		inFooType := reflect.TypeOf(in["foo"]).String()
+
+		bytes, err := Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var bsonOut someMap
+		dec, _ := NewDecoderWithContext(
+			bsoncodec.DecodeContext{
+				SkipAncestors: map[reflect.Type]bool{reflect.TypeOf(someMap{}): true},
+			},
+			bsonrw.NewBSONDocumentReader(bytes))
+		dec.Decode(&bsonOut)
+
+		bsonOutType := reflect.TypeOf(bsonOut).String()
+		assert.Equal(t, inType, bsonOutType, "expected '%s' to equal '%s'", inType, bsonOutType)
+
+		bsonFooOutType := reflect.TypeOf(bsonOut["foo"]).String()
+		documentType := reflect.TypeOf(D{}).String()
+		assert.Equal(t, documentType, bsonFooOutType, "expected '%s' to equal '%s'", inFooType, bsonFooOutType)
 	})
 }
 


### PR DESCRIPTION
GODRIVER-2407

This partially resolves issues around type ancestors by skipping the ancestor branch when decoding empty interfaces for specific types.  It will not completely resolve the issues in GODRIVER-2407, however.  But it will let the user define a map where not only should we skip the ancestor branch but their mapping will serve as the principle type the decoder.

```go
dec, _ := NewDecoderWithContext(
    bsoncodec.DecodeContext{
		EmptyInterfaceTypeMap: map[reflect.Type]reflect.Type{
			reflect.TypeOf(someMap{}): reflect.TypeOf(map[string]interface{}{}),
		},
    },
    bsonrw.NewBSONDocumentReader(bytes))
dec.Decode(&bsonOut)
```

Pros:
- Readable and Idiomatic
- User doesn't have to worry about nesting / maintaining an unmarshaller
- Get the exact type conversions you want

Cons:
- The underlying issue remains unsolved
- Requires a code change
- All types defined will be cast

