### PR TITLE
Use correct variable name for Python path in AWS auth tests.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2119,13 +2119,13 @@ axes:
           GCC_PATH: "/cygdrive/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"
           GO_DIST: "C:\\golang\\go1.17"
           SKIP_ECS_AUTH_TEST: true
-          PYTHON3: "C:/python/Python38/python.exe"
+          PYTHON3_BINARY: "C:/python/Python38/python.exe"
       - id: "ubuntu1804-64-go-1-17"
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
         variables:
           GO_DIST: "/opt/golang/go1.17"
-          PYTHON3: python3
+          PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-17"
         display_name: "MacOS 10.15"
         run_on: macos-1015
@@ -2133,7 +2133,7 @@ axes:
           GO_DIST: "/opt/golang/go1.17"
           SKIP_ECS_AUTH_TEST: true
           SKIP_EC2_AUTH_TEST: true
-          PYTHON3: python3
+          PYTHON3_BINARY: python3
 
 task_groups:
   - name: serverless_task_group


### PR DESCRIPTION
Currently the OS specs in the `os-aws-auth` axis define the `PYTHON3` variable that contains a path to the Python 3 binary for that OS. However, all of the other Evergreen configuration and scripts use the `PYTHON3_BINARY` variable name, leading to CI setup failures like [this](https://evergreen.mongodb.com/task/mongo_go_driver_aws_auth_test__version~4.4_os_aws_auth~windows_64_vsMulti_small_go_1_17_aws_auth_test_6f2489ef35dae2e7b2cfdc2e13b4dbc02b3f40e6_22_07_07_21_43_02). Use the correct variable name and update the Python 3 path to point to a Python 3 binary.

Changes:
* Define `PYTHON3_BINARY` variable instead of `PYTHON3` variable for `os-aws-auth` OS specs.
* Use correct path for `PYTHON3_BINARY` variable copied from the `os-ssl-40` OS specs.