### PR TITLE
Check for and fix suspicious append result assignments.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters-settings:
     exclude: .errcheck-excludes
   gocritic:
     enabled-checks:
-      # Detects suspicious append result assignments. E.g. "a = append(b, 1, 2, 3)"
+      # Detects suspicious append result assignments. E.g. "b := append(a, 1, 2, 3)"
       - appendAssign
   govet:
     disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - deadcode
     - errcheck
     # - errorlint
+    - gocritic
     - goimports
     - gosimple
     - gosec
@@ -29,6 +30,10 @@ linters:
 linters-settings:
   errcheck:
     exclude: .errcheck-excludes
+  gocritic:
+    enabled-checks:
+      # Detects suspicious append result assignments. E.g. "a = append(b, 1, 2, 3)"
+      - appendAssign
   govet:
     disable:
       - cgocall

--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -133,7 +133,7 @@ func TestParseDecimal128FromBigInt(t *testing.T) {
 }
 
 func TestParseDecimal128(t *testing.T) {
-	cases := make([]bigIntTestCase, 0)
+	cases := make([]bigIntTestCase, 0, len(bigIntTestCases))
 	cases = append(cases, bigIntTestCases...)
 	cases = append(cases,
 		bigIntTestCase{s: "-0001231.453454000000565600000000E-21", h: 0xafe6000003faa269, l: 0x81cfeceaabdb1800},
@@ -192,7 +192,7 @@ func TestDecimal128_JSON(t *testing.T) {
 		assert.Equal(t, want.l, got.l, "expected l: %v got: %v", want.l, got.l)
 	})
 	t.Run("unmarshal", func(t *testing.T) {
-		cases := make([]bigIntTestCase, 0)
+		cases := make([]bigIntTestCase, 0, len(bigIntTestCases))
 		cases = append(cases, bigIntTestCases...)
 		cases = append(cases,
 			bigIntTestCase{s: "-0001231.453454000000565600000000E-21", h: 0xafe6000003faa269, l: 0x81cfeceaabdb1800},

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -691,9 +691,6 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		topology.WithClock(func(*session.ClusterClock) *session.ClusterClock { return c.clock }),
 		topology.WithConnectionOptions(func(...topology.ConnectionOption) []topology.ConnectionOption { return connOpts }),
 	)
-	c.topologyOptions = append(topologyOpts, topology.WithServerOptions(
-		func(...topology.ServerOption) []topology.ServerOption { return serverOpts },
-	))
 
 	// Deployment
 	if opts.Deployment != nil {
@@ -704,6 +701,11 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		}
 		c.deployment = opts.Deployment
 	}
+
+	topologyOpts = append(topologyOpts, topology.WithServerOptions(
+		func(...topology.ServerOption) []topology.ServerOption { return serverOpts },
+	))
+	c.topologyOptions = topologyOpts
 
 	return nil
 }

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -691,21 +691,20 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		topology.WithClock(func(*session.ClusterClock) *session.ClusterClock { return c.clock }),
 		topology.WithConnectionOptions(func(...topology.ConnectionOption) []topology.ConnectionOption { return connOpts }),
 	)
-
-	// Deployment
-	if opts.Deployment != nil {
-		// topology options: WithSeedlist, WithURI, WithSRVServiceName and WithSRVMaxHosts
-		// server options: WithClock and WithConnectionOptions + default maxPoolSize
-		if len(serverOpts) > 2+defaultOptions || len(topologyOpts) > 4 {
-			return errors.New("cannot specify topology or server options with a deployment")
-		}
-		c.deployment = opts.Deployment
-	}
-
 	topologyOpts = append(topologyOpts, topology.WithServerOptions(
 		func(...topology.ServerOption) []topology.ServerOption { return serverOpts },
 	))
 	c.topologyOptions = topologyOpts
+
+	// Deployment
+	if opts.Deployment != nil {
+		// topology options: WithSeedlist, WithURI, WithSRVServiceName, WithSRVMaxHosts, and WithServerOptions
+		// server options: WithClock and WithConnectionOptions + default maxPoolSize
+		if len(serverOpts) > 2+defaultOptions || len(topologyOpts) > 5 {
+			return errors.New("cannot specify topology or server options with a deployment")
+		}
+		c.deployment = opts.Deployment
+	}
 
 	return nil
 }

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -984,7 +984,9 @@ func addClientCertFromSeparateFiles(cfg *tls.Config, keyFile, certFile, keyPassw
 		return "", err
 	}
 
-	data := append(keyData, '\n')
+	data := make([]byte, 0, len(keyData)+len(certData)+1)
+	data = append(data, keyData...)
+	data = append(data, '\n')
 	data = append(data, certData...)
 	return addClientCertFromBytes(cfg, data, keyPassword)
 }

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -292,7 +292,10 @@ func (p *parser) parse(original string) error {
 	}
 
 	// add connection arguments from URI and TXT records to connstring
-	connectionArgPairs := append(connectionArgsFromTXT, connectionArgsFromQueryString...)
+	connectionArgPairs := make([]string, 0, len(connectionArgsFromTXT)+len(connectionArgsFromQueryString))
+	connectionArgPairs = append(connectionArgPairs, connectionArgsFromTXT...)
+	connectionArgPairs = append(connectionArgPairs, connectionArgsFromQueryString...)
+
 	for _, pair := range connectionArgPairs {
 		err := p.addOption(pair)
 		if err != nil {


### PR DESCRIPTION
Appending to a slice and assigning the result to a different or new variable than the one being appended to is a common source of intermittent bugs.

Consider the following example:
```go
a := make([]int, 0, 4)
a = append(a, 1, 2, 3)
b := append(a, 4)
a = append(a, 5)
```
After running that, we expect that `a` contains `[1 2 3 5]` and `b` contains `[1 2 3 4]`. However, the last append to `a` actually overwrites the last element of `b` as well because they both share the same underlying array. Check out an example in the Go Playground [here](https://go.dev/play/p/F21yGAitcOl). To make the situation more confusing, if we change the initial capacity of `a` from 4 to 3, we get the behavior we originally expected!

We should avoid appending and assigning to a different variable. Enable the `appendAssign` check that's part of the [go-critic](https://github.com/go-critic/go-critic) linter and fix all "suspicious" append assignments.

Changes:
* Enable the `appendAssign` check from the `go-critic` linter.
* Fix all existing "suspicious" append assignments.
* Run some BSON table-driven test cases in subtests to improve test output readability.