### PR TITLE
GODRIVER-2564 exit 1 on gen corpus

### DIFF
--- a/.evergreen/run-fuzz.sh
+++ b/.evergreen/run-fuzz.sh
@@ -64,5 +64,9 @@ done
 if [ -d $PROJECT_DIRECTORY/fuzz ]; then
 	echo "Tarring up fuzz directory"
 	tar -czf $PROJECT_DIRECTORY/fuzz.tgz $PROJECT_DIRECTORY/fuzz
+
+	# Exit with code 1 to indicate that errors occurred in fuzz tests, resulting in corpus files being generated.
+	# This will trigger a notification to be sent to the Go Driver team.
+	exit 1
 fi
 


### PR DESCRIPTION
GODRIVER-2564

Evergreen notification events are triggered on "Finished" or "Failed" Builds/Versions. To avoid gratuitous notifications, this PR adds an `exit 1` for if generate corpus data is uploaded to the S3 bucket, [here](https://evergreen.mongodb.com/task/mongo_go_driver_fuzz_test__version~5.0_os_ssl_40~ubuntu1804_64_go_1_18_test_fuzz_patch_cb7150a53b0a1318b5fcc8da0ea0bd8601862835_634729649ccd4e5b4bb181ef_22_10_12_20_54_05) is an example of such a failure. If a failure occurs, then notify the #dbx-go slack channel.

[periodic build configuration](https://spruce.mongodb.com/project/mongo-go-driver/settings/periodic-builds), [notification configuration](https://spruce.mongodb.com/project/mongo-go-driver/settings/notifications)