### PR TITLE
GODRIVER-2544 Bump MacOS distro version to 11.0.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2086,8 +2086,8 @@ axes:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
-        display_name: "MacOS 10.15"
-        run_on: macos-1015
+        display_name: "MacOS 11.0"
+        run_on: macos-1100
         variables:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: python3
@@ -2112,8 +2112,8 @@ axes:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
-        display_name: "MacOS 10.15"
-        run_on: macos-1015
+        display_name: "MacOS 11.0"
+        run_on: macos-1100
         variables:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: python3
@@ -2148,8 +2148,8 @@ axes:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
-        display_name: "MacOS 10.15"
-        run_on: macos-1015
+        display_name: "MacOS 11.0"
+        run_on: macos-1100
         variables:
           GO_DIST: "/opt/golang/go1.18"
           SKIP_ECS_AUTH_TEST: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -114,22 +114,6 @@ functions:
              export PATH=$PATH:/cygdrive/c/libmongocrypt/bin
              rm -rf libmongocrypt-all
              echo "fetching build for Windows ... end"
-          elif [ "Darwin" = "$(uname -s)" ]; then
-             # TODO (GODRIVER-2442): Once libmongocrypt compiles on macOS 10.15, remove this elif block.
-             echo "fetching build for Darwin ... begin"
-             mkdir -p install/libmongocrypt
-             mkdir libmongocrypt-all
-             cd libmongocrypt-all
-             # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
-             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_BRANCH/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
-             tar -xf libmongocrypt-all.tar.gz
-             cd ..
-             mv libmongocrypt-all/macos/include ./install/libmongocrypt
-             mv libmongocrypt-all/macos/lib ./install/libmongocrypt
-             rm -rf libmongocrypt-all
-             # Fix prefix in pkg-config prefix path.
-             sed -i "" -E "s+prefix=.*+prefix=$(pwd)/install/libmongocrypt+" ./install/libmongocrypt/lib/pkgconfig/libmongocrypt.pc
-             echo "fetching build for Darwin ... end"
           else
             git clone https://github.com/mongodb/libmongocrypt
             cd libmongocrypt


### PR DESCRIPTION
GODRIVER-2544

Bumps the MacOS distro version used for Evergreen testing from 10.15 to 11.0. This allows tests to actually run (the `go` binary was not working properly on 10.15) and reduces the number of spec test timeouts on MacOS.