### PR TITLE
GODRIVER-2407 Add DocumentDecodeType to DecodeContext

### DIFF
--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -118,20 +118,25 @@ type EncodeContext struct {
 type DecodeContext struct {
 	*Registry
 	Truncate bool
+
 	// Ancestor is the type of a containing document. This is mainly used to determine what type
 	// should be used when decoding an embedded document into an empty interface. For example, if
 	// Ancestor is a bson.M, BSON embedded document values being decoded into an empty interface
 	// will be decoded into a bson.M.
+	//
+	// Deprecated: Use DefaultDocumentType instead.
 	Ancestor reflect.Type
 
-	// DocumentDecodeType will decode embedded documents into the defined type, rather than into primitive.D. This is a
-	// work-around for custom typing.
-	DocumentDecodeType *reflect.Type
+	// DocumentType specifies the Go type to decode nested BSON documents into. The use-case for this field is
+	// restricted to data typed as "interface{}" or "map[string]interface{}". DocumentType overrides the Ancestor field.
+	// If DocumentType is set to a type that a BSON document cannot be unmarshaled into (e.g. "string"), unmarshalling
+	// will result in an error.
+	DocumentType reflect.Type
 }
 
-// SetDocumentDecodeType will set the DocumentDecodeType field on a DecodeContext.
-func (dc *DecodeContext) SetDocumentDecodeType(rtype reflect.Type) *DecodeContext {
-	dc.DocumentDecodeType = &rtype
+// SetDocumentType will set the DocumentType field on a DecodeContext.
+func (dc *DecodeContext) SetDocumentType(rtype reflect.Type) *DecodeContext {
+	dc.DocumentType = rtype
 	return dc
 }
 

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -125,13 +125,8 @@ type DecodeContext struct {
 	Ancestor reflect.Type
 
 	// DocumentDecodeType will decode embedded documents into the defined type, rather than into primitive.D. This is a
-	// work-around for custom typing and is All-Or-None.
+	// work-around for custom typing.
 	DocumentDecodeType *reflect.Type
-}
-
-// HasValidAncestor will return true if the ancestor an be used in decoding logic.
-func (dc *DecodeContext) HasValidAncestor() bool {
-	return dc.Ancestor != nil && dc.DocumentDecodeType == nil
 }
 
 // SetDocumentDecodeType will set the DocumentDecodeType field on a DecodeContext.

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -124,7 +124,7 @@ type DecodeContext struct {
 	// will be decoded into a bson.M.
 	Ancestor reflect.Type
 
-	// DocumentDecodeType will decode embedded documents into the defined type, rather than into primitive.D.  This is
+	// DocumentDecodeType will decode embedded documents into the defined type, rather than into primitive.D. This is a
 	// work-around for custom typing and is All-Or-None.
 	DocumentDecodeType *reflect.Type
 }

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -13,6 +13,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 var (
@@ -127,17 +128,25 @@ type DecodeContext struct {
 	// Deprecated: Use DefaultDocumentType instead.
 	Ancestor reflect.Type
 
-	// DocumentType specifies the Go type to decode top-level and nested BSON documents into. In particular, the
+	// defaultDocumentType specifies the Go type to decode top-level and nested BSON documents into. In particular, the
 	// usage for this field is restricted to data typed as "interface{}" or "map[string]interface{}". If DocumentType is
 	// set to a type that a BSON document cannot be unmarshaled into (e.g. "string"), unmarshalling will result in an
 	// error. DocumentType overrides the Ancestor field.
-	DocumentType reflect.Type
+	defaultDocumentType reflect.Type
 }
 
-// SetDocumentType will set the DocumentType field on a DecodeContext.
-func (dc *DecodeContext) SetDocumentType(rtype reflect.Type) *DecodeContext {
-	dc.DocumentType = rtype
-	return dc
+// DefaultDocumentM will set the defaultDocumentType as primitive.M, to be used when decoding "interface{}" and
+// "map[string]interface{}".
+func (dc *DecodeContext) DefaultDocumentM() error {
+	dc.defaultDocumentType = reflect.TypeOf(primitive.M{})
+	return nil
+}
+
+// DefaultDocumentD will set the defaultDocumentType as primitive.D, to be used when decoding "interface{}" and
+// "map[string]interface{}".
+func (dc *DecodeContext) DefaultDocumentD() error {
+	dc.defaultDocumentType = reflect.TypeOf(primitive.D{})
+	return nil
 }
 
 // ValueCodec is the interface that groups the methods to encode and decode

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -127,10 +127,10 @@ type DecodeContext struct {
 	// Deprecated: Use DefaultDocumentType instead.
 	Ancestor reflect.Type
 
-	// DocumentType specifies the Go type to decode nested BSON documents into. The use-case for this field is
-	// restricted to data typed as "interface{}" or "map[string]interface{}". DocumentType overrides the Ancestor field.
-	// If DocumentType is set to a type that a BSON document cannot be unmarshaled into (e.g. "string"), unmarshalling
-	// will result in an error.
+	// DocumentType specifies the Go type to decode top-level and nested BSON documents into. In particular, the
+	// usage for this field is restricted to data typed as "interface{}" or "map[string]interface{}". If DocumentType is
+	// set to a type that a BSON document cannot be unmarshaled into (e.g. "string"), unmarshalling will result in an
+	// error. DocumentType overrides the Ancestor field.
 	DocumentType reflect.Type
 }
 

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -125,7 +125,7 @@ type DecodeContext struct {
 	// Ancestor is a bson.M, BSON embedded document values being decoded into an empty interface
 	// will be decoded into a bson.M.
 	//
-	// Deprecated: Use DefaultDocumentType instead.
+	// Deprecated: Use DefaultDocumentM or DefaultDocumentD instead.
 	Ancestor reflect.Type
 
 	// defaultDocumentType specifies the Go type to decode top-level and nested BSON documents into. In particular, the
@@ -135,15 +135,15 @@ type DecodeContext struct {
 	defaultDocumentType reflect.Type
 }
 
-// DefaultDocumentM will set the defaultDocumentType as primitive.M, to be used when decoding "interface{}" and
-// "map[string]interface{}".
+// DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as
+// "interface{}" or "map[string]interface{}".
 func (dc *DecodeContext) DefaultDocumentM() error {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.M{})
 	return nil
 }
 
-// DefaultDocumentD will set the defaultDocumentType as primitive.D, to be used when decoding "interface{}" and
-// "map[string]interface{}".
+// DefaultDocumentD will decode empty documents using the primitive.D type. This behavior is restricted to data typed as
+// "interface{}" or "map[string]interface{}".
 func (dc *DecodeContext) DefaultDocumentD() error {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.D{})
 	return nil

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -123,6 +123,21 @@ type DecodeContext struct {
 	// Ancestor is a bson.M, BSON embedded document values being decoded into an empty interface
 	// will be decoded into a bson.M.
 	Ancestor reflect.Type
+
+	// DocumentDecodeType will decode embedded documents into the defined type, rather than into primitive.D.  This is
+	// work-around for custom typing and is All-Or-None.
+	DocumentDecodeType *reflect.Type
+}
+
+// HasValidAncestor will return true if the ancestor an be used in decoding logic.
+func (dc *DecodeContext) HasValidAncestor() bool {
+	return dc.Ancestor != nil && dc.DocumentDecodeType == nil
+}
+
+// SetDocumentDecodeType will set the DocumentDecodeType field on a DecodeContext.
+func (dc *DecodeContext) SetDocumentDecodeType(rtype reflect.Type) *DecodeContext {
+	dc.DocumentDecodeType = &rtype
+	return dc
 }
 
 // ValueCodec is the interface that groups the methods to encode and decode

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -137,16 +137,14 @@ type DecodeContext struct {
 
 // DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
-func (dc *DecodeContext) DefaultDocumentM() error {
+func (dc *DecodeContext) DefaultDocumentM() {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.M{})
-	return nil
 }
 
 // DefaultDocumentD will decode empty documents using the primitive.D type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
-func (dc *DecodeContext) DefaultDocumentD() error {
+func (dc *DecodeContext) DefaultDocumentD() {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.D{})
-	return nil
 }
 
 // ValueCodec is the interface that groups the methods to encode and decode

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -58,11 +58,10 @@ func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWrit
 func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, valueType bsontype.Type) (reflect.Type, error) {
 	isDocument := valueType == bsontype.Type(0) || valueType == bsontype.EmbeddedDocument
 	if isDocument {
-		if dc.DocumentType != nil {
-			// If the bsontype is an embedded document and the DocumentType is set on the DecodeContext, then just
-			// return that type. This gives users an "escape hatch" to avoid the 1-1 embedded document to primitive.D
-			// decoding map.
-			return dc.DocumentType, nil
+		if dc.defaultDocumentType != nil {
+			// If the bsontype is an embedded document and the DocumentType is set on the DecodeContext, then return
+			// that type.
+			return dc.defaultDocumentType, nil
 		}
 		if dc.Ancestor != nil {
 			// Using ancestor information rather than looking up the type map entry forces consistent decoding.

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -57,18 +57,19 @@ func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWrit
 
 func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, valueType bsontype.Type) (reflect.Type, error) {
 	isDocument := valueType == bsontype.Type(0) || valueType == bsontype.EmbeddedDocument
-	if isDocument && dc.HasValidAncestor() {
-		// Using ancestor information rather than looking up the type map entry forces consistent decoding.
-		// If we're decoding into a bson.D, subdocuments should also be decoded as bson.D, even if a type map entry
-		// has been registered.
-		return dc.Ancestor, nil
-	}
-
-	if isDocument && dc.DocumentDecodeType != nil {
-		// If the bsontype is an embedded document and the DocumentDecodeType is set on the DecodeContext, then just
-		// return that type.  This gives users an "escape hatch" to avoid the 1-1 embedded document to primitive.D
-		// decoding map, but this solution is AON.
-		return *dc.DocumentDecodeType, nil
+	if isDocument {
+		if dc.DocumentDecodeType != nil {
+			// If the bsontype is an embedded document and the DocumentDecodeType is set on the DecodeContext, then just
+			// return that type. This gives users an "escape hatch" to avoid the 1-1 embedded document to primitive.D
+			// decoding map.
+			return *dc.DocumentDecodeType, nil
+		}
+		if dc.Ancestor != nil {
+			// Using ancestor information rather than looking up the type map entry forces consistent decoding.
+			// If we're decoding into a bson.D, subdocuments should also be decoded as bson.D, even if a type map entry
+			// has been registered.
+			return dc.Ancestor, nil
+		}
 	}
 
 	rtype, err := dc.LookupTypeMapEntry(valueType)

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -58,11 +58,11 @@ func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWrit
 func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, valueType bsontype.Type) (reflect.Type, error) {
 	isDocument := valueType == bsontype.Type(0) || valueType == bsontype.EmbeddedDocument
 	if isDocument {
-		if dc.DocumentDecodeType != nil {
-			// If the bsontype is an embedded document and the DocumentDecodeType is set on the DecodeContext, then just
+		if dc.DocumentType != nil {
+			// If the bsontype is an embedded document and the DocumentType is set on the DecodeContext, then just
 			// return that type. This gives users an "escape hatch" to avoid the 1-1 embedded document to primitive.D
 			// decoding map.
-			return *dc.DocumentDecodeType, nil
+			return dc.DocumentType, nil
 		}
 		if dc.Ancestor != nil {
 			// Using ancestor information rather than looking up the type map entry forces consistent decoding.

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -66,7 +66,7 @@ func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, val
 
 	if isDocument && dc.DocumentDecodeType != nil {
 		// If the bsontype is an embedded document and the DocumentDecodeType is set on the DecodeContext, then just
-		// return that type.  This gives users an "escape hatch" to avoid the 1-1 embeded document to primitive.D
+		// return that type.  This gives users an "escape hatch" to avoid the 1-1 embedded document to primitive.D
 		// decoding map, but this solution is AON.
 		return *dc.DocumentDecodeType, nil
 	}

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -57,11 +57,18 @@ func (eic EmptyInterfaceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWrit
 
 func (eic EmptyInterfaceCodec) getEmptyInterfaceDecodeType(dc DecodeContext, valueType bsontype.Type) (reflect.Type, error) {
 	isDocument := valueType == bsontype.Type(0) || valueType == bsontype.EmbeddedDocument
-	if isDocument && dc.Ancestor != nil {
+	if isDocument && dc.HasValidAncestor() {
 		// Using ancestor information rather than looking up the type map entry forces consistent decoding.
 		// If we're decoding into a bson.D, subdocuments should also be decoded as bson.D, even if a type map entry
 		// has been registered.
 		return dc.Ancestor, nil
+	}
+
+	if isDocument && dc.DocumentDecodeType != nil {
+		// If the bsontype is an embedded document and the DocumentDecodeType is set on the DecodeContext, then just
+		// return that type.  This gives users an "escape hatch" to avoid the 1-1 embeded document to primitive.D
+		// decoding map, but this solution is AON.
+		return *dc.DocumentDecodeType, nil
 	}
 
 	rtype, err := dc.LookupTypeMapEntry(valueType)

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -173,7 +173,6 @@ func (mc *MapCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val ref
 	}
 	eTypeDecoder, _ := decoder.(typeDecoder)
 
-	// TODO(GODRIVER-2407): Consider removing this.
 	if eType == tEmpty {
 		dc.Ancestor = val.Type()
 	}

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -173,6 +173,7 @@ func (mc *MapCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val ref
 	}
 	eTypeDecoder, _ := decoder.(typeDecoder)
 
+	// TODO(GODRIVER-2407): Consider removing this.
 	if eType == tEmpty {
 		dc.Ancestor = val.Type()
 	}

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -31,8 +31,10 @@ var decPool = sync.Pool{
 // A Decoder reads and decodes BSON documents from a stream. It reads from a bsonrw.ValueReader as
 // the source of BSON data.
 type Decoder struct {
-	dc bsoncodec.DecodeContext
-	vr bsonrw.ValueReader
+	dc               bsoncodec.DecodeContext
+	vr               bsonrw.ValueReader
+	defaultDocumentM bool
+	defaultDocumentD bool
 }
 
 // NewDecoder returns a new decoder that uses the DefaultRegistry to read from vr.
@@ -95,6 +97,12 @@ func (d *Decoder) Decode(val interface{}) error {
 	if err != nil {
 		return err
 	}
+	if d.defaultDocumentM {
+		d.dc.DefaultDocumentM()
+	}
+	if d.defaultDocumentD {
+		d.dc.DefaultDocumentD()
+	}
 	return decoder.DecodeValue(d.dc, d.vr, rval)
 }
 
@@ -114,5 +122,19 @@ func (d *Decoder) SetRegistry(r *bsoncodec.Registry) error {
 // SetContext replaces the current registry of the decoder with dc.
 func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 	d.dc = dc
+	return nil
+}
+
+// DefaultDocumentM will decode empty documents into primitive.M types. This behavior is restricted to data typed as
+// "interface{}" or "map[string]interface{}".
+func (d *Decoder) DefaultDocumentM() error {
+	d.defaultDocumentM = true
+	return nil
+}
+
+// DefaultDocumentD will decode empty documents into primitive.D types.  This behavior is restricted to data typed as
+// "interface{}" or "map[string]interface{}".
+func (d *Decoder) DefaultDocumentD() error {
+	d.defaultDocumentD = true
 	return nil
 }

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -130,14 +130,12 @@ func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 
 // DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
-func (d *Decoder) DefaultDocumentM() error {
+func (d *Decoder) DefaultDocumentM() {
 	d.defaultDocumentM = true
-	return nil
 }
 
 // DefaultDocumentD will decode empty documents using the primitive.D type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
-func (d *Decoder) DefaultDocumentD() error {
+func (d *Decoder) DefaultDocumentD() {
 	d.defaultDocumentD = true
-	return nil
 }

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -31,8 +31,11 @@ var decPool = sync.Pool{
 // A Decoder reads and decodes BSON documents from a stream. It reads from a bsonrw.ValueReader as
 // the source of BSON data.
 type Decoder struct {
-	dc               bsoncodec.DecodeContext
-	vr               bsonrw.ValueReader
+	dc bsoncodec.DecodeContext
+	vr bsonrw.ValueReader
+
+	// We persist defaultDocumentM and defaultDocumentD on the Decoder to prevent overwriting from
+	// (*Decoder).SetContext.
 	defaultDocumentM bool
 	defaultDocumentD bool
 }
@@ -125,14 +128,14 @@ func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 	return nil
 }
 
-// DefaultDocumentM will decode empty documents into primitive.M types. This behavior is restricted to data typed as
+// DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
 func (d *Decoder) DefaultDocumentM() error {
 	d.defaultDocumentM = true
 	return nil
 }
 
-// DefaultDocumentD will decode empty documents into primitive.D types.  This behavior is restricted to data typed as
+// DefaultDocumentD will decode empty documents using the primitive.D type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
 func (d *Decoder) DefaultDocumentD() error {
 	d.defaultDocumentD = true

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -256,11 +256,11 @@ func TestDecoderv2(t *testing.T) {
 		}
 
 		bsonOutType := reflect.TypeOf(bsonOut).String()
-		assert.Equal(t, inType, bsonOutType, "expected '%s' to equal '%s'", inType, bsonOutType)
+		assert.Equal(t, inType, bsonOutType, "expected %v to equal %v", inType, bsonOutType)
 
 		bsonFooOutType := reflect.TypeOf(bsonOut["foo"]).String()
 		documentType := reflect.TypeOf(map[string]interface{}{}).String()
-		assert.Equal(t, documentType, bsonFooOutType, "expected '%s' to equal '%s'", inFooType, bsonFooOutType)
+		assert.Equal(t, documentType, bsonFooOutType, "expected %v to equal %v", inFooType, bsonFooOutType)
 	})
 }
 

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -251,7 +251,9 @@ func TestDecoderv2(t *testing.T) {
 		var bsonOut someMap
 		dc := new(bsoncodec.DecodeContext).SetDocumentDecodeType(reflect.TypeOf(map[string]interface{}{}))
 		dec, _ := NewDecoderWithContext(*dc, bsonrw.NewBSONDocumentReader(bytes))
-		dec.Decode(&bsonOut)
+		if err := dec.Decode(&bsonOut); err != nil {
+			t.Fatal(err)
+		}
 
 		bsonOutType := reflect.TypeOf(bsonOut).String()
 		assert.Equal(t, inType, bsonOutType, "expected '%s' to equal '%s'", inType, bsonOutType)


### PR DESCRIPTION
GODRIVER-2407 

This PR creates a way for a user/client to write a document-type override to the `DecodeContext` per [this JIRA comment](https://jira.mongodb.org/browse/GODRIVER-2407?focusedCommentId=4551812&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4551812).

### Work Around

```go
dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(bytes))
if err != nil {
	t.Fatal(err)
}

// This will default empty interfaces into primitive.D.
dec.DefaultDocumentD()
```

### Long-Term

My understanding is that we would like the encoder/decoder map to be [bijective](https://en.wikipedia.org/wiki/Bijection).

```
        encoder                decoder
go type ───────► bsontype.Type ───────► driver type
```

I believe that the canonical argument for this is that the purpose of a BSON decoder should be to decode BSON and although we support `bson.M` in go, the concept of a BSON Map per se [doesn’t exist](https://bsonspec.org/spec.html).  Maps are documents, despite our driver's extension types.  So to maintain bijectivity in our encoding, we should always enforce that maps encode to documents and documents decode to `primitive.D`.

This could probably be resolved by removing the ancestor logic from the `MapCodec` decoder and updating the tests to reflect that embedded documents map to `primitive.D` in the default case.  

I don't think that the long-term solution proposed here will deprecate the "work around" changes suggested in this PR, having a work around will probably be something we want long-term as well.

