### PR TITLE
GODRIVER-2021 Use pooling to reduce memory allocation.

### DIFF
--- a/benchmark/operation_test.go
+++ b/benchmark/operation_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit nibh eu lorem scelerisque iaculis. Mauris tincidunt est quis gravida sollicitudin. Vestibulum ante dolor, semper eget finibus accumsan, finibus id nulla. Nam mauris libero, mattis sed libero at, vestibulum vehicula tellus. Nullam in finibus neque. Ut bibendum blandit condimentum. Etiam tortor mauris, tempus et accumsan a, lobortis cursus lacus.  Pellentesque fermentum gravida aliquam. Donec fermentum nisi ut venenatis convallis. Praesent ultrices, justo ac fringilla eleifend, augue libero tristique quam, imperdiet rutrum lectus odio id purus. Curabitur vel metus ullamcorper massa dapibus tincidunt. Nam mollis feugiat sapien ut sagittis. Cras sed ex ligula. Etiam nec nisi diam. Pellentesque id metus molestie, tempus velit et, malesuada eros. Praesent convallis arcu et semper molestie. Morbi eu orci tempor, blandit dui egestas, faucibus diam. Aenean ac tempor justo.  Donec id lectus tristique, ultrices enim sed, suscipit sapien. In arcu mauris, venenatis sed venenatis id, mollis a risus. Phasellus id massa et magna volutpat elementum in quis libero. Aliquam a aliquam erat. Nunc leo massa, sagittis at egestas vel, iaculis vitae quam. Pellentesque placerat metus id velit lobortis euismod in non sapien. Duis a quam sed elit fringilla maximus at et purus. Nullam pharetra accumsan efficitur. Integer a mattis urna. Suspendisse vehicula, nunc euismod luctus suscipit, mi mauris sollicitudin diam, porta rhoncus libero metus vitae erat. Sed lacus sem, feugiat vitae nisi at, malesuada ultricies ipsum. Quisque hendrerit posuere metus. Donec magna erat, facilisis et dictum at, tempor in leo. Maecenas luctus vestibulum quam, eu ornare ex aliquam vitae. Mauris ac mauris posuere, mattis nisl nec, fringilla libero.  Nulla in ipsum ut arcu condimentum mollis. Donec viverra massa nec lacus condimentum vulputate. Nulla at dictum eros, quis sodales ante. Duis condimentum accumsan consectetur. Aenean sodales at turpis vitae efficitur. Vestibulum in diam faucibus, consequat sem ut, auctor lorem. Duis tincidunt non eros pretium rhoncus. Sed quis eros ligula. Donec vulputate ultrices enim, quis interdum dui rhoncus eu. In at mollis ex.  In sed pulvinar risus. Morbi efficitur leo magna, eget bibendum leo consequat id. Pellentesque ultricies ipsum leo, sit amet cursus est bibendum a. Mauris eget porta felis. Vivamus dignissim pellentesque risus eget interdum. Mauris ultrices metus at blandit tincidunt. Duis tempor sapien vel luctus mattis. Vivamus ac orci nibh. Nam eget tempor neque. Proin lacus nibh, porttitor nec pellentesque id, dignissim et eros. Nullam et libero faucibus, iaculis mi sed, faucibus leo. In mollis sem ac porta suscipit.  Ut rutrum, justo a gravida lobortis, neque nibh tincidunt mi, id eleifend dolor dolor vel arcu. Fusce vel egestas ante, eu commodo eros. Donec augue odio, bibendum ut nulla ultricies, cursus eleifend lacus. Nulla viverra ac massa vel placerat. Duis aliquam, ipsum vitae ultricies imperdiet, tellus nisl venenatis mauris, et congue elit nulla vitae est. Suspendisse volutpat ullamcorper diam, et vehicula leo bibendum at. In hac habitasse platea dictumst.  Donec mattis neque a lorem ullamcorper rutrum. Curabitur mattis auctor velit, vitae iaculis mauris convallis in. Donec vulputate sapien non ex pretium semper. Vestibulum ut ligula sit amet arcu pellentesque aliquam. Pellentesque odio diam, pharetra at nunc varius, pharetra consectetur sem. Integer pretium magna pretium, mattis lectus eget, laoreet libero. Morbi dictum et dolor eu finibus. Etiam vestibulum finibus quam, vel eleifend tortor mattis viverra. Donec porttitor est vitae ligula volutpat lobortis. Donec ac semper diam. Maecenas sapien eros, blandit non velit in, faucibus auctor risus. In quam nibh, congue a nisl sit amet, tempor volutpat tortor. Curabitur dignissim auctor orci a varius. Nulla faucibus lacus libero, vitae fringilla elit facilisis id.  Aliquam id elit dui. Cras convallis ligula ac leo bibendum lacinia. Duis interdum ac lectus sed tristique. Maecenas sem magna, gravida quis sapien sit amet, varius luctus ligula. Curabitur eleifend mi nibh. Suspendisse iaculis commodo justo, vitae pretium risus scelerisque non. Sed pulvinar augue nec fermentum feugiat. Nam et ligula tellus. Vestibulum euismod accumsan nibh, at rutrum est tristique sit amet. Duis porttitor ex felis, quis consectetur nunc tempor ut. Nulla vitae consequat velit, id condimentum orci. Sed lacinia velit urna, nec laoreet est varius ac. Integer dapibus libero vel bibendum posuere. Curabitur cursus est vel ante euismod dapibus. Ut hendrerit odio id rhoncus efficitur.  Nam luctus sem orci, in congue ipsum ultrices at. Morbi sed tortor ut metus elementum ultrices. Cras vehicula ante magna, nec faucibus neque placerat et. Vivamus justo lacus, aliquet sit amet semper ac, porta vehicula nibh. Duis et rutrum elit. In nisi eros, fringilla ut odio eget, vehicula laoreet elit. Suspendisse potenti. Vivamus ut ultricies lacus. Integer pellentesque posuere mauris, eget aliquet purus tincidunt in. Suspendisse potenti. Nam quis purus iaculis, cursus mauris a, tempus mi.  Pellentesque ullamcorper lacus vitae lacus volutpat, quis ultricies metus sagittis. Etiam imperdiet libero vitae ante cursus tempus. Nulla eu mi sodales neque scelerisque eleifend id non nisi. Maecenas blandit vitae turpis nec lacinia. Duis posuere cursus metus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridaculus mus. Ut ultrices hendrerit quam, sit amet condimentum massa finibus a. Donec et vehicula urna. Pellentesque lorem felis, fermentum vel feugiat et, congue eleifend orci. Suspendisse potenti. Sed dignissim massa at justo tristique, id feugiat neque vulputate.  Pellentesque dui massa, maximus quis consequat quis, fringilla vel turpis. Etiam fermentum ex eget massa varius, a fringilla velit placerat. Sed fringilla convallis urna, ut finibus purus accumsan a. Vestibulum porttitor risus lorem, eu venenatis velit suscipit vel. Ut nec diam egestas, sollicitudin nulla sit amet, porttitor felis. Duis a nisl a ante interdum hendrerit. Integer sollicitudin scelerisque ex, et blandit magna blandit at.  Vivamus a vulputate ante. Nam non tortor a lacus euismod venenatis. Vestibulum libero augue, consequat vitae turpis nec, mattis tristique nibh. Fusce pulvinar dolor vel ipsum eleifend varius. Morbi id ante eget tellus venenatis interdum non sit amet ante. Nulla luctus tempor purus, eget ultrices odio varius eget. Duis commodo eros ac molestie fermentum. Praesent vestibulum est eu massa posuere, et fermentum orci tincidunt. Duis dignissim nunc sit amet elit laoreet mollis. Aenean porttitor et nunc vel venenatis. Nunc viverra ligula nec tincidunt vehicula. Pellentesque in magna volutpat, consequat est eget, varius mauris. Maecenas in tellus eros. Aliquam erat volutpat. Phasellus blandit faucibus velit ac placerat.  Donec luctus hendrerit pretium. Sed mauris purus, lobortis non erat sed, mattis ornare nulla. Fusce eu vulputate lacus. In enim justo, elementum at tortor nec, interdum semper ligula. Donec condimentum erat elit, non luctus augue rhoncus et. Quisque interdum elit dui, in vestibulum lacus aliquet et. Mauris aliquam sed ante id eleifend. Donec velit dolor, blandit et mattis non, bibendum at lorem. Nullam blandit quam sapien. Duis rutrum nunc vitae odio imperdiet condimentum. Nunc vel pellentesque purus. Cras iaculis dui est, quis cursus tortor mattis non. Donec non tincidunt lacus.  Sed eget molestie lacus. Phasellus pharetra ullamcorper purus. Sed sit amet ultricies ligula, aliquam elementum velit. Cras commodo mauris vel sapien rutrum, ac pharetra libero mollis. Donec facilisis sit amet elit ac porttitor. Phasellus rutrum rhoncus sagittis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam iaculis ac odio eu sodales.  Proin blandit fermentum arcu efficitur ornare. Vestibulum pharetra est quis mi lobortis interdum. Proin molestie pretium viverra. Integer pellentesque eros nisi, non rutrum odio interdum ut. Quisque vel ante et mi placerat mollis ut eget eros. Etiam vitae orci lectus. Nulla scelerisque dui in dictum ornare. Aliquam vestibulum fringilla eros, id fermentum dolor euismod eget. Ut vitae massa a augue suscipit bibendum non ac mi. Pellentesque id ligula in sapien fermentum fermentum. In ut sem molestie, consectetur ex tristique, tempor risus.  Maecenas scelerisque, ex eget cursus ornare, dolor nisi condimentum tellus, in venenatis nibh elit rutrum turpis. Sed sed vestibulum ex, molestie sodales leo. Vivamus cursus aliquet consequat. Aliquam et enim eget lorem placerat egestas a at justo. Praesent congue vitae purus vel scelerisque. Praesent faucibus massa felis, non porttitor dolor varius at. Nam fringilla risus sit amet faucibus vestibulum. Aliquam rhoncus ex vel magna blandit, eu dapibus felis tristique. Nam dignissim vestibulum neque vitae suscipit. Nunc a pharetra dui. Etiam nec quam sed mauris pharetra finibus in a tellus. Ut vehicula molestie lectus in pretium. Donec sit amet dui purus.  Nunc in vestibulum sapien. Donec elit quam, mollis luctus gravida ac, ullamcorper quis urna. Vivamus a urna egestas velit tempor interdum non eget dui. Maecenas maximus diam at consequat dictum. Etiam sed metus quis enim faucibus cursus condimentum ut nisi. In et iaculis odio. Curabitur sollicitudin ultrices finibus. Aliquam et nisi porta, vehicula urna id, dictum turpis. Sed id iaculis justo, non semper metus.  Quisque euismod, tellus iaculis sagittis vestibulum, leo magna blandit felis, non pharetra velit lacus sed nunc. Curabitur mollis porttitor odio, sed feugiat leo rhoncus quis. Duis faucibus tellus id venenatis vestibulum. Duis interdum pretium cursus. Integer sed iaculis mi. Phasellus at odio at felis fermentum congue. Morbi at ante ut lacus posuere accumsan quis in orci. Nullam eget sapien eu nibh venenatis malesuada.  Nulla sed ligula et metus mattis placerat sed eget nisl. Nunc cursus et nulla id dictum. Vivamus efficitur aliquam. "
+
+func BenchmarkClientWrite(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		opt  *options.ClientOptions
+	}{
+		{name: "not compressed", opt: options.Client().ApplyURI("mongodb://localhost:27017")},
+		{name: "snappy", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"snappy"})},
+		{name: "zlib", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"zlib"})},
+		{name: "zstd", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"zstd"})},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			client, err := mongo.NewClient(bm.opt)
+			if err != nil {
+				b.Fatalf("error connecting: %v", err)
+			}
+			ctx := context.Background()
+			err = client.Connect(ctx)
+			if err != nil {
+				b.Fatalf("error connecting: %v", err)
+			}
+			defer client.Disconnect(context.Background())
+			coll := client.Database("test").Collection("test")
+
+			b.ResetTimer()
+			b.RunParallel(func(p *testing.PB) {
+				for p.Next() {
+					_, err := coll.InsertOne(context.Background(), bson.D{{"text", text}})
+					if err != nil {
+						b.Fatalf("error inserting one document: %v", err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkClientRead(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		opt  *options.ClientOptions
+	}{
+		{name: "not compressed", opt: options.Client().ApplyURI("mongodb://localhost:27017")},
+		{name: "snappy", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"snappy"})},
+		{name: "zlib", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"zlib"})},
+		{name: "zstd", opt: options.Client().ApplyURI("mongodb://localhost:27017").SetCompressors([]string{"zstd"})},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			client, err := mongo.NewClient(bm.opt)
+			if err != nil {
+				b.Fatalf("error connecting: %v", err)
+			}
+			ctx := context.Background()
+			err = client.Connect(ctx)
+			if err != nil {
+				b.Fatalf("error connecting: %v", err)
+			}
+			defer client.Disconnect(context.Background())
+			coll := client.Database("test").Collection("test")
+			_, err = coll.DeleteMany(context.Background(), bson.D{})
+			if err != nil {
+				b.Fatalf("error deleting the document: %v", err)
+			}
+			_, err = coll.InsertOne(context.Background(), bson.D{{"text", text}})
+			if err != nil {
+				b.Fatalf("error inserting one document: %v", err)
+			}
+
+			b.ResetTimer()
+			b.RunParallel(func(p *testing.PB) {
+				for p.Next() {
+					var res bson.D
+					err := coll.FindOne(context.Background(), bson.D{}).Decode(&res)
+					if err != nil {
+						b.Errorf("error finding one document: %v", err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/benchmark/operation_test.go
+++ b/benchmark/operation_test.go
@@ -54,6 +54,7 @@ func BenchmarkClientWrite(b *testing.B) {
 					}
 				}
 			})
+			_, _ = coll.DeleteMany(context.Background(), bson.D{})
 		})
 	}
 }
