### PR TITLE
GODRIVER-2526 Optimize description.selectByKind.

### DIFF
--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -296,13 +296,16 @@ func selectByTagSet(candidates []Server, tagSets []tag.Set) []Server {
 }
 
 func selectByKind(candidates []Server, kind ServerKind) []Server {
-	var result []Server
-	for _, s := range candidates {
+	index := make([]int, 0, len(candidates))
+	for i, s := range candidates {
 		if s.Kind == kind {
-			result = append(result, s)
+			index = append(index, i)
 		}
 	}
-
+	result := make([]Server, len(index))
+	for i, idx := range index {
+		result[i] = candidates[idx]
+	}
 	return result
 }
 

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -296,14 +296,16 @@ func selectByTagSet(candidates []Server, tagSets []tag.Set) []Server {
 }
 
 func selectByKind(candidates []Server, kind ServerKind) []Server {
-	index := make([]int, 0, len(candidates))
+	// Record the indices of viable candidates first and then appending those to the returned slice
+	// to avoid appending costly Server structs directly as an optimization.
+	viableIndexes := make([]int, 0, len(candidates))
 	for i, s := range candidates {
 		if s.Kind == kind {
-			index = append(index, i)
+			viableIndexes = append(viableIndexes, i)
 		}
 	}
-	result := make([]Server, len(index))
-	for i, idx := range index {
+	result := make([]Server, len(viableIndexes))
+	for i, idx := range viableIndexes {
 		result[i] = candidates[idx]
 	}
 	return result

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -296,7 +296,7 @@ func selectByTagSet(candidates []Server, tagSets []tag.Set) []Server {
 }
 
 func selectByKind(candidates []Server, kind ServerKind) []Server {
-	// Record the indices of viable candidates first and then appending those to the returned slice
+	// Record the indices of viable candidates first and then append those to the returned slice
 	// to avoid appending costly Server structs directly as an optimization.
 	viableIndexes := make([]int, 0, len(candidates))
 	for i, s := range candidates {


### PR DESCRIPTION
[GODRIVER-2526](https://jira.mongodb.org/browse/GODRIVER-2526)

The reporter has hundreds of mongos instances, so appending `Server` causes high memory usage. This PR pre-allocates slice to reduce allocations.

The benchmark show:
```
name                old time/op    new time/op    delta
Selector_Sharded-4    28.4µs ±37%     9.7µs ± 3%  -65.66%  (p=0.000 n=9+8)

name                old alloc/op   new alloc/op   delta
Selector_Sharded-4     111kB ± 0%      42kB ± 0%  -62.28%  (p=0.000 n=10+10)

name                old allocs/op  new allocs/op  delta
Selector_Sharded-4      9.00 ± 0%      3.00 ± 0%  -66.67%  (p=0.000 n=10+10)
```