### PR TITLE
Godriver 2427 Unmarshaler for Unaddressable Data

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -171,7 +171,7 @@ func (m *someMap) UnmarshalBSON(byts []byte) error {
 	return nil
 }
 
-type unaddressableMapStruc struct {
+type unaddressableMapStruct struct {
 	Map someMap
 }
 
@@ -235,11 +235,11 @@ func TestMapCodec(t *testing.T) {
 
 	})
 	t.Run("UnmarshalBSON should run for unaddressable map in addressable struct", func(t *testing.T) {
-		x := &unaddressableMapStruc{}
+		x := &unaddressableMapStruct{}
 		byts, err := Marshal(x)
 		assert.Nil(t, err, "expected no error. got %v", err)
 
-		y := &unaddressableMapStruc{}
+		y := &unaddressableMapStruct{}
 		err = Unmarshal(byts, y)
 		assert.Nil(t, err, "expected no error. got %v", err)
 	})

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -164,6 +164,17 @@ func (k *keyStruct) UnmarshalText(text []byte) error {
 	return nil
 }
 
+type em map[string]interface{}
+
+func (m *em) UnmarshalBSON(byts []byte) error {
+	//Implementation not relevant
+	return nil
+}
+
+type emptyStruct struct {
+	Map em
+}
+
 func TestMapCodec(t *testing.T) {
 	t.Run("EncodeKeysWithStringer", func(t *testing.T) {
 		strstr := stringerString("foo")
@@ -222,6 +233,15 @@ func TestMapCodec(t *testing.T) {
 		assert.Nil(t, err, "Unmarshal error: %v", err)
 		assert.Equal(t, mapObj, got, "expected result %v, got %v", mapObj, got)
 
+	})
+	t.Run("UnmarshalBSON nil map pointer", func(t *testing.T) {
+		x := &emptyStruct{}
+		byts, err := Marshal(x)
+		assert.Nil(t, err, "expected no error. got %v", err)
+
+		y := &emptyStruct{}
+		err = Unmarshal(byts, y)
+		assert.Nil(t, err, "expected no error. got %v", err)
 	})
 }
 

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -164,15 +164,15 @@ func (k *keyStruct) UnmarshalText(text []byte) error {
 	return nil
 }
 
-type em map[string]interface{}
+type someMap map[string]interface{}
 
-func (m *em) UnmarshalBSON(byts []byte) error {
+func (m *someMap) UnmarshalBSON(byts []byte) error {
 	//Implementation not relevant
 	return nil
 }
 
-type emptyStruct struct {
-	Map em
+type unaddressableMapStruc struct {
+	Map someMap
 }
 
 func TestMapCodec(t *testing.T) {
@@ -234,12 +234,12 @@ func TestMapCodec(t *testing.T) {
 		assert.Equal(t, mapObj, got, "expected result %v, got %v", mapObj, got)
 
 	})
-	t.Run("UnmarshalBSON nil map pointer", func(t *testing.T) {
-		x := &emptyStruct{}
+	t.Run("UnmarshalBSON should run for unaddressable map in addressable struct", func(t *testing.T) {
+		x := &unaddressableMapStruc{}
 		byts, err := Marshal(x)
 		assert.Nil(t, err, "expected no error. got %v", err)
 
-		y := &emptyStruct{}
+		y := &unaddressableMapStruc{}
 		err = Unmarshal(byts, y)
 		assert.Nil(t, err, "expected no error. got %v", err)
 	})

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -164,17 +164,6 @@ func (k *keyStruct) UnmarshalText(text []byte) error {
 	return nil
 }
 
-type someMap map[string]interface{}
-
-func (m *someMap) UnmarshalBSON(byts []byte) error {
-	//Implementation not relevant
-	return nil
-}
-
-type unaddressableMapStruct struct {
-	Map someMap
-}
-
 func TestMapCodec(t *testing.T) {
 	t.Run("EncodeKeysWithStringer", func(t *testing.T) {
 		strstr := stringerString("foo")

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -234,15 +234,6 @@ func TestMapCodec(t *testing.T) {
 		assert.Equal(t, mapObj, got, "expected result %v, got %v", mapObj, got)
 
 	})
-	t.Run("UnmarshalBSON should run for unaddressable map in addressable struct", func(t *testing.T) {
-		x := &unaddressableMapStruct{}
-		byts, err := Marshal(x)
-		assert.Nil(t, err, "expected no error. got %v", err)
-
-		y := &unaddressableMapStruct{}
-		err = Unmarshal(byts, y)
-		assert.Nil(t, err, "expected no error. got %v", err)
-	})
 }
 
 func TestExtJSONEscapeKey(t *testing.T) {

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1463,7 +1463,7 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(dc DecodeContext, vr
 		if !val.CanAddr() {
 			return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 		}
-		val = val.Addr() // If they type doesn't implement the interface, a pointer to it must.
+		val = val.Addr() // If the type doesn't implement the interface, a pointer to it must.
 	}
 
 	t, src, err := bsonrw.Copier{}.CopyValueToBytes(vr)
@@ -1513,7 +1513,7 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bson
 		if !val.CanAddr() {
 			return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
 		}
-		val = val.Addr() // If they type doesn't implement the interface, a pointer to it must.
+		val = val.Addr() // If the type doesn't implement the interface, a pointer to it must.
 	}
 
 	fn := val.Convert(tUnmarshaler).MethodByName("UnmarshalBSON")

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1492,13 +1492,6 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bson
 		val.Set(reflect.New(val.Type().Elem()))
 	}
 
-	if !val.Type().Implements(tUnmarshaler) {
-		if !val.CanAddr() {
-			return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
-		}
-		val = val.Addr() // If they type doesn't implement the interface, a pointer to it must.
-	}
-
 	_, src, err := bsonrw.Copier{}.CopyValueToBytes(vr)
 	if err != nil {
 		return err
@@ -1511,9 +1504,16 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bson
 	// field value is "nil", we set "nil" here and don't call UnmarshalBSON. This behavior matches
 	// the behavior of the Go "encoding/json" unmarshaler when the target Go value is a pointer and
 	// the JSON field value is "null".
-	if val.CanSet() && val.Kind() == reflect.Ptr && len(src) == 0 {
+	if val.Kind() == reflect.Ptr && len(src) == 0 {
 		val.Set(reflect.Zero(val.Type()))
 		return nil
+	}
+
+	if !val.Type().Implements(tUnmarshaler) {
+		if !val.CanAddr() {
+			return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
+		}
+		val = val.Addr() // If they type doesn't implement the interface, a pointer to it must.
 	}
 
 	fn := val.Convert(tUnmarshaler).MethodByName("UnmarshalBSON")

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1504,14 +1504,14 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bson
 		return err
 	}
 
-	// If the target Go value is a pointer and the BSON field value is empty, set the value to the
+	// If the target Go value is an addressable pointer and the BSON field value is empty, set the value to the
 	// zero value of the pointer (nil) and don't call UnmarshalBSON. UnmarshalBSON has no way to
 	// change the pointer value from within the function (only the value at the pointer address),
 	// so it can't set the pointer to "nil" itself. Since the most common Go value for an empty BSON
 	// field value is "nil", we set "nil" here and don't call UnmarshalBSON. This behavior matches
 	// the behavior of the Go "encoding/json" unmarshaler when the target Go value is a pointer and
 	// the JSON field value is "null".
-	if val.Kind() == reflect.Ptr && len(src) == 0 {
+	if val.CanSet() && val.Kind() == reflect.Ptr && len(src) == 0 {
 		val.Set(reflect.Zero(val.Type()))
 		return nil
 	}

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1497,7 +1497,7 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bson
 		return err
 	}
 
-	// If the target Go value is an addressable pointer and the BSON field value is empty, set the value to the
+	// If the target Go value is a pointer and the BSON field value is empty, set the value to the
 	// zero value of the pointer (nil) and don't call UnmarshalBSON. UnmarshalBSON has no way to
 	// change the pointer value from within the function (only the value at the pointer address),
 	// so it can't set the pointer to "nil" itself. Since the most common Go value for an empty BSON

--- a/bson/mgocompat/setter_getter.go
+++ b/bson/mgocompat/setter_getter.go
@@ -66,7 +66,7 @@ func SetterDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val re
 		if !val.CanAddr() {
 			return bsoncodec.ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tSetter}, Received: val}
 		}
-		val = val.Addr() // If they type doesn't implement the interface, a pointer to it must.
+		val = val.Addr() // If the type doesn't implement the interface, a pointer to it must.
 	}
 
 	t, src, err := bsonrw.Copier{}.CopyValueToBytes(vr)

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -30,6 +30,15 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 		zeroPtrStruct = unmarshalerPtrStruct{I: &i, M: &m, B: &b, S: &s}
 	}
 
+	var zeroNonPtrStruct unmarshalerNonPtrStruct
+	{
+		i := myInt64(0)
+		m := myMap{}
+		b := myBytes{}
+		s := myString("")
+		zeroNonPtrStruct = unmarshalerNonPtrStruct{I: i, M: m, B: b, S: s}
+	}
+
 	var valPtrStruct unmarshalerPtrStruct
 	{
 		i := myInt64(5)
@@ -37,6 +46,15 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 		b := myBytes{0x00, 0x01}
 		s := myString("test")
 		valPtrStruct = unmarshalerPtrStruct{I: &i, M: &m, B: &b, S: &s}
+	}
+
+	var valNonPtrStruct unmarshalerNonPtrStruct
+	{
+		i := myInt64(5)
+		m := myMap{"key": "value"}
+		b := myBytes{0x00, 0x01}
+		s := myString("test")
+		valNonPtrStruct = unmarshalerNonPtrStruct{I: i, M: m, B: b, S: s}
 	}
 
 	type fooBytes struct {
@@ -136,6 +154,20 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 				Foo: []byte{0, 1, 2, 3, 4, 5},
 			}),
 		},
