### PR TITLE
Skip Stable API count example test.

### DIFF
--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -2905,6 +2905,10 @@ func StableAPIDeprecationErrorsExample() {
 // StableAPIStrictCountExample is an example of using CountDocuments instead of a traditional count
 // with a strict stable API since the count command does not belong to API version 1.
 func StableAPIStrictCountExample(t *testing.T) {
+	// TODO(GODRIVER-2482): The "count" command is now part of Stable API v1 in MongoDB v5.0.x and
+	// TODO v6.x, so this example no longer works correctly in any CI tested server version. Rewrite
+	// TODO this example with a command that is not part of Stable API v1. For now, this example
+	// TODO test is always skipped.
 	uri := mtest.ClusterURI()
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -92,11 +92,12 @@ func TestDocumentationExamples(t *testing.T) {
 	mt := mtest.New(t)
 	defer mt.Close()
 
-	// Because it uses RunCommand with an apiVersion, the strict count example can only be
-	// run on 5.0+ without auth. It also cannot be run on 6.0+ since the count command was
-	// added to API version 1 and no longer results in an error when strict is enabled.
-	mtOpts := mtest.NewOptions().MinServerVersion("5.0").MaxServerVersion("5.3")
+	// Stable API is supported in 5.0+
+	mtOpts := mtest.NewOptions().MinServerVersion("5.0")
 	mt.RunOpts("StableAPIStrictCountExample", mtOpts, func(mt *mtest.T) {
+		// TODO(GODRIVER-2482): Unskip when this test is rewritten to work with Stable API v1.
+		mt.Skip(`skipping because "count" is now part of Stable API v1; see GODRIVER-2482`)
+
 		documentation_examples.StableAPIStrictCountExample(mt.T)
 	})
 


### PR DESCRIPTION
The example `StableAPIStrictCountExample` no longer works because "count" was added to Stable API v1. Skip the test for all server versions for now. See [GODRIVER-2482](https://jira.mongodb.org/browse/GODRIVER-2482) for more details and the plant to eventually update the example.