### PR TITLE
GODRIVER-2522 Run macOS tasks at most once per 24 hours.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2064,6 +2064,7 @@ axes:
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
+        batchtime: 1440 # Run at most once per 24 hours.
         variables:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: python3
@@ -2090,6 +2091,7 @@ axes:
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
+        batchtime: 1440 # Run at most once per 24 hours.
         variables:
           GO_DIST: "/opt/golang/go1.18"
           PYTHON3_BINARY: python3
@@ -2126,6 +2128,7 @@ axes:
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
+        batchtime: 1440 # Run at most once per 24 hours.
         variables:
           GO_DIST: "/opt/golang/go1.18"
           SKIP_ECS_AUTH_TEST: true


### PR DESCRIPTION
[GODRIVER-2522](https://jira.mongodb.org/browse/GODRIVER-2522)

Use `batchtime: 1440` to run macOS builds for batches of commits, at most once per 24 hours.