+		{
+			name: `zero-value non-pointer fields with pointer UnmarshalBSON function should marshal and unmarshal to
+			the same values`,
+			sType: reflect.TypeOf(unmarshalerNonPtrStruct{}),
+			want:  &zeroNonPtrStruct,
+			data:  docToBytes(zeroNonPtrStruct),
+		},
+		{
+			name: `non-zero-value non-pointer fields with pointer UnmarshalBSON function should marshal and unmarshal
+			to the same values`,
+			sType: reflect.TypeOf(unmarshalerNonPtrStruct{}),
+			want:  &valNonPtrStruct,
+			data:  docToBytes(valNonPtrStruct),
+		},
 	}
 }
 
@@ -147,6 +179,16 @@ type unmarshalerPtrStruct struct {
 	M *myMap
 	B *myBytes
 	S *myString
+}
+
+// unmarshalerNonPtrStruct contains a collection of non-pointer fields that are all to custom types that implement the
+// bson.Unmarshaler interface. It is used to test the BSON unmarshal behavior for types with custom UnmarshalBSON
+// functions.
+type unmarshalerNonPtrStruct struct {
+	I myInt64
+	M myMap
+	B myBytes
+	S myString
 }
 
 type myInt64 int64

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -156,7 +156,7 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 		},
 		// GODRIVER-2427
 		// Test that a struct of non-pointer types with UnmarshalBSON functions defined for the pointer of the field
