### PR TITLE
GODRIVER-2347 Further deprecate timeout options and clarify RunCommand behavior.

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -194,11 +194,13 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 //
 // The runCommand parameter must be a document for the command to be executed. It cannot be nil.
 // This must be an order-preserving type such as bson.D. Map types such as bson.M are not valid.
-// If the command document contains a session ID or any transaction-specific fields, the behavior is undefined.
-// Specifying API versioning options in the command document and declaring an API version on the client is not supported.
-// The behavior of RunCommand is undefined in this case.
 //
 // The opts parameter can be used to specify options for this operation (see the options.RunCmdOptions documentation).
+//
+// The behavior of RunCommand is undefined if the command document contains any of the following:
+// - A session ID or any transaction-specific fields
+// - API versioning options when an API version is already declared on the Client
+// - maxTimeMS when Timeout is set on either the Database or Client
 func (db *Database) RunCommand(ctx context.Context, runCommand interface{}, opts ...*options.RunCmdOptions) *SingleResult {
 	if ctx == nil {
 		ctx = context.Background()
@@ -227,9 +229,13 @@ func (db *Database) RunCommand(ctx context.Context, runCommand interface{}, opts
 //
 // The runCommand parameter must be a document for the command to be executed. It cannot be nil.
 // This must be an order-preserving type such as bson.D. Map types such as bson.M are not valid.
-// If the command document contains a session ID or any transaction-specific fields, the behavior is undefined.
 //
 // The opts parameter can be used to specify options for this operation (see the options.RunCmdOptions documentation).
+//
+// The behavior of RunCommandCursor is undefined if the command document contains any of the following:
+// - A session ID or any transaction-specific fields
+// - API versioning options when an API version is already declared on the Client
+// - maxTimeMS when Timeout is set on either the Database or Client
 func (db *Database) RunCommandCursor(ctx context.Context, runCommand interface{}, opts ...*options.RunCmdOptions) (*Cursor, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -34,10 +34,18 @@ type AggregateOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the Aggregate operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// The maximum amount of time that the server should wait for new documents to satisfy a tailable cursor query.
 	// This option is only valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the Aggregate operation can run before
+	// returning an error. MaxAwaitTime is still usable through the deprecated setter.
 	MaxAwaitTime *time.Duration
 
 	// A string that will be included in server logs, profiling logs, and currentOp queries to help trace the operation.
@@ -91,12 +99,20 @@ func (ao *AggregateOptions) SetCollation(c *Collation) *AggregateOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver.
+// The more general Timeout option should be used in its place to control the amount of time that the
+// Aggregate operation can run before returning an error.
 func (ao *AggregateOptions) SetMaxTime(d time.Duration) *AggregateOptions {
 	ao.MaxTime = &d
 	return ao
 }
 
 // SetMaxAwaitTime sets the value for the MaxAwaitTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver.
+// The more general Timeout option should be used in its place to control the amount of time that the
+// Aggregate operation can run before returning an error.
 func (ao *AggregateOptions) SetMaxAwaitTime(d time.Duration) *AggregateOptions {
 	ao.MaxAwaitTime = &d
 	return ao

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -36,6 +36,10 @@ type ChangeStreamOptions struct {
 	FullDocumentBeforeChange *FullDocument
 
 	// The maximum amount of time that the server should wait for new documents to satisfy a tailable cursor query.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time to wait for new documents before returning
+	// an error. MaxAwaitTime is still usable through the deprecated setter.
 	MaxAwaitTime *time.Duration
 
 	// A document specifying the logical starting point for the change stream. Only changes corresponding to an oplog
@@ -104,6 +108,10 @@ func (cso *ChangeStreamOptions) SetFullDocumentBeforeChange(fdbc FullDocument) *
 }
 
 // SetMaxAwaitTime sets the value for the MaxAwaitTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time to wait for new documents before returning
+// an error.
 func (cso *ChangeStreamOptions) SetMaxAwaitTime(d time.Duration) *ChangeStreamOptions {
 	cso.MaxAwaitTime = &d
 	return cso

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -724,11 +724,12 @@ func (c *ClientOptions) SetSocketTimeout(d time.Duration) *ClientOptions {
 }
 
 // SetTimeout specifies the amount of time that a single operation run on this Client can execute before returning an error.
-// This can also be set through the "timeoutMS" URI option (e.g. "timeoutMS=1000"). The default value is nil, meaning operations
-// do not inherit a timeout from the Client.
+// The deadline of any operation run through the Client will be honored above any Timeout set on the Client; Timeout will only
+// be honored if there is no deadline on the operation Context. Timeout can also be set through the "timeoutMS" URI option
+// (e.g. "timeoutMS=1000"). The default value is nil, meaning operations do not inherit a timeout from the Client.
 //
-// If any Timeout is set (even 0) on the Client, the values of other, deprecated timeout-related options will be ignored. In particular:
-// ClientOptions.SocketTimeout, WriteConcern.wTimeout, MaxTime on operations, and TransactionOptions.MaxCommitTime.
+// If any Timeout is set (even 0) on the Client, the values of other, deprecated timeout-related options will be ignored.
+// In particular: ClientOptions.SocketTimeout, WriteConcern.wTimeout, MaxTime on operations, and TransactionOptions.MaxCommitTime.
 func (c *ClientOptions) SetTimeout(d time.Duration) *ClientOptions {
 	c.Timeout = &d
 	return c

--- a/mongo/options/collectionoptions.go
+++ b/mongo/options/collectionoptions.go
@@ -33,8 +33,10 @@ type CollectionOptions struct {
 	// is nil, which means that the registry of the Database used to configure the Collection will be used.
 	Registry *bsoncodec.Registry
 
-	// Timeout is the amount of time that a single operation run on the Collection can execute before returning an error. The default value
-	// is nil, which means that the timeout of the Database used to configure the Collection will be used.
+	// Timeout is the amount of time that a single operation run on the Collection can execute before returning an error. The deadline of
+	// any operation run on the Collection will be honored above any Timeout set on the Collection; Timeout will only be honored if there
+	// is no deadline on the operation Context. The default value is nil, which means that the timeout of the Database used to configure
+	// the Collection will be used.
 	Timeout *time.Duration
 }
 

--- a/mongo/options/countoptions.go
+++ b/mongo/options/countoptions.go
@@ -33,6 +33,10 @@ type CountOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there is
 	// no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the aggregate operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// The number of documents to skip before counting. The default value is 0.
@@ -69,6 +73,10 @@ func (co *CountOptions) SetLimit(i int64) *CountOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the aggregate operation can run before
+// returning an error.
 func (co *CountOptions) SetMaxTime(d time.Duration) *CountOptions {
 	co.MaxTime = &d
 	return co

--- a/mongo/options/dboptions.go
+++ b/mongo/options/dboptions.go
@@ -33,8 +33,10 @@ type DatabaseOptions struct {
 	// is nil, which means that the registry of the Client used to configure the Database will be used.
 	Registry *bsoncodec.Registry
 
-	// Timeout is the amount of time that a single operation run on the Database can execute before returning an error. The default value
-	// nil, which means that the timeout of the Client used to configure the Database will be used.
+	// Timeout is the amount of time that a single operation run on the Database can execute before returning an error. The deadline of
+	// any operation run on the Database will be honored above any Timeout set on the Database; Timeout will only be honored if there
+	// is no deadline on the operation Context. The default value is nil, which means that the timeout of the Client used to configure the
+	// Database will be used.
 	Timeout *time.Duration
 }
 

--- a/mongo/options/distinctoptions.go
+++ b/mongo/options/distinctoptions.go
@@ -17,6 +17,10 @@ type DistinctOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the Distinct operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 }
 
@@ -32,6 +36,10 @@ func (do *DistinctOptions) SetCollation(c *Collation) *DistinctOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the Distinct operation can run before
+// returning an error.
 func (do *DistinctOptions) SetMaxTime(d time.Duration) *DistinctOptions {
 	do.MaxTime = &d
 	return do

--- a/mongo/options/estimatedcountoptions.go
+++ b/mongo/options/estimatedcountoptions.go
@@ -16,6 +16,10 @@ type EstimatedDocumentCountOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the EstimatedDocumentCount operation
+	// can run before returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 }
 
@@ -31,6 +35,10 @@ func (eco *EstimatedDocumentCountOptions) SetComment(comment interface{}) *Estim
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the EstimatedDocumentCount operation
+// can run before returning an error.
 func (eco *EstimatedDocumentCountOptions) SetMaxTime(d time.Duration) *EstimatedDocumentCountOptions {
 	eco.MaxTime = &d
 	return eco

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -377,6 +377,10 @@ type FindOneOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the FindOne operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// A document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
@@ -481,6 +485,10 @@ func (f *FindOneOptions) SetMaxAwaitTime(d time.Duration) *FindOneOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the FindOne operation can run before
+// returning an error.
 func (f *FindOneOptions) SetMaxTime(d time.Duration) *FindOneOptions {
 	f.MaxTime = &d
 	return f
@@ -633,6 +641,10 @@ type FindOneAndReplaceOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the FindOneAndReplace operation can
+	// run before returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// A document describing which fields will be included in the document returned by the operation. The default value
@@ -691,6 +703,10 @@ func (f *FindOneAndReplaceOptions) SetComment(comment interface{}) *FindOneAndRe
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the FindOneAndReplace operation can
+// run before returning an error.
 func (f *FindOneAndReplaceOptions) SetMaxTime(d time.Duration) *FindOneAndReplaceOptions {
 	f.MaxTime = &d
 	return f
@@ -799,6 +815,10 @@ type FindOneAndUpdateOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the FindOneAndUpdate operation can run
+	// before returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// A document describing which fields will be included in the document returned by the operation. The default value
@@ -863,6 +883,10 @@ func (f *FindOneAndUpdateOptions) SetComment(comment interface{}) *FindOneAndUpd
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the FindOneAndUpdate operation can run
+// before returning an error.
 func (f *FindOneAndUpdateOptions) SetMaxTime(d time.Duration) *FindOneAndUpdateOptions {
 	f.MaxTime = &d
 	return f
@@ -963,6 +987,10 @@ type FindOneAndDeleteOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the FindOneAndDelete operation can run
+	// before returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 
 	// A document describing which fields will be included in the document returned by the operation. The default value
@@ -1007,6 +1035,10 @@ func (f *FindOneAndDeleteOptions) SetComment(comment interface{}) *FindOneAndDel
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the FindOneAndDelete operation can run
+// before returning an error.
 func (f *FindOneAndDeleteOptions) SetMaxTime(d time.Duration) *FindOneAndDeleteOptions {
 	f.MaxTime = &d
 	return f

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -29,6 +29,10 @@ type CreateIndexesOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the create index operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 }
 
@@ -38,6 +42,10 @@ func CreateIndexes() *CreateIndexesOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the create index operation can run before
+// returning an error.
 func (c *CreateIndexesOptions) SetMaxTime(d time.Duration) *CreateIndexesOptions {
 	c.MaxTime = &d
 	return c
@@ -91,6 +99,10 @@ func MergeCreateIndexesOptions(opts ...*CreateIndexesOptions) *CreateIndexesOpti
 type DropIndexesOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the drop index operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 }
 
@@ -100,6 +112,10 @@ func DropIndexes() *DropIndexesOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the drop index operation can run before
+// returning an error.
 func (d *DropIndexesOptions) SetMaxTime(duration time.Duration) *DropIndexesOptions {
 	d.MaxTime = &duration
 	return d
@@ -128,6 +144,10 @@ type ListIndexesOptions struct {
 
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the List operation can run before
+	// returning an error. MaxTime is still usable through the deprecated setter.
 	MaxTime *time.Duration
 }
 
@@ -143,6 +163,10 @@ func (l *ListIndexesOptions) SetBatchSize(i int32) *ListIndexesOptions {
 }
 
 // SetMaxTime sets the value for the MaxTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the List operation can run before
+// returning an error.
 func (l *ListIndexesOptions) SetMaxTime(d time.Duration) *ListIndexesOptions {
 	l.MaxTime = &d
 	return l

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -38,6 +38,10 @@ type SessionOptions struct {
 
 	// The default maximum amount of time that a CommitTransaction operation executed in the session can run on the
 	// server. The default value is nil, which means that that there is no time limit for execution.
+	//
+	// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+	// Timeout option should be used in its place to control the amount of time that the CommitTransaction operation can
+	// run before returning an error. DefaultMaxCommitTime is still usable through the deprecated setter.
 	DefaultMaxCommitTime *time.Duration
 
 	// If true, all read operations performed with this session will be read from the same snapshot. This option cannot
@@ -76,6 +80,10 @@ func (s *SessionOptions) SetDefaultWriteConcern(wc *writeconcern.WriteConcern) *
 }
 
 // SetDefaultMaxCommitTime sets the value for the DefaultMaxCommitTime field.
+//
+// Deprecated: This option is deprecated and will eventually be removed in version 2.0 of the driver. The more general
+// Timeout option should be used in its place to control the amount of time that the CommitTransaction operation can
+// run before returning an error.
 func (s *SessionOptions) SetDefaultMaxCommitTime(mct *time.Duration) *SessionOptions {
 	s.DefaultMaxCommitTime = mct
 	return s


### PR DESCRIPTION
GODRIVER-2347

Updates documentation related to CSOT. Advises against including `maxTimeMS` in a `RunCommand` command when `Timeout` is set. Deprecates `MaxTime` and `MaxAwaitTime` and their setters on all operation options. Further clarifies the interaction of `Timeout` and individual operations' context deadlines.

Opening PRs with `csot-implementation` as the base branch messes with the GH Evergreen CI: so [here](https://spruce.mongodb.com/version/6298efbc3627e00cacf49f86/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a patch I'll keep updated with every commit.