### PR TITLE
Confirm that modules are always tidy and vendored.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1068,6 +1068,13 @@ tasks:
         vars:
           targets: check-fmt
 
+  - name: sa-modules
+    tags: ["static-analysis"]
+    commands:
+      - func: run-make
+        vars:
+          targets: check-modules
+
   - name: sa-lint
     tags: ["static-analysis"]
     commands:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TEST_TIMEOUT = 1800
 
 ### Utility targets. ###
 .PHONY: default
-default: add-license build build-examples check-env check-fmt lint test-short
+default: add-license build build-examples check-env check-fmt check-modules lint test-short
 
 .PHONY: add-license
 add-license:
@@ -50,7 +50,7 @@ check-fmt:
 	etc/check_fmt.sh $(PKGS)
 
 # check-modules runs "go mod tidy" then "go mod vendor" and exits with a non-zero exit code if there
-# are any changes. The intent is to confirm two properties:
+# are any module or vendored modules changes. The intent is to confirm two properties:
 #
 # 1. Exactly the required modules are declared as dependencies. We should always be able to run
 # "go mod tidy" and expect that no unrelated changes are made to the "go.mod" file.
@@ -61,7 +61,7 @@ check-fmt:
 check-modules:
 	go mod tidy -v
 	go mod vendor
-	git diff --exit-code
+	git diff --exit-code go.mod go.sum ./vendor
 
 .PHONY: doc
 doc:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,20 @@ build-tests:
 check-fmt:
 	etc/check_fmt.sh $(PKGS)
 
+# check-modules runs "go mod tidy" then "go mod vendor" and exits with a non-zero exit code if there
+# are any changes. The intent is to confirm two properties:
+#
+# 1. Exactly the required modules are declared as dependencies. We should always be able to run
+# "go mod tidy" and expect that no unrelated changes are made to the "go.mod" file.
+#
+# 2. All required modules are copied into the vendor/ directory and are an exact copy of the
+# original module source code (i.e. the vendored modules are not modified from their original code).
+.PHONY: check-modules
+check-modules:
+	go mod tidy -v
+	go mod vendor
+	git diff --exit-code
+
 .PHONY: doc
 doc:
 	godoc -http=:6060 -index


### PR DESCRIPTION
Confirm that PRs always have "tidy" and correctly vendored modules by running `go mod tidy` and `go mod vendor` during Evergreen CI runs. If `go mod tidy` or `go mod vendor` make any changes, return an error code.