### PR TITLE
GODRIVER-449 Correctly unescape usernames and passwords in connection strings

### DIFF
--- a/data/connection-string/valid-auth.json
+++ b/data/connection-string/valid-auth.json
@@ -241,6 +241,27 @@
       }
     },
     {
+      "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
+      "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "!$&'()*+,;=",
+        "password": "!$&'()*+,;=",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
       "description": "Escaped username (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
       "valid": true,

--- a/data/connection-string/valid-auth.yml
+++ b/data/connection-string/valid-auth.yml
@@ -189,6 +189,22 @@ tests:
         options:
             authmechanism: "MONGODB-CR"
     -
+        description: "Subdelimiters in user/pass don't need escaping (MONGODB-CR)"
+        uri: "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "ipv4"
+                host: "127.0.0.1"
+                port: ~
+        auth:
+            username: "!$&'()*+,;="
+            password: "!$&'()*+,;="
+            db: "admin"
+        options:
+            authmechanism: "MONGODB-CR"
+    -
         description: "Escaped username (MONGODB-X509)"
         uri: "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509"
         valid: true

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -233,7 +233,7 @@ func (p *parser) parse(original string) error {
 		if strings.Contains(username, "/") {
 			return fmt.Errorf("unescaped slash in username")
 		}
-		p.Username, err = url.QueryUnescape(username)
+		p.Username, err = url.PathUnescape(username)
 		if err != nil {
 			return internal.WrapErrorf(err, "invalid username")
 		}
@@ -246,7 +246,7 @@ func (p *parser) parse(original string) error {
 		if strings.Contains(password, "/") {
 			return fmt.Errorf("unescaped slash in password")
 		}
-		p.Password, err = url.QueryUnescape(password)
+		p.Password, err = url.PathUnescape(password)
 		if err != nil {
 			return internal.WrapErrorf(err, "invalid password")
 		}


### PR DESCRIPTION
[GODRIVER-449](https://jira.mongodb.org/browse/GODRIVER-449)

Use [url.PathUnescape](https://pkg.go.dev/net/url#PathUnescape) instead of [url.QueryUnescape](https://pkg.go.dev/net/url#QueryUnescape) to more correctly unescape usernames and passwords in connection strings. Specifically, [url.QueryUnescape](https://pkg.go.dev/net/url#QueryUnescape) unescapes "+" to " ", which does not match the behavior required by the [Connection String Spec](https://github.com/mongodb/specifications/blob/0e1d31ec088a4da9380cba95eb987db97bc435ed/source/connection-string/connection-string-spec.rst). [url.PathUnescape](https://pkg.go.dev/net/url#PathUnescape) does not unescape "+" to " ":
> PathUnescape is identical to QueryUnescape except that it does not unescape '+' to ' ' (space). 

Also sync connection string spec tests from https://github.com/mongodb/specifications/commit/c32a5d326c624764dccb6fc38bea057a72be56a4.