### PR TITLE
update for libmongocrypt 1.5.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -95,6 +95,7 @@ functions:
           go env
 
           LIBMONGOCRYPT_BRANCH="r1.5"
+          LIBMONGOCRYPT_TAG="1.5.2"
           # LIBMONGOCRYPT_COMMIT is the commit on libmongocrypt for the tag LIBMONGOCRYPT_TAG.
           LIBMONGOCRYPT_COMMIT="8f8675fa11922f00a4516a7f8a60621aa1ca1550"
           # Install libmongocrypt based on OS.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -94,7 +94,7 @@ functions:
           go version
           go env
 
-          LIBMONGOCRYPT_TAG="1.5.2"
+          LIBMONGOCRYPT_BRANCH="r1.5"
           # LIBMONGOCRYPT_COMMIT is the commit on libmongocrypt for the tag LIBMONGOCRYPT_TAG.
           LIBMONGOCRYPT_COMMIT="8f8675fa11922f00a4516a7f8a60621aa1ca1550"
           # Install libmongocrypt based on OS.
@@ -105,7 +105,7 @@ functions:
              mkdir libmongocrypt-all
              cd libmongocrypt-all
              # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
-             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
+             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_BRANCH/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
              cd ..
              cp libmongocrypt-all/windows-test/bin/mongocrypt.dll c:/libmongocrypt/bin
@@ -120,7 +120,7 @@ functions:
              mkdir libmongocrypt-all
              cd libmongocrypt-all
              # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
-             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
+             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_BRANCH/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
              cd ..
              mv libmongocrypt-all/macos/include ./install/libmongocrypt
@@ -131,7 +131,8 @@ functions:
              echo "fetching build for Darwin ... end"
           else
             git clone https://github.com/mongodb/libmongocrypt
-            git checkout $LIBMONGOCRYPT_COMMIT
+            cd libmongocrypt
+            git checkout $LIBMONGOCRYPT_TAG
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -130,9 +130,7 @@ functions:
              sed -i "" -E "s+prefix=.*+prefix=$(pwd)/install/libmongocrypt+" ./install/libmongocrypt/lib/pkgconfig/libmongocrypt.pc
              echo "fetching build for Darwin ... end"
           else
-            git clone https://github.com/mongodb/libmongocrypt
-            cd libmongocrypt
-            git checkout $LIBMONGOCRYPT_TAG
+            git clone https://github.com/mongodb/libmongocrypt --branch $LIBMONGOCRYPT_TAG
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -94,9 +94,9 @@ functions:
           go version
           go env
 
-          LIBMONGOCRYPT_TAG="1.5.0"
+          LIBMONGOCRYPT_TAG="1.5.2"
           # LIBMONGOCRYPT_COMMIT is the commit on libmongocrypt for the tag LIBMONGOCRYPT_TAG.
-          LIBMONGOCRYPT_COMMIT="c3be59f9b0d756caa4c22c254e0704084cf6bca4"
+          LIBMONGOCRYPT_COMMIT="8f8675fa11922f00a4516a7f8a60621aa1ca1550"
           # Install libmongocrypt based on OS.
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include
@@ -130,7 +130,8 @@ functions:
              sed -i "" -E "s+prefix=.*+prefix=$(pwd)/install/libmongocrypt+" ./install/libmongocrypt/lib/pkgconfig/libmongocrypt.pc
              echo "fetching build for Darwin ... end"
           else
-            git clone https://github.com/mongodb/libmongocrypt --branch $LIBMONGOCRYPT_TAG
+            git clone https://github.com/mongodb/libmongocrypt
+            git checkout $LIBMONGOCRYPT_COMMIT
             ./libmongocrypt/.evergreen/compile.sh
           fi
 

--- a/data/client-side-encryption/legacy/fle2-InsertFind-Unindexed.json
+++ b/data/client-side-encryption/legacy/fle2-InsertFind-Unindexed.json
@@ -241,7 +241,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot query"
+            "errorContains": "encrypt"
           }
         }
       ]

