### PR TITLE
GODRIVER-2419 Update FLE 2 Collection Management

### DIFF
--- a/data/client-side-encryption/fle2-CreateCollection.json
+++ b/data/client-side-encryption/fle2-CreateCollection.json
@@ -100,15 +100,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -136,7 +127,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -145,7 +151,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -154,7 +166,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -297,15 +315,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -333,7 +342,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -342,7 +366,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc"
+              "create": "enxcol_.encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -351,7 +381,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecoc"
+              "create": "enxcol_.encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -537,15 +573,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -573,7 +600,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -582,7 +624,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc"
+              "create": "enxcol_.encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -591,7 +639,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecoc"
+              "create": "enxcol_.encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -646,15 +700,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -674,6 +719,15 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -787,15 +841,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -823,7 +868,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -832,7 +892,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -841,7 +907,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1066,15 +1138,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1102,7 +1165,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1111,7 +1189,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1120,7 +1204,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1275,15 +1365,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1311,7 +1392,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1320,7 +1416,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1329,7 +1431,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1421,15 +1529,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1449,6 +1548,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1617,15 +1725,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1653,7 +1752,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1662,7 +1776,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1671,7 +1791,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1723,15 +1849,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1751,6 +1868,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1902,15 +2028,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1938,7 +2055,22 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "drop": "encryptedCollection"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1947,7 +2079,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1956,7 +2094,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -2020,15 +2164,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -2048,6 +2183,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"

--- a/data/client-side-encryption/fle2-CreateCollection.yml
+++ b/data/client-side-encryption/fle2-CreateCollection.yml
@@ -67,11 +67,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -85,22 +80,30 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -183,11 +186,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -201,22 +199,30 @@ tests:
               drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -324,11 +330,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -342,22 +343,30 @@ tests:
               drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -380,11 +389,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -396,6 +400,11 @@ tests:
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -471,11 +480,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -489,22 +493,30 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -637,11 +649,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -655,22 +662,30 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -760,11 +775,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -778,22 +788,30 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -841,11 +859,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -857,6 +870,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -966,11 +984,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -984,21 +997,29 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
@@ -1020,11 +1041,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1036,6 +1052,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -1136,11 +1157,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1154,21 +1170,29 @@ tests:
               drop: "encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
@@ -1196,11 +1220,6 @@ tests:
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1212,6 +1231,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1760,10 +1760,6 @@ func (coll *Collection) dropEncryptedCollection(ctx context.Context, ef interfac
 		return fmt.Errorf("error transforming document: %v", err)
 	}
 
-	// Drop the data collection.
-	if err := coll.drop(ctx); err != nil {
-		return err
-	}
 	// Drop the three encryption-related, associated collections: `escCollection`, `eccCollection` and `ecocCollection`.
 	// Drop ESCCollection.
 	escCollection, err := getEncryptedStateCollectionName(efBSON, coll.name, "esc")
@@ -1789,6 +1785,11 @@ func (coll *Collection) dropEncryptedCollection(ctx context.Context, ef interfac
 		return err
 	}
 	if err := coll.db.Collection(ecocCollection).drop(ctx); err != nil {
+		return err
+	}
+
+	// Drop the data collection.
+	if err := coll.drop(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -423,13 +423,13 @@ func TestFLE2CreateCollection(t *testing.T) {
 	mt.Run("CreateCollection from encryptedFields", func(mt *mtest.T) {
 		// Drop data and state collections to clean up from a prior test run.
 		{
-			err := mt.DB.Collection("coll").Drop(context.Background())
-			assert.Nil(mt, err, "error in Drop: %v", err)
 			err = mt.DB.Collection("encryptedCollection.esc").Drop(context.Background())
 			assert.Nil(mt, err, "error in Drop: %v", err)
 			err = mt.DB.Collection("encryptedCollection.ecc").Drop(context.Background())
 			assert.Nil(mt, err, "error in Drop: %v", err)
 			err = mt.DB.Collection("encryptedCollection.ecoc").Drop(context.Background())
+			assert.Nil(mt, err, "error in Drop: %v", err)
+			err := mt.DB.Collection("coll").Drop(context.Background())
 			assert.Nil(mt, err, "error in Drop: %v", err)
 		}
 

--- a/mongo/options/createcollectionoptions.go
+++ b/mongo/options/createcollectionoptions.go
@@ -136,6 +136,11 @@ type CreateCollectionOptions struct {
 	//
 	// This option is only valid for MongoDB versions >= 6.0
 	EncryptedFields interface{}
+
+	// ClusteredIndex is used to create a collection with a clustered index.
+	//
+	// This option is only valid for MongoDB versions >= 5.3
+	ClusteredIndex interface{}
 }
 
 // CreateCollection creates a new CreateCollectionOptions instance.
@@ -221,6 +226,12 @@ func (c *CreateCollectionOptions) SetEncryptedFields(encryptedFields interface{}
 	return c
 }
 
+// SetClusteredIndex sets the value for the ClusteredIndex field.
+func (c *CreateCollectionOptions) SetClusteredIndex(clusteredIndex interface{}) *CreateCollectionOptions {
+	c.ClusteredIndex = clusteredIndex
+	return c
+}
+
 // MergeCreateCollectionOptions combines the given CreateCollectionOptions instances into a single
 // CreateCollectionOptions in a last-one-wins fashion.
 func MergeCreateCollectionOptions(opts ...*CreateCollectionOptions) *CreateCollectionOptions {
@@ -269,6 +280,9 @@ func MergeCreateCollectionOptions(opts ...*CreateCollectionOptions) *CreateColle
 		}
 		if opt.EncryptedFields != nil {
 			cc.EncryptedFields = opt.EncryptedFields
+		}
+		if opt.ClusteredIndex != nil {
+			cc.ClusteredIndex = opt.ClusteredIndex
 		}
 	}
 

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -45,6 +45,7 @@ type Create struct {
 	expireAfterSeconds           *int64
 	timeSeries                   bsoncore.Document
 	encryptedFields              bsoncore.Document
+	clusteredIndex               bsoncore.Document
 }
 
 // NewCreate constructs and returns a new Create.
@@ -131,6 +132,9 @@ func (c *Create) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	}
 	if c.encryptedFields != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "encryptedFields", c.encryptedFields)
+	}
+	if c.clusteredIndex != nil {
+		dst = bsoncore.AppendDocumentElement(dst, "clusteredIndex", c.clusteredIndex)
 	}
 	return dst, nil
 }
@@ -384,5 +388,15 @@ func (c *Create) EncryptedFields(ef bsoncore.Document) *Create {
 	}
 
 	c.encryptedFields = ef
+	return c
+}
+
+// ClusteredIndex sets the ClusteredIndex option for this operation.
+func (c *Create) ClusteredIndex(ci bsoncore.Document) *Create {
+	if c == nil {
+		c = new(Create)
+	}
+
+	c.clusteredIndex = ci
 	return c
 }


### PR DESCRIPTION
# Summary
- Add ClusteredIndex option to CreateCollectionOptions
- Create FLE 2 state collections with `ClusteredIndex` option.
- Drop FLE 2 data collection after state collections.

# Background & Motivation
Please see the specification change: https://github.com/mongodb/specifications/pull/1215

ClusteredIndex option to CreateCollectionOptions is part of GODRIVER-2383. It is only added to CreateCollectionOptions to unblock this change.