### PR TITLE
GODRIVER-2453 extend session function comments with thread/fork warnings

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -278,6 +278,8 @@ func (c *Client) Ping(ctx context.Context, rp *readpref.ReadPref) error {
 // StartSession does not actually communicate with the server and will not error if the client is
 // disconnected.
 //
+// StartSession is not thread safe or fork safe. Session instances can only be used by one thread or process at a time.
+//
 // If the DefaultReadConcern, DefaultWriteConcern, or DefaultReadPreference options are not set, the client's read
 // concern, write concern, or read preference will be used, respectively.
 func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) {
@@ -1021,7 +1023,7 @@ func (c *Client) ListDatabaseNames(ctx context.Context, filter interface{}, opts
 
 // WithSession creates a new SessionContext from the ctx and sess parameters and uses it to call the fn callback. The
 // SessionContext must be used as the Context parameter for any operations in the fn callback that should be executed
-// under the session.
+// under the session. WithSession is not thread safe or fork safe.
 //
 // If the ctx parameter already contains a Session, that Session will be replaced with the one provided.
 //
@@ -1033,7 +1035,7 @@ func WithSession(ctx context.Context, sess Session, fn func(SessionContext) erro
 // UseSession creates a new Session and uses it to create a new SessionContext, which is used to call the fn callback.
 // The SessionContext parameter must be used as the Context parameter for any operations in the fn callback that should
 // be executed under a session. After the callback returns, the created Session is ended, meaning that any in-progress
-// transactions started by fn will be aborted even if fn returns an error.
+// transactions started by fn will be aborted even if fn returns an error. UseSession is not thread safe or fork safe.
 //
 // If the ctx parameter already contains a Session, that Session will be replaced with the newly created one.
 //
@@ -1043,6 +1045,7 @@ func (c *Client) UseSession(ctx context.Context, fn func(SessionContext) error) 
 }
 
 // UseSessionWithOptions operates like UseSession but uses the given SessionOptions to create the Session.
+// UseSessionWithOptions is not thread safe or fork safe.
 func (c *Client) UseSessionWithOptions(ctx context.Context, opts *options.SessionOptions, fn func(SessionContext) error) error {
 	defaultSess, err := c.StartSession(opts)
 	if err != nil {

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -278,7 +278,8 @@ func (c *Client) Ping(ctx context.Context, rp *readpref.ReadPref) error {
 // StartSession does not actually communicate with the server and will not error if the client is
 // disconnected.
 //
-// StartSession is not thread safe or fork safe. Session instances can only be used by one thread or process at a time.
+// StartSession is safe to call from multiple goroutines concurrently. However, Sessions returned by StartSession are
+// not safe for concurrent use by multiple goroutines.
 //
 // If the DefaultReadConcern, DefaultWriteConcern, or DefaultReadPreference options are not set, the client's read
 // concern, write concern, or read preference will be used, respectively.
@@ -1023,7 +1024,10 @@ func (c *Client) ListDatabaseNames(ctx context.Context, filter interface{}, opts
 
 // WithSession creates a new SessionContext from the ctx and sess parameters and uses it to call the fn callback. The
 // SessionContext must be used as the Context parameter for any operations in the fn callback that should be executed
-// under the session. WithSession is not thread safe or fork safe.
+// under the session.
+//
+// WithSession is safe to call from multiple goroutines concurrently. However, the SessionContext passed to the
+// WithSession callback function is not safe for concurrent use by multiple goroutines.
 //
 // If the ctx parameter already contains a Session, that Session will be replaced with the one provided.
 //
@@ -1035,7 +1039,10 @@ func WithSession(ctx context.Context, sess Session, fn func(SessionContext) erro
 // UseSession creates a new Session and uses it to create a new SessionContext, which is used to call the fn callback.
 // The SessionContext parameter must be used as the Context parameter for any operations in the fn callback that should
 // be executed under a session. After the callback returns, the created Session is ended, meaning that any in-progress
-// transactions started by fn will be aborted even if fn returns an error. UseSession is not thread safe or fork safe.
+// transactions started by fn will be aborted even if fn returns an error.
+//
+// UseSession is safe to call from multiple goroutines concurrently. However, the SessionContext passed to the
+// UseSession callback function is not safe for concurrent use by multiple goroutines.
 //
 // If the ctx parameter already contains a Session, that Session will be replaced with the newly created one.
 //
@@ -1045,7 +1052,9 @@ func (c *Client) UseSession(ctx context.Context, fn func(SessionContext) error) 
 }
 
 // UseSessionWithOptions operates like UseSession but uses the given SessionOptions to create the Session.
-// UseSessionWithOptions is not thread safe or fork safe.
+//
+// UseSessionWithOptions is safe to call from multiple goroutines concurrently. However, the SessionContext passed to
+// the UseSessionWithOptions callback function is not safe for concurrent use by multiple goroutines.
 func (c *Client) UseSessionWithOptions(ctx context.Context, opts *options.SessionOptions, fn func(SessionContext) error) error {
 	defaultSess, err := c.StartSession(opts)
 	if err != nil {

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -30,7 +30,7 @@ var withTransactionTimeout = 120 * time.Second
 
 // SessionContext combines the context.Context and mongo.Session interfaces. It should be used as the Context arguments
 // to operations that should be executed in a session. This type is not goroutine safe and must not be used concurrently
-// by multiple goroutines.
+// by multiple goroutines. Insances of SessionContext are not thread safe or fork safe.
 //
 // There are two ways to create a SessionContext and use it in a session/transaction. The first is to use one of the
 // callback-based functions such as WithSession and UseSession. These functions create a SessionContext and pass it to
@@ -76,8 +76,9 @@ func SessionFromContext(ctx context.Context) Session {
 // Session is an interface that represents a MongoDB logical session. Sessions can be used to enable causal consistency
 // for a group of operations or to execute operations in an ACID transaction. A new Session can be created from a Client
 // instance. A Session created from a Client must only be used to execute operations using that Client or a Database or
-// Collection created from that Client. Custom implementations of this interface should not be used in production. For
-// more information about sessions, and their use cases, see https://www.mongodb.com/docs/manual/reference/server-sessions/,
+// Collection created from that Client. Instances of Session are not thread safe or fork safe. Custom implementations of
+// this interface should not be used in production. For  more information about sessions, and their use cases, see
+// https://www.mongodb.com/docs/manual/reference/server-sessions/,
 // https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency, and
 // https://www.mongodb.com/docs/manual/core/transactions/.
 //

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -29,8 +29,9 @@ var ErrWrongClient = errors.New("session was not created by this client")
 var withTransactionTimeout = 120 * time.Second
 
 // SessionContext combines the context.Context and mongo.Session interfaces. It should be used as the Context arguments
-// to operations that should be executed in a session. SessionContext is not safe for concurrent use by multiple
-// goroutines.
+// to operations that should be executed in a session.
+//
+// Implementations of SessionContext are not safe for concurrent use by multiple goroutines.
 //
 // There are two ways to create a SessionContext and use it in a session/transaction. The first is to use one of the
 // callback-based functions such as WithSession and UseSession. These functions create a SessionContext and pass it to
@@ -76,12 +77,13 @@ func SessionFromContext(ctx context.Context) Session {
 // Session is an interface that represents a MongoDB logical session. Sessions can be used to enable causal consistency
 // for a group of operations or to execute operations in an ACID transaction. A new Session can be created from a Client
 // instance. A Session created from a Client must only be used to execute operations using that Client or a Database or
-// Collection created from that Client. Implementations of Session are not safe for concurrent use by multiple
-// goroutines. Custom implementations of this interface should not be used in production. For more information about
-// sessions, and their use cases, see
+// Collection created from that Client. Custom implementations of this interface should not be used in production. For
+// more information about sessions, and their use cases, see
 // https://www.mongodb.com/docs/manual/reference/server-sessions/,
 // https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency, and
 // https://www.mongodb.com/docs/manual/core/transactions/.
+//
+// Implementations of Session are not safe for concurrent use by multiple goroutines.
 //
 // StartTransaction starts a new transaction, configured with the given options, on this session. This method will
 // return an error if there is already a transaction in-progress for this session.

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -29,8 +29,8 @@ var ErrWrongClient = errors.New("session was not created by this client")
 var withTransactionTimeout = 120 * time.Second
 
 // SessionContext combines the context.Context and mongo.Session interfaces. It should be used as the Context arguments
-// to operations that should be executed in a session. This type is not goroutine safe and must not be used concurrently
-// by multiple goroutines. Insances of SessionContext are not thread safe or fork safe.
+// to operations that should be executed in a session. SessionContext is not safe for concurrent use by multiple
+// goroutines.
 //
 // There are two ways to create a SessionContext and use it in a session/transaction. The first is to use one of the
 // callback-based functions such as WithSession and UseSession. These functions create a SessionContext and pass it to
@@ -76,8 +76,9 @@ func SessionFromContext(ctx context.Context) Session {
 // Session is an interface that represents a MongoDB logical session. Sessions can be used to enable causal consistency
 // for a group of operations or to execute operations in an ACID transaction. A new Session can be created from a Client
 // instance. A Session created from a Client must only be used to execute operations using that Client or a Database or
-// Collection created from that Client. Instances of Session are not thread safe or fork safe. Custom implementations of
-// this interface should not be used in production. For  more information about sessions, and their use cases, see
+// Collection created from that Client. Implementations of Session are not safe for concurrent use by multiple
+// goroutines. Custom implementations of this interface should not be used in production. For more information about
+// sessions, and their use cases, see
 // https://www.mongodb.com/docs/manual/reference/server-sessions/,
 // https://www.mongodb.com/docs/manual/core/read-isolation-consistency-recency/#causal-consistency, and
 // https://www.mongodb.com/docs/manual/core/transactions/.


### PR DESCRIPTION
[GODRIVER-2453](https://jira.mongodb.org/browse/GODRIVER-2453)

Add phrasing to match the [session spec](https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#clientsession): 

> `ClientSession` instances are not thread safe or fork safe

- [Client.StartSession](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#Client.StartSession)
- [Client.UseSession](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#Client.UseSession)
- [Client.UseSessionWithOptions](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#Client.UseSessionWithOptions)
- [mongo.Session](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#Session)
- [mongo.WithSession](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#WithSession)