### PR TITLE
GODRIVER-2538 Sync change stream tests for clusterTime.

### DIFF
--- a/testdata/change-streams/change-streams-clusterTime.json
+++ b/testdata/change-streams/change-streams-clusterTime.json
@@ -1,0 +1,81 @@
+{
+   "description": "change-streams-clusterTime",
+   "schemaVersion": "1.3",
+   "createEntities": [
+     {
+       "client": {
+         "id": "client0",
+         "useMultipleMongoses": false
+       }
+     },
+     {
+       "database": {
+         "id": "database0",
+         "client": "client0",
+         "databaseName": "database0"
+       }
+     },
+     {
+       "collection": {
+         "id": "collection0",
+         "database": "database0",
+         "collectionName": "collection0"
+       }
+     }
+   ],
+   "runOnRequirements": [
+     {
+       "minServerVersion": "4.0.0",
+       "topologies": [
+         "replicaset",
+         "sharded-replicaset",
+         "load-balanced",
+         "sharded"
+       ]
+     }
+   ],
+   "initialData": [
+     {
+       "collectionName": "collection0",
+       "databaseName": "database0",
+       "documents": []
+     }
+   ],
+   "tests": [
+     {
+       "description": "clusterTime is present",
+       "operations": [
+         {
+           "name": "createChangeStream",
+           "object": "collection0",
+           "arguments": {
+             "pipeline": []
+           },
+           "saveResultAsEntity": "changeStream0"
+         },
+         {
+           "name": "insertOne",
+           "object": "collection0",
+           "arguments": {
+             "document": {
+               "_id": 1
+             }
+           }
+         },
+         {
+           "name": "iterateUntilDocumentOrError",
+           "object": "changeStream0",
+           "expectResult": {
+             "ns": {
+               "db": "database0",
+               "coll": "collection0"
+             },
+             "clusterTime": {
+               "$$exists": true
+             }
+           }
+         }
+       ]
+     }
+   ]
+ }

--- a/testdata/change-streams/change-streams-clusterTime.yml
+++ b/testdata/change-streams/change-streams-clusterTime.yml
@@ -1,0 +1,40 @@
+description: "change-streams-clusterTime"
+ schemaVersion: "1.3"
+ createEntities:
+   - client:
+       id: &client0 client0
+       useMultipleMongoses: false
+   - database:
+       id: &database0 database0
+       client: *client0
+       databaseName: *database0
+   - collection:
+       id: &collection0 collection0
+       database: *database0
+       collectionName: *collection0
+
+ runOnRequirements:
+   - minServerVersion: "4.0.0"
+     topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+
+ initialData:
+   - collectionName: *collection0
+     databaseName: *database0
+     documents: []
+
+ tests:
+   - description: "clusterTime is present"
+     operations:
+       - name: createChangeStream
+         object: *collection0
+         arguments: { pipeline: [] }
+         saveResultAsEntity: &changeStream0 changeStream0
+       - name: insertOne
+         object: *collection0
+         arguments:
+           document: { _id: 1 }
+       - name: iterateUntilDocumentOrError
+         object: *changeStream0
+         expectResult:
+           ns: { db: *database0, coll: *collection0 }
+           clusterTime: { $$exists: true }


### PR DESCRIPTION
GODRIVER-2538

No Go driver changes needed, as we do not have a concrete type representing a change stream event document.