### PR TITLE
GODRIVER-2573 re-apply default serverSelectionTimeout

### DIFF
--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -21,6 +21,8 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
+const defaultServerSelectionTimeout = 30 * time.Second
+
 // Config is used to construct a topology.
 type Config struct {
 	Mode                   MonitorMode
@@ -60,6 +62,12 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 	var serverOpts []ServerOption
 
 	cfgp := new(Config)
+
+	// Set the default "ServerSelectionTimeout" to 30 seconds.
+	cfgp.ServerSelectionTimeout = defaultServerSelectionTimeout
+
+	// Set the default seed list to localhost.
+	cfgp.SeedList = []string{"localhost:27017"}
 
 	// TODO(GODRIVER-814): Add tests for topology, server, and connection related options.
 

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -66,7 +66,7 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 	// Set the default "ServerSelectionTimeout" to 30 seconds.
 	cfgp.ServerSelectionTimeout = defaultServerSelectionTimeout
 
-	// Set the default seed list to localhost.
+	// Set the default "SeedList" to localhost.
 	cfgp.SeedList = []string{"localhost:27017"}
 
 	// TODO(GODRIVER-814): Add tests for topology, server, and connection related options.

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -87,9 +88,19 @@ func TestTopologyNewConfig(t *testing.T) {
 		assert.Nil(t, err, "error constructing topology config: %v", err)
 		assert.Equal(t, defaultServerSelectionTimeout, cfg.ServerSelectionTimeout)
 	})
+	t.Run("non-default ServerSelectionTimeout", func(t *testing.T) {
+		cfg, err := NewConfig(options.Client().SetServerSelectionTimeout(1), nil)
+		assert.Nil(t, err, "error constructing topology config: %v", err)
+		assert.Equal(t, time.Duration(1), cfg.ServerSelectionTimeout)
+	})
 	t.Run("default SeedList", func(t *testing.T) {
 		cfg, err := NewConfig(options.Client(), nil)
 		assert.Nil(t, err, "error constructing topology config: %v", err)
 		assert.Equal(t, []string{"localhost:27017"}, cfg.SeedList)
+	})
+	t.Run("non-default SeedList", func(t *testing.T) {
+		cfg, err := NewConfig(options.Client().ApplyURI("mongodb://localhost:27018"), nil)
+		assert.Nil(t, err, "error constructing topology config: %v", err)
+		assert.Equal(t, []string{"localhost:27018"}, cfg.SeedList)
 	})
 }

--- a/x/mongo/driver/topology/topology_options_test.go
+++ b/x/mongo/driver/topology/topology_options_test.go
@@ -80,3 +80,16 @@ func TestLoadBalancedFromConnString(t *testing.T) {
 		})
 	}
 }
+
+func TestTopologyNewConfig(t *testing.T) {
+	t.Run("default ServerSelectionTimeout", func(t *testing.T) {
+		cfg, err := NewConfig(options.Client(), nil)
+		assert.Nil(t, err, "error constructing topology config: %v", err)
+		assert.Equal(t, defaultServerSelectionTimeout, cfg.ServerSelectionTimeout)
+	})
+	t.Run("default SeedList", func(t *testing.T) {
+		cfg, err := NewConfig(options.Client(), nil)
+		assert.Nil(t, err, "error constructing topology config: %v", err)
+		assert.Equal(t, []string{"localhost:27017"}, cfg.SeedList)
+	})
+}


### PR DESCRIPTION
GODRIVER-2573

Default values `ServerSelectionTimeout` and `SeedList` were removed from the now-deprecated `newConfig` function in PR #1044 for GODRIVER-1530 . There was no basis for this removal and this PR adds it back to the `topology.Config` constructor.