### PR TITLE
GODRIVER-2559 Do not connect to mongocryptd if shared library is loaded

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -437,7 +437,7 @@ func (c *Client) configureAutoEncryption(clientOpts *options.ClientOptions) erro
 	}
 
 	// If the crypt_shared library was loaded successfully, signal to the mongocryptd client creator
-	// that it can bypass spawning mongocryptd.
+	// that it can bypass spawning or connecting to mongocryptd.
 	cryptSharedLibAvailable := mc.CryptSharedLibVersionString() != ""
 	mongocryptdFLE, err := newMongocryptdClient(cryptSharedLibAvailable, clientOpts.AutoEncryptionOptions)
 	if err != nil {

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -436,14 +436,14 @@ func (c *Client) configureAutoEncryption(clientOpts *options.ClientOptions) erro
 		return err
 	}
 
-	// If the crypt_shared library was loaded successfully, signal to the mongocryptd client creator
-	// that it can bypass spawning or connecting to mongocryptd.
-	cryptSharedLibAvailable := mc.CryptSharedLibVersionString() != ""
-	mongocryptdFLE, err := newMongocryptdClient(cryptSharedLibAvailable, clientOpts.AutoEncryptionOptions)
-	if err != nil {
-		return err
+	// If the crypt_shared library was not loaded, try to spawn and connect to mongocryptd.
+	if mc.CryptSharedLibVersionString() == "" {
+		mongocryptdFLE, err := newMongocryptdClient(clientOpts.AutoEncryptionOptions)
+		if err != nil {
+			return err
+		}
+		c.mongocryptdFLE = mongocryptdFLE
 	}
-	c.mongocryptdFLE = mongocryptdFLE
 
 	c.configureCryptFLE(mc, clientOpts.AutoEncryptionOptions)
 	return nil

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2007,8 +2007,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			}
 
 			// Listen for connections in a separate goroutine.
-			listener := listenForConnections(t, func(_ net.Conn) {
+			listener := listenForConnections(t, func(c net.Conn) {
 				mt.Fatalf("Unexpected connection created to mock mongocryptd goroutine")
+				c.Close()
 			})
 			defer listener.Close()
 

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2221,6 +2221,8 @@ func (d *deadlockTest) disconnect(mt *mtest.T) {
 // The user provided run function will be called with the accepted
 // connection. The user is responsible for calling Close on the returned listener.
 func listenForConnections(t *testing.T, run func(net.Conn)) net.Listener {
+        t.Helper()
+        
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Errorf("Could not set up a listener: %v", err)

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2221,8 +2221,8 @@ func (d *deadlockTest) disconnect(mt *mtest.T) {
 // The user provided run function will be called with the accepted
 // connection. The user is responsible for calling Close on the returned listener.
 func listenForConnections(t *testing.T, run func(net.Conn)) net.Listener {
-        t.Helper()
-        
+	t.Helper()
+
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Errorf("Could not set up a listener: %v", err)

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2227,9 +2227,10 @@ func listenForConnections(t *testing.T, run func(net.Conn)) net.Listener {
 	}
 	go func() {
 		for {
-			c, err := l.Accept()
-			if err != nil {
-				t.Errorf("Could not accept a connection: %v", err)
+			// Ignore errors due to closing the listener connection.
+			c, _ := l.Accept()
+			if c == nil {
+				break
 			}
 			go run(c)
 		}

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1991,7 +1991,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		})
 	})
 
-	mt.RunOpts("Do not connect to mongocryptd when shared library is loaded",
+	mt.RunOpts("20. Bypass creating mongocryptd client when shared library is loaded",
 		noClientOpts, func(mt *mtest.T) {
 
 			cryptSharedLibPath := os.Getenv("CRYPT_SHARED_LIB_PATH")
@@ -2029,10 +2029,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				assert.Nil(mt, err, "encrypted client Disconnect error: %v", err)
 			}()
 
-			// Run a Find through the encrypted client to make sure mongocryptd is started ('find' uses the
+			// Run an Insert through the encrypted client to make sure mongocryptd is started ('insert' uses the
 			// mongocryptd and will wait for it to be active).
-			_, err = encClient.Database("test").Collection("test").Find(context.Background(), bson.D{})
-			assert.Nil(mt, err, "Find error: %v", err)
+			_, err = encClient.Database("db").Collection("coll").InsertOne(context.Background(), bson.D{{"unencrypted", "test"}})
+			assert.Nil(mt, err, "InsertOne error: %v", err)
 		})
 }
 


### PR DESCRIPTION
GODRIVER-2559

## Summary
- Do not connect to mongocryptd if shared library is loaded
- Add prose test from https://github.com/mongodb/specifications/commit/09f1d51d549c141c310055e6d6802bc9e297258d

## Background & Motivation

mongocryptd and the [crypt shared library](https://www.mongodb.com/docs/manual/core/queryable-encryption/reference/shared-library/) share the same functionality. Creating a `mongo.Client` to mongocryptd is unnecessary if using the shared library. mongocryptd will not be used if the shared library is used.