### PR TITLE
GODRIVER-2492 remove command to download crypt_shared

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -190,48 +190,6 @@ functions:
           # initialize submodules
           git submodule init
           git submodule update
-    - command: shell.exec
-      params:
-        working_dir: src/go.mongodb.org/mongo-driver
-        script: |
-          ${PREPARE_SHELL}
-
-          MONGODB_VERSION=${VERSION}
-          if [ -z "$MONGODB_VERSION" ]; then
-            # default to latest to match behavior of run-orchestration.sh.
-            MONGODB_VERSION=latest
-          fi
-
-          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
-          get_distro
-          # get_distro defines $DISTRO.
-          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
-          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
-          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
-            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
-            touch expansion.yml
-          else
-            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
-            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
-            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-              -name 'mongo_crypt_v1.so' -o \
-              -name 'mongo_crypt_v1.dll' -o \
-              -name 'mongo_crypt_v1.dylib')"
-            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
-            # environment variable. If we didn't, print an error message and exit.
-            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-              exit 1
-            fi
-            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
-            if [ "Windows_NT" = "$OS" ]; then
-                CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
-            fi
-            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
-          fi
-    - command: expansions.update
-      params:
-        file: src/go.mongodb.org/mongo-driver/expansion.yml
 
   install-linters:
     - command: shell.exec


### PR DESCRIPTION
# Summary
- Remove unnecessary download of crypt_shared library

# Background & Motivation
https://github.com/mongodb-labs/drivers-evergreen-tools/commit/5af4bfe0f18ece58d8492436b115c24a4167f1a3 simplified obtaining the crypt_shared library.
Running the `run-orchestration.sh` script will now generate the `CRYPT_SHARED_LIB_PATH` expansion.