### PR TITLE
~ `aggreate` -> `aggregate`

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -781,7 +781,7 @@ func (coll *Collection) Aggregate(ctx context.Context, pipeline interface{},
 	return aggregate(a)
 }
 
-// aggreate is the helper method for Aggregate
+// aggregate is the helper method for Aggregate
 func aggregate(a aggregateParams) (cur *Cursor, err error) {
 	if a.ctx == nil {
 		a.ctx = context.Background()


### PR DESCRIPTION
small typo in `aggregate` doc.