### PR TITLE
GODRIVER-2449 document Queryable Encryption API as Public Technical Preview

### DIFF
--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -135,18 +135,8 @@
 //    cp ./include/mongocrypt/*.h c:/libmongocrypt/include
 //    export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
 //
-// libmongocrypt communicates with the mongocryptd process for automatic encryption. This process can be started manually
-// or auto-spawned by the driver itself. To enable auto-spawning, ensure the process binary is on the PATH. To start it
-// manually, use AutoEncryptionOptions:
-//
-//    aeo := options.AutoEncryption()
-//    mongocryptdOpts := map[string]interface{}{
-//        "mongocryptdBypassSpawn": true,
-//    }
-//    aeo.SetExtraOptions(mongocryptdOpts)
-// To specify a process URI for mongocryptd, the "mongocryptdURI" option can be passed in the ExtraOptions map as well.
-// See the ClientSideEncryption and ClientSideEncryptionCreateKey examples below for code samples about using this
-// feature.
+// libmongocrypt communicates with the mongocryptd process or mongo_crypt shared library for automatic encryption.
+// See AutoEncryptionOpts.SetExtraOptions for options to configure use of mongocryptd or mongo_crypt.
 //
 // [1] See https://www.mongodb.com/docs/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -123,6 +123,7 @@
 // to install packages via brew and compile the libmongocrypt source code.
 //
 // 3. Windows:
+//
 //    mkdir -p c:/libmongocrypt/bin
 //    mkdir -p c:/libmongocrypt/include
 //

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -92,7 +92,7 @@ func (a *AutoEncryptionOptions) SetBypassAutoEncryption(bypass bool) *AutoEncryp
 	return a
 }
 
-// SetExtraOptions specifies a map of options to configure the mongocryptd process.
+// SetExtraOptions specifies a map of options to configure the mongocryptd process or mongo_crypt shared library.
 //
 // Supported Extra Options
 //

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -144,6 +144,8 @@ func (a *AutoEncryptionOptions) SetTLSConfig(tlsOpts map[string]*tls.Config) *Au
 }
 
 // SetEncryptedFieldsMap specifies a map from namespace to local EncryptedFieldsMap document.
+// EncryptedFieldsMap is used for Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{}) *AutoEncryptionOptions {
 	a.EncryptedFieldsMap = ef
 	return a
@@ -151,6 +153,7 @@ func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{})
 
 // SetBypassQueryAnalysis specifies whether or not query analysis should be used for automatic encryption.
 // Use this option when using explicit encryption with Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 func (a *AutoEncryptionOptions) SetBypassQueryAnalysis(bypass bool) *AutoEncryptionOptions {
 	a.BypassQueryAnalysis = &bypass
 	return a

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -11,6 +11,8 @@ import (
 )
 
 // These constants specify valid values for QueryType
+// QueryType is used for Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 const (
 	QueryTypeEquality string = "equality"
 )
@@ -47,6 +49,8 @@ func (e *EncryptOptions) SetKeyAltName(keyAltName string) *EncryptOptions {
 // - Indexed
 // - Unindexed
 // This is required.
+// Indexed and Unindexed are used for Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 	e.Algorithm = algorithm
 	return e
@@ -55,12 +59,16 @@ func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 // SetQueryType specifies the intended query type. It is only valid to set if algorithm is "Indexed".
 // This should be one of the following:
 // - equality
+// QueryType is used for Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
 	e.QueryType = queryType
 	return e
 }
 
 // SetContentionFactor specifies the contention factor. It is only valid to set if algorithm is "Indexed".
+// ContentionFactor is used for Queryable Encryption.
+// Queryable Encryption is in Public Technical Preview.
 func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOptions {
 	e.ContentionFactor = &contentionFactor
 	return e


### PR DESCRIPTION
GODRIVER-2449

https://github.com/mongodb/mongo-go-driver/commit/23fb886800cc08c295ff809521da35143f88aedd contains the required documentation. The other commits are drive-by fixes to note `mongo_crypt` and fix formatting,.