### PR TITLE
GODRIVER-2536 Return early in replaceErrors.

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -46,6 +46,11 @@ func (e ErrMapForOrderedArgument) Error() string {
 }
 
 func replaceErrors(err error) error {
+	// Return nil when err is nil to avoid costly reflection logic below.
+	if err == nil {
+		return nil
+	}
+
 	if err == topology.ErrTopologyClosed {
 		return ErrClientDisconnected
 	}


### PR DESCRIPTION
GODRIVER-2536

Returns `nil` in `replaceErrors` when `err == nil` to avoid costly reflection logic below. 

[Here's a benchmark](https://gist.github.com/benjirewis/8b088d422788a4beceeb5076652db256) I used to measure the difference in operations per second. The output from `benchstat` was:

```
name             old time/op    new time/op    delta
ReplaceErrors-8    12.2ns ± 1%     2.7ns ± 0%  -78.19%  (p=0.008 n=5+5)
```