### PR TITLE
GODRIVER-2447 update golang.org/x/text to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d h1:bt+R27hbE7uVf7PY9S6wpNg9Xo2WRe/XQT0uGq9RQQw=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=


### PR DESCRIPTION
[GODRIVER-2447](https://jira.mongodb.org/browse/GODRIVER-2447)

[golang.org/x/text < 0.3.3 are at risk for Denial of Service attacks](https://app.snyk.io/org/mongodb-default/project/d1fd28ee-07d4-4de7-88ed-e20dc42a307c#issue-SNYK-GOLANG-GOLANGORGXTEXTENCODINGUNICODE-609611) and [golang.org/x/text < 0.3.7 can have out-of-bounds read](https://app.snyk.io/org/mongodb-default/project/d1fd28ee-07d4-4de7-88ed-e20dc42a307c#issue-SNYK-GOLANG-GOLANGORGXTEXTINTERNALLANGUAGE-2400718). Update the dependency to latest.