### PR TITLE
GODRIVER-2454 use string for QueryType

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -99,11 +99,20 @@ functions:
              mkdir -p c:/libmongocrypt/include
              mkdir -p c:/libmongocrypt/bin
              # TODO (GODRIVER-2436): do not use pre-release of libmongocrypt.
-             curl https://s3.amazonaws.com/mciuploads/libmongocrypt/windows/latest_release/libmongocrypt_unstable.tar.gz --output libmongocrypt.tar.gz
-             tar -xvzf libmongocrypt.tar.gz
-             cp ./bin/mongocrypt.dll c:/libmongocrypt/bin
-             cp ./include/mongocrypt/*.h c:/libmongocrypt/include
+             echo "fetching build for Windows ... begin"
+             mkdir libmongocrypt-all
+             cd libmongocrypt-all
+             # LIBMONGOCRYPT_COMMIT is for 1.5.0-rc2.
+             LIBMONGOCRYPT_COMMIT="1756c5120814152c15a2eee7a679a33a4764ba63"
+             # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
+             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
+             tar -xf libmongocrypt-all.tar.gz
+             cd ..
+             cp libmongocrypt-all/windows-test/bin/mongocrypt.dll c:/libmongocrypt/bin
+             cp libmongocrypt-all/windows-test/include/mongocrypt/*.h c:/libmongocrypt/include
              export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
+             rm -rf libmongocrypt-all
+             echo "fetching build for Windows ... end"
           elif [ "Darwin" = "$(uname -s)" ]; then
              # TODO (GODRIVER-2442): Once libmongocrypt compiles on macOS 10.15, remove this elif block.
              echo "fetching build for Darwin ... begin"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -119,7 +119,6 @@ functions:
              mv libmongocrypt-all/macos/include ./install/libmongocrypt
              mv libmongocrypt-all/macos/lib ./install/libmongocrypt
              rm -rf libmongocrypt-all
-             rm libmongocrypt-all.tar.gz
              # Fix prefix in pkg-config prefix path.
              sed -i "" -E "s+prefix=.*+prefix=$(pwd)/install/libmongocrypt+" ./install/libmongocrypt/lib/pkgconfig/libmongocrypt.pc
              echo "fetching build for Darwin ... end"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -94,6 +94,9 @@ functions:
           go version
           go env
 
+          LIBMONGOCRYPT_TAG="1.5.0-rc2"
+          # LIBMONGOCRYPT_COMMIT is the commit on libmongocrypt for the tag LIBMONGOCRYPT_TAG.
+          LIBMONGOCRYPT_COMMIT="1756c5120814152c15a2eee7a679a33a4764ba63"
           # Install libmongocrypt based on OS.
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include
@@ -102,8 +105,6 @@ functions:
              echo "fetching build for Windows ... begin"
              mkdir libmongocrypt-all
              cd libmongocrypt-all
-             # LIBMONGOCRYPT_COMMIT is for 1.5.0-rc2.
-             LIBMONGOCRYPT_COMMIT="1756c5120814152c15a2eee7a679a33a4764ba63"
              # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
              curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
@@ -119,8 +120,6 @@ functions:
              mkdir -p install/libmongocrypt
              mkdir libmongocrypt-all
              cd libmongocrypt-all
-             # LIBMONGOCRYPT_COMMIT is for 1.5.0-rc1.
-             LIBMONGOCRYPT_COMMIT="6e100b087376d448534cb2ad1b4dc50cb7cbc1f6"
              # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
              curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
@@ -133,7 +132,7 @@ functions:
              echo "fetching build for Darwin ... end"
           else
             # TODO (GODRIVER-2436): do not use pre-release of libmongocrypt.
-            git clone https://github.com/mongodb/libmongocrypt --branch 1.5.0-rc1
+            git clone https://github.com/mongodb/libmongocrypt --branch $LIBMONGOCRYPT_TAG
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -113,14 +113,7 @@ func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue, opts
 		transformed.SetKeyAltName(*eo.KeyAltName)
 	}
 	transformed.SetAlgorithm(eo.Algorithm)
-	if eo.QueryType != nil {
-		switch *eo.QueryType {
-		case options.QueryTypeEquality:
-			transformed.SetQueryType(mcopts.QueryTypeEquality)
-		default:
-			return primitive.Binary{}, fmt.Errorf("unsupported value for QueryType: %v", *eo.QueryType)
-		}
-	}
+	transformed.SetQueryType(eo.QueryType)
 
 	if eo.ContentionFactor != nil {
 		transformed.SetContentionFactor(*eo.ContentionFactor)

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -134,7 +134,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 1}, {"encryptedIndexed", insertPayload}})
 			assert.Nil(mt, err, "Error in InsertOne: %v", err)
 			// Explicit encrypt an indexed value to find.
-			eo = options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality)
+			eo = options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality")
 			findPayload, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 			assert.Nil(mt, err, "error in Encrypt: %v", err)
 			// Find.
@@ -167,7 +167,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 			// Explicit encrypt an indexed value to find with default contentionFactor 0.
 			{
-				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality)
+				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality")
 				findPayload, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 				assert.Nil(mt, err, "error in Encrypt: %v", err)
 				// Find with contentionFactor=0.
@@ -186,7 +186,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 			// Explicit encrypt an indexed value to find with contentionFactor 10.
 			{
-				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality).SetContentionFactor(10)
+				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality").SetContentionFactor(10)
 				findPayload2, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 				assert.Nil(mt, err, "error in Encrypt: %v", err)
 				// Find with contentionFactor=10.

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -134,7 +134,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 1}, {"encryptedIndexed", insertPayload}})
 			assert.Nil(mt, err, "Error in InsertOne: %v", err)
 			// Explicit encrypt an indexed value to find.
-			eo = options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality")
+			eo = options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality)
 			findPayload, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 			assert.Nil(mt, err, "error in Encrypt: %v", err)
 			// Find.
@@ -167,7 +167,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 			// Explicit encrypt an indexed value to find with default contentionFactor 0.
 			{
-				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality")
+				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality)
 				findPayload, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 				assert.Nil(mt, err, "error in Encrypt: %v", err)
 				// Find with contentionFactor=0.
@@ -186,7 +186,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 			// Explicit encrypt an indexed value to find with contentionFactor 10.
 			{
-				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType("equality").SetContentionFactor(10)
+				eo := options.Encrypt().SetAlgorithm("Indexed").SetKeyID(key1ID).SetQueryType(options.QueryTypeEquality).SetContentionFactor(10)
 				findPayload2, err := clientEncryption.Encrypt(context.Background(), rawVal, eo)
 				assert.Nil(mt, err, "error in Encrypt: %v", err)
 				// Find with contentionFactor=10.

--- a/mongo/integration/cmd_monitoring_helpers_test.go
+++ b/mongo/integration/cmd_monitoring_helpers_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -95,7 +96,13 @@ func compareValues(mt *mtest.T, key string, expected, actual bson.RawValue) erro
 		return fmt.Errorf("type mismatch for key %s; expected %s, got %s", key, expected.Type, actual.Type)
 	}
 	if !bytes.Equal(expected.Value, actual.Value) {
-		return fmt.Errorf("value mismatch for key %s; expected %s, got %s", key, expected.Value, actual.Value)
+		return fmt.Errorf(
+			"value mismatch for key %s; expected %s (hex=%s), got %s (hex=%s)",
+			key,
+			expected.Value,
+			hex.EncodeToString(expected.Value),
+			actual.Value,
+			hex.EncodeToString(actual.Value))
 	}
 	return nil
 }

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -449,6 +449,13 @@ func (t *T) CreateCollection(coll Collection, createOnServer bool) *mongo.Collec
 
 	db := coll.Client.Database(coll.DB)
 
+	if coll.CreateOpts != nil && coll.CreateOpts.EncryptedFields != nil {
+		// An encrypted collection consists of a data collection and three state collections.
+		// Aborted test runs may leave these collections.
+		// Drop all four collections to avoid a quiet failure to create all collections.
+		DropEncryptedCollection(t, db.Collection(coll.Name), coll.CreateOpts.EncryptedFields)
+	}
+
 	if createOnServer && t.clientType != Mock {
 		var err error
 		if coll.ViewOn != "" {

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -10,20 +10,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// QueryType describes the type of query the result of Encrypt is used for.
-type QueryType int
-
-// These constants specify valid values for QueryType
-const (
-	QueryTypeEquality QueryType = 1
-)
-
 // EncryptOptions represents options to explicitly encrypt a value.
 type EncryptOptions struct {
 	KeyID            *primitive.Binary
 	KeyAltName       *string
 	Algorithm        string
-	QueryType        *QueryType
+	QueryType        string
 	ContentionFactor *int64
 }
 
@@ -56,8 +48,10 @@ func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 }
 
 // SetQueryType specifies the intended query type. It is only valid to set if algorithm is "Indexed".
-func (e *EncryptOptions) SetQueryType(queryType QueryType) *EncryptOptions {
-	e.QueryType = &queryType
+// This should be one of the following:
+// - equality
+func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
+	e.QueryType = queryType
 	return e
 }
 
@@ -84,7 +78,7 @@ func MergeEncryptOptions(opts ...*EncryptOptions) *EncryptOptions {
 		if opt.Algorithm != "" {
 			eo.Algorithm = opt.Algorithm
 		}
-		if opt.QueryType != nil {
+		if opt.QueryType != "" {
 			eo.QueryType = opt.QueryType
 		}
 		if opt.ContentionFactor != nil {

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -10,6 +10,11 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// These constants specify valid values for QueryType
+const (
+	QueryTypeEquality string = "equality"
+)
+
 // EncryptOptions represents options to explicitly encrypt a value.
 type EncryptOptions struct {
 	KeyID            *primitive.Binary

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -58,10 +58,14 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	// If loading the crypt_shared library isn't disabled, set the default library search path "$SYSTEM"
 	// and set a library override path if one was provided.
 	if !opts.CryptSharedLibDisabled {
-		C.mongocrypt_setopt_append_crypt_shared_lib_search_path(crypt.wrapped, C.CString("$SYSTEM"))
+		systemStr := C.CString("$SYSTEM")
+		defer C.free(unsafe.Pointer(systemStr))
+		C.mongocrypt_setopt_append_crypt_shared_lib_search_path(crypt.wrapped, systemStr)
 
 		if opts.CryptSharedLibOverridePath != "" {
-			C.mongocrypt_setopt_set_crypt_shared_lib_path_override(crypt.wrapped, C.CString(opts.CryptSharedLibOverridePath))
+			cryptSharedLibOverridePathStr := C.CString(opts.CryptSharedLibOverridePath)
+			defer C.free(unsafe.Pointer(cryptSharedLibOverridePathStr))
+			C.mongocrypt_setopt_set_crypt_shared_lib_path_override(crypt.wrapped, cryptSharedLibOverridePathStr)
 		}
 	}
 

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -202,16 +202,11 @@ func (m *MongoCrypt) CreateExplicitEncryptionContext(doc bsoncore.Document, opts
 		return nil, ctx.createErrorFromStatus()
 	}
 
-	if opts.QueryType != nil {
-		switch *opts.QueryType {
-		case options.QueryTypeEquality:
-			queryStr := C.CString("equality")
-			defer C.free(unsafe.Pointer(queryStr))
-			if ok := C.mongocrypt_ctx_setopt_query_type(ctx.wrapped, queryStr, -1); !ok {
-				return nil, ctx.createErrorFromStatus()
-			}
-		default:
-			return nil, fmt.Errorf("unsupported value for QueryType: %v", opts.QueryType)
+	if opts.QueryType != "" {
+		queryStr := C.CString(opts.QueryType)
+		defer C.free(unsafe.Pointer(queryStr))
+		if ok := C.mongocrypt_ctx_setopt_query_type(ctx.wrapped, queryStr, -1); !ok {
+			return nil, ctx.createErrorFromStatus()
 		}
 	}
 

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -198,25 +198,16 @@ func (m *MongoCrypt) CreateExplicitEncryptionContext(doc bsoncore.Document, opts
 	algoStr := C.CString(opts.Algorithm)
 	defer C.free(unsafe.Pointer(algoStr))
 
-	switch opts.Algorithm {
-	case "Indexed":
-		if ok := C.mongocrypt_ctx_setopt_index_type(ctx.wrapped, IndexTypeIndexed); !ok {
-			return nil, ctx.createErrorFromStatus()
-		}
-	case "Unindexed":
-		if ok := C.mongocrypt_ctx_setopt_index_type(ctx.wrapped, IndexTypeUnindexed); !ok {
-			return nil, ctx.createErrorFromStatus()
-		}
-	default:
-		if ok := C.mongocrypt_ctx_setopt_algorithm(ctx.wrapped, algoStr, -1); !ok {
-			return nil, ctx.createErrorFromStatus()
-		}
+	if ok := C.mongocrypt_ctx_setopt_algorithm(ctx.wrapped, algoStr, -1); !ok {
+		return nil, ctx.createErrorFromStatus()
 	}
 
 	if opts.QueryType != nil {
 		switch *opts.QueryType {
 		case options.QueryTypeEquality:
-			if ok := C.mongocrypt_ctx_setopt_query_type(ctx.wrapped, 1); !ok {
+			queryStr := C.CString("equality")
+			defer C.free(unsafe.Pointer(queryStr))
+			if ok := C.mongocrypt_ctx_setopt_query_type(ctx.wrapped, queryStr, -1); !ok {
 				return nil, ctx.createErrorFromStatus()
 			}
 		default:

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
@@ -47,7 +47,7 @@ type ExplicitEncryptionOptions struct {
 	KeyID            *primitive.Binary
 	KeyAltName       *string
 	Algorithm        string
-	QueryType        *QueryType
+	QueryType        string
 	ContentionFactor *int64
 }
 
@@ -75,8 +75,8 @@ func (eeo *ExplicitEncryptionOptions) SetAlgorithm(algorithm string) *ExplicitEn
 }
 
 // SetQueryType specifies the query type.
-func (eeo *ExplicitEncryptionOptions) SetQueryType(queryType QueryType) *ExplicitEncryptionOptions {
-	eeo.QueryType = &queryType
+func (eeo *ExplicitEncryptionOptions) SetQueryType(queryType string) *ExplicitEncryptionOptions {
+	eeo.QueryType = queryType
 	return eeo
 }
 


### PR DESCRIPTION
# Summary

- Change `EncryptOptions.QueryType` from an enum to a string.
- Pass `EncryptOptions.QueryType` as a string to libmongocrypt.
- Pass `EncryptOptions.IndexType` as a string to libmongocrypt.

This includes additional improvements:

- Print hex for binary mismatch (c3869437d126a23bb7bfae311596a7183ce2f4dc).
- Drop encrypted collections before tests (66d82beb42e4107b3e29829f5d488afadf44306c).
- Pin version of libmongocrypt used on Windows to 1.5.0-rc2 (https://github.com/mongodb/mongo-go-driver/pull/988/commits/4ac20c6686f1c24999771605b9425657b9da2082)

# Background & Motivation

String values helps with forward compatibility When new values of QueryType and IndexType are added in libmongocrypt, users would only need to upgrade libmongocrypt, and not the driver, to use the new values. See DRIVERS-2352 for the motivation.

If encrypted collections are not dropped before running a test, Queryable Encryption tests result in a confusing error:
```sh
=== RUN   TestClientSideEncryptionSpec/fle2-BypassQueryAnalysis.json/BypassQueryAnalysis_decrypts
unified_spec_test.go:325: expectation comparison error at index 3: value mismatch for key filter.$or.0._id.$in.0; expected  4Vx4�v44Vx� (hex=100000000412345678123498761234123456789012), got ���4�v44Vx� (hex=1000000004abcdefab123498761234123456789012)
```

Pinning to libmongocrypt 1.5.0-rc2 on Windows is intended to prevent future task failures when new versions of libmongocrypt are released.