### PR TITLE
GODRIVER-2417 Run load balancer tests against 6.0 and 5.0.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2195,7 +2195,7 @@ buildvariants:
 
   - matrix_name: "load-balancer-test"
     # The LB software is only available on Ubuntu 18.04, so we don't test on all OSes.
-    matrix_spec: { version: ["5.0", "6.0", "latest"], os-ssl-40: ["ubuntu1804-64-go-1-17"] }
+    matrix_spec: { version: ["5.0", "6.0", "latest", "rapid"], os-ssl-40: ["ubuntu1804-64-go-1-17"] }
     display_name: "Load Balancer Support ${version} ${os-ssl-40}"
     tasks:
       - name: ".load-balancer"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2195,10 +2195,7 @@ buildvariants:
 
   - matrix_name: "load-balancer-test"
     # The LB software is only available on Ubuntu 18.04, so we don't test on all OSes.
-    # The new "loadBalancerPort" option is supported starting with server 5.2, which responds
-    # correctly to "hello" commands with a service ID when behind a load balancer. Only run load
-    # balancer tests on server 5.2+ ("rapid", "latest" are always 5.2+).
-    matrix_spec: { version: ["rapid", "latest"], os-ssl-40: ["ubuntu1804-64-go-1-17"] }
+    matrix_spec: { version: ["5.0", "6.0", "latest"], os-ssl-40: ["ubuntu1804-64-go-1-17"] }
     display_name: "Load Balancer Support ${version} ${os-ssl-40}"
     tasks:
       - name: ".load-balancer"


### PR DESCRIPTION
GODRIVER-2417

Runs the load balancer tests against 6.0 and 5.0. Previously we were only running against `latest` and `rapid`.