### PR TITLE
GODRIVER-2405 Test RTT90 monitoring.

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -636,9 +636,7 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		)
 	}
 	// Timeout
-	if opts.Timeout != nil {
-		c.timeout = opts.Timeout
-	}
+	c.timeout = opts.Timeout
 	// TLSConfig
 	if opts.TLSConfig != nil {
 		connOpts = append(connOpts, topology.WithTLSConfig(

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -527,8 +527,15 @@ func TestClient(t *testing.T) {
 
 		// Assert that the minimum RTT is eventually >250ms.
 		topo := getTopologyFromClient(mt.Client)
-		assert.Soon(mt, func() {
+		assert.Soon(mt, func(ctx context.Context) {
 			for {
+				// Stop loop if callback has been canceled.
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				time.Sleep(100 * time.Millisecond)
 
 				// Wait for all of the server's minimum RTTs to be >250ms.
@@ -570,8 +577,15 @@ func TestClient(t *testing.T) {
 
 		// Assert that the minimum RTT is eventually >250ms.
 		topo := getTopologyFromClient(mt.Client)
-		assert.Soon(mt, func() {
+		assert.Soon(mt, func(ctx context.Context) {
 			for {
+				// Stop loop if callback has been canceled.
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				time.Sleep(100 * time.Millisecond)
 
 				// Wait for all of the server's minimum RTTs to be >250ms.
@@ -616,8 +630,15 @@ func TestClient(t *testing.T) {
 
 		// Assert that RTT90s are eventually >300ms.
 		topo := getTopologyFromClient(mt.Client)
-		assert.Soon(mt, func() {
+		assert.Soon(mt, func(ctx context.Context) {
 			for {
+				// Stop loop if callback has been canceled.
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				time.Sleep(100 * time.Millisecond)
 
 				// Wait for all of the server's RTT90s to be >300ms.
@@ -662,8 +683,15 @@ func TestClient(t *testing.T) {
 
 		// Assert that RTT90s are eventually >300ms.
 		topo := getTopologyFromClient(mt.Client)
-		assert.Soon(mt, func() {
+		assert.Soon(mt, func(ctx context.Context) {
 			for {
+				// Stop loop if callback has been canceled.
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				time.Sleep(100 * time.Millisecond)
 
 				// Wait for all of the server's RTT90s to be >300ms.

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -544,9 +544,6 @@ func TestClient(t *testing.T) {
 		}, 10*time.Second)
 	})
 
-	// TODO(GODRIVER-2405): Add a similar test to ensure that 90th percentile RTT is used to prevent
-	// TODO sending requests when Timeout is set on the Client.
-	//
 	// Test that if the minimum RTT is greater than the remaining timeout for an operation, the
 	// operation is not sent to the server and no connections are closed.
 	mt.Run("minimum RTT used to prevent sending requests", func(mt *mtest.T) {
@@ -596,6 +593,99 @@ func TestClient(t *testing.T) {
 			err := mt.Client.Ping(ctx, nil)
 			cancel()
 			assert.NotNil(mt, err, "expected Ping to return an error")
+		}
+
+		// Assert that the Ping timeouts result in no connections being closed.
+		closed := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.ConnectionClosed }))
+		assert.Equal(t, 0, closed, "expected no connections to be closed")
+	})
+
+	mt.Run("RTT90 is monitored", func(mt *mtest.T) {
+		if testing.Short() {
+			t.Skip("skipping integration test in short mode")
+		}
+
+		// Reset the client with a dialer that delays all network round trips by 300ms and set the
+		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples.
+		mt.ResetClient(options.Client().
+			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
+			SetHeartbeatInterval(100 * time.Millisecond))
+
+		// Assert that RTT90s are eventually >300ms.
+		topo := getTopologyFromClient(mt.Client)
+		assert.Soon(mt, func() {
+			for {
+				time.Sleep(100 * time.Millisecond)
+
+				// Wait for all of the server's RTT90s to be >300ms.
+				done := true
+				for _, desc := range topo.Description().Servers {
+					server, err := topo.FindServer(desc)
+					assert.Nil(mt, err, "FindServer error: %v", err)
+					if server.RTT90() <= 300*time.Millisecond {
+						done = false
+					}
+				}
+				if done {
+					return
+				}
+			}
+		}, 10*time.Second)
+	})
+
+	// Test that if Timeout is set and the RTT90 is greater than the remaining timeout for an operation, the
+	// operation is not sent to the server, fails with a timeout error, and no connections are closed.
+	mt.Run("RTT90 used to prevent sending requests", func(mt *mtest.T) {
+		if testing.Short() {
+			t.Skip("skipping integration test in short mode")
+		}
+
+		// Assert that we can call Ping with a 250ms timeout.
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+		err := mt.Client.Ping(ctx, nil)
+		assert.Nil(mt, err, "Ping error: %v", err)
+
+		// Reset the client with a dialer that delays all network round trips by 300ms, set the
+		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples, and
+		// set a Timeout of 0 (infinite) on the Client to ensure that RTT90 is used as a sending
+		// threshold.
+		tpm := monitor.NewTestPoolMonitor()
+		mt.ResetClient(options.Client().
+			SetPoolMonitor(tpm.PoolMonitor).
+			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
+			SetHeartbeatInterval(100 * time.Millisecond).
+			SetTimeout(0))
+
+		// Assert that RTT90s are eventually >300ms.
+		topo := getTopologyFromClient(mt.Client)
+		assert.Soon(mt, func() {
+			for {
+				time.Sleep(100 * time.Millisecond)
+
+				// Wait for all of the server's RTT90s to be >300ms.
+				done := true
+				for _, desc := range topo.Description().Servers {
+					server, err := topo.FindServer(desc)
+					assert.Nil(mt, err, "FindServer error: %v", err)
+					if server.MinRTT() <= 300*time.Millisecond {
+						done = false
+					}
+				}
+				if done {
+					return
+				}
+			}
+		}, 10*time.Second)
+
+		// Once we've waited for the RTT90 for the servers to be >300ms, run 10 Ping operations
+		// with a timeout of 300ms and expect that they return timeout errors.
+		for i := 0; i < 10; i++ {
+			ctx, cancel = context.WithTimeout(context.Background(), 300*time.Millisecond)
+			err := mt.Client.Ping(ctx, nil)
+			cancel()
+			assert.NotNil(mt, err, "expected Ping to return an error")
+			assert.True(mt, mongo.IsTimeout(err), "expected a timeout error: got %v", err)
 		}
 
 		// Assert that the Ping timeouts result in no connections being closed.

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -64,6 +64,9 @@ type slowConnDialer struct {
 	delay  time.Duration
 }
 
+var slowConnDialerDelay = 300 * time.Millisecond
+var reducedHeartbeatInterval = 100 * time.Millisecond
+
 func newSlowConnDialer(delay time.Duration) *slowConnDialer {
 	return &slowConnDialer{
 		dialer: &net.Dialer{},
@@ -519,8 +522,8 @@ func TestClient(t *testing.T) {
 		// Reset the client with a dialer that delays all network round trips by 300ms and set the
 		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples.
 		mt.ResetClient(options.Client().
-			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
-			SetHeartbeatInterval(100 * time.Millisecond))
+			SetDialer(newSlowConnDialer(slowConnDialerDelay)).
+			SetHeartbeatInterval(reducedHeartbeatInterval))
 
 		// Assert that the minimum RTT is eventually >250ms.
 		topo := getTopologyFromClient(mt.Client)
@@ -562,8 +565,8 @@ func TestClient(t *testing.T) {
 		tpm := monitor.NewTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
-			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
-			SetHeartbeatInterval(100 * time.Millisecond))
+			SetDialer(newSlowConnDialer(slowConnDialerDelay)).
+			SetHeartbeatInterval(reducedHeartbeatInterval))
 
 		// Assert that the minimum RTT is eventually >250ms.
 		topo := getTopologyFromClient(mt.Client)
@@ -608,8 +611,8 @@ func TestClient(t *testing.T) {
 		// Reset the client with a dialer that delays all network round trips by 300ms and set the
 		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples.
 		mt.ResetClient(options.Client().
-			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
-			SetHeartbeatInterval(100 * time.Millisecond))
+			SetDialer(newSlowConnDialer(slowConnDialerDelay)).
+			SetHeartbeatInterval(reducedHeartbeatInterval))
 
 		// Assert that RTT90s are eventually >300ms.
 		topo := getTopologyFromClient(mt.Client)
@@ -653,8 +656,8 @@ func TestClient(t *testing.T) {
 		tpm := monitor.NewTestPoolMonitor()
 		mt.ResetClient(options.Client().
 			SetPoolMonitor(tpm.PoolMonitor).
-			SetDialer(newSlowConnDialer(300 * time.Millisecond)).
-			SetHeartbeatInterval(100 * time.Millisecond).
+			SetDialer(newSlowConnDialer(slowConnDialerDelay)).
+			SetHeartbeatInterval(reducedHeartbeatInterval).
 			SetTimeout(0))
 
 		// Assert that RTT90s are eventually >300ms.
@@ -668,7 +671,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.MinRTT() <= 300*time.Millisecond {
+					if server.RTT90() <= 300*time.Millisecond {
 						done = false
 					}
 				}

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -114,8 +114,15 @@ func TestSDAMProse(t *testing.T) {
 					AppName:         "streamingRttTest",
 				},
 			})
-			callback := func() {
+			callback := func(ctx context.Context) {
 				for {
+					// Stop loop if callback has been canceled.
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+
 					// We don't know which server received the failpoint command, so we wait until any of the server
 					// RTTs cross the threshold.
 					for _, serverDesc := range testTopology.Description().Servers {

--- a/mongo/integration/unified_runner_events_helper_test.go
+++ b/mongo/integration/unified_runner_events_helper_test.go
@@ -87,8 +87,15 @@ func waitForEvent(mt *mtest.T, test *testCase, op *operation) {
 	eventType := op.Arguments.Lookup("event").StringValue()
 	expectedCount := int(op.Arguments.Lookup("count").Int32())
 
-	callback := func() {
+	callback := func(ctx context.Context) {
 		for {
+			// Stop loop if callback has been canceled.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			var count int
 			// Spec tests only ever wait for ServerMarkedUnknown SDAM events for the time being.
 			if eventType == "ServerMarkedUnknownEvent" {
@@ -127,8 +134,15 @@ func recordPrimary(mt *mtest.T, testCase *testCase) {
 }
 
 func waitForPrimaryChange(mt *mtest.T, testCase *testCase, op *operation) {
-	callback := func() {
+	callback := func(ctx context.Context) {
 		for {
+			// Stop loop if callback has been canceled.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			if getPrimaryAddress(mt, testCase.testTopology, false) != testCase.recordedPrimary {
 				return
 			}

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -373,13 +373,11 @@ func TestConvenientTransactions(t *testing.T) {
 			}
 		}()
 
-		// Create context to manually cancel in callback.
-		cancelCtx, cancel := context.WithCancel(bgCtx)
-		defer cancel()
-
 		// Insert a document within a session and manually cancel context.
-		callback := func() {
-			_, _ = sess.WithTransaction(cancelCtx, func(sessCtx SessionContext) (interface{}, error) {
+		callback := func(ctx context.Context) {
+			transactionCtx, cancel := context.WithCancel(ctx)
+
+			_, _ = sess.WithTransaction(transactionCtx, func(sessCtx SessionContext) (interface{}, error) {
 				_, err := coll.InsertOne(sessCtx, bson.M{"x": 1})
 				assert.Nil(t, err, "InsertOne error: %v", err)
 				cancel()
@@ -430,10 +428,11 @@ func TestConvenientTransactions(t *testing.T) {
 		assert.Nil(t, err, "StartSession error: %v", err)
 		defer sess.EndSession(context.Background())
 
-		// Create context with short timeout.
-		withTransactionContext, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-		defer cancel()
-		callback := func() {
+		callback := func(ctx context.Context) {
+			// Create transaction context with short timeout.
+			withTransactionContext, cancel := context.WithTimeout(ctx, time.Nanosecond)
+			defer cancel()
+
 			_, _ = sess.WithTransaction(withTransactionContext, func(sessCtx SessionContext) (interface{}, error) {
 				_, err := coll.InsertOne(sessCtx, bson.D{{}})
 				return nil, err
@@ -459,10 +458,11 @@ func TestConvenientTransactions(t *testing.T) {
 		assert.Nil(t, err, "StartSession error: %v", err)
 		defer sess.EndSession(context.Background())
 
-		// Create context and cancel it immediately.
-		withTransactionContext, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		cancel()
-		callback := func() {
+		callback := func(ctx context.Context) {
+			// Create transaction context and cancel it immediately.
+			withTransactionContext, cancel := context.WithTimeout(ctx, 2*time.Second)
+			cancel()
+
 			_, _ = sess.WithTransaction(withTransactionContext, func(sessCtx SessionContext) (interface{}, error) {
 				_, err := coll.InsertOne(sessCtx, bson.D{{}})
 				return nil, err
@@ -509,8 +509,8 @@ func TestConvenientTransactions(t *testing.T) {
 		assert.Nil(t, err, "StartSession error: %v", err)
 		defer sess.EndSession(context.Background())
 
-		callback := func() {
-			_, err = sess.WithTransaction(context.Background(), func(sessCtx SessionContext) (interface{}, error) {
+		callback := func(ctx context.Context) {
+			_, err = sess.WithTransaction(ctx, func(sessCtx SessionContext) (interface{}, error) {
 				// Set a timeout of 300ms to cause a timeout on first insertOne
 				// and force a retry.
 				c, cancel := context.WithTimeout(sessCtx, 300*time.Millisecond)

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -234,11 +234,12 @@ func TestConnection(t *testing.T) {
 						}
 						conn := newConnection("", connOpts...)
 
-						ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
-						defer cancel()
 						var connectErr error
-						callback := func() {
-							connectErr = conn.connect(ctx)
+						callback := func(ctx context.Context) {
+							connectCtx, cancel := context.WithTimeout(ctx, tc.contextTimeout)
+							defer cancel()
+
+							connectErr = conn.connect(connectCtx)
 						}
 						assert.Soon(t, callback, tc.maxConnectTime)
 
@@ -268,11 +269,12 @@ func TestConnection(t *testing.T) {
 						}
 						conn := newConnection(address.Address(l.Addr().String()), connOpts...)
 
-						ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
-						defer cancel()
 						var connectErr error
-						callback := func() {
-							connectErr = conn.connect(ctx)
+						callback := func(ctx context.Context) {
+							connectCtx, cancel := context.WithTimeout(ctx, tc.contextTimeout)
+							defer cancel()
+
+							connectErr = conn.connect(connectCtx)
 						}
 						assert.Soon(t, callback, tc.maxConnectTime)
 

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -200,10 +200,22 @@ func TestRTTMonitor(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.getRTT() > 0 && rtt.getMinRTT() > 0 && rtt.getRTT90() > 0 },
+				func() bool { return rtt.getRTT() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected getRTT(), getMinRTT() and getRTT90() to return positive durations within 1 second")
+				"expected getRTT() to return a positive duration within 1 second")
+			assert.Eventuallyf(
+				t,
+				func() bool { return rtt.getMinRTT() > 0 },
+				1*time.Second,
+				10*time.Millisecond,
+				"expected getMinRTT() to return a positive duration within 1 second")
+			assert.Eventuallyf(
+				t,
+				func() bool { return rtt.getRTT90() > 0 },
+				1*time.Second,
+				10*time.Millisecond,
+				"expected getRTT90() to return a positive duration within 1 second")
 			rtt.reset()
 		}
 	})

--- a/x/mongo/driver/topology/topology_errors_test.go
+++ b/x/mongo/driver/topology/topology_errors_test.go
@@ -47,13 +47,13 @@ func TestTopologyErrors(t *testing.T) {
 			assert.Nil(t, err, "error creating topology: %v", err)
 
 			var serverSelectionErr error
-			callback := func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			callback := func(ctx context.Context) {
+				selectServerCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 				defer cancel()
 
 				state := newServerSelectionState(selectNone, make(<-chan time.Time))
 				subCh := make(<-chan description.Topology)
-				_, serverSelectionErr = topo.selectServerFromSubscription(ctx, subCh, state)
+				_, serverSelectionErr = topo.selectServerFromSubscription(selectServerCtx, subCh, state)
 			}
 			assert.Soon(t, callback, 150*time.Millisecond)
 			assert.True(t, errors.Is(serverSelectionErr, context.DeadlineExceeded), "expected %v, received %v",


### PR DESCRIPTION
GODRIVER-2405

Tests that the 90th percentile observed round-trip time is monitored and used to prevent sending messages to the server when `Timeout` is specified. Tests the functionality of the new `percentile` function and the `getRTT90()` method of `rttMonitor`. Bumps the `minSamples` of the `rttMonitor` to 10 instead of 5.

Opening PRs with csot-implementation as the base branch messes with the GH Evergreen CI: so [here](https://spruce.mongodb.com/version/629768842fbabe16459b62db/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a patch I'll keep updated with every commit.