### PR TITLE
Godriver2259 Reduce memory consumption in Connection.CompressWireMessage().

### DIFF
--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -84,11 +84,11 @@ func BenchmarkCompression(b *testing.B) {
 	payload := func() []byte {
 		f, err := os.Open("compression.go")
 		if err != nil {
-			panic(err)
+			b.Error(err)
 		}
 		buf, err := io.ReadAll(f)
 		if err != nil {
-			panic(err)
+			b.Error(err)
 		}
 		for i := 1; i < 10; i++ {
 			buf = append(buf, buf...)

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -638,6 +638,9 @@ func (c *Connection) CompressWireMessage(src, dst []byte) ([]byte, error) {
 		return dst, ErrConnectionClosed
 	}
 	if c.connection.compressor == wiremessage.CompressorNoOp {
+		if len(dst) == 0 {
+			return src, nil
+		}
 		return append(dst, src...), nil
 	}
 	_, reqid, respto, origcode, rem, ok := wiremessage.ReadHeader(src)

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -638,7 +638,10 @@ func (c *Connection) CompressWireMessage(src, dst []byte) ([]byte, error) {
 		return dst, ErrConnectionClosed
 	}
 	if c.connection.compressor == wiremessage.CompressorNoOp {
-		return src, nil
+		if len(dst) == 0 {
+			return src, nil
+		}
+		return append(dst, src...), nil
 	}
 	_, reqid, respto, origcode, rem, ok := wiremessage.ReadHeader(src)
 	if !ok {

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -638,10 +638,7 @@ func (c *Connection) CompressWireMessage(src, dst []byte) ([]byte, error) {
 		return dst, ErrConnectionClosed
 	}
 	if c.connection.compressor == wiremessage.CompressorNoOp {
-		if len(dst) == 0 {
-			return src, nil
-		}
-		return append(dst, src...), nil
+		return src, nil
 	}
 	_, reqid, respto, origcode, rem, ok := wiremessage.ReadHeader(src)
 	if !ok {

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -933,7 +933,8 @@ func BenchmarkConnection(b *testing.B) {
 		buf := make([]byte, 256)
 		_, err := rand.Read(buf)
 		if err != nil {
-			b.Error(err)
+			b.Log(err)
+			b.FailNow()
 		}
 		conn := Connection{connection: &connection{compressor: wiremessage.CompressorNoOp}}
 		for i := 0; i < b.N; i++ {

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"math/rand"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -22,6 +23,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
 
 type testHandshaker struct {
@@ -923,6 +925,23 @@ func TestConnection(t *testing.T) {
 				assertPoolPinnedStats(t, pool, 0, 0)
 			})
 		})
+	})
+}
+
+func BenchmarkConnection(b *testing.B) {
+	b.Run("CompressWireMessage CompressorNoOp", func(b *testing.B) {
+		buf := make([]byte, 256)
+		_, err := rand.Read(buf)
+		if err != nil {
+			b.Error(err)
+		}
+		conn := Connection{connection: &connection{compressor: wiremessage.CompressorNoOp}}
+		for i := 0; i < b.N; i++ {
+			_, err := conn.CompressWireMessage(buf, nil)
+			if err != nil {
+				b.Error(err)
+			}
+		}
 	})
 }
 

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -188,6 +188,22 @@ const (
 	CompressorZstd
 )
 
+// String implements the fmt.Stringer interface.
+func (id CompressorID) String() string {
+	switch id {
+	case CompressorNoOp:
+		return "CompressorNoOp"
+	case CompressorSnappy:
+		return "CompressorSnappy"
+	case CompressorZLib:
+		return "CompressorZLib"
+	case CompressorZstd:
+		return "CompressorZstd"
+	default:
+		return "CompressorInvalid"
+	}
+}
+
 const (
 	// DefaultZlibLevel is the default level for zlib compression
 	DefaultZlibLevel = 6


### PR DESCRIPTION
[GODRIVER-2259](https://jira.mongodb.org/browse/GODRIVER-2259)
[GODRIVER-2023](https://jira.mongodb.org/browse/GODRIVER-2023)

- Tune the Zstd compression.
- Use src slice directly when using no compression.