### PR TITLE
GODRIVER-2398 use CreateCollection() and CreateView() in mtest

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -387,9 +387,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		// create view on db.coll
 		mt.CreateCollection(mtest.Collection{
-			Name:       "view",
-			DB:         cpt.cseColl.Database().Name(),
-			CreateOpts: bson.D{{"viewOn", "coll"}},
+			Name:         "view",
+			DB:           cpt.cseColl.Database().Name(),
+			ViewOn:       "coll",
+			ViewPipeline: mongo.Pipeline{},
 		}, true)
 
 		view := cpt.cseColl.Database().Collection("view")

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -311,7 +311,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
 			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
+			cappedOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",
 				CreateOpts: cappedOpts,
@@ -380,7 +380,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write error", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
 			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
+			cappedOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteMany_capped",
 				CreateOpts: cappedOpts,
@@ -1531,7 +1531,7 @@ func TestCollection(t *testing.T) {
 			// behavior to test the processing of write errors.
 			doc := mongo.NewDeleteOneModel().SetFilter(bson.D{{"x", 1}})
 			models := []mongo.WriteModel{doc, doc}
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
+			cappedOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "delete_write_errors",
 				CreateOpts: cappedOpts,
@@ -1628,7 +1628,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("unordered writeError index", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
 			// Deletes are not allowed on capped collections on MongoDB 5.0.6-. We use this
 			// behavior to test the processing of write errors.
-			cappedOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
+			cappedOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 			capped := mt.CreateCollection(mtest.Collection{
 				Name:       "deleteOne_capped",
 				CreateOpts: cappedOpts,

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -130,20 +130,19 @@ func TestWriteErrorsDetails(t *testing.T) {
 		// Create a JSON Schema validator document that requires properties "a" and "b". Use it in
 		// the collection creation options so that collections created for subtests have the JSON
 		// Schema validator applied.
-		validator := bson.D{{
-			Key: "validator",
-			Value: bson.M{
-				"$jsonSchema": bson.M{
-					"bsonType": "object",
-					"required": []string{"a", "b"},
-					"properties": bson.M{
-						"a": bson.M{"bsonType": "string"},
-						"b": bson.M{"bsonType": "int"},
-					},
+		validator := bson.M{
+			"$jsonSchema": bson.M{
+				"bsonType": "object",
+				"required": []string{"a", "b"},
+				"properties": bson.M{
+					"a": bson.M{"bsonType": "string"},
+					"b": bson.M{"bsonType": "int"},
 				},
 			},
-		}}
-		validatorOpts := mtest.NewOptions().CollectionCreateOptions(validator)
+		}
+
+		cco := options.CreateCollection().SetValidator(validator)
+		validatorOpts := mtest.NewOptions().CollectionCreateOptions(cco)
 
 		cases := []struct {
 			desc                string

--- a/mongo/integration/cursor_test.go
+++ b/mongo/integration/cursor_test.go
@@ -26,7 +26,7 @@ const (
 func TestCursor(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
 	defer mt.Close()
-	cappedCollectionOpts := bson.D{{"capped", true}, {"size", 64 * 1024}}
+	cappedCollectionOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 
 	// Server versions 2.6 and 3.0 use OP_GET_MORE so this works on >= 3.2 and when RequireAPIVersion is false;
 	// getMore cannot be sent with RunCommand as server API options will be attached when they should not be.

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -199,7 +199,7 @@ func TestDatabase(t *testing.T) {
 					mt.CreateCollection(mtest.Collection{Name: listCollUncapped}, true)
 					mt.CreateCollection(mtest.Collection{
 						Name:       listCollCapped,
-						CreateOpts: bson.D{{"capped", true}, {"size", 64 * 1024}},
+						CreateOpts: options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024),
 					}, true)
 
 					filter := bson.D{}
@@ -281,11 +281,8 @@ func TestDatabase(t *testing.T) {
 			// Test that ListCollectionSpecifications correctly uses the supplied filter.
 			cappedName := "list-collection-specs-capped"
 			mt.CreateCollection(mtest.Collection{
-				Name: cappedName,
-				CreateOpts: bson.D{
-					{"capped", true},
-					{"size", 4096},
-				},
+				Name:       cappedName,
+				CreateOpts: options.CreateCollection().SetCapped(true).SetSizeInBytes(4096),
 			}, true)
 
 			filter := bson.M{

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -449,7 +449,8 @@ func (t *T) CreateCollection(coll Collection, createOnServer bool) *mongo.Collec
 			err = db.CreateCollection(context.Background(), coll.Name, coll.CreateOpts)
 		}
 
-		if err != nil {
+		// ignore ErrUnacknowledgedWrite. Client may be configured with unacknowledged write concern.
+		if err != nil && err != driver.ErrUnacknowledgedWrite {
 			// ignore NamespaceExists errors for idempotency
 
 			cmdErr, ok := err.(mongo.CommandError)

--- a/mongo/integration/mtest/options.go
+++ b/mongo/integration/mtest/options.go
@@ -117,10 +117,8 @@ func NewOptions() *Options {
 	return &Options{}
 }
 
-// CollectionCreateOptions sets the options to pass to the create command when creating a collection for a test.
-// For example, if opts = {"capped": "true"}, the create command sent to the server will be
-// {create: <collectionName>, foo: bar}.
-func (op *Options) CollectionCreateOptions(opts bson.D) *Options {
+// CollectionCreateOptions sets the options to pass to Database.CreateCollection() when creating a collection for a test.
+func (op *Options) CollectionCreateOptions(opts *options.CreateCollectionOptions) *Options {
 	op.optFuncs = append(op.optFuncs, func(t *T) {
 		t.collCreateOpts = opts
 	})

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -236,9 +236,7 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		validator := bson.D{
 			{"$jsonSchema", testFile.JSONSchema},
 		}
-		opts.CollectionCreateOptions(bson.D{
-			{"validator", validator},
-		})
+		opts.CollectionCreateOptions(options.CreateCollection().SetValidator(validator))
 	}
 
 	// Start the test without setting client options so the setup will be done with a default client.


### PR DESCRIPTION
GODRIVER-2398

# Summary

This is a test refactor with no functional changes.

- Use `CreateCollection()` and `CreateView()`, not `RunCommand()` to create test collections in mtest.

# Background & Motivation

This is motivated by upcoming CSFLE specification tests of GODRIVER-2398. The `EncryptedFields` option is handled in the `Database.CreateCollection()` helper.

