### PR TITLE
Fix typo in SDAM error handling test.

### DIFF
--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -51,7 +51,7 @@ func TestSDAMErrorHandling(t *testing.T) {
 		mt.RunOpts("network errors", noClientOpts, func(mt *mtest.T) {
 			mt.Run("pool cleared on network timeout", func(mt *mtest.T) {
 				// Assert that the pool is cleared when a connection created by an application
-				// operation thread encounters a timeout caused by connectTimeoutMS during
+				// operation thread encounters a timeout caused by socketTimeoutMS during
 				// handshaking.
 
 				appName := "authConnectTimeoutTest"


### PR DESCRIPTION
The `pool cleared on network timeout` test sets `SocketTimeout` and a blocking fail point on `saslContinue` higher than the set `SocketTimeout` and expects a timeout from `InsertOne`. The comment in the test says the timeout is caused by `connectTimeoutMS`, but I believe the timeout is due to `socketTimeoutMS`.
