### PR TITLE
Run all appropriate tests against serverless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ evg-test-kmip:
 evg-test-serverless:
 	# Serverless should be tested with all unified tests as well as tests in the following components: CRUD, load balancer,
 	# retryable reads, retryable writes, sessions, transactions and cursor behavior.
-	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestCrudSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestWriteErrorsWithLabels -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestWriteErrorsDetails -v -timeout $(TEST_TIMEOUT)s >> test.suite
@@ -208,6 +207,7 @@ evg-test-serverless:
 	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/transactions/legacy -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestConvenientTransactions -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestCursor -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
 
 # benchmark specific targets and support
 perf:driver-test-data.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -189,23 +189,25 @@ evg-test-kmip:
 
 .PHONY: evg-test-serverless
 evg-test-serverless:
+	# Serverless should be tested with all unified tests as well as tests in the following components: CRUD, load balancer,
+	# retryable reads, retryable writes, sessions, transactions and cursor behavior.
+	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestCrudSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration -run TestRetryableWritesSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/retryable-reads -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/sessions -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec/crud/unified -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec/transactions/unified -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec/versioned-api -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/transactions/legacy -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestWriteErrorsWithLabels -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestWriteErrorsDetails -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestHintErrors -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration -run TestAggregatePrimaryPreferredReadPreference -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestWriteConcernError -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestErrorsCodeNamePropagated -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestLoadBalancerSupport -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/retryable-reads -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestRetryableReadsProse -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestRetryableWritesSpec -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestRetryableWritesProse -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/sessions -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestSessionsProse -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestUnifiedSpecs/transactions/legacy -v -timeout $(TEST_TIMEOUT)s >> test.suite
+	go test $(BUILD_TAGS) ./mongo/integration -run TestConvenientTransactions -v -timeout $(TEST_TIMEOUT)s >> test.suite
 	go test $(BUILD_TAGS) ./mongo/integration -run TestCursor -v -timeout $(TEST_TIMEOUT)s >> test.suite
-	go test $(BUILD_TAGS) ./mongo/integration/unified -run TestUnifiedSpec/load-balancers -v -timeout $(TEST_TIMEOUT)s >> test.suite
 
 # benchmark specific targets and support
 perf:driver-test-data.tar.gz

--- a/data/collection-management/README.rst
+++ b/data/collection-management/README.rst
@@ -3,6 +3,4 @@ Collection Management Tests
 ===========================
 
 This directory contains tests for collection management. They are implemented
-in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__
-and require schema version 1.0.
-
+in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__.

--- a/data/collection-management/createCollection-pre_and_post_images.json
+++ b/data/collection-management/createCollection-pre_and_post_images.json
@@ -1,9 +1,10 @@
 {
   "description": "createCollection-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "6.0"
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/data/collection-management/createCollection-pre_and_post_images.yml
+++ b/data/collection-management/createCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "createCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/data/collection-management/modifyCollection-pre_and_post_images.json
+++ b/data/collection-management/modifyCollection-pre_and_post_images.json
@@ -1,9 +1,10 @@
 {
   "description": "modifyCollection-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "6.0"
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/data/collection-management/modifyCollection-pre_and_post_images.yml
+++ b/data/collection-management/modifyCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "modifyCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.json
@@ -43,7 +43,8 @@
       "description": "collection is created with the correct options",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6"
+          "minServerVersion": "3.6",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
+++ b/data/unified-test-format/valid-pass/initialCollectionData-collectionOptions.yml
@@ -27,6 +27,8 @@ tests:
   - description: collection is created with the correct options
     runOnRequirements:
       - minServerVersion: "3.6"
+        # Capped collections cannot be created on serverless instances.
+        serverless: forbid
     operations:
       # Execute a collStats command to ensure the collection was created with the correct options.
       - name: runCommand

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -37,8 +36,8 @@ func TestRetryableReadsProse(t *testing.T) {
 	defer mt.Close()
 
 	mt.Run("PoolClearedError retryability", func(mt *mtest.T) {
-		if os.Getenv("SERVERLESS") == "serverless" {
-			mt.Skip("skipping as serverless has different pool clearing behavior")
+		if mtest.ClusterTopologyKind() == mtest.LoadBalanced {
+			mt.Skip("skipping as load balanced topology has different pool clearing behavior")
 		}
 
 		// Insert a document to test collection.

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +37,10 @@ func TestRetryableReadsProse(t *testing.T) {
 	defer mt.Close()
 
 	mt.Run("PoolClearedError retryability", func(mt *mtest.T) {
+		if os.Getenv("SERVERLESS") == "serverless" {
+			mt.Skip("skipping as serverless has different pool clearing behavior")
+		}
+
 		// Insert a document to test collection.
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.Nil(mt, err, "InsertOne error: %v", err)


### PR DESCRIPTION
GODRIVER-2421
GODRIVER-2396

Runs all tests specified [in the spec](https://github.com/mongodb/specifications/blob/master/source/serverless-testing/README.rst#existing-spec-tests) against serverless instances (we were missing a number of them). Forbids `serverless` on some collection management tests, the `initialCollectionData` UTF test and the retryable reads prose test that asserts `PoolClearedError` retryability (pool clearing logic differs when running against serverless).