### PR TITLE
pin to libmongocrypt 1.5.0-alpha2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -103,7 +103,7 @@ functions:
              export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
           else
             # TODO (GODRIVER-2436): do not use alpha release of libmongocrypt.
-            git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-alpha1
+            git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-alpha2
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/data/client-side-encryption/fle2-CreateCollection.json
+++ b/data/client-side-encryption/fle2-CreateCollection.json
@@ -1472,6 +1472,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -1832,6 +1844,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -2129,6 +2153,18 @@
               }
             },
             "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
             "database_name": "default"
           }
         },

--- a/data/client-side-encryption/fle2-CreateCollection.yml
+++ b/data/client-side-encryption/fle2-CreateCollection.yml
@@ -1,3 +1,4 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
@@ -821,6 +822,13 @@ tests:
               encryptedFields: *encrypted_fields5
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1028,6 +1036,13 @@ tests:
               encryptedFields: *encrypted_fields6
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1200,6 +1215,13 @@ tests:
               create: "encryptedCollection"
               encryptedFields: *encrypted_fields7
             command_name: create
+            database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
             database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:


### PR DESCRIPTION
# Summary 

- Use libmongocrypt 1.5.0-alpha2 in tests.
- Update the fle2-CreateCollection test from https://github.com/mongodb/specifications/pull/1230.
- Update Windows download to use 1.5.0-alpha2 rather than the latest unstable release.

# Background & Motivation

Updating fle2-CreateCollection resolves test failures. MONGOCRYPT-429 requires additional `listCollections` commands in the expectations in the fle2-CreateCollection test.

libmongocrypt 1.5.0-alpha2 includes [this fix](https://jira.mongodb.org/browse/MONGOCRYPT-427) to explain with the csfle shared library.