### PR TITLE
GODRIVER-2514 Use MongoDB managed GCP account for GCP tests.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -178,7 +178,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2377.update-creds $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -178,7 +178,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2377.update-creds $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2258,10 +2258,10 @@ task_groups:
           shell: "bash"
           script: |
             ${PREPARE_SHELL}
-            echo '${testgcpkms_key_file}' > /tmp/testgcpkms_key_file.json
+            echo '${testgcpkms_key_file_2}' > /tmp/testgcpkms_key_file.json
             export GCPKMS_KEYFILE=/tmp/testgcpkms_key_file.json
             export GCPKMS_DRIVERS_TOOLS=$DRIVERS_TOOLS
-            export GCPKMS_SERVICEACCOUNT="${testgcpkms_service_account}"
+            export GCPKMS_SERVICEACCOUNT="${testgcpkms_service_account_2}"
             $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
       # Load the GCPKMS_GCLOUD, GCPKMS_INSTANCE, GCPKMS_REGION, and GCPKMS_ZONE expansions.
       - command: expansions.update

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2258,10 +2258,10 @@ task_groups:
           shell: "bash"
           script: |
             ${PREPARE_SHELL}
-            echo '${testgcpkms_key_file_2}' > /tmp/testgcpkms_key_file.json
+            echo '${testgcpkms_key_file}' > /tmp/testgcpkms_key_file.json
             export GCPKMS_KEYFILE=/tmp/testgcpkms_key_file.json
             export GCPKMS_DRIVERS_TOOLS=$DRIVERS_TOOLS
-            export GCPKMS_SERVICEACCOUNT="${testgcpkms_service_account_2}"
+            export GCPKMS_SERVICEACCOUNT="${testgcpkms_service_account}"
             $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
       # Load the GCPKMS_GCLOUD, GCPKMS_INSTANCE, GCPKMS_REGION, and GCPKMS_ZONE expansions.
       - command: expansions.update

--- a/cmd/testgcpkms/main.go
+++ b/cmd/testgcpkms/main.go
@@ -45,12 +45,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("Error in NewClientEncryption: %v", err))
 	}
-	// TODO(GODRIVER-2514): Update to use key from testing account (see gcpKMS.json). This uses a key from a personal account.
 	dkOpts := options.DataKey().SetMasterKey(bson.M{
-		"projectId": "csfle-poc",
+		"projectId": "devprod-drivers",
 		"location":  "global",
-		"keyRing":   "test",
-		"keyName":   "quickstart",
+		"keyRing":   "key-ring-csfle",
+		"keyName":   "key-name-csfle",
 	})
 	_, err = ce.CreateDataKey(context.Background(), "gcp", dkOpts)
 	if expecterror == "" {


### PR DESCRIPTION
# Summary
- Use MongoDB managed GCP account for GCP tests.

# Background & Motivation
The integration tests added in DRIVERS-2377 were relying on a personal account.
[BUILD-15386](https://jira.mongodb.org/browse/BUILD-15386) provided a service account with necessary permissions.

Here is a patch build with the [testgcpkms tasks](https://spruce.mongodb.com/version/62f13d6f9ccd4e4612bed0eb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
