### PR TITLE
GODRIVER-2339 Use interface for RTTMonitor and add Stats method.

### DIFF
--- a/data/client-side-operations-timeout/error-transformations.json
+++ b/data/client-side-operations-timeout/error-transformations.json
@@ -1,0 +1,181 @@
+{
+  "description": "MaxTimeMSExpired server errors are transformed into a custom timeout error",
+  "schemaVersion": "1.9",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "client",
+        "uriOptions": {
+          "timeoutMS": 50
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "test",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "basic MaxTimeMSExpired error is transformed",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "isTimeoutError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "coll",
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "write concern error MaxTimeMSExpired is transformed",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 50,
+                  "errmsg": "maxTimeMS expired"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "isTimeoutError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "coll",
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/client-side-operations-timeout/error-transformations.yml
+++ b/data/client-side-operations-timeout/error-transformations.yml
@@ -1,0 +1,96 @@
+description: "MaxTimeMSExpired server errors are transformed into a custom timeout error"
+
+schemaVersion: "1.9"
+
+# failCommand is available on 4.0 for replica sets and 4.2 for sharded clusters.
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: ["replicaset"]
+  - minServerVersion: "4.2"
+    topologies: ["replicaset", "sharded"]
+
+createEntities:
+  - client:
+      id: &failPointClient failPointClient
+      useMultipleMongoses: false
+  - client:
+      id: &client client
+      uriOptions:
+        timeoutMS: 50
+      useMultipleMongoses: false
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName test
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents: []
+
+tests:
+  # A server response like {ok: 0, code: 50, ...} is transformed.
+  - description: "basic MaxTimeMSExpired error is transformed"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: ["insert"]
+              errorCode: 50
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+        expectError:
+          isTimeoutError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *collectionName
+                maxTimeMS: { $$type: ["int", "long"] }
+
+  # A server response like {ok: 1, writeConcernError: {code: 50, ...}} is transformed.
+  - description: "write concern error MaxTimeMSExpired is transformed"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: ["insert"]
+              writeConcernError:
+                code: 50
+                errmsg: "maxTimeMS expired"
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+        expectError:
+          isTimeoutError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *collectionName
+                maxTimeMS: { $$type: ["int", "long"] }

--- a/internal/csot_util.go
+++ b/internal/csot_util.go
@@ -37,18 +37,18 @@ func IsTimeoutContext(ctx context.Context) bool {
 // RTT calculations and an empty string for RTT statistics.
 type ZeroRTTMonitor struct{}
 
-// EWMARTT implements the RTT monitor interface.
-func (zrm *ZeroRTTMonitor) EWMARTT() time.Duration {
+// EWMA implements the RTT monitor interface.
+func (zrm *ZeroRTTMonitor) EWMA() time.Duration {
 	return 0
 }
 
-// MinRTT implements the RTT monitor interface.
-func (zrm *ZeroRTTMonitor) MinRTT() time.Duration {
+// Min implements the RTT monitor interface.
+func (zrm *ZeroRTTMonitor) Min() time.Duration {
 	return 0
 }
 
-// RTT90 implements the RTT monitor interface.
-func (zrm *ZeroRTTMonitor) RTT90() time.Duration {
+// P90 implements the RTT monitor interface.
+func (zrm *ZeroRTTMonitor) P90() time.Duration {
 	return 0
 }
 

--- a/internal/csot_util.go
+++ b/internal/csot_util.go
@@ -33,25 +33,26 @@ func IsTimeoutContext(ctx context.Context) bool {
 	return ctx.Value(timeoutKey{}) != nil
 }
 
-// TestRTTMonitor implements the RTTMonitor interface and is used internally for testing.
-type TestRTTMonitor struct{}
+// ZeroRTTMonitor implements the RTTMonitor interface and is used internally for testing. It returns 0 for all
+// RTT calculations and an empty string for RTT statistics.
+type ZeroRTTMonitor struct{}
 
 // AvgRTT implements the RTT monitor interface.
-func (trm *TestRTTMonitor) AvgRTT() time.Duration {
+func (zrm *ZeroRTTMonitor) AvgRTT() time.Duration {
 	return 0
 }
 
 // MinRTT implements the RTT monitor interface.
-func (trm *TestRTTMonitor) MinRTT() time.Duration {
+func (zrm *ZeroRTTMonitor) MinRTT() time.Duration {
 	return 0
 }
 
 // RTT90 implements the RTT monitor interface.
-func (trm *TestRTTMonitor) RTT90() time.Duration {
+func (zrm *ZeroRTTMonitor) RTT90() time.Duration {
 	return 0
 }
 
 // Stats implements the RTT monitor interface.
-func (trm *TestRTTMonitor) Stats() string {
+func (zrm *ZeroRTTMonitor) Stats() string {
 	return ""
 }

--- a/internal/csot_util.go
+++ b/internal/csot_util.go
@@ -37,8 +37,8 @@ func IsTimeoutContext(ctx context.Context) bool {
 // RTT calculations and an empty string for RTT statistics.
 type ZeroRTTMonitor struct{}
 
-// AvgRTT implements the RTT monitor interface.
-func (zrm *ZeroRTTMonitor) AvgRTT() time.Duration {
+// EWMARTT implements the RTT monitor interface.
+func (zrm *ZeroRTTMonitor) EWMARTT() time.Duration {
 	return 0
 }
 

--- a/internal/csot_util.go
+++ b/internal/csot_util.go
@@ -32,3 +32,26 @@ func MakeTimeoutContext(ctx context.Context, to time.Duration) (context.Context,
 func IsTimeoutContext(ctx context.Context) bool {
 	return ctx.Value(timeoutKey{}) != nil
 }
+
+// TestRTTMonitor implements the RTTMonitor interface and is used internally for testing.
+type TestRTTMonitor struct{}
+
+// AvgRTT implements the RTT monitor interface.
+func (trm *TestRTTMonitor) AvgRTT() time.Duration {
+	return 0
+}
+
+// MinRTT implements the RTT monitor interface.
+func (trm *TestRTTMonitor) MinRTT() time.Duration {
+	return 0
+}
+
+// RTT90 implements the RTT monitor interface.
+func (trm *TestRTTMonitor) RTT90() time.Duration {
+	return 0
+}
+
+// Stats implements the RTT monitor interface.
+func (trm *TestRTTMonitor) Stats() string {
+	return ""
+}

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -8,7 +8,6 @@ package mongo
 
 import (
 	"context"
-	"time"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -36,16 +35,8 @@ func (c *changeStreamDeployment) Connection(context.Context) (driver.Connection,
 	return c.conn, nil
 }
 
-func (c *changeStreamDeployment) MinRTT() time.Duration {
-	return c.server.MinRTT()
-}
-
-func (c *changeStreamDeployment) RTT90() time.Duration {
-	return c.server.RTT90()
-}
-
-func (c *changeStreamDeployment) RTTStats() string {
-	return c.server.RTTStats()
+func (c *changeStreamDeployment) RTTMonitor() driver.RTTMonitor {
+	return c.server.RTTMonitor()
 }
 
 func (c *changeStreamDeployment) ProcessError(err error, conn driver.Connection) driver.ProcessErrorResult {

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -44,6 +44,10 @@ func (c *changeStreamDeployment) RTT90() time.Duration {
 	return c.server.RTT90()
 }
 
+func (c *changeStreamDeployment) RTTStats() string {
+	return c.server.RTTStats()
+}
+
 func (c *changeStreamDeployment) ProcessError(err error, conn driver.Connection) driver.ProcessErrorResult {
 	ep, ok := c.server.(driver.ErrorProcessor)
 	if !ok {

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -539,7 +539,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTTMonitor().MinRTT() <= 250*time.Millisecond {
+					if server.RTTMonitor().Min() <= 250*time.Millisecond {
 						done = false
 					}
 				}
@@ -585,7 +585,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTTMonitor().MinRTT() <= 250*time.Millisecond {
+					if server.RTTMonitor().Min() <= 250*time.Millisecond {
 						done = false
 					}
 				}
@@ -638,7 +638,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTTMonitor().RTT90() <= 300*time.Millisecond {
+					if server.RTTMonitor().P90() <= 300*time.Millisecond {
 						done = false
 					}
 				}
@@ -691,7 +691,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTTMonitor().RTT90() <= 275*time.Millisecond {
+					if server.RTTMonitor().P90() <= 275*time.Millisecond {
 						done = false
 					}
 				}

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -539,7 +539,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.MinRTT() <= 250*time.Millisecond {
+					if server.RTTMonitor().MinRTT() <= 250*time.Millisecond {
 						done = false
 					}
 				}
@@ -585,7 +585,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.MinRTT() <= 250*time.Millisecond {
+					if server.RTTMonitor().MinRTT() <= 250*time.Millisecond {
 						done = false
 					}
 				}
@@ -638,7 +638,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTT90() <= 300*time.Millisecond {
+					if server.RTTMonitor().RTT90() <= 300*time.Millisecond {
 						done = false
 					}
 				}
@@ -691,7 +691,7 @@ func TestClient(t *testing.T) {
 				for _, desc := range topo.Description().Servers {
 					server, err := topo.FindServer(desc)
 					assert.Nil(mt, err, "FindServer error: %v", err)
-					if server.RTT90() <= 275*time.Millisecond {
+					if server.RTTMonitor().RTT90() <= 275*time.Millisecond {
 						done = false
 					}
 				}

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -8,10 +8,10 @@ package mtest
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -134,19 +134,9 @@ func (md *mockDeployment) Connection(context.Context) (driver.Connection, error)
 	return md.conn, nil
 }
 
-// MinRTT always returns 0. It implements the driver.Server interface.
-func (md *mockDeployment) MinRTT() time.Duration {
-	return 0
-}
-
-// RTT90 always returns 0. It implements the driver.Server interface.
-func (md *mockDeployment) RTT90() time.Duration {
-	return 0
-}
-
-// RTTStats always returns "". It implements the driver.Server interface.
-func (md *mockDeployment) RTTStats() string {
-	return ""
+// RTTMonitor implements the driver.Server interface.
+func (md *mockDeployment) RTTMonitor() driver.RTTMonitor {
+	return &internal.TestRTTMonitor{}
 }
 
 // Connect is a no-op method which implements the driver.Connector interface.

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -136,7 +136,7 @@ func (md *mockDeployment) Connection(context.Context) (driver.Connection, error)
 
 // RTTMonitor implements the driver.Server interface.
 func (md *mockDeployment) RTTMonitor() driver.RTTMonitor {
-	return &internal.TestRTTMonitor{}
+	return &internal.ZeroRTTMonitor{}
 }
 
 // Connect is a no-op method which implements the driver.Connector interface.

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -144,6 +144,11 @@ func (md *mockDeployment) RTT90() time.Duration {
 	return 0
 }
 
+// RTTStats always returns "". It implements the driver.Server interface.
+func (md *mockDeployment) RTTStats() string {
+	return ""
+}
+
 // Connect is a no-op method which implements the driver.Connector interface.
 func (md *mockDeployment) Connect() error {
 	return nil

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -457,7 +457,7 @@ func (lbcd *loadBalancedCursorDeployment) Connection(_ context.Context) (Connect
 
 // RTTMonitor implements the driver.Server interface.
 func (lbcd *loadBalancedCursorDeployment) RTTMonitor() RTTMonitor {
-	return &internal.TestRTTMonitor{}
+	return &internal.ZeroRTTMonitor{}
 }
 
 func (lbcd *loadBalancedCursorDeployment) ProcessError(err error, conn Connection) ProcessErrorResult {

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -11,10 +11,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/event"
+	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
@@ -455,19 +455,9 @@ func (lbcd *loadBalancedCursorDeployment) Connection(_ context.Context) (Connect
 	return lbcd.conn, nil
 }
 
-// MinRTT always returns 0. It implements the driver.Server interface.
-func (lbcd *loadBalancedCursorDeployment) MinRTT() time.Duration {
-	return 0
-}
-
-// RTT90 always returns 0. It implements the driver.Server interface.
-func (lbcd *loadBalancedCursorDeployment) RTT90() time.Duration {
-	return 0
-}
-
-// RTTStats always returns "". It implements the driver.Server interface.
-func (lbcd *loadBalancedCursorDeployment) RTTStats() string {
-	return ""
+// RTTMonitor implements the driver.Server interface.
+func (lbcd *loadBalancedCursorDeployment) RTTMonitor() RTTMonitor {
+	return &internal.TestRTTMonitor{}
 }
 
 func (lbcd *loadBalancedCursorDeployment) ProcessError(err error, conn Connection) ProcessErrorResult {

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -465,6 +465,11 @@ func (lbcd *loadBalancedCursorDeployment) RTT90() time.Duration {
 	return 0
 }
 
+// RTTStats always returns "". It implements the driver.Server interface.
+func (lbcd *loadBalancedCursorDeployment) RTTStats() string {
+	return ""
+}
+
 func (lbcd *loadBalancedCursorDeployment) ProcessError(err error, conn Connection) ProcessErrorResult {
 	return lbcd.errorProcessor.ProcessError(err, conn)
 }

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -88,7 +88,7 @@ type RTTMonitor interface {
 	Stats() string
 }
 
-var _ RTTMonitor = &internal.TestRTTMonitor{}
+var _ RTTMonitor = &internal.ZeroRTTMonitor{}
 
 // PinnedConnection represents a Connection that can be pinned by one or more cursors or transactions. Implementations
 // of this interface should maintain the following invariants:
@@ -229,7 +229,7 @@ func (ssd SingleConnectionDeployment) Connection(context.Context) (Connection, e
 
 // RTTMonitor implements the driver.Server interface.
 func (ssd SingleConnectionDeployment) RTTMonitor() RTTMonitor {
-	return &internal.TestRTTMonitor{}
+	return &internal.ZeroRTTMonitor{}
 }
 
 // TODO(GODRIVER-617): We can likely use 1 type for both the Type and the RetryMode by using 2 bits for the mode and 1

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -75,8 +75,8 @@ type Connection interface {
 
 // RTTMonitor represents a round-trip-time monitor.
 type RTTMonitor interface {
-	// AvgRTT returns the exponentially weighted moving average observed round-trip time.
-	AvgRTT() time.Duration
+	// EWMARTT returns the exponentially weighted moving average observed round-trip time.
+	EWMARTT() time.Duration
 
 	// MinRTT returns the minimum observed round-trip time over the window period.
 	MinRTT() time.Duration

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -56,6 +56,9 @@ type Server interface {
 
 	// RTT90 returns the 90th percentile round-trip time to the server observed over the window period.
 	RTT90() time.Duration
+
+	// RTTStats returns stringified stats of the current state of the round-trip-time monitor.
+	RTTStats() string
 }
 
 // Connection represents a connection to a MongoDB server.
@@ -220,6 +223,11 @@ func (ssd SingleConnectionDeployment) MinRTT() time.Duration {
 // RTT90 always returns 0. It implements the driver.Server interface.
 func (ssd SingleConnectionDeployment) RTT90() time.Duration {
 	return 0
+}
+
+// RTTStats always returns "". It implements the driver.Server interface.
+func (ssd SingleConnectionDeployment) RTTStats() string {
+	return ""
 }
 
 // TODO(GODRIVER-617): We can likely use 1 type for both the Type and the RetryMode by using 2 bits for the mode and 1

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -75,14 +75,14 @@ type Connection interface {
 
 // RTTMonitor represents a round-trip-time monitor.
 type RTTMonitor interface {
-	// EWMARTT returns the exponentially weighted moving average observed round-trip time.
-	EWMARTT() time.Duration
+	// EWMA returns the exponentially weighted moving average observed round-trip time.
+	EWMA() time.Duration
 
-	// MinRTT returns the minimum observed round-trip time over the window period.
-	MinRTT() time.Duration
+	// Min returns the minimum observed round-trip time over the window period.
+	Min() time.Duration
 
-	// RTT90 returns the 90th percentile observed round-trip time over the window period.
-	RTT90() time.Duration
+	// P90 returns the 90th percentile observed round-trip time over the window period.
+	P90() time.Duration
 
 	// Stats returns stringified stats of the current state of the monitor.
 	Stats() string

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -479,7 +479,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 				remainingTimeout := time.Until(deadline)
 
 				maxTimeMSVal := int64(remainingTimeout/time.Millisecond) -
-					int64(srvr.RTTMonitor().RTT90()/time.Millisecond)
+					int64(srvr.RTTMonitor().P90()/time.Millisecond)
 
 				// A maxTimeMS value <= 0 indicates that we are already at or past the Context's deadline.
 				if maxTimeMSVal <= 0 {
@@ -534,10 +534,10 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		// a Timeout Context, use the 90th percentile RTT as a threshold. Otherwise, use the minimum observed
 		// RTT.
 		if deadline, ok := ctx.Deadline(); ok {
-			if internal.IsTimeoutContext(ctx) && time.Now().Add(srvr.RTTMonitor().RTT90()).After(deadline) {
+			if internal.IsTimeoutContext(ctx) && time.Now().Add(srvr.RTTMonitor().P90()).After(deadline) {
 				err = internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
 					"remaining time %v until context deadline is less than 90th percentile RTT\n%v", time.Until(deadline), srvr.RTTMonitor().Stats())
-			} else if time.Now().Add(srvr.RTTMonitor().MinRTT()).After(deadline) {
+			} else if time.Now().Add(srvr.RTTMonitor().Min()).After(deadline) {
 				err = op.networkError(context.DeadlineExceeded)
 			}
 		}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -484,7 +484,8 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 				// A maxTimeMS value <= 0 indicates that we are already at or past the Context's deadline.
 				if maxTimeMSVal <= 0 {
 					return internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
-						"Context deadline has already been surpassed by %v", remainingTimeout)
+						"remaining time %v until context deadline is less than or equal to 90th percentile RTT\n%v",
+						remainingTimeout, srvr.RTTStats())
 				}
 				maxTimeMS = uint64(maxTimeMSVal)
 			}
@@ -535,7 +536,7 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		if deadline, ok := ctx.Deadline(); ok {
 			if internal.IsTimeoutContext(ctx) && time.Now().Add(srvr.RTT90()).After(deadline) {
 				err = internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
-					"Remaining timeout %v applied from Timeout is less than 90th percentile RTT", time.Until(deadline))
+					"remaining time %v until context deadline is less than 90th percentile RTT\n%v", time.Until(deadline), srvr.RTTStats())
 			} else if time.Now().Add(srvr.MinRTT()).After(deadline) {
 				err = op.networkError(context.DeadlineExceeded)
 			}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -725,7 +725,7 @@ func (ms *mockRetryServer) Connection(ctx context.Context) (Connection, error) {
 }
 
 func (ms *mockRetryServer) RTTMonitor() RTTMonitor {
-	return &internal.TestRTTMonitor{}
+	return &internal.ZeroRTTMonitor{}
 }
 
 func TestRetry(t *testing.T) {

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -724,16 +724,8 @@ func (ms *mockRetryServer) Connection(ctx context.Context) (Connection, error) {
 	return nil, retryableError{error: errors.New("test error")}
 }
 
-func (ms *mockRetryServer) MinRTT() time.Duration {
-	return 0
-}
-
-func (ms *mockRetryServer) RTT90() time.Duration {
-	return 0
-}
-
-func (ms *mockRetryServer) RTTStats() string {
-	return ""
+func (ms *mockRetryServer) RTTMonitor() RTTMonitor {
+	return &internal.TestRTTMonitor{}
 }
 
 func TestRetry(t *testing.T) {

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -732,6 +732,10 @@ func (ms *mockRetryServer) RTT90() time.Duration {
 	return 0
 }
 
+func (ms *mockRetryServer) RTTStats() string {
+	return ""
+}
+
 func TestRetry(t *testing.T) {
 	t.Run("retries multiple times with RetryContext", func(t *testing.T) {
 		d := new(mockDeployment)

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -251,8 +251,8 @@ func percentile(perc float64, samples []time.Duration, minSamples int) time.Dura
 	return time.Duration(p)
 }
 
-// AvgRTT returns the exponentially weighted moving average observed round-trip time.
-func (r *rttMonitor) AvgRTT() time.Duration {
+// EWMARTT returns the exponentially weighted moving average observed round-trip time.
+func (r *rttMonitor) EWMARTT() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -43,7 +43,7 @@ type rttMonitor struct {
 	samples       []time.Duration
 	offset        int
 	minRTT        time.Duration
-	RTT90         time.Duration
+	rtt90         time.Duration
 	averageRTT    time.Duration
 	averageRTTSet bool
 
@@ -52,6 +52,8 @@ type rttMonitor struct {
 	ctx      context.Context
 	cancelFn context.CancelFunc
 }
+
+var _ driver.RTTMonitor = &rttMonitor{}
 
 func newRTTMonitor(cfg *rttConfig) *rttMonitor {
 	if cfg.interval <= 0 {
@@ -179,7 +181,7 @@ func (r *rttMonitor) reset() {
 	}
 	r.offset = 0
 	r.minRTT = 0
-	r.RTT90 = 0
+	r.rtt90 = 0
 	r.averageRTT = 0
 	r.averageRTTSet = false
 }
@@ -196,7 +198,7 @@ func (r *rttMonitor) addSample(rtt time.Duration) {
 	// setting these to prevent noisy samples on startup from artificially increasing RTT and to allow the
 	// calculation of a 90th percentile.
 	r.minRTT = min(r.samples, minSamples)
-	r.RTT90 = percentile(90.0, r.samples, minSamples)
+	r.rtt90 = percentile(90.0, r.samples, minSamples)
 
 	if !r.averageRTTSet {
 		r.averageRTT = rtt
@@ -249,32 +251,32 @@ func percentile(perc float64, samples []time.Duration, minSamples int) time.Dura
 	return time.Duration(p)
 }
 
-// getRTT returns the exponentially weighted moving average observed round-trip time.
-func (r *rttMonitor) getRTT() time.Duration {
+// AvgRTT returns the exponentially weighted moving average observed round-trip time.
+func (r *rttMonitor) AvgRTT() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	return r.averageRTT
 }
 
-// getMinRTT returns the minimum observed round-trip time over the window period.
-func (r *rttMonitor) getMinRTT() time.Duration {
+// MinRTT returns the minimum observed round-trip time over the window period.
+func (r *rttMonitor) MinRTT() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	return r.minRTT
 }
 
-// getRTT90 returns the 90th percentile observed round-trip time over the window period.
-func (r *rttMonitor) getRTT90() time.Duration {
+// RTT90 returns the 90th percentile observed round-trip time over the window period.
+func (r *rttMonitor) RTT90() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return r.RTT90
+	return r.rtt90
 }
 
-// getStats returns stringified stats of the current state of the monitor.
-func (r *rttMonitor) getStats() string {
+// Stats returns stringified stats of the current state of the monitor.
+func (r *rttMonitor) Stats() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -301,5 +303,5 @@ func (r *rttMonitor) getStats() string {
 
 	return fmt.Sprintf(`Round-trip-time monitor statistics:`+"\n"+
 		`average RTT: %v, minimum RTT: %v, 90th percentile RTT: %v, standard dev: %v`+"\n",
-		time.Duration(avg), r.minRTT, r.RTT90, time.Duration(stdDev))
+		time.Duration(avg), r.minRTT, r.rtt90, time.Duration(stdDev))
 }

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -296,6 +296,6 @@ func (r *rttMonitor) getStats() string {
 	}
 
 	return fmt.Sprintf(`Round-trip-time monitor statistics:`+"\n"+
-		`average RTT: %v, minimum RTT: %v, 90th percentile RTT: %v, standard dev: %.6fms`,
+		`average RTT: %v, minimum RTT: %v, 90th percentile RTT: %v, standard dev: %.6fms`+"\n",
 		r.averageRTT, r.minRTT, r.RTT90, stdDev/float64(time.Millisecond))
 }

--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -251,24 +251,24 @@ func percentile(perc float64, samples []time.Duration, minSamples int) time.Dura
 	return time.Duration(p)
 }
 
-// EWMARTT returns the exponentially weighted moving average observed round-trip time.
-func (r *rttMonitor) EWMARTT() time.Duration {
+// EWMA returns the exponentially weighted moving average observed round-trip time.
+func (r *rttMonitor) EWMA() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	return r.averageRTT
 }
 
-// MinRTT returns the minimum observed round-trip time over the window period.
-func (r *rttMonitor) MinRTT() time.Duration {
+// Min returns the minimum observed round-trip time over the window period.
+func (r *rttMonitor) Min() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	return r.minRTT
 }
 
-// RTT90 returns the 90th percentile observed round-trip time over the window period.
-func (r *rttMonitor) RTT90() time.Duration {
+// P90 returns the 90th percentile observed round-trip time over the window period.
+func (r *rttMonitor) P90() time.Duration {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -103,25 +103,25 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.getRTT() > 0 && rtt.getMinRTT() > 0 && rtt.getRTT90() > 0 },
+			func() bool { return rtt.AvgRTT() > 0 && rtt.MinRTT() > 0 && rtt.RTT90() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected getRTT(), getMinRTT() and getRTT90() to return positive durations within 1 second")
+			"expected AvgRTT(), MinRTT() and RTT90() to return positive durations within 1 second")
 		assert.True(
 			t,
-			rtt.getRTT() > 0,
-			"expected getRTT() to return a positive duration, got %v",
-			rtt.getRTT())
+			rtt.AvgRTT() > 0,
+			"expected AvgRTT() to return a positive duration, got %v",
+			rtt.AvgRTT())
 		assert.True(
 			t,
-			rtt.getMinRTT() > 0,
-			"expected getMinRTT() to return a positive duration, got %v",
-			rtt.getMinRTT())
+			rtt.MinRTT() > 0,
+			"expected MinRTT() to return a positive duration, got %v",
+			rtt.MinRTT())
 		assert.True(
 			t,
-			rtt.getRTT90() > 0,
-			"expected getRTT90() to return a positive duration, got %v",
-			rtt.getRTT90())
+			rtt.RTT90() > 0,
+			"expected RTT90() to return a positive duration, got %v",
+			rtt.RTT90())
 	})
 
 	t.Run("creates the correct size samples slice", func(t *testing.T) {
@@ -203,22 +203,22 @@ func TestRTTMonitor(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.getRTT() > 0 },
+				func() bool { return rtt.AvgRTT() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected getRTT() to return a positive duration within 1 second")
+				"expected AvgRTT() to return a positive duration within 1 second")
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.getMinRTT() > 0 },
+				func() bool { return rtt.MinRTT() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected getMinRTT() to return a positive duration within 1 second")
+				"expected MinRTT() to return a positive duration within 1 second")
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.getRTT90() > 0 },
+				func() bool { return rtt.RTT90() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected getRTT90() to return a positive duration within 1 second")
+				"expected RTT90() to return a positive duration within 1 second")
 			rtt.reset()
 		}
 	})
@@ -305,22 +305,22 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.getRTT() > 0 },
+			func() bool { return rtt.AvgRTT() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected getRTT() to return a positive duration within 1 second")
+			"expected AvgRTT() to return a positive duration within 1 second")
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.getMinRTT() > 0 },
+			func() bool { return rtt.MinRTT() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected getMinRTT() to return a positive duration within 1 second")
+			"expected MinRTT() to return a positive duration within 1 second")
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.getRTT90() > 0 },
+			func() bool { return rtt.RTT90() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected getRTT90() to return a positive duration within 1 second")
+			"expected RTT90() to return a positive duration within 1 second")
 
 		rtt.disconnect()
 		l.Close()

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -103,15 +103,15 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.AvgRTT() > 0 && rtt.MinRTT() > 0 && rtt.RTT90() > 0 },
+			func() bool { return rtt.EWMARTT() > 0 && rtt.MinRTT() > 0 && rtt.RTT90() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected AvgRTT(), MinRTT() and RTT90() to return positive durations within 1 second")
+			"expected EWMARTT(), MinRTT() and RTT90() to return positive durations within 1 second")
 		assert.True(
 			t,
-			rtt.AvgRTT() > 0,
-			"expected AvgRTT() to return a positive duration, got %v",
-			rtt.AvgRTT())
+			rtt.EWMARTT() > 0,
+			"expected EWMARTT() to return a positive duration, got %v",
+			rtt.EWMARTT())
 		assert.True(
 			t,
 			rtt.MinRTT() > 0,
@@ -203,10 +203,10 @@ func TestRTTMonitor(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.AvgRTT() > 0 },
+				func() bool { return rtt.EWMARTT() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected AvgRTT() to return a positive duration within 1 second")
+				"expected EWMARTT() to return a positive duration within 1 second")
 			assert.Eventuallyf(
 				t,
 				func() bool { return rtt.MinRTT() > 0 },
@@ -305,10 +305,10 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.AvgRTT() > 0 },
+			func() bool { return rtt.EWMARTT() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected AvgRTT() to return a positive duration within 1 second")
+			"expected EWMARTT() to return a positive duration within 1 second")
 		assert.Eventuallyf(
 			t,
 			func() bool { return rtt.MinRTT() > 0 },

--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -103,25 +103,25 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.EWMARTT() > 0 && rtt.MinRTT() > 0 && rtt.RTT90() > 0 },
+			func() bool { return rtt.EWMA() > 0 && rtt.Min() > 0 && rtt.P90() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected EWMARTT(), MinRTT() and RTT90() to return positive durations within 1 second")
+			"expected EWMA(), Min() and P90() to return positive durations within 1 second")
 		assert.True(
 			t,
-			rtt.EWMARTT() > 0,
-			"expected EWMARTT() to return a positive duration, got %v",
-			rtt.EWMARTT())
+			rtt.EWMA() > 0,
+			"expected EWMA() to return a positive duration, got %v",
+			rtt.EWMA())
 		assert.True(
 			t,
-			rtt.MinRTT() > 0,
-			"expected MinRTT() to return a positive duration, got %v",
-			rtt.MinRTT())
+			rtt.Min() > 0,
+			"expected Min() to return a positive duration, got %v",
+			rtt.Min())
 		assert.True(
 			t,
-			rtt.RTT90() > 0,
-			"expected RTT90() to return a positive duration, got %v",
-			rtt.RTT90())
+			rtt.P90() > 0,
+			"expected P90() to return a positive duration, got %v",
+			rtt.P90())
 	})
 
 	t.Run("creates the correct size samples slice", func(t *testing.T) {
@@ -203,22 +203,22 @@ func TestRTTMonitor(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.EWMARTT() > 0 },
+				func() bool { return rtt.EWMA() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected EWMARTT() to return a positive duration within 1 second")
+				"expected EWMA() to return a positive duration within 1 second")
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.MinRTT() > 0 },
+				func() bool { return rtt.Min() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected MinRTT() to return a positive duration within 1 second")
+				"expected Min() to return a positive duration within 1 second")
 			assert.Eventuallyf(
 				t,
-				func() bool { return rtt.RTT90() > 0 },
+				func() bool { return rtt.P90() > 0 },
 				1*time.Second,
 				10*time.Millisecond,
-				"expected RTT90() to return a positive duration within 1 second")
+				"expected P90() to return a positive duration within 1 second")
 			rtt.reset()
 		}
 	})
@@ -305,22 +305,22 @@ func TestRTTMonitor(t *testing.T) {
 
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.EWMARTT() > 0 },
+			func() bool { return rtt.EWMA() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected EWMARTT() to return a positive duration within 1 second")
+			"expected EWMA() to return a positive duration within 1 second")
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.MinRTT() > 0 },
+			func() bool { return rtt.Min() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected MinRTT() to return a positive duration within 1 second")
+			"expected Min() to return a positive duration within 1 second")
 		assert.Eventuallyf(
 			t,
-			func() bool { return rtt.RTT90() > 0 },
+			func() bool { return rtt.P90() > 0 },
 			1*time.Second,
 			10*time.Millisecond,
-			"expected RTT90() to return a positive duration within 1 second")
+			"expected P90() to return a positive duration within 1 second")
 
 		rtt.disconnect()
 		l.Close()

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -779,7 +779,7 @@ func (s *Server) check() (description.Server, error) {
 	if descPtr != nil {
 		// The check was successful. Set the average RTT and the 90th percentile RTT and return.
 		desc := *descPtr
-		desc = desc.SetAverageRTT(s.rttMonitor.EWMARTT())
+		desc = desc.SetAverageRTT(s.rttMonitor.EWMA())
 		desc.HeartbeatInterval = s.cfg.heartbeatInterval
 		return desc, nil
 	}
@@ -834,7 +834,7 @@ func (s *Server) String() string {
 		str += fmt.Sprintf(", Tag sets: %s", desc.Tags)
 	}
 	if state == serverConnected {
-		str += fmt.Sprintf(", Average RTT: %s, Min RTT: %s", desc.AverageRTT, s.RTTMonitor().MinRTT())
+		str += fmt.Sprintf(", Average RTT: %s, Min RTT: %s", desc.AverageRTT, s.RTTMonitor().Min())
 	}
 	if desc.LastError != nil {
 		str += fmt.Sprintf(", Last error: %s", desc.LastError)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -779,7 +779,7 @@ func (s *Server) check() (description.Server, error) {
 	if descPtr != nil {
 		// The check was successful. Set the average RTT and the 90th percentile RTT and return.
 		desc := *descPtr
-		desc = desc.SetAverageRTT(s.rttMonitor.AvgRTT())
+		desc = desc.SetAverageRTT(s.rttMonitor.EWMARTT())
 		desc.HeartbeatInterval = s.cfg.heartbeatInterval
 		return desc, nil
 	}

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -824,6 +824,11 @@ func (s *Server) RTT90() time.Duration {
 	return s.rttMonitor.getRTT90()
 }
 
+// RTTStats returns stringified stats of the current state of the round-trip-time monitor.
+func (s *Server) RTTStats() string {
+	return s.rttMonitor.getStats()
+}
+
 // OperationCount returns the current number of in-progress operations for this server.
 func (s *Server) OperationCount() int64 {
 	return atomic.LoadInt64(&s.operationCount)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -779,7 +779,7 @@ func (s *Server) check() (description.Server, error) {
 	if descPtr != nil {
 		// The check was successful. Set the average RTT and the 90th percentile RTT and return.
 		desc := *descPtr
-		desc = desc.SetAverageRTT(s.rttMonitor.getRTT())
+		desc = desc.SetAverageRTT(s.rttMonitor.AvgRTT())
 		desc.HeartbeatInterval = s.cfg.heartbeatInterval
 		return desc, nil
 	}
@@ -814,19 +814,9 @@ func extractTopologyVersion(err error) *description.TopologyVersion {
 	return nil
 }
 
-// MinRTT returns the minimum round-trip time to the server observed over the last 5 minutes.
-func (s *Server) MinRTT() time.Duration {
-	return s.rttMonitor.getMinRTT()
-}
-
-// RTT90 returns the 90th percentile round-trip time to the server observed over the last 5 minutes.
-func (s *Server) RTT90() time.Duration {
-	return s.rttMonitor.getRTT90()
-}
-
-// RTTStats returns stringified stats of the current state of the round-trip-time monitor.
-func (s *Server) RTTStats() string {
-	return s.rttMonitor.getStats()
+// RTTMonitor returns this server's round-trip-time monitor.
+func (s *Server) RTTMonitor() driver.RTTMonitor {
+	return s.rttMonitor
 }
 
 // OperationCount returns the current number of in-progress operations for this server.
@@ -844,7 +834,7 @@ func (s *Server) String() string {
 		str += fmt.Sprintf(", Tag sets: %s", desc.Tags)
 	}
 	if state == serverConnected {
-		str += fmt.Sprintf(", Average RTT: %s, Min RTT: %s", desc.AverageRTT, s.MinRTT())
+		str += fmt.Sprintf(", Average RTT: %s, Min RTT: %s", desc.AverageRTT, s.RTTMonitor().MinRTT())
 	}
 	if desc.LastError != nil {
 		str += fmt.Sprintf(", Last error: %s", desc.LastError)

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -53,7 +53,7 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 
 				monitor.addSample(time.Duration(test.NewRttMs * float64(time.Millisecond)))
 				expectedRTT := time.Duration(test.NewAvgRtt * float64(time.Millisecond))
-				actualRTT := monitor.AvgRTT()
+				actualRTT := monitor.EWMARTT()
 				assert.Equal(t, expectedRTT, actualRTT, "expected average RTT %s, got %s", expectedRTT, actualRTT)
 			})
 		}(t, file)

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -53,7 +53,7 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 
 				monitor.addSample(time.Duration(test.NewRttMs * float64(time.Millisecond)))
 				expectedRTT := time.Duration(test.NewAvgRtt * float64(time.Millisecond))
-				actualRTT := monitor.EWMARTT()
+				actualRTT := monitor.EWMA()
 				assert.Equal(t, expectedRTT, actualRTT, "expected average RTT %s, got %s", expectedRTT, actualRTT)
 			})
 		}(t, file)

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -53,7 +53,7 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 
 				monitor.addSample(time.Duration(test.NewRttMs * float64(time.Millisecond)))
 				expectedRTT := time.Duration(test.NewAvgRtt * float64(time.Millisecond))
-				actualRTT := monitor.getRTT()
+				actualRTT := monitor.AvgRTT()
 				assert.Equal(t, expectedRTT, actualRTT, "expected average RTT %s, got %s", expectedRTT, actualRTT)
 			})
 		}(t, file)


### PR DESCRIPTION
GODRIVER-2339

Syncs CSOT spec tests for error transformations. Extends the `IsTimeout()` helper to recognize the `MaxTimeMSExpired` error. Modifies the `Server` interface to contain a new `RTTMonitor` interface. Adds `Stats()` method to `rttMonitor`. Returns RTT monitor stats with `ErrDeadlineWouldBeExceeded` errors.