### PR TITLE
GODRIVER-2533 Fix data race from NumberSessionsInProgress.

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -793,7 +793,7 @@ func (c *Client) Watch(ctx context.Context, pipeline interface{},
 // closed (i.e. EndSession has not been called).
 func (c *Client) NumberSessionsInProgress() int {
 	// The underlying session pool uses an int64 for checkedOut to allow atomic
-	// access. We convert to an int here to maintain backward compatability with
+	// access. We convert to an int here to maintain backward compatibility with
 	// older versions of the driver that did not atomically access checkedOut.
 	return int(c.sessionPool.CheckedOut())
 }

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -792,7 +792,10 @@ func (c *Client) Watch(ctx context.Context, pipeline interface{},
 // NumberSessionsInProgress returns the number of sessions that have been started for this client but have not been
 // closed (i.e. EndSession has not been called).
 func (c *Client) NumberSessionsInProgress() int {
-	return c.sessionPool.CheckedOut()
+	// The underlying session pool uses an int64 for checkedOut to allow atomic
+	// access. We convert to an int here to maintain backward compatability with
+	// older versions of the driver that did not atomically access checkedOut.
+	return int(c.sessionPool.CheckedOut())
 }
 
 // Timeout returns the timeout set for this client.

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -475,6 +475,43 @@ func TestSessions(t *testing.T) {
 		assert.True(mt, limitedSessionUse, limitedSessMsg, len(ops))
 
 	})
+
+	// Regression test for GODRIVER-2533. Note that this test assumes the race detector is enabled
+	// (GODRIVER-2072).
+	mt.Run("NumberSessionsInProgress data race", func(mt *mtest.T) {
+		// Start two goroutines under the same 100ms Context that continously run
+		// NumberSessionsInProgress and a basic collection operation
+		// (CountDocuments) simultaneously.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		go func(ctx context.Context) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				}
+
+				_ = mt.Client.NumberSessionsInProgress()
+			}
+		}(ctx)
+
+		go func(ctx context.Context) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				}
+
+				_, err := mt.Coll.CountDocuments(context.Background(), bson.D{})
+				assert.Nil(mt, err, "CountDocument error: %v", err)
+			}
+		}(ctx)
+
+		// Wait for context to be done to ensure goroutines stop using mtest Client
+		// before test cleanup.
+		<-ctx.Done()
+	})
 }
 
 func assertCollectionCount(mt *mtest.T, expectedCount int64) {


### PR DESCRIPTION
GODRIVER-2533

Fixes data race in `session.Pool` by switching `checkedOut` from an `int` to an atomically-accessed `int64`. Adds a regression test for the data race.