--- a/data/client-side-encryption/legacy/fle2-InsertFind-Unindexed.yml
+++ b/data/client-side-encryption/legacy/fle2-InsertFind-Unindexed.yml
@@ -80,4 +80,8 @@ tests:
         arguments:
           filter: { encryptedUnindexed: "value123" }
         result:
-          errorContains: "Cannot query"
+          # Expected error message changed in https://github.com/10gen/mongo-enterprise-modules/commit/212b584d4f7a44bed41c826a180a4aff00923d7a#diff-5f12b55e8d5c52c2f62853ec595dc2c1e2e5cb4fdbf7a32739a8e3acb3c6f818
+          # Before the message was "cannot query non-indexed fields with the randomized encryption algorithm"
+          # After: "can only execute encrypted equality queries with an encrypted equality index"
+          # Use a small common substring.
+          errorContains: "encrypt"

--- a/data/client-side-encryption/unified/createDataKey-kms_providers-invalid.json
+++ b/data/client-side-encryption/unified/createDataKey-kms_providers-invalid.json
@@ -1,5 +1,5 @@
 {
-  "description": "createDataKey-provider-invalid",
+  "description": "createDataKey-kms_providers-invalid",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {

--- a/data/client-side-encryption/unified/createDataKey-kms_providers-invalid.yml
+++ b/data/client-side-encryption/unified/createDataKey-kms_providers-invalid.yml
@@ -1,4 +1,4 @@
-description: createDataKey-provider-invalid
+description: createDataKey-kms_providers-invalid
 
 schemaVersion: "1.8"
 

--- a/data/client-side-encryption/unified/rewrapManyDataKey.json
+++ b/data/client-side-encryption/unified/rewrapManyDataKey.json
@@ -1,5 +1,5 @@
 {
-  "description": "rewrapManyDataKey-kms_providers",
+  "description": "rewrapManyDataKey",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {
@@ -128,7 +128,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+",
+              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
               "subType": "00"
             }
           },
@@ -196,7 +196,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==",
+              "base64": "CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==",
               "subType": "00"
             }
           },

--- a/data/client-side-encryption/unified/rewrapManyDataKey.yml
+++ b/data/client-side-encryption/unified/rewrapManyDataKey.yml
@@ -2,7 +2,7 @@
 # commands sort the resulting documents in ascending order by the single-element
 # keyAltNames array to ensure alphabetic order by original KMS provider as
 # defined in initialData.
-description: rewrapManyDataKey-kms_providers
+description: rewrapManyDataKey
 
 schemaVersion: "1.8"
 
@@ -50,7 +50,7 @@ initialData:
           region: us-east-1
       - _id: &azure_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure_key"]
