### PR TITLE
GODRIVER-2411 Allow loading the new crypt_shared library.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -500,7 +500,7 @@ functions:
 
           # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
           # find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
-          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
             echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
             exit 1
           fi

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -489,18 +489,17 @@ functions:
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
 
-          # Find the crypt_shared library file in the current directory and set the
-          # CRYPT_SHARED_LIB_PATH to the path of that file. Only look for .so, .dll, or .dylib files
-          # to prevent matching any other downloaded files.
+          # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
+          # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
+          # downloaded files.
           export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
             -name 'mongo_crypt_v1.so' -o \
             -name 'mongo_crypt_v1.dll' -o \
             -name 'mongo_crypt_v1.dylib')"
           echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
 
-          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we
-          # always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment
-          # variable.
+          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
+          # find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
           if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
             echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
             exit 1

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -12,6 +12,9 @@ stepback: true
 # Actual testing tasks are marked with `type: test`
 command_type: setup
 
+# Fail builds when pre tasks fail.
+pre_error_fails_task: true
+
 # Protect ourself against rogue test case, or curl gone wild, that runs forever
 # 12 minutes is the longest we'll ever run
 exec_timeout_secs: 3600 # 12 minutes is the longest we'll ever run
@@ -159,6 +162,32 @@ functions:
           # initialize submodules
           git submodule init
           git submodule update
+    - command: shell.exec
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+
+          # Skip the csfle library download if there is no csfle build for the current platform.
+          # Don't try to determine this automatically to prevent misconfiguration errors from
+          # silently skipping the csfle download and changing the testing conditions.
+          if [ "${SKIP_CSFLE_DOWNLOAD}" = "true" ]; then
+            echo "There is no csfle library for this platform, skipping download..."
+            exit 0
+          fi
+
+          # Download the csfle dynamic library for the current platform to the current working
+          # directory. The run-tests.sh and versioned API test scripts expect to find a
+          # mongo_csfle_v1.* file in the "src/go.mongodb.org/mongo-driver" working directory.
+          # TODO(GODRIVER-2437): Update version to "latest-stable" once the csfle library has a
+          # feature-complete stable release.
+          ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            --component csfle \
+            --version latest \
+            --edition enterprise \
+            --out "$(pwd)" \
+            --only "**/mongo_csfle_v1.*" \
+            --strip-path-components 1
 
   install-linters:
     - command: shell.exec
@@ -274,8 +303,8 @@ functions:
             cat $i | tr -d '\r' > $i.new
             mv $i.new $i
           done
-          # Copy client certificate because symlinks do not work on Windows.
-          cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem
+          # Copy client certificate because symlinks do not work on Windows. Ignore any copy errors.
+          cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem || echo "Ignoring copy error"
 
   make-files-executable:
     - command: shell.exec
@@ -459,6 +488,14 @@ functions:
             export PYTHON="$(pwd)/venv/bin/python"
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
+
+          # Find the csfle library file in the current directory and set the CSFLE_PATH to the path of that
+          # file. Only look for .so, .dll, or .dylib files to prevent matching any other downloaded files.
+          export CSFLE_PATH="$(find $(pwd) -maxdepth 1 -type f \
+            -name 'mongo_csfle_v1.so' -o \
+            -name 'mongo_csfle_v1.dll' -o \
+            -name 'mongo_csfle_v1.dylib')"
+          echo "CSFLE_PATH=$CSFLE_PATH"
 
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
@@ -652,7 +689,9 @@ functions:
     - command: shell.exec
       params:
         script: |
-          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop
+          # Attempt to shut down a running load balancer. Ignore any errors that happen if the load
+          # balancer is not running.
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop || echo "Ignoring load balancer stop error"
 
   add-aws-auth-variables-to-file:
     - command: shell.exec
@@ -1916,6 +1955,9 @@ axes:
           # to prevent attempting to link the client-side encryption (libmongocrypt) binaries when
           # running Go tests.
           GO_BUILD_TAGS: ""
+          # There is no csfle library download for Ubuntu 14.04. Skip downloading it and let the
+          # tests use mongocryptd instead.
+          SKIP_CSFLE_DOWNLOAD: "true"
 
   # OSes that require >= 3.2 for SSL
   - id: os-ssl-32
@@ -1936,6 +1978,9 @@ axes:
         variables:
           GO_DIST: "/opt/golang/go1.17"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
+          # There is no csfle library download for Ubuntu 16.04. Skip downloading it and let the
+          # tests use mongocryptd instead.
+          SKIP_CSFLE_DOWNLOAD: "true"
       - id: "osx-go-1-17"
         display_name: "MacOS 10.14"
         run_on: macos-1014

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -185,7 +185,7 @@ functions:
             --component crypt_shared \
             --version latest \
             --edition enterprise \
-            --out "$(pwd)" \
+            --out . \
             --only "**/mongo_crypt_v1.*" \
             --strip-path-components 1
 
@@ -489,20 +489,31 @@ functions:
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
 
-          # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
-          # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
-          # downloaded files.
-          export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-            -name 'mongo_crypt_v1.so' -o \
-            -name 'mongo_crypt_v1.dll' -o \
-            -name 'mongo_crypt_v1.dylib')"
-          echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
+          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, try to find the
+          # crypt_shared library downloaded in the "prepare-resources" task and set the CRYPT_SHARED_LIB_PATH
+          # environment variable with a path to the file.
+          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ]; then
+            # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
+            # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
+            # downloaded files.
+            export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+              -name 'mongo_crypt_v1.so' -o \
+              -name 'mongo_crypt_v1.dll' -o \
+              -name 'mongo_crypt_v1.dylib')"
 
-          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
-          # find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
-          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-            echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-            exit 1
+            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+            # environment variable. If we didn't, print an error message and exit.
+            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+              echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+              exit 1
+            fi
+
+            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+            if [ "Windows_NT" = "$OS" ]; then
+                export CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+            fi
+
+            echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
           fi
 
           export GOFLAGS=-mod=vendor

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -168,25 +168,25 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
-          # Skip the csfle library download if there is no csfle build for the current platform.
-          # Don't try to determine this automatically to prevent misconfiguration errors from
-          # silently skipping the csfle download and changing the testing conditions.
-          if [ "${SKIP_CSFLE_DOWNLOAD}" = "true" ]; then
-            echo "There is no csfle library for this platform, skipping download..."
+          # Skip the crypt_shared library download if there is no crypt_shared build for the current
+          # platform. Don't try to determine this automatically to prevent misconfiguration errors
+          # from silently skipping the crypt_shared download and changing the testing conditions.
+          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" = "true" ]; then
+            echo "There is no crypt_shared library for this platform, skipping download..."
             exit 0
           fi
 
-          # Download the csfle dynamic library for the current platform to the current working
+          # Download the crypt_shared dynamic library for the current platform to the current working
           # directory. The run-tests.sh and versioned API test scripts expect to find a
-          # mongo_csfle_v1.* file in the "src/go.mongodb.org/mongo-driver" working directory.
-          # TODO(GODRIVER-2437): Update version to "latest-stable" once the csfle library has a
+          # mongo_crypt_v1.* file in the "src/go.mongodb.org/mongo-driver" working directory.
+          # TODO(GODRIVER-2437): Update version to "latest-stable" once the crypt_shared library has a
           # feature-complete stable release.
           ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
-            --component csfle \
+            --component crypt_shared \
             --version latest \
             --edition enterprise \
             --out "$(pwd)" \
-            --only "**/mongo_csfle_v1.*" \
+            --only "**/mongo_crypt_v1.*" \
             --strip-path-components 1
 
   install-linters:
