### PR TITLE
GODRIVER-2408 Bump maxWireVersion for MongoDB 6.0

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(2, 15)
+	SupportedWireVersions = description.NewVersionRange(2, 17)
 )
 
 const (


### PR DESCRIPTION
GODRIVER-2408