### PR TITLE
GODRIVER-2458 Multi-batch writes CSOT test.

### DIFF
--- a/mongo/integration/csot_cse_prose_test.go
+++ b/mongo/integration/csot_cse_prose_test.go
@@ -28,7 +28,7 @@ func TestCSOTClientSideEncryptionProse(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").CreateClient(false))
 	defer mt.Close()
 
-	mt.RunOpts("1. maxTimeMS is not set for commands sent to mongocryptd",
+	mt.RunOpts("2. maxTimeMS is not set for commands sent to mongocryptd",
 		noClientOpts, func(mt *mtest.T) {
 			if testing.Short() {
 				mt.Skip("skipping integration test in short mode")

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -25,9 +25,6 @@ func TestCSOTProse(t *testing.T) {
 
 	mt.RunOpts("1. multi-batch writes", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
 		// Test that multi-batch writes do not refresh the Timeout between batches.
-		if testing.Short() {
-			t.Skip("skipping integration test in short mode")
-		}
 
 		err := mt.Client.Database("db").Collection("coll").Drop(context.Background())
 		assert.Nil(mt, err, "Drop error: %v", err)

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -29,7 +29,7 @@ func TestCSOTProse(t *testing.T) {
 		err := mt.Client.Database("db").Collection("coll").Drop(context.Background())
 		assert.Nil(mt, err, "Drop error: %v", err)
 
-		// Configure a fail point to block both inserts of the multi-write for 1010ms (2020ms total).
+		// Configure a fail point to block both inserts of the multi-write for 2010ms (4020ms total).
 		mt.SetFailPoint(mtest.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: mtest.FailPointMode{
@@ -38,11 +38,11 @@ func TestCSOTProse(t *testing.T) {
 			Data: mtest.FailPointData{
 				FailCommands:    []string{"insert"},
 				BlockConnection: true,
-				BlockTimeMS:     1010,
+				BlockTimeMS:     2010,
 			},
 		})
 
-		// Use a separate client with 2s Timeout and a separate command monitor to run a multi-batch
+		// Use a separate client with 4s Timeout and a separate command monitor to run a multi-batch
 		// insert against db.coll.
 		var started []*event.CommandStartedEvent
 		cm := &event.CommandMonitor{
@@ -52,7 +52,7 @@ func TestCSOTProse(t *testing.T) {
 		}
 		cli, err := mongo.Connect(context.Background(),
 			options.Client().
-				SetTimeout(2*time.Second).
+				SetTimeout(4*time.Second).
 				SetMonitor(cm).
 				ApplyURI(mtest.ClusterURI()))
 		assert.Nil(mt, err, "Connect error: %v", err)

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -30,7 +30,7 @@ func TestCSOTProse(t *testing.T) {
 		err := mt.Client.Database("db").Collection("coll").Drop(context.Background())
 		assert.Nil(mt, err, "Drop error: %v", err)
 
-		// Configure a fail point to block both inserts of the multi-write for 510ms (1020ms total).
+		// Configure a fail point to block both inserts of the multi-write for 1010ms (2020ms total).
 		mt.SetFailPoint(mtest.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: mtest.FailPointMode{
@@ -39,11 +39,11 @@ func TestCSOTProse(t *testing.T) {
 			Data: mtest.FailPointData{
 				FailCommands:    []string{"insert"},
 				BlockConnection: true,
-				BlockTimeMS:     510,
+				BlockTimeMS:     1010,
 			},
 		})
 
-		// Use a separate client with 1s Timeout and a separate command monitor to run a multi-batch
+		// Use a separate client with 2s Timeout and a separate command monitor to run a multi-batch
 		// insert against db.coll.
 		var started []*event.CommandStartedEvent
 		cm := &event.CommandMonitor{
@@ -53,7 +53,7 @@ func TestCSOTProse(t *testing.T) {
 		}
 		cli, err := mongo.Connect(context.Background(),
 			options.Client().
-				SetTimeout(1*time.Second).
+				SetTimeout(2*time.Second).
 				SetMonitor(cm).
 				ApplyURI(mtest.ClusterURI()))
 		assert.Nil(mt, err, "Connect error: %v", err)

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -20,7 +23,61 @@ func TestCSOTProse(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
 	defer mt.Close()
 
-	mt.Run("server selection", func(mt *mtest.T) {
+	mt.RunOpts("1. multi-batch writes", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
+		// Test that multi-batch writes do not refresh the Timeout between batches.
+		if testing.Short() {
+			t.Skip("skipping integration test in short mode")
+		}
+
+		err := mt.Client.Database("db").Collection("coll").Drop(context.Background())
+		assert.Nil(mt, err, "Drop error: %v", err)
+
+		// Configure a fail point to block both inserts of the multi-write for 1010ms (2020ms total).
+		mt.SetFailPoint(mtest.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: mtest.FailPointMode{
+				Times: 2,
+			},
+			Data: mtest.FailPointData{
+				FailCommands:    []string{"insert"},
+				BlockConnection: true,
+				BlockTimeMS:     1010,
+			},
+		})
+
+		// Use a separate client with 2s Timeout and a separate command monitor to run a multi-batch
+		// insert against db.coll.
+		var started []*event.CommandStartedEvent
+		cm := &event.CommandMonitor{
+			Started: func(_ context.Context, evt *event.CommandStartedEvent) {
+				started = append(started, evt)
+			},
+		}
+		cli, err := mongo.Connect(context.Background(),
+			options.Client().
+				SetTimeout(2*time.Second).
+				SetMonitor(cm).
+				ApplyURI(mtest.ClusterURI()))
+		assert.Nil(mt, err, "Connect error: %v", err)
+
+		var docs []interface{}
+		for i := 0; i < 100001; i++ {
+			docs = append(docs, bson.D{})
+		}
+
+		// Expect a timeout error from InsertMany (from the second batch).
+		_, err = cli.Database("db").Collection("coll").InsertMany(context.Background(), docs)
+		assert.NotNil(mt, err, "expected error from InsertMany, got nil")
+		assert.True(mt, mongo.IsTimeout(err), "expected error to be a timeout, got %v", err)
+
+		// Expect that two 'insert's were sent.
+		assert.True(mt, len(started) == 2, "expected two started events, got %d", len(started))
+		assert.Equal(mt, started[0].CommandName,
+			"insert", "expected an insert event, got %v", started[0].CommandName)
+		assert.Equal(mt, started[1].CommandName,
+			"insert", "expected a second insert event, got %v", started[1].CommandName)
+	})
+	mt.Run("8. server selection", func(mt *mtest.T) {
 		cliOpts := options.Client().ApplyURI("mongodb://invalid/?serverSelectionTimeoutMS=10")
 		mtOpts := mtest.NewOptions().ClientOptions(cliOpts).CreateCollection(false)
 		mt.RunOpts("serverSelectionTimeoutMS honored if timeoutMS is not set", mtOpts, func(mt *mtest.T) {


### PR DESCRIPTION
GODRIVER-2458

Implements [this prose test](https://github.com/mongodb/specifications/tree/master/source/client-side-operations-timeout/tests#multi-batch-writes). Uses numbers for existing CSOT prose tests.

Note that I bumped some of the timeouts beyond the test description, since the `InsertMany` call of 50 1MB documents takes a while on my machine.

Aside: I worry about tests like this on Windows and Mac; I'm thinking about solutions for timing tests on those OSes (maybe we just skip timing-related tests?)