@@ -489,18 +489,20 @@ functions:
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
 
-          # Find the csfle library file in the current directory and set the CSFLE_PATH to the path of that
-          # file. Only look for .so, .dll, or .dylib files to prevent matching any other downloaded files.
-          export CSFLE_PATH="$(find $(pwd) -maxdepth 1 -type f \
-            -name 'mongo_csfle_v1.so' -o \
-            -name 'mongo_csfle_v1.dll' -o \
-            -name 'mongo_csfle_v1.dylib')"
-          echo "CSFLE_PATH=$CSFLE_PATH"
+          # Find the crypt_shared library file in the current directory and set the
+          # CRYPT_SHARED_LIB_PATH to the path of that file. Only look for .so, .dll, or .dylib files
+          # to prevent matching any other downloaded files.
+          export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+            -name 'mongo_crypt_v1.so' -o \
+            -name 'mongo_crypt_v1.dll' -o \
+            -name 'mongo_crypt_v1.dylib')"
+          echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
 
-          # If the task doesn't have the SKIP_CSFLE_DOWNLOAD variable set, expect that we always find a csfle
-          # library file and set the CSFLE_PATH environment variable.
-          if [ "${SKIP_CSFLE_DOWNLOAD}" != "true" ] && [ -z "${CSFLE_PATH}" ]; then
-            echo 'SKIP_CSFLE_DOWNLOAD is not "true", but CSFLE_PATH is empty. Exiting.'
+          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we
+          # always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment
+          # variable.
+          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+            echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
             exit 1
           fi
 
@@ -1962,9 +1964,9 @@ axes:
           # to prevent attempting to link the client-side encryption (libmongocrypt) binaries when
           # running Go tests.
           GO_BUILD_TAGS: ""
-          # There is no csfle library download for Ubuntu 14.04. Skip downloading it and let the
+          # There is no crypt_shared library download for Ubuntu 14.04. Skip downloading it and let the
           # tests use mongocryptd instead.
-          SKIP_CSFLE_DOWNLOAD: "true"
+          SKIP_CRYPT_SHARED_LIB_DOWNLOAD: "true"
 
   # OSes that require >= 3.2 for SSL
   - id: os-ssl-32
@@ -1985,9 +1987,9 @@ axes:
         variables:
           GO_DIST: "/opt/golang/go1.17"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
-          # There is no csfle library download for Ubuntu 16.04. Skip downloading it and let the
+          # There is no crypt_shared library download for Ubuntu 16.04. Skip downloading it and let the
           # tests use mongocryptd instead.
-          SKIP_CSFLE_DOWNLOAD: "true"
+          SKIP_CRYPT_SHARED_LIB_DOWNLOAD: "true"
       - id: "osx-go-1-17"
         display_name: "MacOS 10.14"
         run_on: macos-1014

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -497,6 +497,13 @@ functions:
             -name 'mongo_csfle_v1.dylib')"
           echo "CSFLE_PATH=$CSFLE_PATH"
 
+          # If the task doesn't have the SKIP_CSFLE_DOWNLOAD variable set, expect that we always find a csfle
+          # library file and set the CSFLE_PATH environment variable.
+          if [ "${SKIP_CSFLE_DOWNLOAD}" != "true" ] && [ -z "${CSFLE_PATH}" ]; then
+            echo 'SKIP_CSFLE_DOWNLOAD is not "true", but CSFLE_PATH is empty. Exiting.'
+            exit 1
+          fi
+
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
           SSL="${SSL}" \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -84,6 +84,14 @@ if [ -z ${GO_BUILD_TAGS+x} ]; then
   GO_BUILD_TAGS="cse"
 fi
 
+# Find the csfle library file in the current directory and set the CSFLE_PATH to the path of that
+# file. Only look for .so, .dll, or .dylib files to prevent matching any other downloaded files.
+export CSFLE_PATH="$(find $(pwd) -maxdepth 1 -type f \
+  -name 'mongo_csfle_v1.so' -o \
+  -name 'mongo_csfle_v1.dll' -o \
+  -name 'mongo_csfle_v1.dylib')"
+echo "CSFLE_PATH=$CSFLE_PATH"
+
 AUTH=${AUTH} \
 SSL=${SSL} \
 MONGO_GO_DRIVER_CA_FILE=${MONGO_GO_DRIVER_CA_FILE} \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -92,6 +92,13 @@ export CSFLE_PATH="$(find $(pwd) -maxdepth 1 -type f \
   -name 'mongo_csfle_v1.dylib')"
 echo "CSFLE_PATH=$CSFLE_PATH"
 
+# If the task doesn't have the SKIP_CSFLE_DOWNLOAD variable set, expect that we always find a csfle
+# library file and set the CSFLE_PATH environment variable.
+if [ "${SKIP_CSFLE_DOWNLOAD}" != "true" ] && [ -z "${CSFLE_PATH}" ]; then
+  echo 'SKIP_CSFLE_DOWNLOAD is not "true", but CSFLE_PATH is empty. Exiting.'
+  exit 1
+fi
+
 AUTH=${AUTH} \
 SSL=${SSL} \
 MONGO_GO_DRIVER_CA_FILE=${MONGO_GO_DRIVER_CA_FILE} \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -84,20 +84,31 @@ if [ -z ${GO_BUILD_TAGS+x} ]; then
   GO_BUILD_TAGS="cse"
 fi
 
-# Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
-# the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
-# downloaded files.
-export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-  -name 'mongo_crypt_v1.so' -o \
-  -name 'mongo_crypt_v1.dll' -o \
-  -name 'mongo_crypt_v1.dylib')"
-echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
+# If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, try to find the
+# crypt_shared library downloaded in the "prepare-resources" task and set the CRYPT_SHARED_LIB_PATH
+# environment variable with a path to the file.
+if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ]; then
+  # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
+  # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
+  # downloaded files.
+  export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+    -name 'mongo_crypt_v1.so' -o \
+    -name 'mongo_crypt_v1.dll' -o \
+    -name 'mongo_crypt_v1.dylib')"
 
-# If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
-# find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
-if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-  echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-  exit 1
+  # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+  # environment variable. If we didn't, print an error message and exit.
+  if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+    echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+    exit 1
+  fi
+
+  # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+  if [ "Windows_NT" = "$OS" ]; then
+      export CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+  fi
+
+  echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
 fi
 
 AUTH=${AUTH} \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -84,18 +84,19 @@ if [ -z ${GO_BUILD_TAGS+x} ]; then
   GO_BUILD_TAGS="cse"
 fi
 
-# Find the csfle library file in the current directory and set the CSFLE_PATH to the path of that
-# file. Only look for .so, .dll, or .dylib files to prevent matching any other downloaded files.
-export CSFLE_PATH="$(find $(pwd) -maxdepth 1 -type f \
-  -name 'mongo_csfle_v1.so' -o \
-  -name 'mongo_csfle_v1.dll' -o \
-  -name 'mongo_csfle_v1.dylib')"
-echo "CSFLE_PATH=$CSFLE_PATH"
+# Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
+# the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
+# downloaded files.
+export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+  -name 'mongo_crypt_v1.so' -o \
+  -name 'mongo_crypt_v1.dll' -o \
+  -name 'mongo_crypt_v1.dylib')"
+echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
 
-# If the task doesn't have the SKIP_CSFLE_DOWNLOAD variable set, expect that we always find a csfle
-# library file and set the CSFLE_PATH environment variable.
-if [ "${SKIP_CSFLE_DOWNLOAD}" != "true" ] && [ -z "${CSFLE_PATH}" ]; then
-  echo 'SKIP_CSFLE_DOWNLOAD is not "true", but CSFLE_PATH is empty. Exiting.'
+# If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
+# find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
+if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+  echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
   exit 1
 fi
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -95,7 +95,7 @@ echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
 
 # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, expect that we always
 # find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH environment variable.
