### PR TITLE
GODRIVER-2464 Add timeout for RTT monitor hello operations.

### DIFF
--- a/data/server-discovery-and-monitoring/integration/hello-command-error.json
+++ b/data/server-discovery-and-monitoring/integration/hello-command-error.json
@@ -117,7 +117,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -161,22 +161,6 @@
                 "_id": 4
               }
             ]
-          }
-        },
-        {
-          "name": "assertEventCount",
-          "object": "testRunner",
-          "arguments": {
-            "event": "ServerMarkedUnknownEvent",
-            "count": 1
-          }
-        },
-        {
-          "name": "assertEventCount",
-          "object": "testRunner",
-          "arguments": {
-            "event": "PoolClearedEvent",
-            "count": 1
           }
         }
       ],

--- a/data/server-discovery-and-monitoring/integration/hello-command-error.yml
+++ b/data/server-discovery-and-monitoring/integration/hello-command-error.yml
@@ -84,15 +84,16 @@ tests:
           documents:
             - _id: 1
             - _id: 2
-      # Configure the next streaming hello check to fail with a command
-      # error.
-      # Use times: 2 so that the RTT hello is blocked as well.
+      # Configure the next streaming hello check to fail with a command error.
+      # Use "times: 4" to increase the probability that the Monitor check fails
+      # since the RTT hello may trigger this failpoint one or many times as
+      # well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: commandErrorCheckTest
@@ -119,17 +120,19 @@ tests:
           documents:
             - _id: 3
             - _id: 4
-      # Assert the server was marked Unknown and pool was cleared exactly once.
-      - name: assertEventCount
-        object: testRunner
-        arguments:
-          event: ServerMarkedUnknownEvent
-          count: 1
-      - name: assertEventCount
-        object: testRunner
-        arguments:
-          event: PoolClearedEvent
-          count: 1
+      # We cannot assert the server was marked Unknown and pool was cleared an
+      # exact number of times because the RTT hello may have triggered this
+      # failpoint one or many times as well.
+      # - name: assertEventCount
+      #   object: testRunner
+      #   arguments:
+      #     event: ServerMarkedUnknownEvent
+      #     count: 1
+      # - name: assertEventCount
+      #   object: testRunner
+      #   arguments:
+      #     event: PoolClearedEvent
+      #     count: 1
 
     expectations:
       - command_started_event:

--- a/data/server-discovery-and-monitoring/integration/hello-network-error.json
+++ b/data/server-discovery-and-monitoring/integration/hello-network-error.json
@@ -116,7 +116,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [

--- a/data/server-discovery-and-monitoring/integration/hello-network-error.yml
+++ b/data/server-discovery-and-monitoring/integration/hello-network-error.yml
@@ -84,14 +84,15 @@ tests:
             - _id: 1
             - _id: 2
       # Configure the next streaming hello check to fail with a non-timeout
-      # network error. Use times: 2 to ensure that the the Monitor check fails
-      # since the RTT hello may trigger this failpoint as well.
+      # network error. Use "times: 4" to increase the probability that the
+      # Monitor check fails since the RTT hello may trigger this failpoint one
+      # or many times as well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: networkErrorCheckTest
@@ -116,8 +117,8 @@ tests:
             - _id: 3
             - _id: 4
       # We cannot assert the server was marked Unknown and pool was cleared an
-      # exact number of times because the RTT hello may or may not have
-      # triggered this failpoint as well.
+      # exact number of times because the RTT hello may have triggered this
+      # failpoint one or many times as well.
       # - name: assertEventCount
       #   object: testRunner
       #   arguments:

--- a/data/server-discovery-and-monitoring/integration/hello-timeout.json
+++ b/data/server-discovery-and-monitoring/integration/hello-timeout.json
@@ -117,7 +117,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -159,22 +159,6 @@
                 "_id": 4
               }
             ]
-          }
-        },
-        {
-          "name": "assertEventCount",
-          "object": "testRunner",
-          "arguments": {
-            "event": "ServerMarkedUnknownEvent",
-            "count": 1
-          }
-        },
-        {
-          "name": "assertEventCount",
-          "object": "testRunner",
-          "arguments": {
-            "event": "PoolClearedEvent",
-            "count": 1
           }
         }
       ],

--- a/data/server-discovery-and-monitoring/integration/hello-timeout.yml
+++ b/data/server-discovery-and-monitoring/integration/hello-timeout.yml
@@ -84,14 +84,16 @@ tests:
           documents:
             - _id: 1
             - _id: 2
-      # Configure the next streaming hello check to fail with a timeout
-      # Use times: 2 so that the RTT hello is blocked as well.
+      # Configure the next streaming hello check to fail with a timeout.
+      # Use "times: 4" to increase the probability that the Monitor check times
+      # out since the RTT hello may trigger this failpoint one or many times as
+      # well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: timeoutMonitorCheckTest
@@ -119,17 +121,19 @@ tests:
           documents:
             - _id: 3
             - _id: 4
-      # Assert the server was marked Unknown and pool was cleared exactly once.
-      - name: assertEventCount
-        object: testRunner
-        arguments:
-          event: ServerMarkedUnknownEvent
-          count: 1
-      - name: assertEventCount
-        object: testRunner
-        arguments:
-          event: PoolClearedEvent
-          count: 1
+      # We cannot assert the server was marked Unknown and pool was cleared an
+      # exact number of times because the RTT hello may have triggered this
+      # failpoint one or many times as well.
+      # - name: assertEventCount
+      #   object: testRunner
+      #   arguments:
+      #     event: ServerMarkedUnknownEvent
+      #     count: 1
+      # - name: assertEventCount
+      #   object: testRunner
+      #   arguments:
+      #     event: PoolClearedEvent
+      #     count: 1
 
     expectations:
       - command_started_event:


### PR DESCRIPTION
[GODRIVER-2464](https://jira.mongodb.org/browse/GODRIVER-2464)

Currently the RTT monitor uses a context without timeout to run the "hello" operation (see [here](https://github.com/mongodb/mongo-go-driver/blob/95de0fb36ca077bbe9a92b3fbf66ef0d28c6eeae/x/mongo/driver/topology/rtt_monitor.go#L128)). As a result, it's possible for RTT monitor "hello" operations to get stuck indefinitely if there is a network problem, preventing the monitor from recording more RTT samples. The motivation for this ticket comes from troubleshooting [GODRIVER-2438](https://jira.mongodb.org/browse/GODRIVER-2438).

Add a timeout to the RTT monitor "hello" operation to prevent network issues from causing the RTT monitor to get stuck. Add a test that confirms that the RTT monitor can recover from a stuck operation.

Also includes proposed SDAM spec test fixes from https://github.com/mongodb/specifications/pull/1272.