### PR TITLE
Ensure zombie credentials are not used in EC2 auth tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -802,6 +802,10 @@ functions:
           if [ "${SKIP_EC2_AUTH_TEST}" = "true" ]; then
             exit 0
           fi
+
+          # Write an empty prepare_mongodb_aws so no auth environment variables are set.
+          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
+
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
 
   run-aws-auth-test-with-aws-credentials-as-environment-variables:
@@ -2159,7 +2163,7 @@ task_groups:
               --out . \
               --only "**/mongo_crypt_v1.*" \
               --strip-path-components 1
-     
+
             # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
             # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
             # downloaded files.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -803,8 +803,8 @@ functions:
             exit 0
           fi
 
-          # Write an empty prepare_mongodb_aws so no auth environment variables are set.
-          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
+          # Truncate "prepare_mongodb_aws.sh" to zero length. If file not present, creates zero-length file.
+          : > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
 
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
 

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -15,6 +15,9 @@ echo "Running MONGODB-AWS authentication tests"
 # ensure no secrets are printed in log files
 set +x
 
+# Write an empty prepare_mongodb_aws so no auth environment variables are set.
+echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
+
 # load the script
 shopt -s expand_aliases # needed for `urlencode` alias
 [ -s "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh" ] && source "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -15,9 +15,6 @@ echo "Running MONGODB-AWS authentication tests"
 # ensure no secrets are printed in log files
 set +x
 
-# Write an empty prepare_mongodb_aws so no auth environment variables are set.
-echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-
 # load the script
 shopt -s expand_aliases # needed for `urlencode` alias
 [ -s "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh" ] && source "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"


### PR DESCRIPTION
Resolves GODRIVER-2534

Overwrite `prepare_mongodb_aws.sh` before running EC2 auth test to avoid zombie credentials from preventing the driver from fetching the credentials using the AWS end point.