### PR TITLE
GODRIVER-2485 update unified CSE tests

### DIFF
--- a/data/client-side-encryption/unified/addKeyAltName.json
+++ b/data/client-side-encryption/unified/addKeyAltName.json
@@ -98,7 +98,9 @@
             },
             "keyAltName": "new_key_alt_name"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/data/client-side-encryption/unified/addKeyAltName.yml
+++ b/data/client-side-encryption/unified/addKeyAltName.yml
@@ -48,7 +48,7 @@ tests:
           # First 3 letters of local_key_id replaced with 'A' (value: "#alkeylocalkey").
           id: &non_existent_id { $binary: { base64: AAAjYWxrZXlsb2NhbGtleQ==, subType: "04" } }
           keyAltName: new_key_alt_name
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/data/client-side-encryption/unified/getKey.json
+++ b/data/client-side-encryption/unified/getKey.json
@@ -133,7 +133,9 @@
               }
             }
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/data/client-side-encryption/unified/getKey.yml
+++ b/data/client-side-encryption/unified/getKey.yml
@@ -59,7 +59,7 @@ tests:
         arguments:
           # *aws_key_id with first three letters replaced with 'A' (value: "3awsawsawsawsa").
           id: &non_existent_id { $binary: { base64: AAAzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/data/client-side-encryption/unified/getKeyByAltName.json
+++ b/data/client-side-encryption/unified/getKeyByAltName.json
@@ -128,7 +128,9 @@
           "arguments": {
             "keyAltName": "does_not_exist"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/data/client-side-encryption/unified/getKeyByAltName.yml
+++ b/data/client-side-encryption/unified/getKeyByAltName.yml
@@ -58,7 +58,7 @@ tests:
         object: *clientEncryption0
         arguments:
           keyAltName: does_not_exist
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/data/client-side-encryption/unified/removeKeyAltName.json
+++ b/data/client-side-encryption/unified/removeKeyAltName.json
@@ -102,7 +102,9 @@
             },
             "keyAltName": "does_not_exist"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/data/client-side-encryption/unified/removeKeyAltName.yml
+++ b/data/client-side-encryption/unified/removeKeyAltName.yml
@@ -49,7 +49,7 @@ tests:
           # First 3 letters of local_key_id replaced with 'A' (value: "#alkeylocalkey").
           id: &non_existent_id { $binary: { base64: AAAjYWxrZXlsb2NhbGtleQ==, subType: "04" } }
           keyAltName: does_not_exist
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:


### PR DESCRIPTION
# Summary

- Resync key management unified tests with https://github.com/mongodb/specifications/commit/79f682a4a7e62fcce18099b4552d48d1f679e096