-if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ] && [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
   echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
   exit 1
 fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,9 +98,11 @@ issues:
       linters:
         - unused
         - structcheck
-    # Disable "unused" linter for "crypt.go" because the linter doesn't work correctly without
-    # enabling CGO.
-    - path: x/mongo/driver/crypt.go
+    # Disable "unused" linter for code files that depend on the "mongocrypt.MongoCrypt" type because
+    # the linter build doesn't work correctly with CGO enabled. As a result, all calls to a
+    # "mongocrypt.MongoCrypt" API appear to always panic (see mongocrypt_not_enabled.go), leading
+    # to confusing messages about unused code.
+    - path: x/mongo/driver/crypt.go|mongo/(crypt_retrievers|mongocryptd).go
       linters:
         - unused
     # Ignore "TLS MinVersion too low", "TLS InsecureSkipVerify set true", and "Use of weak random

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -26,6 +26,8 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/auth"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt"
+	mcopts "go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/ocsp"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
@@ -71,7 +73,7 @@ type Client struct {
 	// client-side encryption fields
 	keyVaultClientFLE  *Client
 	keyVaultCollFLE    *Collection
-	mongocryptdFLE     *mcryptClient
+	mongocryptdFLE     *mongocryptdClient
 	cryptFLE           driver.Crypt
 	metadataClientFLE  *Client
 	internalClientFLE  *Client
@@ -720,10 +722,23 @@ func (c *Client) configureAutoEncryption(clientOpts *options.ClientOptions) erro
 	if err := c.configureMetadataClientFLE(clientOpts); err != nil {
 		return err
 	}
-	if err := c.configureMongocryptdClientFLE(clientOpts.AutoEncryptionOptions); err != nil {
+
+	mc, err := c.newMongoCrypt(clientOpts.AutoEncryptionOptions)
+	if err != nil {
 		return err
 	}
-	return c.configureCryptFLE(clientOpts.AutoEncryptionOptions)
+
+	// If csfle was loaded successfully, signal to the mongocryptd client creator that the csfle
+	// library is available so it can bypass spawning mongocryptd.
+	csfleAvailable := mc.CSFLEVersionString() != ""
+	mongocryptdFLE, err := newMongocryptdClient(csfleAvailable, clientOpts.AutoEncryptionOptions)
+	if err != nil {
+		return err
+	}
+	c.mongocryptdFLE = mongocryptdFLE
+
+	c.configureCryptFLE(mc, clientOpts.AutoEncryptionOptions)
+	return nil
 }
 
 func (c *Client) getOrCreateInternalClient(clientOpts *options.ClientOptions) (*Client, error) {
@@ -778,19 +793,13 @@ func (c *Client) configureMetadataClientFLE(clientOpts *options.ClientOptions) e
 	return err
 }
 
-func (c *Client) configureMongocryptdClientFLE(opts *options.AutoEncryptionOptions) error {
-	var err error
-	c.mongocryptdFLE, err = newMcryptClient(opts)
-	return err
-}
-
-func (c *Client) configureCryptFLE(opts *options.AutoEncryptionOptions) error {
+func (c *Client) newMongoCrypt(opts *options.AutoEncryptionOptions) (*mongocrypt.MongoCrypt, error) {
 	// convert schemas in SchemaMap to bsoncore documents
 	cryptSchemaMap := make(map[string]bsoncore.Document)
 	for k, v := range opts.SchemaMap {
 		schema, err := transformBsoncoreDocument(c.registry, v, true, "schemaMap")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		cryptSchemaMap[k] = schema
 	}
@@ -800,21 +809,71 @@ func (c *Client) configureCryptFLE(opts *options.AutoEncryptionOptions) error {
 	for k, v := range opts.EncryptedFieldsMap {
 		encryptedFields, err := transformBsoncoreDocument(c.registry, v, true, "encryptedFieldsMap")
 		if err != nil {
-			return err
+			return nil, err
 		}
 		cryptEncryptedFieldsMap[k] = encryptedFields
 	}
 
 	kmsProviders, err := transformBsoncoreDocument(c.registry, opts.KmsProviders, true, "kmsProviders")
 	if err != nil {
-		return fmt.Errorf("error creating KMS providers document: %v", err)
+		return nil, fmt.Errorf("error creating KMS providers document: %v", err)
 	}
 
-	// configure options
-	var bypass bool
-	if opts.BypassAutoEncryption != nil {
-		bypass = *opts.BypassAutoEncryption
+	// Set the csfle library override path from the "csflePath" extra option if one was set.
+	csflePath := ""
+	if val, ok := opts.ExtraOptions["csflePath"]; ok {
+		str, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf(`expected AutoEncryption extra option "csflePath" to be a string, but is a %T`, val)
+		}
+		csflePath = str
 	}
+
+	// Explicitly disable loading the csfle library if requested. Note that this is ONLY intended
+	// for use from tests; there is no supported public API for explicitly disabling loading the
+	// csfle library.
+	csfleDisabled := false
+	if v, ok := opts.ExtraOptions["__csfleDisabledForTestOnly"]; ok {
+		csfleDisabled = v.(bool)
+	}
+
+	bypassAutoEncryption := opts.BypassAutoEncryption != nil && *opts.BypassAutoEncryption
+	bypassQueryAnalysis := opts.BypassQueryAnalysis != nil && *opts.BypassQueryAnalysis
+
+	mc, err := mongocrypt.NewMongoCrypt(mcopts.MongoCrypt().
+		SetKmsProviders(kmsProviders).
+		SetLocalSchemaMap(cryptSchemaMap).
+		SetBypassQueryAnalysis(bypassQueryAnalysis).
+		SetEncryptedFieldsMap(cryptEncryptedFieldsMap).
+		SetCSFLEDisabled(csfleDisabled || bypassAutoEncryption).
+		SetCSFLEOverridePath(csflePath))
+	if err != nil {
+		return nil, err
+	}
+
+	var csfleRequired bool
+	if val, ok := opts.ExtraOptions["csfleRequired"]; ok {
+		b, ok := val.(bool)
+		if !ok {
+			return nil, fmt.Errorf(`expected AutoEncryption extra option "csfleRequired" to be a bool, but is a %T`, val)
+		}
+		csfleRequired = b
+	}
+
+	// If the "csfleRequired" extra option is set to true, check the MongoCrypt version string to
+	// confirm that the library was successfully loaded. If the version string is empty, return an
+	// error indicating that we couldn't load the CSFLE library.
+	if csfleRequired && mc.CSFLEVersionString() == "" {
+		return nil, errors.New(
+			`AutoEncryption extra option "csfleRequired" is true, but we failed to load the csfle library`)
+	}
+
+	return mc, nil
+}
+
+//nolint:unused // the unused linter thinks that this function is unreachable because "c.newMongoCrypt" always panics without the "cse" build tag set.
+func (c *Client) configureCryptFLE(mc *mongocrypt.MongoCrypt, opts *options.AutoEncryptionOptions) {
+	bypass := opts.BypassAutoEncryption != nil && *opts.BypassAutoEncryption
 	kr := keyRetriever{coll: c.keyVaultCollFLE}
 	var cir collInfoRetriever
 	// If bypass is true, c.metadataClientFLE is nil and the collInfoRetriever
@@ -824,20 +883,14 @@ func (c *Client) configureCryptFLE(opts *options.AutoEncryptionOptions) error {
 		cir = collInfoRetriever{client: c.metadataClientFLE}
 	}
 
-	cryptOpts := &driver.CryptOptions{
+	c.cryptFLE = driver.NewCrypt(&driver.CryptOptions{
+		MongoCrypt:           mc,
 		CollInfoFn:           cir.cryptCollInfo,
 		KeyFn:                kr.cryptKeys,
 		MarkFn:               c.mongocryptdFLE.markCommand,
-		KmsProviders:         kmsProviders,
 		TLSConfig:            opts.TLSConfig,
 		BypassAutoEncryption: bypass,
-		SchemaMap:            cryptSchemaMap,
-		BypassQueryAnalysis:  opts.BypassQueryAnalysis != nil && *opts.BypassQueryAnalysis,
-		EncryptedFieldsMap:   cryptEncryptedFieldsMap,
-	}
-
-	c.cryptFLE, err = driver.NewCrypt(cryptOpts)
-	return err
+	})
 }
 
 // validSession returns an error if the session doesn't belong to the client

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -50,10 +50,10 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 
 	mc, err := mongocrypt.NewMongoCrypt(mcopts.MongoCrypt().
 		SetKmsProviders(kmsProviders).
-		// Explicitly disable loading the csfle library for the Crypt used for ClientEncryption
-		// because it's only need for AutoEncryption and we don't expect users to have the csfle
-		// library installed if they're using ClientEncryption.
-		SetCSFLEDisabled(true))
+		// Explicitly disable loading the crypt_shared library for the Crypt used for
+		// ClientEncryption because it's only needed for AutoEncryption and we don't expect users to
+		// have the crypt_shared library installed if they're using ClientEncryption.
+		SetCryptSharedLibDisabled(true))
 	if err != nil {
 		return nil, err
 	}

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -474,23 +474,23 @@ func TestClient(t *testing.T) {
 				"unexpected modification to serverAPI; expected %v, got %v", convertedAPIOptions, client.serverAPI)
 		})
 	})
