### PR TITLE
GODRIVER-2569 Use the paralleltest linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - paralleltest
     - prealloc
     - revive
     - staticcheck
@@ -35,6 +36,9 @@ linters-settings:
     disable:
       - cgocall
       - composites
+  paralleltest:
+    # Ignore missing calls to `t.Parallel()` and only report incorrect uses of `t.Parallel()`.
+    ignore-missing: true
   staticcheck:
     checks: [
       "all",


### PR DESCRIPTION
[GODRIVER-2569](https://jira.mongodb.org/browse/GODRIVER-2569)

Use the [paralleltest](https://github.com/kunwardeep/paralleltest) linter to report when tests use `t.Parallel()` incorrectly (e.g. without capturing the test case for loop variable).