### PR TITLE
GODRIVER-2492 use consistent versions of crypt_shared and server

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -174,7 +174,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch crypt_shared-download $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -212,6 +212,7 @@ functions:
           else
             echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
             download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
+            touch expansion.yml
           fi
     - command: expansions.update
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -200,6 +200,12 @@ functions:
             exit 0
           fi
 
+          echo "VERSION expansion is: ${VERSION}"
+          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
+          echo "MONGO_CRYPT_SHARED_DOWNLOAD_URL is $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+
+          # TODO: if MONGO_CRYPT_SHARED_DOWNLOAD_URL is possible to determine. Then this ought to be responsible for skipping.
+
           # Download the crypt_shared dynamic library for the current platform to the current working
           # directory. The run-tests.sh and versioned API test scripts expect to find a
           # mongo_crypt_v1.* file in the "src/go.mongodb.org/mongo-driver" working directory.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,11 +192,17 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
+          VERSION=${VERSION}
+          if [ -z "$VERSION" ]; then
+            # default to latest to match behavior of run-orchestration.sh.
+            VERSION=latest
+          fi
+
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
-          get_mongodb_download_url_for "$DISTRO" "${VERSION}"
+          get_mongodb_download_url_for "$DISTRO" "$VERSION"
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
-            echo "There is no crypt_shared library for distro='$DISTRO' and version='${VERSION}'".
+            echo "There is no crypt_shared library for distro='$DISTRO' and version='$VERSION'".
             echo "SKIP_CRYPT_SHARED_LIB_DOWNLOAD: true" > expansion.yml
           else
             echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -216,7 +216,7 @@ functions:
           fi
     - command: expansions.update
       params:
-        file: expansion.yml
+        file: src/go.mongodb.org/mongo-driver/expansion.yml
 
   install-linters:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -174,7 +174,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2355-windows-fix $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,11 +192,6 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
-          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" = "true" ]; then
-            echo "Skipping download of crypt_shared package"
-            exit 0
-          fi
-
           MONGODB_VERSION=${VERSION}
           if [ -z "$MONGODB_VERSION" ]; then
             # default to latest to match behavior of run-orchestration.sh.
@@ -539,6 +534,12 @@ functions:
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
 
+          if [ "${SKIP_CRYPT_SHARED_LIB}" = "true" ]; then
+            CRYPT_SHARED_LIB_PATH=""
+          else
+            CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+          fi
+
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
           SSL="${SSL}" \
@@ -558,7 +559,7 @@ functions:
           GCP_EMAIL="${cse_gcp_email}" \
           GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
           REQUIRE_API_VERSION="${REQUIRE_API_VERSION}" \
-          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
+          CRYPT_SHARED_LIB_PATH="$CRYPT_SHARED_LIB_PATH" \
           make evg-test-versioned-api \
           PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH
@@ -1633,9 +1634,9 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
-          # Don't download the crypt_shared library, which should cause all of the tests to fall
+          # Don't use the crypt_shared library, which should cause all of the tests to fall
           # back to using mongocryptd instead of crypt_shared.
-          SKIP_CRYPT_SHARED_LIB_DOWNLOAD: "true"
+          SKIP_CRYPT_SHARED_LIB: "true"
 
   - name: test-replicaset-auth-nossl
     tags: ["test", "replicaset", "authssl"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,6 +192,11 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
+          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" = "true" ]; then
+            echo "Skipping download of crypt_shared package"
+            exit 0
+          fi
+
           MONGODB_VERSION=${VERSION}
           if [ -z "$MONGODB_VERSION" ]; then
             # default to latest to match behavior of run-orchestration.sh.
@@ -205,11 +210,25 @@ functions:
           # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
             echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
-            echo "SKIP_CRYPT_SHARED_LIB_DOWNLOAD: true" > expansion.yml
+            touch expansion.yml
           else
             echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
             download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
-            touch expansion.yml
+            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+              -name 'mongo_crypt_v1.so' -o \
+              -name 'mongo_crypt_v1.dll' -o \
+              -name 'mongo_crypt_v1.dylib')"
+            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+            # environment variable. If we didn't, print an error message and exit.
+            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+              exit 1
+            fi
+            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+            if [ "Windows_NT" = "$OS" ]; then
+                CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+            fi
+            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
           fi
     - command: expansions.update
       params:
