### PR TITLE
GODRIVER-2502 Add test that reads are not retried in a transaction.

### DIFF
--- a/data/transactions/unified/do-not-retry-read-in-transaction.json
+++ b/data/transactions/unified/do-not-retry-read-in-transaction.json
@@ -1,0 +1,115 @@
+{
+  "description": "do not retry read in a transaction",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2.0",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "retryReads": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-read-in-transaction-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "find does not retry in a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "startTransaction": true
+                },
+                "commandName": "find",
+                "databaseName": "retryable-read-in-transaction-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/transactions/unified/do-not-retry-read-in-transaction.yml
+++ b/data/transactions/unified/do-not-retry-read-in-transaction.yml
@@ -1,0 +1,64 @@
+description: "do not retry read in a transaction"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.0.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.2.0"
+    topologies: [ sharded, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+      uriOptions: { retryReads: true }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-read-in-transaction-test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      id: &session0 session0
+      client: *client0
+
+tests:
+  - description: "find does not retry in a transaction"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: failPoint # fail the following find command
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              closeConnection: true
+
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          session: *session0
+        expectError:
+          isError: true
+          errorLabelsContain: ["TransientTransactionError"]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                startTransaction: true
+              commandName: find
+              databaseName: *databaseName


### PR DESCRIPTION
GODRIVER-2502

Adds a test to ensure that a read type operation will not be retried when a transaction is active.