### PR TITLE
Pin golangci-lint to a version that supports Go 1.17

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -242,7 +242,10 @@ functions:
 
           # Install linters. Use "go install" instead of "go get" to prevent modifying the go.mod
           # file.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          # TODO(GODRIVER-2519): The "latest" version of golangci-lint currently requires Go 1.19.
+          # TODO Pin to the "latest" version of golangci-lint again when we update the Evergreen CI
+          # TODO to use Go 1.19.
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
           go install github.com/walle/lll/...@latest
 
   upload-mo-artifacts:


### PR DESCRIPTION
The "latest" version of golangci-lint currently requires Go 1.19. We can pin back to "latest" when we complete [GODRIVER-2519](https://jira.mongodb.org/browse/GODRIVER-2519).