### PR TITLE
GODRIVER-2495 Undeprecate legacy timeouts.

### DIFF
--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -35,9 +35,9 @@ type AggregateOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// The maximum amount of time that the server should wait for new documents to satisfy a tailable cursor query.
@@ -96,9 +96,9 @@ func (ao *AggregateOptions) SetCollation(c *Collation) *AggregateOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (ao *AggregateOptions) SetMaxTime(d time.Duration) *AggregateOptions {
 	ao.MaxTime = &d
 	return ao

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -154,10 +154,9 @@ type ClientOptions struct {
 
 	// SocketTimeout specifies the timeout to be used for the Client's socket reads and writes.
 	//
-	// NOTE(benjirewis): The use of SocketTimeout is discouraged. The more general Timeout option should
-	// be used in its place to control the amount of time that a single operation can run before
-	// returning an error. Setting SocketTimeout and Timeout on a single client will result in undefined
-	// behavior.
+	// NOTE(benjirewis): SocketTimeout will be deprecated in a future release. The more general Timeout option
+	// may be used in its place to control the amount of time that a single operation can run before returning
+	// an error. Setting SocketTimeout and Timeout on a single client will result in undefined behavior.
 	SocketTimeout *time.Duration
 }
 
@@ -716,9 +715,9 @@ func (c *ClientOptions) SetServerSelectionTimeout(d time.Duration) *ClientOption
 // network error. This can also be set through the "socketTimeoutMS" URI option (e.g. "socketTimeoutMS=1000"). The
 // default value is 0, meaning no timeout is used and socket operations can block indefinitely.
 //
-// NOTE(benjirewis): The use of SocketTimeout is discouraged. The more general Timeout option should be used in its
-// place to control the amount of time that a single operation can run before returning an error. Setting SocketTimeout
-// and Timeout on a single client will result in undefined behavior.
+// NOTE(benjirewis): SocketTimeout will be deprecated in a future release. The more general Timeout option may be used
+// in its place to control the amount of time that a single operation can run before returning an error. Setting
+// SocketTimeout and Timeout on a single client will result in undefined behavior.
 func (c *ClientOptions) SetSocketTimeout(d time.Duration) *ClientOptions {
 	c.SocketTimeout = &d
 	return c

--- a/mongo/options/countoptions.go
+++ b/mongo/options/countoptions.go
@@ -34,9 +34,9 @@ type CountOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there is
 	// no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place to
-	// control the amount of time that a single operation can run before returning an error. MaxTime is ignored if Timeout
-	// is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used in
+	// its place to control the amount of time that a single operation can run before returning an error. MaxTime is
+	// ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// The number of documents to skip before counting. The default value is 0.
@@ -74,9 +74,9 @@ func (co *CountOptions) SetLimit(i int64) *CountOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (co *CountOptions) SetMaxTime(d time.Duration) *CountOptions {
 	co.MaxTime = &d
 	return co

--- a/mongo/options/distinctoptions.go
+++ b/mongo/options/distinctoptions.go
@@ -22,9 +22,9 @@ type DistinctOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be
+	// used in its place to control the amount of time that a single operation can run before returning an error.
+	// MaxTime is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 }
 
@@ -47,9 +47,9 @@ func (do *DistinctOptions) SetComment(comment interface{}) *DistinctOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (do *DistinctOptions) SetMaxTime(d time.Duration) *DistinctOptions {
 	do.MaxTime = &d
 	return do

--- a/mongo/options/estimatedcountoptions.go
+++ b/mongo/options/estimatedcountoptions.go
@@ -17,9 +17,9 @@ type EstimatedDocumentCountOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 }
 
@@ -36,8 +36,8 @@ func (eco *EstimatedDocumentCountOptions) SetComment(comment interface{}) *Estim
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option
+// may be used in its place to control the amount of time that a single operation can run before
 // returning an error. MaxTime is ignored if Timeout is set on the client.
 func (eco *EstimatedDocumentCountOptions) SetMaxTime(d time.Duration) *EstimatedDocumentCountOptions {
 	eco.MaxTime = &d

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -60,9 +60,9 @@ type FindOptions struct {
 	// MaxTime is the maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place to control
-	// the amount of time that a single operation can run before returning an error. MaxTime is ignored if Timeout is set on the
-	// client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used in its
+	// place to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
+	// Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// Min is a document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
@@ -184,9 +184,9 @@ func (f *FindOptions) SetMaxAwaitTime(d time.Duration) *FindOptions {
 
 // SetMaxTime specifies the max time to allow the query to run.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be
-// used used in its place to control the amount of time that a single operation can run before returning
-// an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used used in its place to control the amount of time that a single operation
+// can run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *FindOptions) SetMaxTime(d time.Duration) *FindOptions {
 	f.MaxTime = &d
 	return f
@@ -370,9 +370,9 @@ type FindOneOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// A document specifying the inclusive lower bound for a specific index. The default value is 0, which means that
@@ -478,9 +478,9 @@ func (f *FindOneOptions) SetMaxAwaitTime(d time.Duration) *FindOneOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *FindOneOptions) SetMaxTime(d time.Duration) *FindOneOptions {
 	f.MaxTime = &d
 	return f
@@ -634,9 +634,9 @@ type FindOneAndReplaceOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its
-	// place to control the amount of time that a single operation can run before returning an error. MaxTime is ignored
-	// if Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// A document describing which fields will be included in the document returned by the operation. The default value
@@ -696,9 +696,9 @@ func (f *FindOneAndReplaceOptions) SetComment(comment interface{}) *FindOneAndRe
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *FindOneAndReplaceOptions) SetMaxTime(d time.Duration) *FindOneAndReplaceOptions {
 	f.MaxTime = &d
 	return f
@@ -808,8 +808,8 @@ type FindOneAndUpdateOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its
-	// place to control the amount of time that a single operation can run before returning an error. MaxTime is
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime is
 	// ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
@@ -876,9 +876,9 @@ func (f *FindOneAndUpdateOptions) SetComment(comment interface{}) *FindOneAndUpd
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *FindOneAndUpdateOptions) SetMaxTime(d time.Duration) *FindOneAndUpdateOptions {
 	f.MaxTime = &d
 	return f
@@ -980,9 +980,9 @@ type FindOneAndDeleteOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// A document describing which fields will be included in the document returned by the operation. The default value
@@ -1028,9 +1028,9 @@ func (f *FindOneAndDeleteOptions) SetComment(comment interface{}) *FindOneAndDel
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *FindOneAndDeleteOptions) SetMaxTime(d time.Duration) *FindOneAndDeleteOptions {
 	f.MaxTime = &d
 	return f

--- a/mongo/options/gridfsoptions.go
+++ b/mongo/options/gridfsoptions.go
@@ -226,9 +226,9 @@ type GridFSFindOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 
 	// If true, the cursor created by the operation will not timeout after a period of inactivity. The default value
@@ -268,9 +268,9 @@ func (f *GridFSFindOptions) SetLimit(i int32) *GridFSFindOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (f *GridFSFindOptions) SetMaxTime(d time.Duration) *GridFSFindOptions {
 	f.MaxTime = &d
 	return f

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -30,9 +30,9 @@ type CreateIndexesOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 }
 
@@ -43,9 +43,9 @@ func CreateIndexes() *CreateIndexesOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (c *CreateIndexesOptions) SetMaxTime(d time.Duration) *CreateIndexesOptions {
 	c.MaxTime = &d
 	return c
@@ -100,9 +100,9 @@ type DropIndexesOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 }
 
@@ -113,9 +113,9 @@ func DropIndexes() *DropIndexesOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (d *DropIndexesOptions) SetMaxTime(duration time.Duration) *DropIndexesOptions {
 	d.MaxTime = &duration
 	return d
@@ -145,9 +145,9 @@ type ListIndexesOptions struct {
 	// The maximum amount of time that the query can run on the server. The default value is nil, meaning that there
 	// is no time limit for query execution.
 	//
-	// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should be used in its place
-	// to control the amount of time that a single operation can run before returning an error. MaxTime is ignored if
-	// Timeout is set on the client.
+	// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout option may be used
+	// in its place to control the amount of time that a single operation can run before returning an error. MaxTime
+	// is ignored if Timeout is set on the client.
 	MaxTime *time.Duration
 }
 
@@ -164,9 +164,9 @@ func (l *ListIndexesOptions) SetBatchSize(i int32) *ListIndexesOptions {
 
 // SetMaxTime sets the value for the MaxTime field.
 //
-// NOTE(benjirewis): The use of MaxTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. MaxTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): MaxTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can
+// run before returning an error. MaxTime is ignored if Timeout is set on the client.
 func (l *ListIndexesOptions) SetMaxTime(d time.Duration) *ListIndexesOptions {
 	l.MaxTime = &d
 	return l

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -39,9 +39,9 @@ type SessionOptions struct {
 	// The default maximum amount of time that a CommitTransaction operation executed in the session can run on the
 	// server. The default value is nil, which means that that there is no time limit for execution.
 	//
-	// NOTE(benjirewis): The use of DefaultMaxCommitTime is discouraged. The more general Timeout option should be
-	// used in its place to control the amount of time that a single operation can run before returning an error.
-	// DefaultMaxCommitTime is ignored if Timeout is set on the client.
+	// NOTE(benjirewis): DefaultMaxCommitTime will be deprecated in a future release. The more general Timeout option
+	// may be used in its place to control the amount of time that a single operation can run before returning an
+	// error. DefaultMaxCommitTime is ignored if Timeout is set on the client.
 	DefaultMaxCommitTime *time.Duration
 
 	// If true, all read operations performed with this session will be read from the same snapshot. This option cannot
@@ -81,9 +81,10 @@ func (s *SessionOptions) SetDefaultWriteConcern(wc *writeconcern.WriteConcern) *
 
 // SetDefaultMaxCommitTime sets the value for the DefaultMaxCommitTime field.
 //
-// NOTE(benjirewis): The use of DefaultMaxCommitTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. DefaultMaxCommitTime is ignored if Timeout is set on the client.
+// NOTE(benjirewis): DefaultMaxCommitTime will be deprecated in a future release. The more
+// general Timeout option may be used in its place to control the amount of time that a
+// single operation can run before returning an error. DefaultMaxCommitTime is ignored if
+// Timeout is set on the client.
 func (s *SessionOptions) SetDefaultMaxCommitTime(mct *time.Duration) *SessionOptions {
 	s.DefaultMaxCommitTime = mct
 	return s

--- a/mongo/options/transactionoptions.go
+++ b/mongo/options/transactionoptions.go
@@ -35,9 +35,9 @@ type TransactionOptions struct {
 	// server. The default value is nil, which means that the default maximum commit time of the session used to
 	// start the transaction will be used.
 	//
-	// NOTE(benjirewis): The use of MaxCommitTime is discouraged. The more general Timeout option be used in its
-	// place to control the amount of time that a single operation can run before returning an error. MaxCommitTime
-	// is ignored if Timeout is set on the client.
+	// NOTE(benjirewis): MaxCommitTime will be deprecated in a future release. The more general Timeout option may
+	// be used in its place to control the amount of time that a single operation can run before returning an error.
+	// MaxCommitTime is ignored if Timeout is set on the client.
 	MaxCommitTime *time.Duration
 }
 
@@ -66,8 +66,8 @@ func (t *TransactionOptions) SetWriteConcern(wc *writeconcern.WriteConcern) *Tra
 
 // SetMaxCommitTime sets the value for the MaxCommitTime field.
 //
-// NOTE(benjirewis): The use of MaxCommitTime is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
+// NOTE(benjirewis): MaxCommitTime will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can run before
 // returning an error. MaxCommitTime is ignored if Timeout is set on the client.
 func (t *TransactionOptions) SetMaxCommitTime(mct *time.Duration) *TransactionOptions {
 	t.MaxCommitTime = mct

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -33,10 +33,10 @@ type WriteConcern struct {
 	w interface{}
 	j bool
 
-	// NOTE(benjirewis): The use of wTimeout is discouraged. The more general Timeout option should
-	// be used in its place to control the amount of time that a single operation can run before
-	// returning an error. Using wTimeout and setting Timeout on the client will result in undefined
-	// behavior.
+	// NOTE(benjirewis): wTimeout will be deprecated in a future release. The more general Timeout
+	// option may be used in its place to control the amount of time that a single operation can run
+	// before returning an error. Using wTimeout and setting Timeout on the client will result in
+	// undefined behavior.
 	wTimeout time.Duration
 }
 
@@ -88,10 +88,10 @@ func J(j bool) Option {
 
 // WTimeout specifies specifies a time limit for the write concern.
 //
-// NOTE(benjirewis): The use of wTimeout is discouraged. The more general Timeout option should
-// be used in its place to control the amount of time that a single operation can run before
-// returning an error. Using wTimeout and setting Timeout on the client will result in undefined
-// behavior.
+// NOTE(benjirewis): wTimeout will be deprecated in a future release. The more general Timeout
+// option may be used in its place to control the amount of time that a single operation can run
+// before returning an error. Using wTimeout and setting Timeout on the client will result in
+// undefined behavior.
 func WTimeout(d time.Duration) Option {
 	return func(concern *WriteConcern) {
 		concern.wTimeout = d


### PR DESCRIPTION
GODRIVER-2495

Changes `Deprecated:` notices for legacy timeouts to `NOTE` sections suggesting using `Timeout` in place of the given legacy timeout option.

Deprecating legacy timeout options with the addition of `Timeout` to `ClientOptions` has left some users with static analysis failures (deprecation warnings) and no stable alternative (as `Timeout` is still provisional API). We should wait until CSOT is more stable before doing [GODRIVER-2342](https://jira.mongodb.org/browse/GODRIVER-2342).