@@ -520,33 +539,6 @@ functions:
           fi
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
 
-          # If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, try to find the
-          # crypt_shared library downloaded in the "prepare-resources" task and set the CRYPT_SHARED_LIB_PATH
-          # environment variable with a path to the file.
-          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ]; then
-            # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
-            # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
-            # downloaded files.
-            export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-              -name 'mongo_crypt_v1.so' -o \
-              -name 'mongo_crypt_v1.dll' -o \
-              -name 'mongo_crypt_v1.dylib')"
-
-            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
-            # environment variable. If we didn't, print an error message and exit.
-            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-              echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-              exit 1
-            fi
-
-            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
-            if [ "Windows_NT" = "$OS" ]; then
-                export CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
-            fi
-
-            echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
-          fi
-
           export GOFLAGS=-mod=vendor
           AUTH="${AUTH}" \
           SSL="${SSL}" \
@@ -566,6 +558,7 @@ functions:
           GCP_EMAIL="${cse_gcp_email}" \
           GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
           REQUIRE_API_VERSION="${REQUIRE_API_VERSION}" \
+          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
           make evg-test-versioned-api \
           PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
           LD_LIBRARY_PATH=$LD_LIBRARY_PATH

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -174,7 +174,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch crypt_shared-download $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,17 +192,17 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
-          VERSION=${VERSION}
-          if [ -z "$VERSION" ]; then
+          MONGODB_VERSION=${VERSION}
+          if [ -z "$MONGODB_VERSION" ]; then
             # default to latest to match behavior of run-orchestration.sh.
-            VERSION=latest
+            MONGODB_VERSION=latest
           fi
 
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
-          get_mongodb_download_url_for "$DISTRO" "$VERSION"
+          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
-            echo "There is no crypt_shared library for distro='$DISTRO' and version='$VERSION'".
+            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
             echo "SKIP_CRYPT_SHARED_LIB_DOWNLOAD: true" > expansion.yml
           else
             echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,17 +192,6 @@ functions:
         script: |
           ${PREPARE_SHELL}
 
-          # Skip the crypt_shared library download if there is no crypt_shared build for the current
-          # platform. Don't try to determine this automatically to prevent misconfiguration errors
-          # from silently skipping the crypt_shared download and changing the testing conditions.
-          if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" = "true" ]; then
-            echo "There is no crypt_shared library for this platform, skipping download..."
-            exit 0
-          fi
-
-          # TODO: remove xtrace.
-          set -o xtrace 
-
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
           get_mongodb_download_url_for "$DISTRO" "${VERSION}"
@@ -2043,9 +2032,6 @@ axes:
           # to prevent attempting to link the client-side encryption (libmongocrypt) binaries when
           # running Go tests.
           GO_BUILD_TAGS: ""
-          # There is no crypt_shared library download for Ubuntu 14.04. Skip downloading it and let the
-          # tests use mongocryptd instead.
-          SKIP_CRYPT_SHARED_LIB_DOWNLOAD: "true"
 
   # OSes that require >= 3.2 for SSL
   - id: os-ssl-32
@@ -2066,9 +2052,6 @@ axes:
         variables:
           GO_DIST: "/opt/golang/go1.17"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
-          # There is no crypt_shared library download for Ubuntu 16.04. Skip downloading it and let the
-          # tests use mongocryptd instead.
-          SKIP_CRYPT_SHARED_LIB_DOWNLOAD: "true"
       - id: "osx-go-1-17"
         display_name: "MacOS 10.15"
         run_on: macos-1015

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -536,8 +536,12 @@ functions:
 
           if [ "${SKIP_CRYPT_SHARED_LIB}" = "true" ]; then
             CRYPT_SHARED_LIB_PATH=""
