### PR TITLE
Improve reliability of SDAM error 'before handshake completes' tests.

### DIFF
--- a/mongo/integration/sdam_error_handling_test.go
+++ b/mongo/integration/sdam_error_handling_test.go
@@ -85,7 +85,23 @@ func TestSDAMErrorHandling(t *testing.T) {
 				assert.NotNil(mt, err, "expected InsertOne error, got nil")
 				assert.True(mt, mongo.IsTimeout(err), "expected timeout error, got %v", err)
 				assert.True(mt, mongo.IsNetworkError(err), "expected network error, got %v", err)
-				assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
+				// Assert that the pool is cleared within 2 seconds.
+				assert.Soon(mt, func(ctx context.Context) {
+					ticker := time.NewTicker(100 * time.Millisecond)
+					defer ticker.Stop()
+
+					for {
+						select {
+						case <-ticker.C:
+						case <-ctx.Done():
+							return
+						}
+
+						if tpm.IsPoolCleared() {
+							return
+						}
+					}
+				}, 2*time.Second)
 			})
 
 			mt.RunOpts("pool cleared on non-timeout network error", noClientOpts, func(mt *mtest.T) {
@@ -114,9 +130,23 @@ func TestSDAMErrorHandling(t *testing.T) {
 						// Set minPoolSize to enable the background pool maintenance goroutine.
 						SetMinPoolSize(5))
 
-					time.Sleep(200 * time.Millisecond)
+					// Assert that the pool is cleared within 2 seconds.
+					assert.Soon(mt, func(ctx context.Context) {
+						ticker := time.NewTicker(100 * time.Millisecond)
+						defer ticker.Stop()
 
-					assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
+						for {
+							select {
+							case <-ticker.C:
+							case <-ctx.Done():
+								return
+							}
+
+							if tpm.IsPoolCleared() {
+								return
+							}
+						}
+					}, 2*time.Second)
 				})
 
 				mt.Run("foreground", func(mt *mtest.T) {
@@ -143,7 +173,24 @@ func TestSDAMErrorHandling(t *testing.T) {
 					_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 					assert.NotNil(mt, err, "expected InsertOne error, got nil")
 					assert.False(mt, mongo.IsTimeout(err), "expected non-timeout error, got %v", err)
-					assert.True(mt, tpm.IsPoolCleared(), "expected pool to be cleared but was not")
+
+					// Assert that the pool is cleared within 2 seconds.
+					assert.Soon(mt, func(ctx context.Context) {
+						ticker := time.NewTicker(100 * time.Millisecond)
+						defer ticker.Stop()
+
+						for {
+							select {
+							case <-ticker.C:
+							case <-ctx.Done():
+								return
+							}
+
+							if tpm.IsPoolCleared() {
+								return
+							}
+						}
+					}, 2*time.Second)
 				})
 			})
 		})


### PR DESCRIPTION
The SDAM [error before handshake completes](https://github.com/mongodb/mongo-go-driver/blob/25122e12942e5d1fa1dff4df03d8110515df3037/mongo/integration/sdam_error_handling_test.go#L91) tests fail intermittently because returning errors to operation calls and handling connection errors are not guaranteed to run in a particular order. For example, if a connection establishment error occurs, it's possible for the operation caller to get an error returned before the SDAM error handler is called. Note that the race condition is only applicable to handshake errors; application errors are handled synchronously and always before returning the error to the user.

Resolve that problem by waiting for up to 2 seconds for the connection pool to be cleared after a connection establishment error happens in the SDAM error handling tests.