### PR TITLE
GODRIVER-2184 Skip all integration tests when the -short flag is included.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,7 @@ test-race:
 
 .PHONY: test-short
 test-short:
-	for TEST in $(TEST_PKGS) ; do \
-    	go test $(BUILD_TAGS) -timeout $(TEST_TIMEOUT)s -short $(COVER_ARGS) $$TEST ; \
-    done
+	go test $(BUILD_TAGS) -timeout 60s -short $(COVER_ARGS) ./...
 
 .PHONY: update-bson-corpus-tests
 update-bson-corpus-tests:

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -8,6 +8,7 @@ package documentation_examples_test
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 	"testing"
@@ -23,6 +24,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// All tests that use mtest.Setup() are expected to be integration tests, so skip them when the
+	// -short flag is included in the "go test" command. Also, we have to parse flags here to use
+	// testing.Short() because flags aren't parsed before TestMain() is called.
+	flag.Parse()
+	if testing.Short() {
+		log.Print("skipping mtest integration test in short mode")
+		return
+	}
+
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -368,6 +368,10 @@ func TestClient(t *testing.T) {
 			{"number of sessions does not divide evenly", endSessionsBatchSize + 1, []int{endSessionsBatchSize, 1}},
 		}
 		for _, tc := range testCases {
+			if testing.Short() {
+				t.Skip("skipping integration test in short mode")
+			}
+
 			t.Run(tc.name, func(t *testing.T) {
 				// Setup a client and skip the test based on server version.
 				var started []*event.CommandStartedEvent

--- a/mongo/gridfs/gridfs_test.go
+++ b/mongo/gridfs/gridfs_test.go
@@ -24,6 +24,10 @@ var (
 )
 
 func TestGridFS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	cs := testutil.ConnString(t)
 	poolMonitor := &event.PoolMonitor{
 		Event: func(evt *event.PoolEvent) {

--- a/mongo/integration/client_options_test.go
+++ b/mongo/integration/client_options_test.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package mongo
+package integration
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -23,7 +24,7 @@ func TestClientOptions_CustomDialer(t *testing.T) {
 	cs := testutil.ConnString(t)
 	opts := options.Client().ApplyURI(cs.String()).SetDialer(td)
 	testutil.AddTestServerAPIVersion(opts)
-	client, err := NewClient(opts)
+	client, err := mongo.NewClient(opts)
 	require.NoError(t, err)
 	err = client.Connect(context.Background())
 	require.NoError(t, err)
@@ -37,7 +38,7 @@ func TestClientOptions_CustomDialer(t *testing.T) {
 
 type testDialer struct {
 	called int32
-	d      Dialer
+	d      mongo.Dialer
 }
 
 func (td *testDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -512,10 +512,6 @@ func TestClient(t *testing.T) {
 	})
 
 	mt.Run("minimum RTT is monitored", func(mt *mtest.T) {
-		if testing.Short() {
-			t.Skip("skipping integration test in short mode")
-		}
-
 		// Reset the client with a dialer that delays all network round trips by 300ms and set the
 		// heartbeat interval to 100ms to reduce the time it takes to collect RTT samples.
 		mt.ResetClient(options.Client().
@@ -547,10 +543,6 @@ func TestClient(t *testing.T) {
 	// Test that if the minimum RTT is greater than the remaining timeout for an operation, the
 	// operation is not sent to the server and no connections are closed.
 	mt.Run("minimum RTT used to prevent sending requests", func(mt *mtest.T) {
-		if testing.Short() {
-			t.Skip("skipping integration test in short mode")
-		}
-
 		// Assert that we can call Ping with a 250ms timeout.
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 		defer cancel()
@@ -676,10 +668,6 @@ func TestClient(t *testing.T) {
 }
 
 func TestClientStress(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
 	mtOpts := mtest.NewOptions().CreateClient(false)
 	mt := mtest.New(t, mtOpts)
 	defer mt.Close()

--- a/mongo/integration/main_test.go
+++ b/mongo/integration/main_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"flag"
 	"log"
 	"os"
 	"testing"
@@ -15,6 +16,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// All tests that use mtest.Setup() are expected to be integration tests, so skip them when the
+	// -short flag is included in the "go test" command. Also, we have to parse flags here to use
+	// testing.Short() because flags aren't parsed before TestMain() is called.
+	flag.Parse()
+	if testing.Short() {
+		log.Print("skipping mtest integration test in short mode")
+		return
+	}
+
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -165,6 +165,12 @@ func newT(wrapped *testing.T, opts ...*Options) *T {
 // New creates a new T instance with the given options. If the current environment does not satisfy constraints
 // specified in the options, the test will be skipped automatically.
 func New(wrapped *testing.T, opts ...*Options) *T {
+	// All tests that use mtest.New() are expected to be integration tests, so skip them when the
+	// -short flag is included in the "go test" command.
+	if testing.Short() {
+		wrapped.Skip("skipping mtest integration test in short mode")
+	}
+
 	t := newT(wrapped, opts...)
 
 	// only create a client if it needs to be shared in sub-tests

--- a/mongo/integration/unified/main_test.go
+++ b/mongo/integration/unified/main_test.go
@@ -7,6 +7,7 @@
 package unified
 
 import (
+	"flag"
 	"log"
 	"os"
 	"testing"
@@ -15,6 +16,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// All tests that use mtest.Setup() are expected to be integration tests, so skip them when the
+	// -short flag is included in the "go test" command. Also, we have to parse flags here to use
+	// testing.Short() because flags aren't parsed before TestMain() is called.
+	flag.Parse()
+	if testing.Short() {
+		log.Print("skipping mtest integration test in short mode")
+		return
+	}
+
 	if err := mtest.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -45,6 +45,10 @@ func (we wrappedError) Unwrap() error {
 }
 
 func TestConvenientTransactions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	client := setupConvenientTransactions(t)
 	db := client.Database("TestConvenientTransactions")
 	dbAdmin := client.Database("admin")

--- a/x/mongo/driver/integration/aggregate_test.go
+++ b/x/mongo/driver/integration/aggregate_test.go
@@ -58,6 +58,10 @@ func skipIfBelow32(ctx context.Context, t *testing.T, topo *topology.Topology) {
 }
 
 func TestAggregate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	t.Run("TestMaxTimeMSInGetMore", func(t *testing.T) {
 		ctx := context.Background()
 		monitor, started, succeeded, failed := setUpMonitor()

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -125,9 +125,6 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 }
 
 func TestPollingSRVRecordsSpec(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
 	for _, tt := range srvPollingTests {
 		t.Run(tt.name, func(t *testing.T) {
 			cs, err := connstring.ParseAndValidate("mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100")
@@ -159,9 +156,6 @@ func TestPollingSRVRecordsSpec(t *testing.T) {
 }
 
 func TestPollSRVRecords(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
 	t.Run("Not unknown or sharded topology", func(t *testing.T) {
 		cs, err := connstring.ParseAndValidate("mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100")
 		require.NoError(t, err, "Problem parsing the uri: %v", err)
@@ -309,10 +303,6 @@ func TestPollingSRVRecordsLoadBalanced(t *testing.T) {
 }
 
 func TestPollSRVRecordsMaxHosts(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
 	// simulateSRVPoll creates a topology with srvMaxHosts, mocks the DNS changes described by
 	// recordsToAdd and recordsToRemove, and returns the the topology.
 	simulateSRVPoll := func(srvMaxHosts int, recordsToAdd []*net.SRV, recordsToRemove []*net.SRV) (*Topology, func(ctx context.Context) error) {
@@ -387,10 +377,6 @@ func TestPollSRVRecordsMaxHosts(t *testing.T) {
 }
 
 func TestPollSRVRecordsServiceName(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
 	// simulateSRVPoll creates a topology with srvServiceName, mocks the DNS changes described by
 	// recordsToAdd and recordsToRemove, and returns the topology.
 	simulateSRVPoll := func(srvServiceName string, recordsToAdd []*net.SRV, recordsToRemove []*net.SRV) (*Topology, func(ctx context.Context) error) {


### PR DESCRIPTION
[GODRIVER-2184](https://jira.mongodb.org/browse/GODRIVER-2184)

We want to be able to run tests with the `-short` flag and expect the tests to run reasonably quickly with minimal dependencies. For example, we want to be able to run the following command to easily run all non-integration-tests:
```
go test -short ./...
```