### PR TITLE
GODRIVER-2464 Add delay in RTT monitor test so Windows can measure a non-zero latency.

### DIFF
--- a/x/mongo/driver/topology/rtt_monitor_test.go
+++ b/x/mongo/driver/topology/rtt_monitor_test.go
@@ -275,6 +275,10 @@ func TestRTTMonitor(t *testing.T) {
 							return
 						}
 
+						// Delay for 10ms so that systems with limited timing granularity (e.g. some
+						// older versions of Windows) can measure a non-zero latency.
+						time.Sleep(10 * time.Millisecond)
+
 						if _, err := conn.Write(makeHelloReply()); err != nil {
 							// The connection read/write loop is cancelled by closing the connection,
 							// so may be an expected error here. Log the error to make debugging


### PR DESCRIPTION
The new `TestRTTMonitor/stuck_operations_time_out` test added in https://github.com/mongodb/mongo-go-driver/pull/994 fails frequently on Windows tasks because Go running on some versions of Windows can't measure very short periods of time (<1ms) reliably (see test failure example [here](https://spruce.mongodb.com/task/mongo_go_driver_tests_42_plus_zlib_zstd_support__version~5.0_os_ssl_40~windows_64_go_1_17_test_replicaset_auth_nossl_03207bb751fa9b9b34c71c22830a265df7f98a83_22_07_13_15_25_04/tests?execution=0&sortBy=STATUS&sortDir=ASC) and related Go issue [here](https://github.com/golang/go/issues/8687)).

Add a 10ms delay in the `TestRTTMonitor/stuck_operations_time_out` test "hello" responder so that Windows can successfully measure a non-zero round-trip latency.