-	t.Run("mongocryptd or csfle", func(t *testing.T) {
-		csflePath := os.Getenv("CSFLE_PATH")
-		if csflePath == "" {
-			t.Skip("CSFLE_PATH not set, skipping")
+	t.Run("mongocryptd or crypt_shared", func(t *testing.T) {
+		cryptSharedLibPath := os.Getenv("CRYPT_SHARED_LIB_PATH")
+		if cryptSharedLibPath == "" {
+			t.Skip("CRYPT_SHARED_LIB_PATH not set, skipping")
 		}
 
 		testCases := []struct {
-			description string
-			useCSFLE    bool
+			description       string
+			useCryptSharedLib bool
 		}{
 			{
-				description: "when csfle is loaded, should not attempt to spawn mongocryptd",
-				useCSFLE:    true,
+				description:       "when crypt_shared is loaded, should not attempt to spawn mongocryptd",
+				useCryptSharedLib: true,
 			},
 			{
-				description: "when csfle is not loaded, should attempt to spawn mongocryptd",
-				useCSFLE:    false,
+				description:       "when crypt_shared is not loaded, should attempt to spawn mongocryptd",
+				useCryptSharedLib: false,
 			},
 		}
 		for _, tc := range testCases {
@@ -501,15 +501,15 @@ func TestClient(t *testing.T) {
 					"mongocryptdPath": "/does/not/exist",
 				}
 
-				// If we're using the csfle library, set the "csfleRequired" option to true and the
-				// "csflePath" option to the csfle library path from the CSFLE_PATH environment
-				// variable. If we're not using the csfle library, explicitly disable loading the
-				// csfle library.
-				if tc.useCSFLE {
-					extraOptions["csfleRequired"] = true
-					extraOptions["csflePath"] = csflePath
+				// If we're using the crypt_shared library, set the "cryptSharedLibRequired" option
+				// to true and the "cryptSharedLibPath" option to the crypt_shared library path from
+				// the CRYPT_SHARED_LIB_PATH environment variable. If we're not using the
+				// crypt_shared library, explicitly disable loading the crypt_shared library.
+				if tc.useCryptSharedLib {
+					extraOptions["cryptSharedLibRequired"] = true
+					extraOptions["cryptSharedLibPath"] = cryptSharedLibPath
 				} else {
-					extraOptions["__csfleDisabledForTestOnly"] = true
+					extraOptions["__cryptSharedLibDisabledForTestOnly"] = true
 				}
 
 				_, err := NewClient(options.Client().
@@ -519,10 +519,10 @@ func TestClient(t *testing.T) {
 						}).
 						SetExtraOptions(extraOptions)))
 
-				// If we're using the csfle library, expect that Connect() doesn't attempt to spawn
-				// mongocryptd and no error is returned. If we're not using the csfle library,
+				// If we're using the crypt_shared library, expect that Connect() doesn't attempt to spawn
+				// mongocryptd and no error is returned. If we're not using the crypt_shared library,
 				// expect that Connect() tries to spawn mongocryptd and returns an error.
-				if tc.useCSFLE {
+				if tc.useCryptSharedLib {
 					assert.Nil(t, err, "Connect() error: %v", err)
 				} else {
 					assert.NotNil(t, err, "expected Connect() error, but got nil")

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1813,14 +1813,15 @@ func (d *deadlockTest) disconnect(mt *mtest.T) {
 	assert.Nil(mt, err, "clientTest Disconnect error: %v", err)
 }
 
-// getCSFLEExtraOptions returns an AutoEncryption extra options map with csfle required set and a
-// csfle library override path set if available.
+// getCSFLEExtraOptions returns an AutoEncryption extra options map with csfle library path
+// information if the CSFLE_PATH environment variable is set.
 func getCSFLEExtraOptions() map[string]interface{} {
-	if mtest.GetCSFLEPath() == "" {
-		return map[string]interface{}{}
+	path := mtest.GetCSFLEPath()
+	if path == "" {
+		return nil
 	}
 	return map[string]interface{}{
 		"csfleRequired": true,
-		"csflePath":     mtest.GetCSFLEPath(),
+		"csflePath":     path,
 	}
 }

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1812,16 +1812,3 @@ func (d *deadlockTest) disconnect(mt *mtest.T) {
 	d.clientTest.Disconnect(context.Background())
 	assert.Nil(mt, err, "clientTest Disconnect error: %v", err)
 }
-
-// getCryptSharedLibExtraOptions returns an AutoEncryption extra options map with crypt_shared
-// library path information if the CRYPT_SHARED_LIB_PATH environment variable is set.
-func getCryptSharedLibExtraOptions() map[string]interface{} {
-	path := os.Getenv("CRYPT_SHARED_LIB_PATH")
-	if path == "" {
-		return nil
-	}
-	return map[string]interface{}{
-		"cryptSharedLibRequired": true,
-		"cryptSharedLibPath":     path,
-	}
-}

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1816,6 +1816,9 @@ func (d *deadlockTest) disconnect(mt *mtest.T) {
 // getCSFLEExtraOptions returns an AutoEncryption extra options map with csfle required set and a
 // csfle library override path set if available.
 func getCSFLEExtraOptions() map[string]interface{} {
+	if mtest.GetCSFLEPath() == "" {
+		return map[string]interface{}{}
+	}
 	return map[string]interface{}{
 		"csfleRequired": true,
 		"csflePath":     mtest.GetCSFLEPath(),

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -123,7 +123,7 @@ func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
 			SetSchemaMap(schemaMap).
-			SetExtraOptions(getCSFLEExtraOptions())
+			SetExtraOptions(getCryptSharedLibExtraOptions())
 
 		var capturedEvents []event.CommandStartedEvent
 
@@ -338,7 +338,7 @@ func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 		aeOpts := options.AutoEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetExtraOptions(getCSFLEExtraOptions())
+			SetExtraOptions(getCryptSharedLibExtraOptions())
 		clientOpts := options.Client().
 			ApplyURI(mtest.ClusterURI()).
 			SetAutoEncryptionOptions(aeOpts)

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -122,7 +122,8 @@ func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 		aeOpts := options.AutoEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetSchemaMap(schemaMap)
+			SetSchemaMap(schemaMap).
+			SetExtraOptions(getCSFLEExtraOptions())
 
 		var capturedEvents []event.CommandStartedEvent
 
@@ -336,7 +337,8 @@ func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 	mt.Run("auto encryption and decryption", func(mt *mtest.T) {
 		aeOpts := options.AutoEncryption().
 			SetKmsProviders(kmsProvidersMap).
-			SetKeyVaultNamespace("keyvault.datakeys")
+			SetKeyVaultNamespace("keyvault.datakeys").
+			SetExtraOptions(getCSFLEExtraOptions())
 		clientOpts := options.Client().
 			ApplyURI(mtest.ClusterURI()).
 			SetAutoEncryptionOptions(aeOpts)

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -9,7 +9,6 @@ package mtest
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -879,9 +878,4 @@ func (t *T) interfaceToInt32(i interface{}) (int32, error) {
 	}
 
 	return 0, fmt.Errorf("type %T cannot be converted to int32", i)
-}
-
-// GetCSFLEPath returns the test csfle library path provided by the CSFLE_PATH environment variable.
-func GetCSFLEPath() string {
-	return os.Getenv("CSFLE_PATH")
 }

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -9,6 +9,7 @@ package mtest
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -878,4 +879,9 @@ func (t *T) interfaceToInt32(i interface{}) (int32, error) {
 	}
 
 	return 0, fmt.Errorf("type %T cannot be converted to int32", i)
+}
+
+// GetCSFLEPath returns the test csfle library path provided by the CSFLE_PATH environment variable.
+func GetCSFLEPath() string {
+	return os.Getenv("CSFLE_PATH")
 }

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -296,7 +296,9 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 				if testClientOpts.AutoEncryptionOptions.ExtraOptions == nil {
 					testClientOpts.AutoEncryptionOptions.ExtraOptions = make(map[string]interface{})
 				}
-				testClientOpts.AutoEncryptionOptions.ExtraOptions["csfleRequired"] = true
+				if mtest.GetCSFLEPath() != "" { 
+				    testClientOpts.AutoEncryptionOptions.ExtraOptions["csfleRequired"] = true
+				}
 				testClientOpts.AutoEncryptionOptions.ExtraOptions["csflePath"] = mtest.GetCSFLEPath()
 			}
 		}

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -986,4 +987,17 @@ func getTopologyFromClient(client *mongo.Client) *topology.Topology {
 	deploymentField := clientElem.FieldByName("deployment")
 	deploymentField = reflect.NewAt(deploymentField.Type(), unsafe.Pointer(deploymentField.UnsafeAddr())).Elem()
 	return deploymentField.Interface().(*topology.Topology)
+}
+
+// getCryptSharedLibExtraOptions returns an AutoEncryption extra options map with crypt_shared
+// library path information if the CRYPT_SHARED_LIB_PATH environment variable is set.
+func getCryptSharedLibExtraOptions() map[string]interface{} {
+	path := os.Getenv("CRYPT_SHARED_LIB_PATH")
+	if path == "" {
+		return nil
+	}
+	return map[string]interface{}{
+		"cryptSharedLibRequired": true,
+		"cryptSharedLibPath":     path,
+	}
 }

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -284,10 +285,10 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		// Reset the client using the client options specified in the test.
 		testClientOpts := createClientOptions(mt, test.ClientOptions)
 
-		// If the CSFLE_PATH environment variable is set, AutoEncryptionOptions is set, and
+		// If the CRYPT_SHARED_LIB_PATH environment variable is set, AutoEncryptionOptions is set, and
 		// AutoEncryption isn't disabled (neither bypassAutoEncryption nor bypassQueryAnalysis are
-		// true), then add extra options to load and require the csfle library.
-		if path := mtest.GetCSFLEPath(); path != "" && testClientOpts.AutoEncryptionOptions != nil {
+		// true), then add extra options to load and require the crypt_shared library.
+		if path := os.Getenv("CRYPT_SHARED_LIB_PATH"); path != "" && testClientOpts.AutoEncryptionOptions != nil {
 			bypassAutoEncryption := testClientOpts.AutoEncryptionOptions.BypassAutoEncryption != nil &&
 				*testClientOpts.AutoEncryptionOptions.BypassAutoEncryption
 			bypassQueryAnalysis := testClientOpts.AutoEncryptionOptions.BypassQueryAnalysis != nil &&
@@ -296,8 +297,8 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 				if testClientOpts.AutoEncryptionOptions.ExtraOptions == nil {
 					testClientOpts.AutoEncryptionOptions.ExtraOptions = make(map[string]interface{})
 				}
-				testClientOpts.AutoEncryptionOptions.ExtraOptions["csfleRequired"] = true
-				testClientOpts.AutoEncryptionOptions.ExtraOptions["csflePath"] = mtest.GetCSFLEPath()
+				testClientOpts.AutoEncryptionOptions.ExtraOptions["cryptSharedLibRequired"] = true
+				testClientOpts.AutoEncryptionOptions.ExtraOptions["cryptSharedLibPath"] = path
 			}
 		}
 

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -285,10 +284,10 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		// Reset the client using the client options specified in the test.
 		testClientOpts := createClientOptions(mt, test.ClientOptions)
 
-		// If the CRYPT_SHARED_LIB_PATH environment variable is set, AutoEncryptionOptions is set, and
-		// AutoEncryption isn't disabled (neither bypassAutoEncryption nor bypassQueryAnalysis are
-		// true), then add extra options to load and require the crypt_shared library.
-		if path := os.Getenv("CRYPT_SHARED_LIB_PATH"); path != "" && testClientOpts.AutoEncryptionOptions != nil {
+		// If AutoEncryptionOptions is set and AutoEncryption isn't disabled (neither
+		// bypassAutoEncryption nor bypassQueryAnalysis are true), then add extra options to load
+		// the crypt_shared library.
+		if testClientOpts.AutoEncryptionOptions != nil {
 			bypassAutoEncryption := testClientOpts.AutoEncryptionOptions.BypassAutoEncryption != nil &&
 				*testClientOpts.AutoEncryptionOptions.BypassAutoEncryption
 			bypassQueryAnalysis := testClientOpts.AutoEncryptionOptions.BypassQueryAnalysis != nil &&
@@ -297,8 +296,10 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 				if testClientOpts.AutoEncryptionOptions.ExtraOptions == nil {
 					testClientOpts.AutoEncryptionOptions.ExtraOptions = make(map[string]interface{})
 				}
-				testClientOpts.AutoEncryptionOptions.ExtraOptions["cryptSharedLibRequired"] = true
-				testClientOpts.AutoEncryptionOptions.ExtraOptions["cryptSharedLibPath"] = path
+
+				for k, v := range getCryptSharedLibExtraOptions() {
+					testClientOpts.AutoEncryptionOptions.ExtraOptions[k] = v
+				}
 			}
 		}
 

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -284,10 +284,10 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 		// Reset the client using the client options specified in the test.
 		testClientOpts := createClientOptions(mt, test.ClientOptions)
 
-		// If AutoEncryptionOptions is set and AutoEncryption isn't disabled (neither
-		// bypassAutoEncryption nor bypassQueryAnalysis are true), then add extra options to load
-		// and require the csfle library.
-		if testClientOpts.AutoEncryptionOptions != nil {
+		// If the CSFLE_PATH environment variable is set, AutoEncryptionOptions is set, and
+		// AutoEncryption isn't disabled (neither bypassAutoEncryption nor bypassQueryAnalysis are
+		// true), then add extra options to load and require the csfle library.
+		if path := mtest.GetCSFLEPath(); path != "" && testClientOpts.AutoEncryptionOptions != nil {
 			bypassAutoEncryption := testClientOpts.AutoEncryptionOptions.BypassAutoEncryption != nil &&
 				*testClientOpts.AutoEncryptionOptions.BypassAutoEncryption
 			bypassQueryAnalysis := testClientOpts.AutoEncryptionOptions.BypassQueryAnalysis != nil &&
@@ -296,9 +296,7 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 				if testClientOpts.AutoEncryptionOptions.ExtraOptions == nil {
 					testClientOpts.AutoEncryptionOptions.ExtraOptions = make(map[string]interface{})
 				}
-				if mtest.GetCSFLEPath() != "" { 
-				    testClientOpts.AutoEncryptionOptions.ExtraOptions["csfleRequired"] = true
-				}
+				testClientOpts.AutoEncryptionOptions.ExtraOptions["csfleRequired"] = true
 				testClientOpts.AutoEncryptionOptions.ExtraOptions["csflePath"] = mtest.GetCSFLEPath()
 			}
 		}

--- a/mongo/mongocryptd.go
+++ b/mongo/mongocryptd.go
@@ -35,7 +35,7 @@ type mongocryptdClient struct {
 	spawnArgs   []string
 }
 
-func newMongocryptdClient(csfleAvailable bool, opts *options.AutoEncryptionOptions) (*mongocryptdClient, error) {
+func newMongocryptdClient(cryptSharedLibAvailable bool, opts *options.AutoEncryptionOptions) (*mongocryptdClient, error) {
 	// create mcryptClient instance and spawn process if necessary
 	var bypassSpawn bool
 	var bypassAutoEncryption bool
@@ -54,8 +54,8 @@ func newMongocryptdClient(csfleAvailable bool, opts *options.AutoEncryptionOptio
 		// - mongocryptdBypassSpawn is passed
 		// - bypassAutoEncryption is true because mongocryptd is not used during decryption
 		// - bypassQueryAnalysis is true because mongocryptd is not used during decryption
-		// - the csfle library is available because it replaces all mongocryptd functionality.
-		bypassSpawn: bypassSpawn || bypassAutoEncryption || bypassQueryAnalysis || csfleAvailable,
+		// - the crypt_shared library is available because it replaces all mongocryptd functionality.
+		bypassSpawn: bypassSpawn || bypassAutoEncryption || bypassQueryAnalysis || cryptSharedLibAvailable,
 	}
 
 	if !mc.bypassSpawn {

--- a/mongo/mongocryptd.go
+++ b/mongo/mongocryptd.go
@@ -28,14 +28,14 @@ const (
 var defaultTimeoutArgs = []string{"--idleShutdownTimeoutSecs=60"}
 var databaseOpts = options.Database().SetReadConcern(readconcern.New()).SetReadPreference(readpref.Primary())
 
-type mcryptClient struct {
+type mongocryptdClient struct {
 	bypassSpawn bool
 	client      *Client
 	path        string
 	spawnArgs   []string
 }
 
-func newMcryptClient(opts *options.AutoEncryptionOptions) (*mcryptClient, error) {
+func newMongocryptdClient(csfleAvailable bool, opts *options.AutoEncryptionOptions) (*mongocryptdClient, error) {
 	// create mcryptClient instance and spawn process if necessary
 	var bypassSpawn bool
 	var bypassAutoEncryption bool
@@ -49,12 +49,13 @@ func newMcryptClient(opts *options.AutoEncryptionOptions) (*mcryptClient, error)
 
 	bypassQueryAnalysis := opts.BypassQueryAnalysis != nil && *opts.BypassQueryAnalysis
 
-	mc := &mcryptClient{
+	mc := &mongocryptdClient{
 		// mongocryptd should not be spawned if any of these conditions are true:
 		// - mongocryptdBypassSpawn is passed
 		// - bypassAutoEncryption is true because mongocryptd is not used during decryption
 		// - bypassQueryAnalysis is true because mongocryptd is not used during decryption
-		bypassSpawn: bypassSpawn || bypassAutoEncryption || bypassQueryAnalysis,
+		// - the csfle library is available because it replaces all mongocryptd functionality.
+		bypassSpawn: bypassSpawn || bypassAutoEncryption || bypassQueryAnalysis || csfleAvailable,
 	}
 
 	if !mc.bypassSpawn {
@@ -81,7 +82,7 @@ func newMcryptClient(opts *options.AutoEncryptionOptions) (*mcryptClient, error)
 }
 
 // markCommand executes the given command on mongocryptd.
-func (mc *mcryptClient) markCommand(ctx context.Context, dbName string, cmd bsoncore.Document) (bsoncore.Document, error) {
+func (mc *mongocryptdClient) markCommand(ctx context.Context, dbName string, cmd bsoncore.Document) (bsoncore.Document, error) {
 	// Remove the explicit session from the context if one is set.
 	// The explicit session will be from a different client.
 	// If an explicit session is set, it is applied after automatic encryption.
@@ -110,16 +111,16 @@ func (mc *mcryptClient) markCommand(ctx context.Context, dbName string, cmd bson
 }
 
 // connect connects the underlying Client instance. This must be called before performing any mark operations.
-func (mc *mcryptClient) connect(ctx context.Context) error {
+func (mc *mongocryptdClient) connect(ctx context.Context) error {
 	return mc.client.Connect(ctx)
 }
 
 // disconnect disconnects the underlying Client instance. This should be called after all operations have completed.
-func (mc *mcryptClient) disconnect(ctx context.Context) error {
+func (mc *mongocryptdClient) disconnect(ctx context.Context) error {
 	return mc.client.Disconnect(ctx)
 }
 
-func (mc *mcryptClient) spawnProcess() error {
+func (mc *mongocryptdClient) spawnProcess() error {
 	// Ignore gosec warning about subprocess launched with externally-provided path variable.
 	/* #nosec G204 */
 	cmd := exec.Command(mc.path, mc.spawnArgs...)

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -103,6 +103,12 @@ func (a *AutoEncryptionOptions) SetBypassAutoEncryption(bypass bool) *AutoEncryp
 // "mongocryptdBypassSpawn" - If set to true, the Client will not attempt to spawn a mongocryptd
 // process. Must be a bool.
 //
+// "mongocryptdSpawnPath" - The path used when spawning mongocryptd.
+// Defaults to empty string and spawns mongocryptd from system path. Must be a string.
+//
+// "mongocryptdSpawnArgs" - Command line arguments passed when spawning mongocryptd.
+// Defaults to ["--idleShutdownTimeoutSecs=60"]. Must be an array of strings.
+//
 // "csfleRequired" - If set to true, Client creation will return an error if the csfle library is
 // not loaded. If unset or set to false, Client creation will not return an error if the csfle
 // library is not loaded. The default is unset. Must be a bool.

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -93,6 +93,28 @@ func (a *AutoEncryptionOptions) SetBypassAutoEncryption(bypass bool) *AutoEncryp
 }
 
 // SetExtraOptions specifies a map of options to configure the mongocryptd process.
+//
+// Supported Extra Options
+//
+// "mongocryptdURI" - The mongocryptd URI. Allows setting a custom URI used to communicate with the
+// mongocryptd process. The default is "mongodb://localhost:27020", which works with the default
+// mongocryptd process spawned by the Client. Must be a string.
+//
+// "mongocryptdBypassSpawn" - If set to true, the Client will not attempt to spawn a mongocryptd
+// process. Must be a bool.
+//
+// "csfleRequired" - If set to true, Client creation will return an error if the csfle library is
+// not loaded. If unset or set to false, Client creation will not return an error if the csfle
+// library is not loaded. The default is unset. Must be a bool.
+//
+// "csflePath" - The csfle library override path. This must be the path to the csfle dynamic library
+// file (for example, a .so, .dll, or .dylib file), not the directory that contains it. If the
+// override path is a relative path, it will be resolved relative to the working directory of the
+// process. If the override path is a relative path and the first path component is the literal
+// string "$ORIGIN", the "$ORIGIN" component will be replaced by the absolute path to the directory
+// containing the linked libmongocrypt library. Setting an override path disables the default system
+// library search path. If an override path is specified but the csfle library cannot be loaded,
+// Client creation will return an error. Must be a string.
 func (a *AutoEncryptionOptions) SetExtraOptions(extraOpts map[string]interface{}) *AutoEncryptionOptions {
 	a.ExtraOptions = extraOpts
 	return a

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -109,18 +109,18 @@ func (a *AutoEncryptionOptions) SetBypassAutoEncryption(bypass bool) *AutoEncryp
 // "mongocryptdSpawnArgs" - Command line arguments passed when spawning mongocryptd.
 // Defaults to ["--idleShutdownTimeoutSecs=60"]. Must be an array of strings.
 //
-// "csfleRequired" - If set to true, Client creation will return an error if the csfle library is
-// not loaded. If unset or set to false, Client creation will not return an error if the csfle
-// library is not loaded. The default is unset. Must be a bool.
+// "cryptSharedLibRequired" - If set to true, Client creation will return an error if the
+// crypt_shared library is not loaded. If unset or set to false, Client creation will not return an
+// error if the crypt_shared library is not loaded. The default is unset. Must be a bool.
 //
-// "csflePath" - The csfle library override path. This must be the path to the csfle dynamic library
-// file (for example, a .so, .dll, or .dylib file), not the directory that contains it. If the
-// override path is a relative path, it will be resolved relative to the working directory of the
-// process. If the override path is a relative path and the first path component is the literal
-// string "$ORIGIN", the "$ORIGIN" component will be replaced by the absolute path to the directory
-// containing the linked libmongocrypt library. Setting an override path disables the default system
-// library search path. If an override path is specified but the csfle library cannot be loaded,
-// Client creation will return an error. Must be a string.
+// "cryptSharedLibPath" - The crypt_shared library override path. This must be the path to the
+// crypt_shared dynamic library file (for example, a .so, .dll, or .dylib file), not the directory
+// that contains it. If the override path is a relative path, it will be resolved relative to the
+// working directory of the process. If the override path is a relative path and the first path
+// component is the literal string "$ORIGIN", the "$ORIGIN" component will be replaced by the
+// absolute path to the directory containing the linked libmongocrypt library. Setting an override
+// path disables the default system library search path. If an override path is specified but the
+// crypt_shared library cannot be loaded, Client creation will return an error. Must be a string.
 func (a *AutoEncryptionOptions) SetExtraOptions(extraOpts map[string]interface{}) *AutoEncryptionOptions {
 	a.ExtraOptions = extraOpts
 	return a

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -35,15 +35,13 @@ type MarkCommandFn func(ctx context.Context, db string, cmd bsoncore.Document) (
 
 // CryptOptions specifies options to configure a Crypt instance.
 type CryptOptions struct {
+	MongoCrypt           *mongocrypt.MongoCrypt
 	CollInfoFn           CollectionInfoFn
 	KeyFn                KeyRetrieverFn
 	MarkFn               MarkCommandFn
-	KmsProviders         bsoncore.Document
-	SchemaMap            map[string]bsoncore.Document
 	TLSConfig            map[string]*tls.Config
 	BypassAutoEncryption bool
 	BypassQueryAnalysis  bool
-	EncryptedFieldsMap   map[string]bsoncore.Document
 }
 
 // Crypt is an interface implemented by types that can encrypt and decrypt instances of
@@ -81,27 +79,15 @@ type crypt struct {
 }
 
 // NewCrypt creates a new Crypt instance configured with the given AutoEncryptionOptions.
-func NewCrypt(opts *CryptOptions) (Crypt, error) {
-	c := &crypt{
+func NewCrypt(opts *CryptOptions) Crypt {
+	return &crypt{
+		mongoCrypt:           opts.MongoCrypt,
 		collInfoFn:           opts.CollInfoFn,
 		keyFn:                opts.KeyFn,
 		markFn:               opts.MarkFn,
 		tlsConfig:            opts.TLSConfig,
 		bypassAutoEncryption: opts.BypassAutoEncryption,
 	}
-
-	mongocryptOpts := options.MongoCrypt().
-		SetKmsProviders(opts.KmsProviders).
-		SetLocalSchemaMap(opts.SchemaMap).
-		SetBypassQueryAnalysis(opts.BypassQueryAnalysis).
-		SetEncryptedFieldsMap(opts.EncryptedFieldsMap)
-	mc, err := mongocrypt.NewMongoCrypt(mongocryptOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	c.mongoCrypt = mc
-	return c, nil
 }
 
 // Encrypt encrypts the given command.

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -55,13 +55,13 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 		C.mongocrypt_setopt_bypass_query_analysis(wrapped)
 	}
 
-	// If loading the csfle library isn't disabled, set the default library search path "$SYSTEM"
+	// If loading the crypt_shared library isn't disabled, set the default library search path "$SYSTEM"
 	// and set a library override path if one was provided.
-	if !opts.CSFLEDisabled {
-		C.mongocrypt_setopt_append_csfle_search_path(crypt.wrapped, C.CString("$SYSTEM"))
+	if !opts.CryptSharedLibDisabled {
+		C.mongocrypt_setopt_append_crypt_shared_lib_search_path(crypt.wrapped, C.CString("$SYSTEM"))
 
-		if opts.CSFLEOverridePath != "" {
-			C.mongocrypt_setopt_set_csfle_lib_path_override(crypt.wrapped, C.CString(opts.CSFLEOverridePath))
+		if opts.CryptSharedLibOverridePath != "" {
+			C.mongocrypt_setopt_set_crypt_shared_lib_path_override(crypt.wrapped, C.CString(opts.CryptSharedLibOverridePath))
 		}
 	}
 
@@ -255,19 +255,19 @@ func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Co
 	return ctx, nil
 }
 
-// CSFLEVersion returns the version number for the loaded csfle library, or 0 if the csfle library
-// was not loaded.
-func (m *MongoCrypt) CSFLEVersion() uint64 {
-	return uint64(C.mongocrypt_csfle_version(m.wrapped))
+// CryptSharedLibVersion returns the version number for the loaded crypt_shared library, or 0 if the
+// crypt_shared library was not loaded.
+func (m *MongoCrypt) CryptSharedLibVersion() uint64 {
+	return uint64(C.mongocrypt_crypt_shared_lib_version(m.wrapped))
 }
 
-// CSFLEVersionString returns the version string  for the loaded csfle library, or an empty string
-// if the csfle library was not loaded.
-func (m *MongoCrypt) CSFLEVersionString() string {
+// CryptSharedLibVersionString returns the version string for the loaded crypt_shared library, or an
+// empty string if the crypt_shared library was not loaded.
+func (m *MongoCrypt) CryptSharedLibVersionString() string {
 	// Pass in a pointer for "len", but ignore the value because C.GoString can determine the string
 	// length without it.
 	len := C.uint(0)
-	str := C.GoString(C.mongocrypt_csfle_version_string(m.wrapped, &len))
+	str := C.GoString(C.mongocrypt_crypt_shared_lib_version_string(m.wrapped, &len))
 	return str
 }
 

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -49,6 +49,18 @@ func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Co
 	panic(cseNotSupportedMsg)
 }
 
+// CSFLEVersion returns the version number for the loaded csfle library, or 0 if the csfle library
+// was not loaded.
+func (m *MongoCrypt) CSFLEVersion() uint64 {
+	panic(cseNotSupportedMsg)
+}
+
+// CSFLEVersionString returns the version string  for the loaded csfle library, or an empty string
+// if the csfle library was not loaded.
+func (m *MongoCrypt) CSFLEVersionString() string {
+	panic(cseNotSupportedMsg)
+}
+
 // Close cleans up any resources associated with the given MongoCrypt instance.
 func (m *MongoCrypt) Close() {
 	panic(cseNotSupportedMsg)

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -49,15 +49,15 @@ func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Co
 	panic(cseNotSupportedMsg)
 }
 
-// CSFLEVersion returns the version number for the loaded csfle library, or 0 if the csfle library
-// was not loaded.
-func (m *MongoCrypt) CSFLEVersion() uint64 {
+// CryptSharedLibVersion returns the version number for the loaded crypt_shared library, or 0 if the
+// crypt_shared library was not loaded.
+func (m *MongoCrypt) CryptSharedLibVersion() uint64 {
 	panic(cseNotSupportedMsg)
 }
 
-// CSFLEVersionString returns the version string  for the loaded csfle library, or an empty string
-// if the csfle library was not loaded.
-func (m *MongoCrypt) CSFLEVersionString() string {
+// CryptSharedLibVersionString returns the version string for the loaded crypt_shared library, or an
+// empty string if the crypt_shared library was not loaded.
+func (m *MongoCrypt) CryptSharedLibVersionString() string {
 	panic(cseNotSupportedMsg)
 }
 

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
@@ -16,6 +16,8 @@ type MongoCryptOptions struct {
 	LocalSchemaMap      map[string]bsoncore.Document
 	BypassQueryAnalysis bool
 	EncryptedFieldsMap  map[string]bsoncore.Document
+	CSFLEDisabled       bool
+	CSFLEOverridePath   string
 }
 
 // MongoCrypt creates a new MongoCryptOptions instance.
@@ -44,5 +46,18 @@ func (mo *MongoCryptOptions) SetBypassQueryAnalysis(bypassQueryAnalysis bool) *M
 // SetEncryptedFieldsMap specifies the encrypted fields map.
 func (mo *MongoCryptOptions) SetEncryptedFieldsMap(efcMap map[string]bsoncore.Document) *MongoCryptOptions {
 	mo.EncryptedFieldsMap = efcMap
+	return mo
+}
+
+// SetCSFLEDisabled explicitly disables loading the csfle dynamic library if set to true.
+func (mo *MongoCryptOptions) SetCSFLEDisabled(disabled bool) *MongoCryptOptions {
+	mo.CSFLEDisabled = disabled
+	return mo
+}
+
+// SetCSFLEOverridePath sets the override path to the csfle dynamic library file. Setting an
+// override path disables the default operating system dynamic library search path.
+func (mo *MongoCryptOptions) SetCSFLEOverridePath(path string) *MongoCryptOptions {
+	mo.CSFLEOverridePath = path
 	return mo
 }

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
@@ -12,12 +12,12 @@ import (
 
 // MongoCryptOptions specifies options to configure a MongoCrypt instance.
 type MongoCryptOptions struct {
-	KmsProviders        bsoncore.Document
-	LocalSchemaMap      map[string]bsoncore.Document
-	BypassQueryAnalysis bool
-	EncryptedFieldsMap  map[string]bsoncore.Document
-	CSFLEDisabled       bool
-	CSFLEOverridePath   string
+	KmsProviders               bsoncore.Document
+	LocalSchemaMap             map[string]bsoncore.Document
+	BypassQueryAnalysis        bool
+	EncryptedFieldsMap         map[string]bsoncore.Document
+	CryptSharedLibDisabled     bool
+	CryptSharedLibOverridePath string
 }
 
 // MongoCrypt creates a new MongoCryptOptions instance.
@@ -49,15 +49,15 @@ func (mo *MongoCryptOptions) SetEncryptedFieldsMap(efcMap map[string]bsoncore.Do
 	return mo
 }
 
-// SetCSFLEDisabled explicitly disables loading the csfle dynamic library if set to true.
-func (mo *MongoCryptOptions) SetCSFLEDisabled(disabled bool) *MongoCryptOptions {
-	mo.CSFLEDisabled = disabled
+// SetCryptSharedLibDisabled explicitly disables loading the crypt_shared library if set to true.
+func (mo *MongoCryptOptions) SetCryptSharedLibDisabled(disabled bool) *MongoCryptOptions {
+	mo.CryptSharedLibDisabled = disabled
 	return mo
 }
 
-// SetCSFLEOverridePath sets the override path to the csfle dynamic library file. Setting an
-// override path disables the default operating system dynamic library search path.
-func (mo *MongoCryptOptions) SetCSFLEOverridePath(path string) *MongoCryptOptions {
-	mo.CSFLEOverridePath = path
+// SetCryptSharedLibOverridePath sets the override path to the crypt_shared library file. Setting
+// an override path disables the default operating system dynamic library search path.
+func (mo *MongoCryptOptions) SetCryptSharedLibOverridePath(path string) *MongoCryptOptions {
+	mo.CryptSharedLibOverridePath = path
 	return mo
 }


### PR DESCRIPTION
Allow loading the new crypt_shared library in the Go driver.

Changes related to crypt_shared:
* Support loading the new crypt_shared library.
  * Add new AutoEncryption extra options "cryptSharedLibRequired" and "cryptSharedLibPath" and document how to use the options on `AutoEncryptionOptions.SetExtraOptions`.
  * Separate creation of a `mongocrypt.MongoCrypt` from creation of a `driver.crypt` to prevent having to pass options that are only relevant to `mongocrypt.NewMongoCrypt` through `driver.NewCrypt`.
* Don't spawn mongocryptd when the crypt_shared library is loaded.
  * Test that when the crypt_shared library is loaded, mongocryptd is not spawned.
* Download the crypt_shared library in Evergreen CI tasks for supported platforms and set the `CRYPT_SHARED_LIB_PATH` environment variable to allow Go tests to load the library.
* Force loading the crypt_shared library for most spec and prose tests.

Additional improvements:
* Set Evergreen option `pre_error_fails_task: true` to force pre-stage task failure to fail the CI run immediately. Previously, the CI run would continue, even after a pre-stage task failure, leading to incomplete test setups.
* Change `mongo.mcryptClient` to `mongo.mongocryptdClient` to reduce confusion about which Go types are associated with which encryption C libraries/processes.
* Prevent "queryable encryption" tests from unexpectedly interacting with each other by dropping the key vault collection ("datakeys") before every test.
* Document usage of "mongocryptdURI" and "mongocryptdBypassSpawn" along with new options "cryptSharedLibRequired" and "cryptSharedLibPath" on `AutoEncryptionOptions.SetExtraOptions`.