### PR TITLE
GODRIVER-2542 optimize objectid hex func

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -61,7 +61,9 @@ func (id ObjectID) Timestamp() time.Time {
 
 // Hex returns the hex encoding of the ObjectID as a string.
 func (id ObjectID) Hex() string {
-	return hex.EncodeToString(id[:])
+	var buf [24]byte
+	hex.Encode(buf[:], id[:])
+	return string(buf[:])
 }
 
 func (id ObjectID) String() string {

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -28,6 +28,13 @@ func TestString(t *testing.T) {
 	require.Contains(t, id.String(), id.Hex())
 }
 
+func BenchmarkHex(b *testing.B) {
+	id := NewObjectID()
+	for i := 0; i < b.N; i++ {
+		id.Hex()
+	}
+}
+
 func TestFromHex_RoundTrip(t *testing.T) {
 	before := NewObjectID()
 	after, err := ObjectIDFromHex(before.Hex())


### PR DESCRIPTION
EncodeToString internally creates slice not array and thus makes unnecessary allocation AFAIU, since we know exactly the size of result hex. I wrote the following benchmark to prove the benefit:

```
import (
	"encoding/hex"
	"testing"

	"go.mongodb.org/mongo-driver/bson/primitive"
)

var Blackhole string

func BenchmarkHex(b *testing.B) {
	id := primitive.NewObjectID()
	b.Run("BufEncode", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			var buf [24]byte
			hex.Encode(buf[:], id[:])
			Blackhole = string(buf[:])
		}
	})
	b.Run("EncodeToString", func(b *testing.B) {
		b.ReportAllocs()
		for i := 0; i < b.N; i++ {
			Blackhole = hex.EncodeToString(id[:])
		}
	})
}
```

It produces the following results:
```
BenchmarkHex/BufEncode
BenchmarkHex/BufEncode-10         	54523264	        22.25 ns/op	      24 B/op	       1 allocs/op
BenchmarkHex/EncodeToString
BenchmarkHex/EncodeToString-10    	32200645	        36.76 ns/op	      48 B/op	       2 allocs/op
```
On my m1pro mac.