### PR TITLE
GODRIVER-2494 Skip StaleShardVersion resume test on 6.1+.

### DIFF
--- a/data/change-streams/change-streams-resume-errorLabels.json
+++ b/data/change-streams/change-streams-resume-errorLabels.json
@@ -1478,6 +1478,11 @@
     },
     {
       "description": "change stream resumes after StaleShardVersion",
+      "runOnRequirements": [
+         {
+           "maxServerVersion": "6.0.99"
+         }
+       ],
       "operations": [
         {
           "name": "failPoint",

--- a/data/change-streams/change-streams-resume-errorLabels.yml
+++ b/data/change-streams/change-streams-resume-errorLabels.yml
@@ -743,6 +743,9 @@ tests:
               databaseName: *database0
 
   - description: change stream resumes after StaleShardVersion
+    runOnRequirements:
+       # StaleShardVersion is obsolete as of 6.1 and is no longer marked as resumable.
+       - maxServerVersion: "6.0.99"
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
GODRIVER-2494

Skips the `StaleShardVersion` change stream resumability test on 6.1+, as `StaleShardVersion` was removed in server version 6.1.0 and is no longer considered resumable.

This should fix the "latest" test failures for now.