-		// will marshal and unmarshal to the same Go values when the non-pointer values are teh respctive zero values.
+		// will marshal and unmarshal to the same Go values when the non-pointer values are the respctive zero values.
 		{
 			name: `zero-value non-pointer fields with pointer UnmarshalBSON function should marshal and unmarshal to
 			the same values`,

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -154,6 +154,9 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 				Foo: []byte{0, 1, 2, 3, 4, 5},
 			}),
 		},
+		// GODRIVER-2427
+		// Test that a struct of non-pointer types with UnmarshalBSON functions defined for the pointer of the field
+		// will marshal and unmarshal to the same Go values when the non-pointer values are teh respctive zero values.
 		{
 			name: `zero-value non-pointer fields with pointer UnmarshalBSON function should marshal and unmarshal to
 			the same values`,
@@ -161,6 +164,9 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			want:  &zeroNonPtrStruct,
 			data:  docToBytes(zeroNonPtrStruct),
 		},
+		// GODRIVER-2427
+		// Test that a struct of non-pointer types with UnmarshalBSON functions defined for the pointer of the field
+		// unmarshal to the same Go values when the non-pointer values are non-zero values.
 		{
 			name: `non-zero-value non-pointer fields with pointer UnmarshalBSON function should marshal and unmarshal
 			to the same values`,


### PR DESCRIPTION
GODRIVER-2427

Reporter is getting an error when defining an unmarshaler for unaddressable data.  Using `(Value).CanSet()` to determine if we should use the zero value setter resolves this problem.  `(Value).CanSet()` determines for a value if 

> [it is addressable and was not obtained by the use of unexported struct fields](https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/reflect/value.go;l=324)

The behavior of the `json/encoding` package is to allow the unmarshaler to run in such cases, [for example](https://go.dev/play/p/ZrfEEGeus9O).  Given that, I would expect the BSON unmarshaler to call `UnmarshalBSON` for unadressable values as well.