-        keyMaterial: { $binary: { base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+, subType: "00" } }
+        keyMaterial: { $binary: { base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -72,7 +72,7 @@ initialData:
           keyName: key-name-csfle
       - _id: &kmip_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
         keyAltNames: ["kmip_key"]
-        keyMaterial: { $binary: { base64: VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==, subType: "00" } }
+        keyMaterial: { $binary: { base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.mongodb.org/mongo-driver
 go 1.10
 
 retract (
+	v1.10.0 // Contains a possible data corruption bug in RewrapManyDataKey when using libmongocrypt versions less than 1.5.2.
 	[v1.7.0, v1.7.1] // Contains data race bug in background connection establishment.
 	[v1.6.0, v1.6.1] // Contains data race bug in background connection establishment.
 )

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -255,7 +255,7 @@ func (ce *ClientEncryption) RewrapManyDataKey(ctx context.Context, filter interf
 
 	// libmongocrypt versions 1.5.0 and 1.5.1 have a severe bug in RewrapManyDataKey.
 	// Check if the version string starts with 1.5.0 or 1.5.1. This accounts for pre-release versions, like 1.5.0-rc0.
-	libmongocryptVersion := mongocrypt.MongoCryptVersion()
+	libmongocryptVersion := mongocrypt.Version()
 	if strings.Index(libmongocryptVersion, "1.5.0") == 0 || strings.Index(libmongocryptVersion, "1.5.1") == 0 {
 		return nil, fmt.Errorf("RewrapManyDataKey requires libmongocrypt 1.5.2 or newer. Detected version: %v", libmongocryptVersion)
 	}

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -256,7 +256,7 @@ func (ce *ClientEncryption) RewrapManyDataKey(ctx context.Context, filter interf
 	// libmongocrypt versions 1.5.0 and 1.5.1 have a severe bug in RewrapManyDataKey.
 	// Check if the version string starts with 1.5.0 or 1.5.1. This accounts for pre-release versions, like 1.5.0-rc0.
 	libmongocryptVersion := mongocrypt.Version()
-	if strings.Index(libmongocryptVersion, "1.5.0") == 0 || strings.Index(libmongocryptVersion, "1.5.1") == 0 {
+	if strings.HasPrefix(libmongocryptVersion, "1.5.0") || strings.HasPrefix(libmongocryptVersion, "1.5.1") {
 		return nil, fmt.Errorf("RewrapManyDataKey requires libmongocrypt 1.5.2 or newer. Detected version: %v", libmongocryptVersion)
 	}
 

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -249,8 +249,16 @@ func setRewrapManyDataKeyWriteModels(rewrappedDocuments []bsoncore.Document, wri
 // RewrapManyDataKey decrypts and encrypts all matching data keys with a possibly new masterKey value. For all
 // matching documents, this method will overwrite the "masterKey", "updateDate", and "keyMaterial". On error, some
 // matching data keys may have been rewrapped.
+// libmongocrypt 1.5.2 is required. An error is returned if the detected version of libmongocrypt is less than 1.5.2.
 func (ce *ClientEncryption) RewrapManyDataKey(ctx context.Context, filter interface{},
 	opts ...*options.RewrapManyDataKeyOptions) (*RewrapManyDataKeyResult, error) {
+
+	// libmongocrypt versions 1.5.0 and 1.5.1 have a severe bug in RewrapManyDataKey.
+	// Check if the version string starts with 1.5.0 or 1.5.1. This accounts for pre-release versions, like 1.5.0-rc0.
+	libmongocryptVersion := mongocrypt.MongoCryptVersion()
+	if strings.Index(libmongocryptVersion, "1.5.0") == 0 || strings.Index(libmongocryptVersion, "1.5.1") == 0 {
+		return nil, fmt.Errorf("RewrapManyDataKey requires libmongocrypt 1.5.2 or newer. Detected version: %v", libmongocryptVersion)
+	}
 
 	rmdko := options.MergeRewrapManyDataKeyOptions(opts...)
 	if ctx == nil {

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -107,9 +107,13 @@
 //
 // The libmongocrypt C library is required when using client-side encryption. Specific versions of libmongocrypt
 // are required for different versions of the Go Driver:
+//
 // - Go Driver v1.2.0 requires libmongocrypt v1.0.0 or higher
+//
 // - Go Driver v1.5.0 requires libmongocrypt v1.1.0 or higher
+//
 // - Go Driver v1.8.0 requires libmongocrypt v1.3.0 or higher
+//
 // - Go Driver v1.10.0 requires libmongocrypt v1.5.2 or higher
 //
 // To install libmongocrypt, follow the instructions for your

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -110,7 +110,7 @@
 // - Go Driver v1.2.0 requires libmongocrypt v1.0.0 or higher
 // - Go Driver v1.5.0 requires libmongocrypt v1.1.0 or higher
 // - Go Driver v1.8.0 requires libmongocrypt v1.3.0 or higher
-// - Go Driver v1.10.0 requires libmongocrypt v1.5.0 or higher
+// - Go Driver v1.10.0 requires libmongocrypt v1.5.2 or higher
 //
 // To install libmongocrypt, follow the instructions for your
 // operating system:

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -114,7 +114,10 @@
 //
 // - Go Driver v1.8.0 requires libmongocrypt v1.3.0 or higher
 //
-// - Go Driver v1.10.0 requires libmongocrypt v1.5.2 or higher
+// - Go Driver v1.10.0 requires libmongocrypt v1.5.0 or higher.
+// There is a severe bug when calling RewrapManyDataKey with libmongocrypt versions less than 1.5.2.
+// This bug may result in data corruption.
+// Please use libmongocrypt 1.5.2 or higher when calling RewrapManyDataKey.
 //
 // To install libmongocrypt, follow the instructions for your
 // operating system:

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1966,7 +1966,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 							if val, ok := dataKeyMap[dstProvider]; ok {
 								rwOpts.SetMasterKey(val)
 							}
-							res, err := clientEncryption2.RewrapManyDataKey(context.Background(), bson.D{{}}, rwOpts)
+							res, err := clientEncryption2.RewrapManyDataKey(context.Background(), bson.D{}, rwOpts)
 							assert.Nil(mt, err, "error in RewrapManyDataKey: %v", err)
 							assert.Equal(mt, res.BulkWriteResult.ModifiedCount, int64(1), "expected ModifiedCount of 1, got %v", res.BulkWriteResult.ModifiedCount)
 						}

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -35,6 +35,7 @@ func Version() string {
 	str := C.GoString(C.mongocrypt_version(nil))
 	return str
 }
+
 // NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
 func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	// create mongocrypt_t handle

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -29,9 +29,9 @@ type MongoCrypt struct {
 	wrapped *C.mongocrypt_t
 }
 
-// MongoCryptVersion returns the version string for the loaded libmongocrypt, or an empty string
+// Version returns the version string for the loaded libmongocrypt, or an empty string
 // if libmongocrypt was not loaded.
-func MongoCryptVersion() string {
+func Version() string {
 	str := C.GoString(C.mongocrypt_version(nil))
 	return str
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -29,6 +29,12 @@ type MongoCrypt struct {
 	wrapped *C.mongocrypt_t
 }
 
+// MongoCryptVersion returns the version string for the loaded libmongocrypt, or an empty string
+// if libmongocrypt was not loaded.
+func MongoCryptVersion() string {
+	str := C.GoString(C.mongocrypt_version(nil))
+	return str
+}
 // NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
 func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	// create mongocrypt_t handle

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -19,9 +19,9 @@ const cseNotSupportedMsg = "client-side encryption not enabled. add the cse buil
 // MongoCrypt represents a mongocrypt_t handle.
 type MongoCrypt struct{}
 
-// MongoCryptVersion returns the version string for the loaded libmongocrypt, or an empty string
+// Version returns the version string for the loaded libmongocrypt, or an empty string
 // if libmongocrypt was not loaded.
-func MongoCryptVersion() string {
+func Version() string {
 	return ""
 }
 

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -19,6 +19,12 @@ const cseNotSupportedMsg = "client-side encryption not enabled. add the cse buil
 // MongoCrypt represents a mongocrypt_t handle.
 type MongoCrypt struct{}
 
+// MongoCryptVersion returns the version string for the loaded libmongocrypt, or an empty string
+// if libmongocrypt was not loaded.
+func MongoCryptVersion() string {
+	return ""
+}
+
 // NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
 func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	panic(cseNotSupportedMsg)


### PR DESCRIPTION
# Summary

Resolve GODRIVER-2511:
- Add CSFLE prose test 16.
- Update tests to use libmongocrypt 1.5.2.

Resolve GODRIVER-2513:
- Return error if libmongocrypt < 1.5.2 is detected in RewrapManyDataKey.
- Retract Go 1.10.0.

Resolve GODRIVER-2509:
- Resync RewrapManyDataKey specification tests to https://github.com/mongodb/specifications/commit/10b4a41f8d282cebc5d3681adba27de18539d9f4.

Resolve GODRIVER-2512:
- Resync fle2-InsertFind-Unindexed.json file to https://github.com/mongodb/specifications/pull/1286.

# Background & Motivation

libmongocrypt 1.5.2 includes a fix to a severe bug introduced in libmongocrypt 1.5.0: MONGOCRYPT-464.