@@ -100,6 +101,7 @@ func BenchmarkClientBulkWrite(b *testing.B) {
 					}
 				}
 			})
+			_, _ = coll.DeleteMany(context.Background(), bson.D{})
 		})
 	}
 }

--- a/benchmark/operation_test.go
+++ b/benchmark/operation_test.go
@@ -31,7 +31,7 @@ func BenchmarkClientWrite(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			client, err := mongo.NewClient(bm.opt)
 			if err != nil {
-				b.Fatalf("error connecting: %v", err)
+				b.Fatalf("error creating client: %v", err)
 			}
 			ctx := context.Background()
 			err = client.Connect(ctx)
@@ -72,7 +72,7 @@ func BenchmarkClientBulkWrite(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			client, err := mongo.NewClient(bm.opt)
 			if err != nil {
-				b.Fatalf("error connecting: %v", err)
+				b.Fatalf("error creating client: %v", err)
 			}
 			ctx := context.Background()
 			err = client.Connect(ctx)
@@ -118,7 +118,7 @@ func BenchmarkClientRead(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			client, err := mongo.NewClient(bm.opt)
 			if err != nil {
-				b.Fatalf("error connecting: %v", err)
+				b.Fatalf("error creating client: %v", err)
 			}
 			ctx := context.Background()
 			err = client.Connect(ctx)

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -305,7 +305,7 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 		Legacy:         LegacyKillCursors,
 		CommandMonitor: bc.cmdMonitor,
 		ServerAPI:      bc.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 }
 
 func (bc *BatchCursor) getMore(ctx context.Context) {
@@ -384,7 +384,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		CommandMonitor: bc.cmdMonitor,
 		Crypt:          bc.crypt,
 		ServerAPI:      bc.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 	// Once the cursor has been drained, we can unpin the connection if one is currently pinned.
 	if bc.id == 0 {

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -28,6 +28,7 @@ type ChannelConn struct {
 
 // WriteWireMessage implements the driver.Connection interface.
 func (c *ChannelConn) WriteWireMessage(ctx context.Context, wm []byte) error {
+	// Copy wm in case it came from a buffer pool.
 	b := make([]byte, len(wm))
 	copy(b, wm)
 	select {

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -28,8 +28,10 @@ type ChannelConn struct {
 
 // WriteWireMessage implements the driver.Connection interface.
 func (c *ChannelConn) WriteWireMessage(ctx context.Context, wm []byte) error {
+	b := make([]byte, len(wm))
+	copy(b, wm)
 	select {
-	case c.Written <- wm:
+	case c.Written <- b:
 	default:
 		c.WriteErr = errors.New("could not write wiremessage to written channel")
 	}
@@ -38,6 +40,7 @@ func (c *ChannelConn) WriteWireMessage(ctx context.Context, wm []byte) error {
 
 // ReadWireMessage implements the driver.Connection interface.
 func (c *ChannelConn) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
+	dst = dst[:0]
 	var wm []byte
 	var err error
 	select {
@@ -45,7 +48,13 @@ func (c *ChannelConn) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, 
 	case err = <-c.ReadErr:
 	case <-ctx.Done():
 	}
-	return wm, err
+	if l := len(wm); l > 0 {
+		if l > cap(dst) {
+			dst = make([]byte, 0, l)
+		}
+		dst = append(dst, wm...)
+	}
+	return dst, err
 }
 
 // Description implements the driver.Connection interface.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -319,7 +319,7 @@ var writeBuffers = sync.Pool{
 
 // Execute runs this operation. The scratch parameter will be used and overwritten (potentially many
 // times), this should mainly be used to enable pooling of byte slices.
-func (op Operation) Execute(ctx context.Context, scratch []byte) error {
+func (op Operation) Execute(ctx context.Context) error {
 	err := op.Validate()
 	if err != nil {
 		return err
@@ -475,23 +475,22 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		}
 
 		desc := description.SelectedServer{Server: conn.Description(), Kind: op.Deployment.Kind()}
-		scratch = scratch[:0]
 		if desc.WireVersion == nil || desc.WireVersion.Max < 4 {
 			switch op.Legacy {
 			case LegacyFind:
-				return op.legacyFind(ctx, scratch, srvr, conn, desc, maxTimeMS)
+				return op.legacyFind(ctx, (*wm)[:0], srvr, conn, desc, maxTimeMS)
 			case LegacyGetMore:
-				return op.legacyGetMore(ctx, scratch, srvr, conn, desc)
+				return op.legacyGetMore(ctx, (*wm)[:0], srvr, conn, desc)
 			case LegacyKillCursors:
-				return op.legacyKillCursors(ctx, scratch, srvr, conn, desc)
+				return op.legacyKillCursors(ctx, (*wm)[:0], srvr, conn, desc)
 			}
 		}
 		if desc.WireVersion == nil || desc.WireVersion.Max < 3 {
 			switch op.Legacy {
 			case LegacyListCollections:
-				return op.legacyListCollections(ctx, scratch, srvr, conn, desc)
+				return op.legacyListCollections(ctx, (*wm)[:0], srvr, conn, desc)
 			case LegacyListIndexes:
-				return op.legacyListIndexes(ctx, scratch, srvr, conn, desc, maxTimeMS)
+				return op.legacyListIndexes(ctx, (*wm)[:0], srvr, conn, desc, maxTimeMS)
 			}
 		}
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -312,7 +312,9 @@ func (op Operation) Validate() error {
 
 var memoryPool = sync.Pool{
 	New: func() interface{} {
-		b := make([]byte, 1024) // Start with 1kb buffers.
+		// Start with 1kb buffers.
+		b := make([]byte, 1024)
+		// Return a pointer as the static analysis tool suggests.
 		return &b
 	},
 }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -309,6 +310,13 @@ func (op Operation) Validate() error {
 	return nil
 }
 
+var writeBuffers = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 1024) // Start with 1kb buffers.
+		return &b
+	},
+}
+
 // Execute runs this operation. The scratch parameter will be used and overwritten (potentially many
 // times), this should mainly be used to enable pooling of byte slices.
 func (op Operation) Execute(ctx context.Context, scratch []byte) error {
@@ -382,6 +390,19 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		conn = nil
 	}
 
+	wm := writeBuffers.Get().(*[]byte)
+	defer func() {
+		// Proper usage of a sync.Pool requires each entry to have approximately the same memory
+		// cost. To obtain this property when the stored type contains a variably-sized buffer,
+		// we add a hard limit on the maximum buffer to place back in the pool. We limit the
+		// size to 16MiB because that's the maximum wire message size supported by MongoDB.
+		//
+		// Comment copied from https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/fmt/print.go;l=147
+		if cap(*wm) > 16*1024*1024 {
+			return
+		}
+		writeBuffers.Put(wm)
+	}()
 	for {
 		// If the server or connection are nil, try to select a new server and get a new connection.
 		if srvr == nil || conn == nil {
@@ -492,11 +513,8 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 			}
 		}
 
-		// convert to wire message
-		if len(scratch) > 0 {
-			scratch = scratch[:0]
-		}
-		wm, startedInfo, err := op.createWireMessage(ctx, scratch, desc, maxTimeMS, conn)
+		var startedInfo startedInformation
+		*wm, startedInfo, err = op.createWireMessage(ctx, (*wm)[:0], desc, maxTimeMS, conn)
 		if err != nil {
 			return err
 		}
@@ -511,11 +529,14 @@ func (op Operation) Execute(ctx context.Context, scratch []byte) error {
 		op.publishStartedEvent(ctx, startedInfo)
 
 		// get the moreToCome flag information before we compress
-		moreToCome := wiremessage.IsMsgMoreToCome(wm)
+		moreToCome := wiremessage.IsMsgMoreToCome(*wm)
 
 		// compress wiremessage if allowed
 		if compressor, ok := conn.(Compressor); ok && op.canCompress(startedInfo.cmdName) {
-			wm, err = compressor.CompressWireMessage(wm, nil)
+			b := writeBuffers.Get().(*[]byte)
+			*b, err = compressor.CompressWireMessage(*wm, (*b)[:0])
+			writeBuffers.Put(wm)
+			wm = b
 			if err != nil {
 				return err
 			}
@@ -781,19 +802,18 @@ func (op Operation) retryable(desc description.Server) bool {
 
 // roundTrip writes a wiremessage to the connection and then reads a wiremessage. The wm parameter
 // is reused when reading the wiremessage.
-func (op Operation) roundTrip(ctx context.Context, conn Connection, wm []byte) ([]byte, error) {
-	err := conn.WriteWireMessage(ctx, wm)
+func (op Operation) roundTrip(ctx context.Context, conn Connection, wm *[]byte) ([]byte, error) {
+	err := conn.WriteWireMessage(ctx, *wm)
 	if err != nil {
 		return nil, op.networkError(err)
 	}
-
 	return op.readWireMessage(ctx, conn, wm)
 }
 
-func (op Operation) readWireMessage(ctx context.Context, conn Connection, wm []byte) ([]byte, error) {
+func (op Operation) readWireMessage(ctx context.Context, conn Connection, wm *[]byte) ([]byte, error) {
 	var err error
 
-	wm, err = conn.ReadWireMessage(ctx, wm[:0])
+	*wm, err = conn.ReadWireMessage(ctx, (*wm)[:0])
 	if err != nil {
 		return nil, op.networkError(err)
 	}
@@ -801,17 +821,19 @@ func (op Operation) readWireMessage(ctx context.Context, conn Connection, wm []b
 	// If we're using a streamable connection, we set its streaming state based on the moreToCome flag in the server
 	// response.
 	if streamer, ok := conn.(StreamerConnection); ok {
-		streamer.SetStreaming(wiremessage.IsMsgMoreToCome(wm))
+		streamer.SetStreaming(wiremessage.IsMsgMoreToCome(*wm))
 	}
 
 	// decompress wiremessage
-	wm, err = op.decompressWireMessage(wm)
+	*wm, err = op.decompressWireMessage(*wm)
 	if err != nil {
 		return nil, err
 	}
 
 	// decode
-	res, err := op.decodeResult(wm)
+	b, err := op.decodeResult(*wm)
+	res := make([]byte, len(b))
+	copy(res, b)
 	// Update cluster/operation time and recovery tokens before handling the error to ensure we're properly updating
 	// everything.
 	op.updateClusterTimes(res)
@@ -857,8 +879,8 @@ func (op Operation) networkError(err error) error {
 
 // moreToComeRoundTrip writes a wiremessage to the provided connection. This is used when an OP_MSG is
 // being sent with  the moreToCome bit set.
-func (op *Operation) moreToComeRoundTrip(ctx context.Context, conn Connection, wm []byte) ([]byte, error) {
-	err := conn.WriteWireMessage(ctx, wm)
+func (op *Operation) moreToComeRoundTrip(ctx context.Context, conn Connection, wm *[]byte) ([]byte, error) {
+	err := conn.WriteWireMessage(ctx, *wm)
 	if err != nil {
 		if op.Client != nil {
 			op.Client.MarkDirty()
@@ -895,23 +917,29 @@ func (Operation) decompressWireMessage(wm []byte) ([]byte, error) {
 	}
 	compressedSize := length - 25 // header (16) + original opcode (4) + uncompressed size (4) + compressor ID (1)
 	// return the original wiremessage
-	msg, rem, ok := wiremessage.ReadCompressedCompressedMessage(rem, compressedSize)
+	msg, _, ok := wiremessage.ReadCompressedCompressedMessage(rem, compressedSize)
 	if !ok {
 		return nil, errors.New("malformed OP_COMPRESSED: insufficient bytes for compressed wiremessage")
 	}
 
-	header := make([]byte, 0, uncompressedSize+16)
-	header = wiremessage.AppendHeader(header, uncompressedSize+16, reqid, respto, opcode)
+	b := make([]byte, len(msg))
+	copy(b, msg)
+
+	if l := int(uncompressedSize) + 16; cap(wm) < l {
+		wm = make([]byte, 0, l)
+	}
+	wm = wiremessage.AppendHeader(wm[:0], uncompressedSize+16, reqid, respto, opcode)
 	opts := CompressionOpts{
 		Compressor:       compressorID,
 		UncompressedSize: uncompressedSize,
 	}
-	uncompressed, err := DecompressPayload(msg, opts)
+	uncompressed, err := DecompressPayload(b, opts)
 	if err != nil {
 		return nil, err
 	}
+	wm = append(wm, uncompressed...)
 
-	return append(header, uncompressed...), nil
+	return wm, nil
 }
 
 func (op Operation) createWireMessage(
@@ -1688,8 +1716,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		res := bson.Raw{}
 		// Only copy the reply for commands that are not security sensitive
 		if !info.redacted {
-			res = make([]byte, len(info.response))
-			copy(res, info.response)
+			res = bson.Raw(info.response)
 		}
 		successEvent := &event.CommandSucceededEvent{
 			Reply:                res,

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -64,7 +64,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 		Selector:          at.selector,
 		WriteConcern:      at.writeConcern,
 		ServerAPI:         at.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -111,7 +111,7 @@ func (a *Aggregate) Execute(ctx context.Context) error {
 		IsOutputAggregate:              a.hasOutputStage,
 		MaxTime:                        a.maxTime,
 		Timeout:                        a.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -106,7 +106,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		Crypt:          c.crypt,
 		ServerAPI:      c.serverAPI,
 		Timeout:        c.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 }
 
 // Session sets the session for this operation.

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -66,7 +66,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 		Selector:          ct.selector,
 		WriteConcern:      ct.writeConcern,
 		ServerAPI:         ct.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -126,7 +126,7 @@ func (c *Count) Execute(ctx context.Context) error {
 		Selector:          c.selector,
 		ServerAPI:         c.serverAPI,
 		Timeout:           c.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 	// Swallow error if NamespaceNotFound(26) is returned from aggregate on non-existent namespace
 	if err != nil {

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -77,7 +77,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		Selector:          c.selector,
 		WriteConcern:      c.writeConcern,
 		ServerAPI:         c.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/createIndexes.go
+++ b/x/mongo/driver/operation/createIndexes.go
@@ -117,7 +117,7 @@ func (ci *CreateIndexes) Execute(ctx context.Context) error {
 		WriteConcern:      ci.writeConcern,
 		ServerAPI:         ci.serverAPI,
 		Timeout:           ci.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -111,7 +111,7 @@ func (d *Delete) Execute(ctx context.Context) error {
 		WriteConcern:      d.writeConcern,
 		ServerAPI:         d.serverAPI,
 		Timeout:           d.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -105,7 +105,7 @@ func (d *Distinct) Execute(ctx context.Context) error {
 		Selector:          d.selector,
 		ServerAPI:         d.serverAPI,
 		Timeout:           d.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -102,7 +102,7 @@ func (dc *DropCollection) Execute(ctx context.Context) error {
 		WriteConcern:      dc.writeConcern,
 		ServerAPI:         dc.serverAPI,
 		Timeout:           dc.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -53,7 +53,7 @@ func (dd *DropDatabase) Execute(ctx context.Context) error {
 		Selector:       dd.selector,
 		WriteConcern:   dd.writeConcern,
 		ServerAPI:      dd.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -99,7 +99,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 		WriteConcern:      di.writeConcern,
 		ServerAPI:         di.serverAPI,
 		Timeout:           di.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -59,7 +59,7 @@ func (es *EndSessions) Execute(ctx context.Context) error {
 		Deployment:        es.deployment,
 		Selector:          es.selector,
 		ServerAPI:         es.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -105,7 +105,7 @@ func (f *Find) Execute(ctx context.Context) error {
 		Legacy:            driver.LegacyFind,
 		ServerAPI:         f.serverAPI,
 		Timeout:           f.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -143,7 +143,7 @@ func (fam *FindAndModify) Execute(ctx context.Context) error {
 		Crypt:          fam.crypt,
 		ServerAPI:      fam.serverAPI,
 		Timeout:        fam.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -194,7 +194,7 @@ func (h *Hello) Execute(ctx context.Context) error {
 		return errors.New("a Hello must have a Deployment set before Execute can be called")
 	}
 
-	return h.createOperation().Execute(ctx, nil)
+	return h.createOperation().Execute(ctx)
 }
 
 // StreamResponse gets the next streaming Hello response from the server.
@@ -229,7 +229,7 @@ func (h *Hello) GetHandshakeInformation(ctx context.Context, _ address.Address, 
 			return nil
 		},
 		ServerAPI: h.serverAPI,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 	if err != nil {
 		return driver.HandshakeInformation{}, err
 	}

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -199,7 +199,7 @@ func (h *Hello) Execute(ctx context.Context) error {
 
 // StreamResponse gets the next streaming Hello response from the server.
 func (h *Hello) StreamResponse(ctx context.Context, conn driver.StreamerConnection) error {
-	return h.createOperation().ExecuteExhaust(ctx, conn, nil)
+	return h.createOperation().ExecuteExhaust(ctx, conn)
 }
 
 func (h *Hello) createOperation() driver.Operation {

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -110,7 +110,7 @@ func (i *Insert) Execute(ctx context.Context) error {
 		WriteConcern:      i.writeConcern,
 		ServerAPI:         i.serverAPI,
 		Timeout:           i.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -163,7 +163,7 @@ func (ld *ListDatabases) Execute(ctx context.Context) error {
 		Crypt:          ld.crypt,
 		ServerAPI:      ld.serverAPI,
 		Timeout:        ld.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -88,7 +88,7 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 		Legacy:            driver.LegacyListCollections,
 		ServerAPI:         lc.serverAPI,
 		Timeout:           lc.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -83,7 +83,7 @@ func (li *ListIndexes) Execute(ctx context.Context) error {
 		Type:           driver.Read,
 		ServerAPI:      li.serverAPI,
 		Timeout:        li.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -162,7 +162,7 @@ func (u *Update) Execute(ctx context.Context) error {
 		Crypt:             u.crypt,
 		ServerAPI:         u.serverAPI,
 		Timeout:           u.timeout,
-	}.Execute(ctx, nil)
+	}.Execute(ctx)
 
 }
 

--- a/x/mongo/driver/operation_exhaust.go
+++ b/x/mongo/driver/operation_exhaust.go
@@ -19,7 +19,7 @@ func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection,
 	}
 
 	scratch = scratch[:0]
-	res, err := op.readWireMessage(ctx, conn, &scratch)
+	res, _, err := op.readWireMessage(ctx, conn, scratch)
 	if err != nil {
 		return err
 	}

--- a/x/mongo/driver/operation_exhaust.go
+++ b/x/mongo/driver/operation_exhaust.go
@@ -13,13 +13,18 @@ import (
 
 // ExecuteExhaust reads a response from the provided StreamerConnection. This will error if the connection's
 // CurrentlyStreaming function returns false.
-func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection, scratch []byte) error {
+func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection) error {
 	if !conn.CurrentlyStreaming() {
 		return errors.New("exhaust read must be done with a connection that is currently streaming")
 	}
 
-	scratch = scratch[:0]
-	res, _, err := op.readWireMessage(ctx, conn, scratch)
+	wm := memoryPool.Get().(*[]byte)
+	defer func() {
+		memoryPool.Put(wm)
+	}()
+	var res []byte
+	var err error
+	res, *wm, err = op.readWireMessage(ctx, conn, (*wm)[:0])
 	if err != nil {
 		return err
 	}

--- a/x/mongo/driver/operation_exhaust.go
+++ b/x/mongo/driver/operation_exhaust.go
@@ -19,7 +19,7 @@ func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection,
 	}
 
 	scratch = scratch[:0]
-	res, err := op.readWireMessage(ctx, conn, scratch)
+	res, err := op.readWireMessage(ctx, conn, &scratch)
 	if err != nil {
 		return err
 	}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -207,7 +207,7 @@ func TestOperation(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				gotWM, gotErr := Operation{}.roundTrip(context.Background(), tc.conn, &tc.paramWM)
+				gotWM, _, gotErr := Operation{}.roundTrip(context.Background(), tc.conn, tc.paramWM)
 				if !bytes.Equal(gotWM, tc.wantWM) {
 					t.Errorf("Returned wire messages are not equal. got %v; want %v", gotWM, tc.wantWM)
 				}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -620,7 +620,7 @@ func TestOperation(t *testing.T) {
 			conn := &mockConnection{
 				rStreaming: false,
 			}
-			err := Operation{}.ExecuteExhaust(context.TODO(), conn, nil)
+			err := Operation{}.ExecuteExhaust(context.TODO(), conn)
 			assert.NotNil(t, err, "expected error, got nil")
 		})
 	})
@@ -671,7 +671,7 @@ func TestOperation(t *testing.T) {
 		// Reset the server response and go through ExecuteExhaust to mimic streaming the next response. After
 		// execution, the connection should still be in a streaming state.
 		conn.rReadWM = streamingResponse
-		err = op.ExecuteExhaust(context.TODO(), conn, nil)
+		err = op.ExecuteExhaust(context.TODO(), conn)
 		assert.Nil(t, err, "ExecuteExhaust error: %v", err)
 		assert.True(t, conn.CurrentlyStreaming(), "expected CurrentlyStreaming to be true")
 	})

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -651,7 +651,7 @@ func TestOperation(t *testing.T) {
 			Database:   "admin",
 			Deployment: SingleConnectionDeployment{conn},
 		}
-		err := op.Execute(context.TODO(), nil)
+		err := op.Execute(context.TODO())
 		assert.Nil(t, err, "Execute error: %v", err)
 
 		// The wire message sent to the server should not have exhaustAllowed=true. After execution, the connection
@@ -663,7 +663,7 @@ func TestOperation(t *testing.T) {
 		streamingResponse := createExhaustServerResponse(serverResponseDoc, true)
 		conn.rReadWM = streamingResponse
 		conn.rCanStream = true
-		err = op.Execute(context.TODO(), nil)
+		err = op.Execute(context.TODO())
 		assert.Nil(t, err, "Execute error: %v", err)
 		assertExhaustAllowedSet(t, conn.pWriteWM, true)
 		assert.True(t, conn.CurrentlyStreaming(), "expected CurrentlyStreaming to be true")
@@ -690,7 +690,7 @@ func TestOperation(t *testing.T) {
 			},
 		}
 
-		err := op.Execute(ctx, nil)
+		err := op.Execute(ctx)
 		assert.NotNil(t, err, "expected an error from Execute(), got nil")
 		// Assert that error is just context deadline exceeded and is therefore not a driver.Error marked
 		// with the TransientTransactionError label.
@@ -711,7 +711,7 @@ func TestOperation(t *testing.T) {
 			},
 		}
 
-		err := op.Execute(ctx, nil)
+		err := op.Execute(ctx)
 		assert.NotNil(t, err, "expected an error from Execute(), got nil")
 		// Assert that error is just context canceled and is therefore not a driver.Error marked with
 		// the TransientTransactionError label.
@@ -856,7 +856,7 @@ func TestRetry(t *testing.T) {
 			Database:   "testing",
 			RetryMode:  &retry,
 			Type:       Read,
-		}.Execute(ctx, nil)
+		}.Execute(ctx)
 		assert.NotNil(t, err, "expected an error from Execute()")
 
 		// Expect Connection() to be called at least 3 times. The first call is the initial attempt

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -207,7 +207,7 @@ func TestOperation(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				gotWM, gotErr := Operation{}.roundTrip(context.Background(), tc.conn, tc.paramWM)
+				gotWM, gotErr := Operation{}.roundTrip(context.Background(), tc.conn, &tc.paramWM)
 				if !bytes.Equal(gotWM, tc.wantWM) {
 					t.Errorf("Returned wire messages are not equal. got %v; want %v", gotWM, tc.wantWM)
 				}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -417,6 +417,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 }
 
 func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, errMsg string, err error) {
+	// Clear dst in case it came from a memory pool.
 	dst = dst[:0]
 	go c.cancellationListener.Listen(ctx, c.cancellationListenerCallback)
 	defer func() {

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -417,8 +417,6 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 }
 
 func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, errMsg string, err error) {
-	// Clear dst in case it came from a memory pool.
-	dst = dst[:0]
 	go c.cancellationListener.Listen(ctx, c.cancellationListenerCallback)
 	defer func() {
 		// If the context is cancelled after we finish reading the server response, the cancellation listener could fire

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -406,7 +406,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 		if err == io.EOF {
 			message = "socket was unexpectedly closed"
 		}
-		return nil, ConnectionError{
+		return dst, ConnectionError{
 			ConnectionID: c.id,
 			Wrapped:      transformNetworkError(ctx, err, contextDeadlineUsed),
 			message:      message,
@@ -417,6 +417,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 }
 
 func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, errMsg string, err error) {
+	dst = dst[:0]
 	go c.cancellationListener.Listen(ctx, c.cancellationListenerCallback)
 	defer func() {
 		// If the context is cancelled after we finish reading the server response, the cancellation listener could fire
@@ -438,7 +439,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 	// reading messages from an exhaust cursor.
 	_, err = io.ReadFull(c.nc, sizeBuf[:])
 	if err != nil {
-		return nil, "incomplete read of message header", err
+		return dst, "incomplete read of message header", err
 	}
 
 	// read the length as an int32
@@ -451,7 +452,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 		maxMessageSize = defaultMaxMessageSize
 	}
 	if uint32(size) > maxMessageSize {
-		return nil, errResponseTooLarge.Error(), errResponseTooLarge
+		return dst, errResponseTooLarge.Error(), errResponseTooLarge
 	}
 
 	if int(size) > cap(dst) {
@@ -465,7 +466,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 
 	_, err = io.ReadFull(c.nc, dst[4:])
 	if err != nil {
-		return nil, "incomplete read of full message", err
+		return dst, "incomplete read of full message", err
 	}
 
 	return dst, "", nil
@@ -625,9 +626,6 @@ func (c *Connection) CompressWireMessage(src, dst []byte) ([]byte, error) {
 		return dst, ErrConnectionClosed
 	}
 	if c.connection.compressor == wiremessage.CompressorNoOp {
-		if len(dst) == 0 {
-			return src, nil
-		}
 		return append(dst, src...), nil
 	}
 	_, reqid, respto, origcode, rem, ok := wiremessage.ReadHeader(src)


### PR DESCRIPTION
[GODRIVER-2021](https://jira.mongodb.org/browse/GODRIVER-2021)
[GODRIVER-1670](https://jira.mongodb.org/browse/GODRIVER-1670)

Use pooling to reduce memory allocation.

The benchstat from benchmark/operation_test.go shows:
```
name                          old time/op    new time/op    delta
ClientWrite/not_compressed-4     153µs ± 2%     154µs ± 2%     ~     (p=0.079 n=9+10)
ClientWrite/snappy-4             183µs ± 2%     187µs ±12%     ~     (p=0.878 n=8+8)
ClientWrite/zlib-4              1.35ms ±36%    1.39ms ±27%     ~     (p=0.842 n=10+9)
ClientWrite/zstd-4               286µs ±13%     286µs ±16%     ~     (p=0.666 n=9+9)

name                          old alloc/op   new alloc/op   delta
ClientWrite/not_compressed-4    34.3kB ± 0%    23.9kB ± 0%  -30.32%  (p=0.000 n=10+9)
ClientWrite/snappy-4            52.1kB ± 0%    36.4kB ± 0%  -30.14%  (p=0.000 n=10+10)
ClientWrite/zlib-4               907kB ± 0%     896kB ± 0%   -1.26%  (p=0.000 n=10+8)
ClientWrite/zstd-4              54.1kB ± 0%    39.5kB ± 0%  -26.99%  (p=0.000 n=9+10)

name                          old allocs/op  new allocs/op  delta
ClientWrite/not_compressed-4      59.0 ± 0%      54.0 ± 0%   -8.47%  (p=0.000 n=10+10)
ClientWrite/snappy-4              66.0 ± 0%      57.0 ± 0%  -13.64%  (p=0.000 n=10+10)
ClientWrite/zlib-4                 103 ± 0%        96 ± 0%   -6.80%  (p=0.000 n=8+7)
ClientWrite/zstd-4                 108 ± 0%        99 ± 0%   -8.33%  (p=0.000 n=10+10)
```

```
name                         old time/op    new time/op    delta
ClientRead/not_compressed-4     248µs ± 2%     256µs ±11%     ~     (p=1.000 n=8+9)
ClientRead/snappy-4             270µs ± 1%     272µs ± 2%     ~     (p=0.113 n=9+10)
ClientRead/zlib-4              1.78ms ± 3%    1.78ms ± 2%     ~     (p=0.863 n=9+9)
ClientRead/zstd-4               399µs ± 2%     399µs ± 3%     ~     (p=0.971 n=10+10)

name                         old alloc/op   new alloc/op   delta
ClientRead/not_compressed-4    26.5kB ± 0%    26.1kB ± 0%   -1.59%  (p=0.000 n=9+10)
ClientRead/snappy-4            44.1kB ± 0%    43.6kB ± 0%   -1.08%  (p=0.000 n=10+10)
ClientRead/zlib-4               899kB ± 0%     903kB ± 0%   +0.48%  (p=0.000 n=9+10)
ClientRead/zstd-4               124kB ± 0%     123kB ± 0%   -1.11%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
ClientRead/not_compressed-4      73.0 ± 0%      67.0 ± 0%   -8.22%  (p=0.000 n=10+10)
ClientRead/snappy-4              80.0 ± 0%      70.0 ± 0%  -12.50%  (p=0.000 n=10+10)
ClientRead/zlib-4                 130 ± 0%       122 ± 0%   -5.77%  (p=0.000 n=8+10)
ClientRead/zstd-4                 137 ± 0%       127 ± 0%   -7.30%  (p=0.000 n=10+10)
```

coauthor: Matt Dale