### PR TITLE
GODRIVER-2439 Update expected FLE 2 find payloads

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -96,14 +96,14 @@ functions:
              mkdir -p c:/libmongocrypt/include
              mkdir -p c:/libmongocrypt/bin
              # TODO (GODRIVER-2436): do not use alpha release of libmongocrypt.
-             curl https://s3.amazonaws.com/mciuploads/libmongocrypt/windows/latest_release/libmongocrypt_unstable.tar.gz --output libmongocrypt.tar.gz
-             tar -xvzf libmongocrypt.tar.gz
-             cp ./bin/mongocrypt.dll c:/libmongocrypt/bin
-             cp ./include/mongocrypt/*.h c:/libmongocrypt/include
+             git clone https://github.com/mongodb/libmongocrypt --branch MONGOCRYPT-433
+             ./libmongocrypt/.evergreen/compile.sh
+             cp ./install/libmongocrypt/bin/mongocrypt.dll c:/libmongocrypt/bin
+             cp ./install/libmongocrypt/include/mongocrypt/*.h c:/libmongocrypt/include
              export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
           else
             # TODO (GODRIVER-2436): do not use alpha release of libmongocrypt.
-            git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-alpha2
+            git clone https://github.com/mongodb/libmongocrypt --branch MONGOCRYPT-433
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -95,15 +95,15 @@ functions:
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include
              mkdir -p c:/libmongocrypt/bin
-             # TODO (GODRIVER-2436): do not use alpha release of libmongocrypt.
-             git clone https://github.com/mongodb/libmongocrypt --branch MONGOCRYPT-433
+             # TODO (GODRIVER-2436): do not use pre-release of libmongocrypt.
+             git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-rc0
              ./libmongocrypt/.evergreen/compile.sh
              cp ./install/libmongocrypt/bin/mongocrypt.dll c:/libmongocrypt/bin
              cp ./install/libmongocrypt/include/mongocrypt/*.h c:/libmongocrypt/include
              export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
           else
-            # TODO (GODRIVER-2436): do not use alpha release of libmongocrypt.
-            git clone https://github.com/mongodb/libmongocrypt --branch MONGOCRYPT-433
+            # TODO (GODRIVER-2436): do not use pre-release of libmongocrypt.
+            git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-rc0
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/data/client-side-encryption/fle2-Delete.json
+++ b/data/client-side-encryption/fle2-Delete.json
@@ -225,7 +225,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }

--- a/data/client-side-encryption/fle2-Delete.yml
+++ b/data/client-side-encryption/fle2-Delete.yml
@@ -71,7 +71,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/data/client-side-encryption/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/data/client-side-encryption/fle2-EncryptedFields-vs-jsonSchema.json
@@ -230,7 +230,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/data/client-side-encryption/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/data/client-side-encryption/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -72,7 +72,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/data/client-side-encryption/fle2-FindOneAndUpdate.json
+++ b/data/client-side-encryption/fle2-FindOneAndUpdate.json
@@ -230,7 +230,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }
@@ -490,7 +490,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/data/client-side-encryption/fle2-FindOneAndUpdate.yml
+++ b/data/client-side-encryption/fle2-FindOneAndUpdate.yml
@@ -70,7 +70,7 @@ tests:
                 "encryptedIndexed": { 
                   "$eq": {
                     "$binary": {
-                        "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                        "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                         "subType": "06"
                     }
                   }
@@ -172,7 +172,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/data/client-side-encryption/fle2-InsertFind-Indexed.json
+++ b/data/client-side-encryption/fle2-InsertFind-Indexed.json
@@ -226,7 +226,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/data/client-side-encryption/fle2-InsertFind-Indexed.yml
+++ b/data/client-side-encryption/fle2-InsertFind-Indexed.yml
@@ -68,7 +68,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/data/client-side-encryption/fle2-Update.json
+++ b/data/client-side-encryption/fle2-Update.json
@@ -232,7 +232,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }
@@ -496,7 +496,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }

--- a/data/client-side-encryption/fle2-Update.yml
+++ b/data/client-side-encryption/fle2-Update.yml
@@ -74,7 +74,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }
@@ -179,7 +179,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }


### PR DESCRIPTION
GODRIVER-2439

# Summary
- Update libmongocrypt dependency to 1.5.0-rc0.
- Resync FLE 2 tests.

# Background & Motivation
Please see the "Downstream Changes Summary" of DRIVERS-2343.