### PR TITLE
Clean up internal/testutil/helpers package.

### DIFF
--- a/internal/testutil/helpers/helpers.go
+++ b/internal/testutil/helpers/helpers.go
@@ -4,63 +4,21 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package testhelpers // import "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+package helpers
 
 import (
-	"fmt"
 	"io/ioutil"
-	"math"
 	"path"
-	"strings"
-	"time"
-
 	"testing"
-
-	"io"
-
-	"reflect"
 
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
-
-// Test helpers
-
-// IsNil returns true if the object is nil
-func IsNil(object interface{}) bool {
-	if object == nil {
-		return true
-	}
-
-	value := reflect.ValueOf(object)
-	kind := value.Kind()
-
-	// checking to see if type is Chan, Func, Interface, Map, Ptr, or Slice
-	if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-		return true
-	}
-
-	return false
-}
-
-// RequireNotNil throws an error if var is nil
-func RequireNotNil(t *testing.T, variable interface{}, msgFormat string, msgVars ...interface{}) {
-	if IsNil(variable) {
-		t.Fatalf(msgFormat, msgVars...)
-	}
-}
-
-// RequireNil throws an error if var is not nil
-func RequireNil(t *testing.T, variable interface{}, msgFormat string, msgVars ...interface{}) {
-	t.Helper()
-	if !IsNil(variable) {
-		t.Fatalf(msgFormat, msgVars...)
-	}
-}
 
 // FindJSONFilesInDir finds the JSON files in a directory.
 func FindJSONFilesInDir(t *testing.T, dir string) []string {
+	t.Helper()
+
 	files := make([]string, 0)
 
 	entries, err := ioutil.ReadDir(dir)
@@ -77,133 +35,6 @@ func FindJSONFilesInDir(t *testing.T, dir string) []string {
 	return files
 }
 
-// RequireNoErrorOnClose ensures there is not an error when calling Close.
-func RequireNoErrorOnClose(t *testing.T, c io.Closer) {
-	require.NoError(t, c.Close())
-}
-
-// VerifyConnStringOptions verifies the options on the connection string.
-func VerifyConnStringOptions(t *testing.T, cs connstring.ConnString, options map[string]interface{}) {
-	// Check that all options are present.
-	for key, value := range options {
-
-		key = strings.ToLower(key)
-		switch key {
-		case "appname":
-			require.Equal(t, value, cs.AppName)
-		case "authsource":
-			require.Equal(t, value, cs.AuthSource)
-		case "authmechanism":
-			require.Equal(t, value, cs.AuthMechanism)
-		case "authmechanismproperties":
-			convertedMap := value.(map[string]interface{})
-			require.Equal(t,
-				mapInterfaceToString(convertedMap),
-				cs.AuthMechanismProperties)
-		case "compressors":
-			require.Equal(t, convertToStringSlice(value), cs.Compressors)
-		case "connecttimeoutms":
-			require.Equal(t, value, float64(cs.ConnectTimeout/time.Millisecond))
-		case "directconnection":
-			require.True(t, cs.DirectConnectionSet)
-			require.Equal(t, value, cs.DirectConnection)
-		case "heartbeatfrequencyms":
-			require.Equal(t, value, float64(cs.HeartbeatInterval/time.Millisecond))
-		case "journal":
-			require.True(t, cs.JSet)
-			require.Equal(t, value, cs.J)
-		case "loadbalanced":
-			require.True(t, cs.LoadBalancedSet)
-			require.Equal(t, value, cs.LoadBalanced)
-		case "localthresholdms":
-			require.True(t, cs.LocalThresholdSet)
-			require.Equal(t, value, float64(cs.LocalThreshold/time.Millisecond))
-		case "maxidletimems":
-			require.Equal(t, value, float64(cs.MaxConnIdleTime/time.Millisecond))
-		case "maxpoolsize":
-			require.True(t, cs.MaxPoolSizeSet)
-			require.Equal(t, value, cs.MaxPoolSize)
-		case "maxstalenessseconds":
-			require.True(t, cs.MaxStalenessSet)
-			require.Equal(t, value, float64(cs.MaxStaleness/time.Second))
-		case "minpoolsize":
-			require.True(t, cs.MinPoolSizeSet)
-			require.Equal(t, value, int64(cs.MinPoolSize))
-		case "readpreference":
-			require.Equal(t, value, cs.ReadPreference)
-		case "readpreferencetags":
-			sm, ok := value.([]interface{})
-			require.True(t, ok)
-			tags := make([]map[string]string, 0, len(sm))
-			for _, i := range sm {
-				m, ok := i.(map[string]interface{})
-				require.True(t, ok)
-				tags = append(tags, mapInterfaceToString(m))
-			}
-			require.Equal(t, tags, cs.ReadPreferenceTagSets)
-		case "readconcernlevel":
-			require.Equal(t, value, cs.ReadConcernLevel)
-		case "replicaset":
-			require.Equal(t, value, cs.ReplicaSet)
-		case "retrywrites":
-			require.True(t, cs.RetryWritesSet)
-			require.Equal(t, value, cs.RetryWrites)
-		case "serverselectiontimeoutms":
-			require.Equal(t, value, float64(cs.ServerSelectionTimeout/time.Millisecond))
-		case "srvmaxhosts":
-			require.Equal(t, value, float64(cs.SRVMaxHosts))
-		case "srvservicename":
-			require.Equal(t, value, cs.SRVServiceName)
-		case "ssl", "tls":
-			require.Equal(t, value, cs.SSL)
-		case "sockettimeoutms":
-			require.Equal(t, value, float64(cs.SocketTimeout/time.Millisecond))
-		case "tlsallowinvalidcertificates", "tlsallowinvalidhostnames", "tlsinsecure":
-			require.True(t, cs.SSLInsecureSet)
-			require.Equal(t, value, cs.SSLInsecure)
-		case "tlscafile":
-			require.True(t, cs.SSLCaFileSet)
-			require.Equal(t, value, cs.SSLCaFile)
-		case "tlscertificatekeyfile":
-			require.True(t, cs.SSLClientCertificateKeyFileSet)
-			require.Equal(t, value, cs.SSLClientCertificateKeyFile)
-		case "tlscertificatekeyfilepassword":
-			require.True(t, cs.SSLClientCertificateKeyPasswordSet)
-			require.Equal(t, value, cs.SSLClientCertificateKeyPassword())
-		case "w":
-			if cs.WNumberSet {
-				valueInt := GetIntFromInterface(value)
-				require.NotNil(t, valueInt)
-				require.Equal(t, *valueInt, int64(cs.WNumber))
-			} else {
-				require.Equal(t, value, cs.WString)
-			}
-		case "wtimeoutms":
-			require.Equal(t, value, float64(cs.WTimeout/time.Millisecond))
-		case "waitqueuetimeoutms":
-		case "zlibcompressionlevel":
-			require.Equal(t, value, float64(cs.ZlibLevel))
-		case "zstdcompressionlevel":
-			require.Equal(t, value, float64(cs.ZstdLevel))
-		case "tlsdisableocspendpointcheck":
-			require.Equal(t, value, cs.SSLDisableOCSPEndpointCheck)
-		default:
-			opt, ok := cs.UnknownOptions[key]
-			require.True(t, ok)
-			require.Contains(t, opt, fmt.Sprint(value))
-		}
-	}
-}
-
-// RawSliceToInterfaceSlice converts a []bson.Raw to []interface{}.
-func RawSliceToInterfaceSlice(elems []bson.Raw) []interface{} {
-	out := make([]interface{}, 0, len(elems))
-	for _, elem := range elems {
-		out = append(out, elem)
-	}
-	return out
-}
-
 // RawToInterfaceSlice converts a bson.Raw that is internally an array to []interface{}.
 func RawToInterfaceSlice(doc bson.Raw) []interface{} {
 	values, _ := doc.Values()
@@ -214,65 +45,4 @@ func RawToInterfaceSlice(doc bson.Raw) []interface{} {
 	}
 
 	return out
-}
-
-// Convert each interface{} value in the map to a string.
-func mapInterfaceToString(m map[string]interface{}) map[string]string {
-	out := make(map[string]string)
-
-	for key, value := range m {
-		out[key] = fmt.Sprint(value)
-	}
-
-	return out
-}
-
-func convertToStringSlice(i interface{}) []string {
-	s, ok := i.([]interface{})
-	if !ok {
-		return nil
-	}
-	ret := make([]string, 0, len(s))
-	for _, v := range s {
-		str, ok := v.(string)
-		if !ok {
-			continue
-		}
-		ret = append(ret, str)
-	}
-	return ret
-}
-
-// GetIntFromInterface attempts to convert an empty interface value to an integer.
-//
-// Returns nil if it is not possible.
-func GetIntFromInterface(i interface{}) *int64 {
-	var out int64
-
-	switch v := i.(type) {
-	case int:
-		out = int64(v)
-	case int32:
-		out = int64(v)
-	case int64:
-		out = v
-	case float32:
-		f := float64(v)
-		if math.Floor(f) != f || f > float64(math.MaxInt64) {
-			break
-		}
-
-		out = int64(f)
-
-	case float64:
-		if math.Floor(v) != v || v > float64(math.MaxInt64) {
-			break
-		}
-
-		out = int64(v)
-	default:
-		return nil
-	}
-
-	return &out
 }

--- a/internal/testutil/helpers/helpers.go
+++ b/internal/testutil/helpers/helpers.go
@@ -7,6 +7,7 @@
 package helpers
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -35,14 +36,26 @@ func FindJSONFilesInDir(t *testing.T, dir string) []string {
 	return files
 }
 
-// RawToInterfaceSlice converts a bson.Raw that is internally an array to []interface{}.
-func RawToInterfaceSlice(doc bson.Raw) []interface{} {
-	values, _ := doc.Values()
-
-	out := make([]interface{}, 0, len(values))
-	for _, val := range values {
-		out = append(out, val.Document())
+// RawToDocuments converts a bson.Raw that is internally an array of documents to []bson.Raw.
+func RawToDocuments(doc bson.Raw) []bson.Raw {
+	values, err := doc.Values()
+	if err != nil {
+		panic(fmt.Sprintf("error converting BSON document to values: %v", err))
 	}
 
+	out := make([]bson.Raw, len(values))
+	for i := range values {
+		out[i] = values[i].Document()
+	}
+
+	return out
+}
+
+// RawToInterfaces takes one or many bson.Raw documents and returns them as a []interface{}.
+func RawToInterfaces(docs ...bson.Raw) []interface{} {
+	out := make([]interface{}, len(docs))
+	for i := range docs {
+		out[i] = docs[i]
+	}
 	return out
 }

--- a/mongo/description/max_staleness_spec_test.go
+++ b/mongo/description/max_staleness_spec_test.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"testing"
 
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 )
 
 const maxStalenessTestsDir = "../../data/max-staleness"
@@ -24,7 +24,7 @@ func TestMaxStalenessSpec(t *testing.T) {
 		"Single",
 		"Unknown",
 	} {
-		for _, file := range testhelpers.FindJSONFilesInDir(t,
+		for _, file := range helpers.FindJSONFilesInDir(t,
 			path.Join(maxStalenessTestsDir, topology)) {
 
 			runTest(t, maxStalenessTestsDir, topology, file)

--- a/mongo/description/selector_spec_test.go
+++ b/mongo/description/selector_spec_test.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"testing"
 
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 )
 
 const selectorTestsDir = "../../data/server-selection/server_selection"
@@ -28,7 +28,7 @@ func TestServerSelectionSpec(t *testing.T) {
 		for _, subdir := range [...]string{"read", "write"} {
 			subdirPath := path.Join(topology, subdir)
 
-			for _, file := range testhelpers.FindJSONFilesInDir(t,
+			for _, file := range helpers.FindJSONFilesInDir(t,
 				path.Join(selectorTestsDir, subdirPath)) {
 
 				runTest(t, selectorTestsDir, subdirPath, file)

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/gridfs"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -171,7 +172,7 @@ func executeAggregate(mt *mtest.T, agg aggregator, sess mongo.Session, args bson
 
 		switch key {
 		case "pipeline":
-			pipeline = rawArrayToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "batchSize":
 			opts.SetBatchSize(val.Int32())
 		case "collation":
@@ -209,7 +210,7 @@ func executeWatch(mt *mtest.T, w watcher, sess mongo.Session, args bson.Raw) (*m
 
 		switch key {
 		case "pipeline":
-			pipeline = rawArrayToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		default:
 			mt.Fatalf("unrecognized watch option: %v", key)
 		}
@@ -312,7 +313,7 @@ func executeInsertMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.I
 
 		switch key {
 		case "documents":
-			docs = rawArrayToInterfaceSlice(val.Array())
+			docs = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "options":
 			// Some of the older tests use this to set the "ordered" option
 			optsDoc := val.Document()
@@ -699,7 +700,7 @@ func executeFindOneAndUpdate(mt *mtest.T, sess mongo.Session, args bson.Raw) *mo
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: rawArrayToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 			})
 		case "sort":
 			opts = opts.SetSort(val.Document())
@@ -881,7 +882,7 @@ func executeUpdateOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Up
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: rawArrayToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 			})
 		case "upsert":
 			opts = opts.SetUpsert(val.Boolean())
@@ -929,7 +930,7 @@ func executeUpdateMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.U
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: rawArrayToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 			})
 		case "upsert":
 			opts = opts.SetUpsert(val.Boolean())
@@ -1115,7 +1116,7 @@ func createBulkWriteModel(mt *mtest.T, rawModel bson.Raw) mongo.WriteModel {
 		}
 		if arrayFilters, err := args.LookupErr("arrayFilters"); err == nil {
 			uom.SetArrayFilters(options.ArrayFilters{
-				Filters: rawArrayToInterfaceSlice(arrayFilters.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(arrayFilters.Array())...),
 			})
 		}
 		if hintVal, err := args.LookupErr("hint"); err == nil {
@@ -1138,7 +1139,7 @@ func createBulkWriteModel(mt *mtest.T, rawModel bson.Raw) mongo.WriteModel {
 		}
 		if arrayFilters, err := args.LookupErr("arrayFilters"); err == nil {
 			umm.SetArrayFilters(options.ArrayFilters{
-				Filters: rawArrayToInterfaceSlice(arrayFilters.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(arrayFilters.Array())...),
 			})
 		}
 		if hintVal, err := args.LookupErr("hint"); err == nil {

--- a/mongo/integration/crud_spec_test.go
+++ b/mongo/integration/crud_spec_test.go
@@ -18,6 +18,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
@@ -111,7 +112,7 @@ func runCrudFile(t *testing.T, file string) {
 
 func runCrudTest(mt *mtest.T, test crudTest, testFile crudTestFile) {
 	if len(testFile.Data) > 0 {
-		docs := rawSliceToInterfaceSlice(testFile.Data)
+		docs := helpers.RawToInterfaces(testFile.Data...)
 		_, err := mt.Coll.InsertMany(context.Background(), docs)
 		assert.Nil(mt, err, "InsertMany error: %v", err)
 	}

--- a/mongo/integration/json_helpers_test.go
+++ b/mongo/integration/json_helpers_test.go
@@ -454,29 +454,6 @@ func createReadPref(opt bson.RawValue) *readpref.ReadPref {
 	return readPrefFromString(mode)
 }
 
-// transform a slice of BSON documents to a slice of interface{}.
-func rawSliceToInterfaceSlice(docs []bson.Raw) []interface{} {
-	out := make([]interface{}, len(docs))
-
-	for i, doc := range docs {
-		out[i] = doc
-	}
-
-	return out
-}
-
-// transform a BSON raw array to a slice of interface{}.
-func rawArrayToInterfaceSlice(docs bson.Raw) []interface{} {
-	vals, _ := docs.Values()
-
-	out := make([]interface{}, len(vals))
-	for i, val := range vals {
-		out[i] = val.Document()
-	}
-
-	return out
-}
-
 // retrieve the error associated with a result.
 func errorFromResult(t testing.TB, result interface{}) *operationError {
 	t.Helper()

--- a/mongo/integration/unified/bulkwrite_helpers.go
+++ b/mongo/integration/unified/bulkwrite_helpers.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -74,7 +74,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				uom.SetArrayFilters(options.ArrayFilters{
-					Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+					Filters: helpers.RawToInterfaceSlice(val.Array()),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())
@@ -123,7 +123,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				umm.SetArrayFilters(options.ArrayFilters{
-					Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+					Filters: helpers.RawToInterfaceSlice(val.Array()),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())

--- a/mongo/integration/unified/bulkwrite_helpers.go
+++ b/mongo/integration/unified/bulkwrite_helpers.go
@@ -74,7 +74,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				uom.SetArrayFilters(options.ArrayFilters{
-					Filters: helpers.RawToInterfaceSlice(val.Array()),
+					Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())
@@ -123,7 +123,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				umm.SetArrayFilters(options.ArrayFilters{
-					Filters: helpers.RawToInterfaceSlice(val.Array()),
+					Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())

--- a/mongo/integration/unified/client_operation_execution.go
+++ b/mongo/integration/unified/client_operation_execution.go
@@ -85,7 +85,7 @@ func executeCreateChangeStream(ctx context.Context, operation *operation) (*oper
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = helpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "resumeAfter":
 			opts.SetResumeAfter(val.Document())
 		case "showExpandedEvents":

--- a/mongo/integration/unified/client_operation_execution.go
+++ b/mongo/integration/unified/client_operation_execution.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -85,7 +85,7 @@ func executeCreateChangeStream(ctx context.Context, operation *operation) (*oper
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaceSlice(val.Array())
 		case "resumeAfter":
 			opts.SetResumeAfter(val.Document())
 		case "showExpandedEvents":

--- a/mongo/integration/unified/collection_data.go
+++ b/mongo/integration/unified/collection_data.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
@@ -70,20 +71,11 @@ func (c *collectionData) createCollection(ctx context.Context) error {
 		return nil
 	}
 
-	docs := rawSliceToInterfaceSlice(c.Documents)
+	docs := helpers.RawToInterfaces(c.Documents...)
 	if _, err := coll.InsertMany(ctx, docs); err != nil {
 		return fmt.Errorf("error inserting data: %v", err)
 	}
 	return nil
-}
-
-// rawSliceToInterfaceSlice converts a []bson.Raw to []interface{}.
-func rawSliceToInterfaceSlice(elems []bson.Raw) []interface{} {
-	out := make([]interface{}, 0, len(elems))
-	for _, elem := range elems {
-		out = append(out, elem)
-	}
-	return out
 }
 
 // verifyContents asserts that the collection on the server represented by this collectionData instance contains the

--- a/mongo/integration/unified/collection_data.go
+++ b/mongo/integration/unified/collection_data.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
@@ -71,11 +70,20 @@ func (c *collectionData) createCollection(ctx context.Context) error {
 		return nil
 	}
 
-	docs := testhelpers.RawSliceToInterfaceSlice(c.Documents)
+	docs := rawSliceToInterfaceSlice(c.Documents)
 	if _, err := coll.InsertMany(ctx, docs); err != nil {
 		return fmt.Errorf("error inserting data: %v", err)
 	}
 	return nil
+}
+
+// rawSliceToInterfaceSlice converts a []bson.Raw to []interface{}.
+func rawSliceToInterfaceSlice(elems []bson.Raw) []interface{} {
+	out := make([]interface{}, 0, len(elems))
+	for _, elem := range elems {
+		out = append(out, elem)
+	}
+	return out
 }
 
 // verifyContents asserts that the collection on the server represented by this collectionData instance contains the

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -13,7 +13,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -78,7 +78,7 @@ func executeAggregate(ctx context.Context, operation *operation) (*operationResu
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaceSlice(val.Array())
 		case "let":
 			opts.SetLet(val.Document())
 		default:
@@ -808,7 +808,7 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 		switch key {
 		case "arrayFilters":
 			opts.SetArrayFilters(options.ArrayFilters{
-				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaceSlice(val.Array()),
 			})
 		case "bypassDocumentValidation":
 			opts.SetBypassDocumentValidation(val.Boolean())
@@ -895,7 +895,7 @@ func executeInsertMany(ctx context.Context, operation *operation) (*operationRes
 		case "comment":
 			opts.SetComment(val)
 		case "documents":
-			documents = testhelpers.RawToInterfaceSlice(val.Array())
+			documents = helpers.RawToInterfaceSlice(val.Array())
 		case "ordered":
 			opts.SetOrdered(val.Boolean())
 		default:

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -78,7 +78,7 @@ func executeAggregate(ctx context.Context, operation *operation) (*operationResu
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = helpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "let":
 			opts.SetLet(val.Document())
 		default:
@@ -808,7 +808,7 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 		switch key {
 		case "arrayFilters":
 			opts.SetArrayFilters(options.ArrayFilters{
-				Filters: helpers.RawToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 			})
 		case "bypassDocumentValidation":
 			opts.SetBypassDocumentValidation(val.Boolean())
@@ -895,7 +895,7 @@ func executeInsertMany(ctx context.Context, operation *operation) (*operationRes
 		case "comment":
 			opts.SetComment(val)
 		case "documents":
-			documents = helpers.RawToInterfaceSlice(val.Array())
+			documents = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "ordered":
 			opts.SetOrdered(val.Boolean())
 		default:

--- a/mongo/integration/unified/crud_helpers.go
+++ b/mongo/integration/unified/crud_helpers.go
@@ -41,7 +41,7 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 		switch key {
 		case "arrayFilters":
 			ua.opts.SetArrayFilters(options.ArrayFilters{
-				Filters: helpers.RawToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...),
 			})
 		case "bypassDocumentValidation":
 			ua.opts.SetBypassDocumentValidation(val.Boolean())

--- a/mongo/integration/unified/crud_helpers.go
+++ b/mongo/integration/unified/crud_helpers.go
@@ -11,7 +11,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -41,7 +41,7 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 		switch key {
 		case "arrayFilters":
 			ua.opts.SetArrayFilters(options.ArrayFilters{
-				Filters: testhelpers.RawToInterfaceSlice(val.Array()),
+				Filters: helpers.RawToInterfaceSlice(val.Array()),
 			})
 		case "bypassDocumentValidation":
 			ua.opts.SetBypassDocumentValidation(val.Boolean())

--- a/mongo/integration/unified/database_operation_execution.go
+++ b/mongo/integration/unified/database_operation_execution.go
@@ -42,7 +42,7 @@ func executeCreateView(ctx context.Context, operation *operation) (*operationRes
 		case "collection":
 			collName = val.StringValue()
 		case "pipeline":
-			pipeline = helpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaces(helpers.RawToDocuments(val.Array())...)
 		case "viewOn":
 			viewOn = val.StringValue()
 		default:

--- a/mongo/integration/unified/database_operation_execution.go
+++ b/mongo/integration/unified/database_operation_execution.go
@@ -12,7 +12,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -42,7 +42,7 @@ func executeCreateView(ctx context.Context, operation *operation) (*operationRes
 		case "collection":
 			collName = val.StringValue()
 		case "pipeline":
-			pipeline = testhelpers.RawToInterfaceSlice(val.Array())
+			pipeline = helpers.RawToInterfaceSlice(val.Array())
 		case "viewOn":
 			viewOn = val.StringValue()
 		default:

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -16,6 +16,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
@@ -84,7 +85,7 @@ type TestFile struct {
 // runTestDirectory runs the files in the given directory, which must be in the unified spec format, with
 // expectValidFail determining whether the tests should expect to pass or fail
 func runTestDirectory(t *testing.T, directoryPath string, expectValidFail bool) {
-	for _, filename := range testhelpers.FindJSONFilesInDir(t, directoryPath) {
+	for _, filename := range helpers.FindJSONFilesInDir(t, directoryPath) {
 		t.Run(filename, func(t *testing.T) {
 			runTestFile(t, path.Join(directoryPath, filename), expectValidFail)
 		})

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -16,7 +16,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -26,6 +26,7 @@ import (
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/gridfs"
@@ -891,7 +892,7 @@ func setupSessions(mt *mtest.T, test *testCase) (mongo.Session, mongo.Session) {
 func insertDocuments(mt *mtest.T, coll *mongo.Collection, rawDocs []bson.Raw) {
 	mt.Helper()
 
-	docsToInsert := rawSliceToInterfaceSlice(rawDocs)
+	docsToInsert := helpers.RawToInterfaces(rawDocs...)
 	if len(docsToInsert) == 0 {
 		return
 	}

--- a/x/mongo/driver/auth/auth_spec_test.go
+++ b/x/mongo/driver/auth/auth_spec_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -104,7 +105,7 @@ func mapInterfaceToString(m map[string]interface{}) map[string]string {
 
 // Test case for all connection string spec tests.
 func TestAuthSpec(t *testing.T) {
-	for _, file := range testhelpers.FindJSONFilesInDir(t, authTestsDir) {
+	for _, file := range helpers.FindJSONFilesInDir(t, authTestsDir) {
 		runTestsInFile(t, authTestsDir, file)
 	}
 }

--- a/x/mongo/driver/auth/auth_spec_test.go
+++ b/x/mongo/driver/auth/auth_spec_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 

--- a/x/mongo/driver/connstring/connstring_spec_test.go
+++ b/x/mongo/driver/connstring/connstring_spec_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -169,13 +170,13 @@ func runTest(t *testing.T, filename string, test testCase, warningsError bool) {
 
 // Test case for all connection string spec tests.
 func TestConnStringSpec(t *testing.T) {
-	for _, file := range testhelpers.FindJSONFilesInDir(t, connstringTestsDir) {
+	for _, file := range helpers.FindJSONFilesInDir(t, connstringTestsDir) {
 		runTestsInFile(t, connstringTestsDir, file, false)
 	}
 }
 
 func TestURIOptionsSpec(t *testing.T) {
-	for _, file := range testhelpers.FindJSONFilesInDir(t, urioptionsTestDir) {
+	for _, file := range helpers.FindJSONFilesInDir(t, urioptionsTestDir) {
 		runTestsInFile(t, urioptionsTestDir, file, true)
 	}
 }

--- a/x/mongo/driver/connstring/connstring_spec_test.go
+++ b/x/mongo/driver/connstring/connstring_spec_test.go
@@ -8,13 +8,15 @@ package connstring_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"math"
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -154,7 +156,7 @@ func runTest(t *testing.T, filename string, test testCase, warningsError bool) {
 		}
 
 		// Check that all options are present.
-		testhelpers.VerifyConnStringOptions(t, cs, test.Options)
+		verifyConnStringOptions(t, cs, test.Options)
 
 		// Check that non-present options are unset. This will be redundant with the above checks
 		// for options that are present.
@@ -176,4 +178,178 @@ func TestURIOptionsSpec(t *testing.T) {
 	for _, file := range testhelpers.FindJSONFilesInDir(t, urioptionsTestDir) {
 		runTestsInFile(t, urioptionsTestDir, file, true)
 	}
+}
+
+// verifyConnStringOptions verifies the options on the connection string.
+func verifyConnStringOptions(t *testing.T, cs connstring.ConnString, options map[string]interface{}) {
+	// Check that all options are present.
+	for key, value := range options {
+
+		key = strings.ToLower(key)
+		switch key {
+		case "appname":
+			require.Equal(t, value, cs.AppName)
+		case "authsource":
+			require.Equal(t, value, cs.AuthSource)
+		case "authmechanism":
+			require.Equal(t, value, cs.AuthMechanism)
+		case "authmechanismproperties":
+			convertedMap := value.(map[string]interface{})
+			require.Equal(t,
+				mapInterfaceToString(convertedMap),
+				cs.AuthMechanismProperties)
+		case "compressors":
+			require.Equal(t, convertToStringSlice(value), cs.Compressors)
+		case "connecttimeoutms":
+			require.Equal(t, value, float64(cs.ConnectTimeout/time.Millisecond))
+		case "directconnection":
+			require.True(t, cs.DirectConnectionSet)
+			require.Equal(t, value, cs.DirectConnection)
+		case "heartbeatfrequencyms":
+			require.Equal(t, value, float64(cs.HeartbeatInterval/time.Millisecond))
+		case "journal":
+			require.True(t, cs.JSet)
+			require.Equal(t, value, cs.J)
+		case "loadbalanced":
+			require.True(t, cs.LoadBalancedSet)
+			require.Equal(t, value, cs.LoadBalanced)
+		case "localthresholdms":
+			require.True(t, cs.LocalThresholdSet)
+			require.Equal(t, value, float64(cs.LocalThreshold/time.Millisecond))
+		case "maxidletimems":
+			require.Equal(t, value, float64(cs.MaxConnIdleTime/time.Millisecond))
+		case "maxpoolsize":
+			require.True(t, cs.MaxPoolSizeSet)
+			require.Equal(t, value, cs.MaxPoolSize)
+		case "maxstalenessseconds":
+			require.True(t, cs.MaxStalenessSet)
+			require.Equal(t, value, float64(cs.MaxStaleness/time.Second))
+		case "minpoolsize":
+			require.True(t, cs.MinPoolSizeSet)
+			require.Equal(t, value, int64(cs.MinPoolSize))
+		case "readpreference":
+			require.Equal(t, value, cs.ReadPreference)
+		case "readpreferencetags":
+			sm, ok := value.([]interface{})
+			require.True(t, ok)
+			tags := make([]map[string]string, 0, len(sm))
+			for _, i := range sm {
+				m, ok := i.(map[string]interface{})
+				require.True(t, ok)
+				tags = append(tags, mapInterfaceToString(m))
+			}
+			require.Equal(t, tags, cs.ReadPreferenceTagSets)
+		case "readconcernlevel":
+			require.Equal(t, value, cs.ReadConcernLevel)
+		case "replicaset":
+			require.Equal(t, value, cs.ReplicaSet)
+		case "retrywrites":
+			require.True(t, cs.RetryWritesSet)
+			require.Equal(t, value, cs.RetryWrites)
+		case "serverselectiontimeoutms":
+			require.Equal(t, value, float64(cs.ServerSelectionTimeout/time.Millisecond))
+		case "srvmaxhosts":
+			require.Equal(t, value, float64(cs.SRVMaxHosts))
+		case "srvservicename":
+			require.Equal(t, value, cs.SRVServiceName)
+		case "ssl", "tls":
+			require.Equal(t, value, cs.SSL)
+		case "sockettimeoutms":
+			require.Equal(t, value, float64(cs.SocketTimeout/time.Millisecond))
+		case "tlsallowinvalidcertificates", "tlsallowinvalidhostnames", "tlsinsecure":
+			require.True(t, cs.SSLInsecureSet)
+			require.Equal(t, value, cs.SSLInsecure)
+		case "tlscafile":
+			require.True(t, cs.SSLCaFileSet)
+			require.Equal(t, value, cs.SSLCaFile)
+		case "tlscertificatekeyfile":
+			require.True(t, cs.SSLClientCertificateKeyFileSet)
+			require.Equal(t, value, cs.SSLClientCertificateKeyFile)
+		case "tlscertificatekeyfilepassword":
+			require.True(t, cs.SSLClientCertificateKeyPasswordSet)
+			require.Equal(t, value, cs.SSLClientCertificateKeyPassword())
+		case "w":
+			if cs.WNumberSet {
+				valueInt := getIntFromInterface(value)
+				require.NotNil(t, valueInt)
+				require.Equal(t, *valueInt, int64(cs.WNumber))
+			} else {
+				require.Equal(t, value, cs.WString)
+			}
+		case "wtimeoutms":
+			require.Equal(t, value, float64(cs.WTimeout/time.Millisecond))
+		case "waitqueuetimeoutms":
+		case "zlibcompressionlevel":
+			require.Equal(t, value, float64(cs.ZlibLevel))
+		case "zstdcompressionlevel":
+			require.Equal(t, value, float64(cs.ZstdLevel))
+		case "tlsdisableocspendpointcheck":
+			require.Equal(t, value, cs.SSLDisableOCSPEndpointCheck)
+		default:
+			opt, ok := cs.UnknownOptions[key]
+			require.True(t, ok)
+			require.Contains(t, opt, fmt.Sprint(value))
+		}
+	}
+}
+
+// Convert each interface{} value in the map to a string.
+func mapInterfaceToString(m map[string]interface{}) map[string]string {
+	out := make(map[string]string)
+
+	for key, value := range m {
+		out[key] = fmt.Sprint(value)
+	}
+
+	return out
+}
+
+// getIntFromInterface attempts to convert an empty interface value to an integer.
+//
+// Returns nil if it is not possible.
+func getIntFromInterface(i interface{}) *int64 {
+	var out int64
+
+	switch v := i.(type) {
+	case int:
+		out = int64(v)
+	case int32:
+		out = int64(v)
+	case int64:
+		out = v
+	case float32:
+		f := float64(v)
+		if math.Floor(f) != f || f > float64(math.MaxInt64) {
+			break
+		}
+
+		out = int64(f)
+
+	case float64:
+		if math.Floor(v) != v || v > float64(math.MaxInt64) {
+			break
+		}
+
+		out = int64(v)
+	default:
+		return nil
+	}
+
+	return &out
+}
+
+func convertToStringSlice(i interface{}) []string {
+	s, ok := i.([]interface{})
+	if !ok {
+		return nil
+	}
+	ret := make([]string, 0, len(s))
+	for _, v := range s {
+		str, ok := v.(string)
+		if !ok {
+			continue
+		}
+		ret = append(ret, str)
+	}
+	return ret
 }

--- a/x/mongo/driver/session/client_session_test.go
+++ b/x/mongo/driver/session/client_session_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/internal/uuid"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -92,7 +91,7 @@ func TestClientSession(t *testing.T) {
 			I: 0,
 		}
 		err = sess.AdvanceOperationTime(optime1)
-		testhelpers.RequireNil(t, err, "error updating first operation time: %s", err)
+		assert.Nil(t, err, "error updating first operation time: %s", err)
 		compareOperationTimes(t, optime1, sess.OperationTime)
 
 		optime2 := &primitive.Timestamp{
@@ -100,7 +99,7 @@ func TestClientSession(t *testing.T) {
 			I: 0,
 		}
 		err = sess.AdvanceOperationTime(optime2)
-		testhelpers.RequireNil(t, err, "error updating second operation time: %s", err)
+		assert.Nil(t, err, "error updating second operation time: %s", err)
 		compareOperationTimes(t, optime2, sess.OperationTime)
 
 		optime3 := &primitive.Timestamp{
@@ -108,14 +107,14 @@ func TestClientSession(t *testing.T) {
 			I: 1,
 		}
 		err = sess.AdvanceOperationTime(optime3)
-		testhelpers.RequireNil(t, err, "error updating third operation time: %s", err)
+		assert.Nil(t, err, "error updating third operation time: %s", err)
 		compareOperationTimes(t, optime3, sess.OperationTime)
 
 		err = sess.AdvanceOperationTime(&primitive.Timestamp{
 			T: 1,
 			I: 10,
 		})
-		testhelpers.RequireNil(t, err, "error updating fourth operation time: %s", err)
+		assert.Nil(t, err, "error updating fourth operation time: %s", err)
 		compareOperationTimes(t, optime3, sess.OperationTime)
 		sess.EndSession()
 	})

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	testHelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
@@ -124,11 +125,11 @@ func TestCMAPSpec(t *testing.T) {
 
 func runCMAPTest(t *testing.T, testFileName string) {
 	content, err := ioutil.ReadFile(path.Join(cmapTestDir, testFileName))
-	testHelpers.RequireNil(t, err, "unable to read content of test file")
+	require.NoErrorf(t, err, "unable to read content of test file")
 
 	var test cmapTestFile
 	err = json.Unmarshal(content, &test)
-	testHelpers.RequireNil(t, err, "error unmarshalling testFile %v", err)
+	require.NoErrorf(t, err, "error unmarshalling testFile")
 
 	if test.SkipReason != "" {
 		t.Skip(test.SkipReason)
@@ -138,7 +139,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 	}
 
 	l, err := net.Listen("tcp", "localhost:0")
-	testHelpers.RequireNil(t, err, "unable to create listener: %v", err)
+	require.NoError(t, err, "unable to create listener")
 
 	testInfo := &testInfo{
 		objects:                make(map[string]interface{}),
@@ -210,7 +211,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 
 	s := NewServer(address.Address(l.Addr().String()), primitive.NewObjectID(), sOpts...)
 	s.state = serverConnected
-	testHelpers.RequireNil(t, err, "error connecting connection pool: %v", err)
+	require.NoError(t, err, "error connecting connection pool")
 	defer s.pool.close(context.Background())
 
 	for _, op := range test.Operations {

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
-	testHelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
 )
@@ -116,7 +116,7 @@ type testInfo struct {
 const cmapTestDir = "../../../../data/connection-monitoring-and-pooling/"
 
 func TestCMAPSpec(t *testing.T) {
-	for _, testFileName := range testHelpers.FindJSONFilesInDir(t, cmapTestDir) {
+	for _, testFileName := range helpers.FindJSONFilesInDir(t, cmapTestDir) {
 		t.Run(testFileName, func(t *testing.T) {
 			runCMAPTest(t, testFileName)
 		})

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -20,7 +20,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -570,7 +570,7 @@ func runTest(t *testing.T, directory string, filename string) {
 // Test case for all SDAM spec tests.
 func TestSDAMSpec(t *testing.T) {
 	for _, subdir := range []string{"single", "rs", "sharded", "load-balanced", "errors", "monitoring"} {
-		for _, file := range testhelpers.FindJSONFilesInDir(t, path.Join(testsDir, subdir)) {
+		for _, file := range helpers.FindJSONFilesInDir(t, path.Join(testsDir, subdir)) {
 			runTest(t, subdir, file)
 		}
 	}

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 )
 
 // Test case for all server selection rtt spec tests.
@@ -29,7 +29,7 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 
 	const testsDir string = "../../../../data/server-selection/rtt"
 
-	for _, file := range testhelpers.FindJSONFilesInDir(t, testsDir) {
+	for _, file := range helpers.FindJSONFilesInDir(t, testsDir) {
 		func(t *testing.T, filename string) {
 			filepath := path.Join(testsDir, filename)
 			content, err := ioutil.ReadFile(filepath)

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -21,7 +21,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
-	testhelpers "go.mongodb.org/mongo-driver/internal/testutil/helpers"
+	"go.mongodb.org/mongo-driver/internal/testutil/helpers"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -675,7 +675,7 @@ type inWindowTestCase struct {
 func TestServerSelectionSpecInWindow(t *testing.T) {
 	const testsDir = "../../../../data/server-selection/in_window"
 
-	files := testhelpers.FindJSONFilesInDir(t, testsDir)
+	files := helpers.FindJSONFilesInDir(t, testsDir)
 
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {


### PR DESCRIPTION
Improvements:
* Update package name at `internal/testutil/helpers` to align with import path (i.e. rename package to `helpers`).
* Move all single-use functions in `helpers` package to where they are used and un-export them.
* Remove duplicate test assertion functions from `helpers` package.
* Add `t.Helper()` to the one remaining test helper function.