### PR TITLE
Fix new lint failures and drop deprecated linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
   disable-all: true
   # TODO(GODRIVER-2156): Enable all commented-out linters.
   enable:
-    - deadcode
     - errcheck
     # - errorlint
     - gocritic
@@ -20,12 +19,10 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
     - unconvert
     - unparam
-    - varcheck
 
 linters-settings:
   errcheck:
@@ -97,7 +94,6 @@ issues:
     - path: x/mongo/driver/auth/internal/awsv4
       linters:
         - unused
-        - structcheck
     # Disable "unused" linter for code files that depend on the "mongocrypt.MongoCrypt" type because
     # the linter build doesn't work correctly with CGO enabled. As a result, all calls to a
     # "mongocrypt.MongoCrypt" API appear to always panic (see mongocrypt_not_enabled.go), leading
@@ -115,9 +111,12 @@ issues:
     # "benchmark" directories.
     - path: (internal\/|benchmark\/)
       text: exported (.+) should have comment( \(or a comment on this block\))? or be unexported
-    # Disable deadcode and unused linter for "golang.org/x/exp/rand" package in internal/randutil/rand.
+    # Ignore missing package comments for directories that aren't frequently used by external users.
+    # TODO(GODRIVER-2517): Remove "mongo/testaws" and "mongo/testatlas" from the ignored paths when
+    # TODO we move those packages to the "cmd/" directory.
+    - path: (internal\/|benchmark\/|x\/|cmd\/|mongo\/integration\/|mongo\/(testaws\/|testatlas\/))
+      text: should have a package comment
+    # Disable unused linter for "golang.org/x/exp/rand" package in internal/randutil/rand.
     - path: internal/randutil/rand
       linters:
-        - deadcode
         - unused
-        - varcheck

--- a/bson/bsonoptions/doc.go
+++ b/bson/bsonoptions/doc.go
@@ -1,0 +1,8 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package bsonoptions defines the optional configurations for the BSON codecs.
+package bsonoptions

--- a/bson/bsonrw/bsonrwtest/bsonrwtest.go
+++ b/bson/bsonrw/bsonrwtest/bsonrwtest.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package bsonrwtest provides utilities for testing the "bson/bsonrw" package.
 package bsonrwtest // import "go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
 
 import (

--- a/mongo/address/addr.go
+++ b/mongo/address/addr.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package address provides structured representations of network addresses.
 package address // import "go.mongodb.org/mongo-driver/mongo/address"
 
 import (

--- a/mongo/description/description.go
+++ b/mongo/description/description.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package description contains types and functions for describing the state of MongoDB clusters.
 package description // import "go.mongodb.org/mongo-driver/mongo/description"
 
 // Unknown is an unknown server or topology kind.

--- a/mongo/options/doc.go
+++ b/mongo/options/doc.go
@@ -4,5 +4,5 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-// Package options asdfasdfa.
+// Package options defines the optional configurations for the MongoDB Go Driver.
 package options

--- a/mongo/options/doc.go
+++ b/mongo/options/doc.go
@@ -1,0 +1,8 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Package options asdfasdfa.
+package options

--- a/mongo/readconcern/readconcern.go
+++ b/mongo/readconcern/readconcern.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package readconcern defines read concerns for MongoDB operations.
 package readconcern // import "go.mongodb.org/mongo-driver/mongo/readconcern"
 
 import (

--- a/mongo/readpref/readpref.go
+++ b/mongo/readpref/readpref.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package readpref defines read preferences for MongoDB queries.
 package readpref // import "go.mongodb.org/mongo-driver/mongo/readpref"
 
 import (

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package writeconcern defines write concerns for MongoDB operations.
 package writeconcern // import "go.mongodb.org/mongo-driver/mongo/writeconcern"
 
 import (

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package tag provides a way to define filters for tagged servers.
 package tag // import "go.mongodb.org/mongo-driver/tag"
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Package version defines the Go Driver version.
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.


### PR DESCRIPTION
The "revive" linter now requires package comments on all packages. Add package comments to all packages commonly used by external users. Ignore package comment warnings on all other packages.

As of `golangci-lint` v1.49.0, the "deadcode", "structcheck", and "varcheck" linters are deprecated (replaced by "unused"), so remove them from the configuration.