### PR TITLE
Stop treating context errors as network errors where possible.

### DIFF
--- a/mongo/session.go
+++ b/mongo/session.go
@@ -200,10 +200,6 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			default:
 			}
 
-			// End if context has timed out or been canceled, as retrying has no chance of success.
-			if ctx.Err() != nil {
-				return res, err
-			}
 			if errorHasLabel(err, driver.TransientTransactionError) {
 				continue
 			}
@@ -218,10 +214,9 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 	CommitLoop:
 		for {
 			err = s.CommitTransaction(ctx)
-			// End when error is nil (transaction has been committed), or when context has timed out or been
-			// canceled, as retrying has no chance of success.
-			if err == nil || ctx.Err() != nil {
-				return res, err
+			// End when error is nil, as transaction has been committed.
+			if err == nil {
+				return res, nil
 			}
 
 			select {

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -531,15 +531,17 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 			serviceID:    startedInfo.serviceID,
 		}
 
-		// Check if there's enough time to perform a round trip before the Context deadline. If ctx is
-		// a Timeout Context, use the 90th percentile RTT as a threshold. Otherwise, use the minimum observed
-		// RTT.
-		if deadline, ok := ctx.Deadline(); ok {
+		// Check for possible context error. If no context error, check if there's enough time to perform a
+		// round trip before the Context deadline. If ctx is a Timeout Context, use the 90th percentile RTT
+		// as a threshold. Otherwise, use the minimum observed RTT.
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		} else if deadline, ok := ctx.Deadline(); ok {
 			if internal.IsTimeoutContext(ctx) && time.Now().Add(srvr.RTTMonitor().P90()).After(deadline) {
 				err = internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
 					"remaining time %v until context deadline is less than 90th percentile RTT\n%v", time.Until(deadline), srvr.RTTMonitor().Stats())
 			} else if time.Now().Add(srvr.RTTMonitor().Min()).After(deadline) {
-				err = op.networkError(context.DeadlineExceeded)
+				err = context.DeadlineExceeded
 			}
 		}
 

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -677,8 +677,8 @@ func TestOperation(t *testing.T) {
 	})
 	t.Run("context deadline exceeded not marked as TransientTransactionError", func(t *testing.T) {
 		conn := new(mockConnection)
-		// Create a context with a very short timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		// Create a context that's already timed out.
+		ctx, cancel := context.WithDeadline(context.Background(), time.Unix(893934480, 0))
 		defer cancel()
 
 		op := Operation{

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -694,9 +694,7 @@ func TestOperation(t *testing.T) {
 		assert.NotNil(t, err, "expected an error from Execute(), got nil")
 		// Assert that error is just context deadline exceeded and is therefore not a driver.Error marked
 		// with the TransientTransactionError label.
-		if !cmp.Equal(err, context.DeadlineExceeded, cmp.Comparer(compareErrors)) {
-			t.Errorf("err is not equal to expected error. got %v; want %v", err, context.DeadlineExceeded)
-		}
+		assert.Equal(t, err, context.DeadlineExceeded, "expected context.DeadlineExceeded error, got %v", err)
 	})
 	t.Run("canceled context not marked as TransientTransactionError", func(t *testing.T) {
 		conn := new(mockConnection)
@@ -717,9 +715,7 @@ func TestOperation(t *testing.T) {
 		assert.NotNil(t, err, "expected an error from Execute(), got nil")
 		// Assert that error is just context canceled and is therefore not a driver.Error marked with
 		// the TransientTransactionError label.
-		if !cmp.Equal(err, context.Canceled, cmp.Comparer(compareErrors)) {
-			t.Errorf("err is not equal to expected error. got %v; want %v", err, context.Canceled)
-		}
+		assert.Equal(t, err, context.Canceled, "expected context.Canceled error, got %v", err)
 	})
 }
 

--- a/x/mongo/driver/topology/connection_errors_test.go
+++ b/x/mongo/driver/topology/connection_errors_test.go
@@ -50,19 +50,5 @@ func TestConnectionErrors(t *testing.T) {
 			err := conn.connect(ctx)
 			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
 		})
-		t.Run("write error", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
-			err := conn.writeWireMessage(ctx, []byte{})
-			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
-		})
-		t.Run("read error", func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
-			_, err := conn.readWireMessage(ctx, []byte{})
-			assert.True(t, errors.Is(err, context.Canceled), "expected error %v, got %v", context.Canceled, err)
-		})
 	})
 }

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -351,16 +351,6 @@ func TestConnection(t *testing.T) {
 					t.Errorf("errors do not match. got %v; want %v", got, want)
 				}
 			})
-			t.Run("completed context", func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
-				want := ConnectionError{ConnectionID: "foobar", Wrapped: ctx.Err(), message: "failed to write"}
-				got := conn.writeWireMessage(ctx, []byte{})
-				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
-					t.Errorf("errors do not match. got %v; want %v", got, want)
-				}
-			})
 			t.Run("deadlines", func(t *testing.T) {
 				testCases := []struct {
 					name        string
@@ -486,16 +476,6 @@ func TestConnection(t *testing.T) {
 				conn := &connection{id: "foobar"}
 				want := ConnectionError{ConnectionID: "foobar", message: "connection is closed"}
 				_, got := conn.readWireMessage(context.Background(), []byte{})
-				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
-					t.Errorf("errors do not match. got %v; want %v", got, want)
-				}
-			})
-			t.Run("completed context", func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				conn := &connection{id: "foobar", nc: &net.TCPConn{}, state: connConnected}
-				want := ConnectionError{ConnectionID: "foobar", Wrapped: ctx.Err(), message: "failed to read"}
-				_, got := conn.readWireMessage(ctx, []byte{})
 				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 					t.Errorf("errors do not match. got %v; want %v", got, want)
 				}


### PR DESCRIPTION
GODRIVER-2468
GODRIVER-1965

Stops returning a network error when minimum RTT exceeds time remaining until deadline. Stops checking for context expiration in `writeWireMessage` and `readWireMessage`; removes associated tests. Stops checking for context expiration in `WithTransaction`. Starts checking for _any_ context error before running `roundTrip` in `Execute` (including cancelation). Adds tests to ensure that `Execute` does not mark done contexts with the `TransientTransactionError` label.

Network errors can be marked with the `TransientTransactionError` label [here](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/operation.go#L848), and can therefore be retryable. Context errors do not represent retryable scenarios, so we should stop calling `networkError()` on context errors where possible. Once we stop treating context errors as retryable, we no longer need to check explicitly for them in `WithTransaction`.