+            echo "crypt_shared library is skipped"
+          elif [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+            echo "crypt_shared library path is empty"
           else
             CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+            echo "crypt_shared library will be loaded from path: $CRYPT_SHARED_LIB_PATH"
           fi
 
           export GOFLAGS=-mod=vendor

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -200,7 +200,9 @@ functions:
 
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
+          # get_distro defines $DISTRO.
           get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
             echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
             echo "SKIP_CRYPT_SHARED_LIB_DOWNLOAD: true" > expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -174,7 +174,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2355-windows-fix $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -200,24 +200,22 @@ functions:
             exit 0
           fi
 
-          echo "VERSION expansion is: ${VERSION}"
+          # TODO: remove xtrace.
+          set -o xtrace 
+
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
-          echo "MONGO_CRYPT_SHARED_DOWNLOAD_URL is $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
-
-          # TODO: if MONGO_CRYPT_SHARED_DOWNLOAD_URL is possible to determine. Then this ought to be responsible for skipping.
-
-          # Download the crypt_shared dynamic library for the current platform to the current working
-          # directory. The run-tests.sh and versioned API test scripts expect to find a
-          # mongo_crypt_v1.* file in the "src/go.mongodb.org/mongo-driver" working directory.
-          # TODO(GODRIVER-2437): Update version to "latest-stable" once the crypt_shared library has a
-          # feature-complete stable release.
-          ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
-            --component crypt_shared \
-            --version latest \
-            --edition enterprise \
-            --out . \
-            --only "**/mongo_crypt_v1.*" \
-            --strip-path-components 1
+          get_distro
+          get_mongodb_download_url_for "$DISTRO" "${VERSION}"
+          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
+            echo "There is no crypt_shared library for distro='$DISTRO' and version='${VERSION}'".
+            echo "SKIP_CRYPT_SHARED_LIB_DOWNLOAD: true" > expansion.yml
+          else
+            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
+          fi
+    - command: expansions.update
+      params:
+        file: expansion.yml
 
   install-linters:
     - command: shell.exec

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -86,6 +86,12 @@ await_server "KMS", 5698
 
 echo "finished awaiting servers"
 
+if [ "${SKIP_CRYPT_SHARED_LIB}" = "true" ]; then
+  CRYPT_SHARED_LIB_PATH=""
+else
+  CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+fi
+
 AUTH=${AUTH} \
 SSL=${SSL} \
 MONGO_GO_DRIVER_CA_FILE=${MONGO_GO_DRIVER_CA_FILE} \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -88,8 +88,12 @@ echo "finished awaiting servers"
 
 if [ "${SKIP_CRYPT_SHARED_LIB}" = "true" ]; then
   CRYPT_SHARED_LIB_PATH=""
+  echo "crypt_shared library is skipped"
+elif [ -z "${CRYPT_SHARED_LIB_PATH}" ]; then
+  echo "crypt_shared library path is empty"
 else
   CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+  echo "crypt_shared library will be loaded from path: $CRYPT_SHARED_LIB_PATH"
 fi
 
 AUTH=${AUTH} \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -69,33 +69,6 @@ if [ -z ${GO_BUILD_TAGS+x} ]; then
   GO_BUILD_TAGS="cse"
 fi
 
-# If the task doesn't have the SKIP_CRYPT_SHARED_LIB_DOWNLOAD variable set, try to find the
-# crypt_shared library downloaded in the "prepare-resources" task and set the CRYPT_SHARED_LIB_PATH
-# environment variable with a path to the file.
-if [ "${SKIP_CRYPT_SHARED_LIB_DOWNLOAD}" != "true" ]; then
-  # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
-  # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
-  # downloaded files.
-  export CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-    -name 'mongo_crypt_v1.so' -o \
-    -name 'mongo_crypt_v1.dll' -o \
-    -name 'mongo_crypt_v1.dylib')"
-
-  # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
-  # environment variable. If we didn't, print an error message and exit.
-  if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-    echo 'SKIP_CRYPT_SHARED_LIB_DOWNLOAD is not "true", but CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-    exit 1
-  fi
-
-  # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
-  if [ "Windows_NT" = "$OS" ]; then
-      export CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
-  fi
-
-  echo "CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH"
-fi
-
 # Ensure mock KMS servers are running before starting tests.
 await_server() {
   for i in $(seq 300); do
@@ -136,6 +109,7 @@ GCP_EMAIL="${cse_gcp_email}" \
 GCP_PRIVATE_KEY="${cse_gcp_private_key}" \
 CSFLE_TLS_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem" \
 CSFLE_TLS_CERTIFICATE_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem" \
+CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH \
 make evg-test \
 PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH


### PR DESCRIPTION
# Summary
- Download the same version of crypt_shared as the server version.

# Background & Motivation

This PR validates changes proposed in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/213.

Queryable Encryption is in Technical Preview and is subject to backwards breaking changes. If backwards breaking changes are made, using different version of the server and crypt_shared may complicate diagnosing driver test failures.