### PR TITLE
GODRIVER-2368 Add example for AWS Lambda handler.

### DIFF
--- a/examples/_example_aws_lambda_handler.go
+++ b/examples/_example_aws_lambda_handler.go
@@ -1,0 +1,43 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package examples
+
+import (
+	"context"
+	"os"
+
+	runtime "github.com/aws/aws-lambda-go/lambda"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Start AWS Lambda Example 1
+
+var client, err = func() (*mongo.Client, error) {
+	client, err := mongo.NewClient(options.Client().ApplyURI(os.Getenv("MONGODB_URI")))
+	if err != nil {
+		return nil, err
+	}
+	err = client.Connect(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}()
+
+func HandleRequest(ctx context.Context) error {
+	if err != nil {
+		return err
+	}
+	return client.Ping(context.TODO(), nil)
+}
+
+// End AWS Lambda Example 1
+
+func main() {
+	runtime.Start(HandleRequest)
+}

--- a/examples/_example_aws_lambda_handler.go
+++ b/examples/_example_aws_lambda_handler.go
@@ -17,17 +17,7 @@ import (
 
 // Start AWS Lambda Example 1
 
-var client, err = func() (*mongo.Client, error) {
-	client, err := mongo.NewClient(options.Client().ApplyURI(os.Getenv("MONGODB_URI")))
-	if err != nil {
-		return nil, err
-	}
-	err = client.Connect(context.TODO())
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}()
+var client, err = mongo.Connect(context.TODO(), options.Client().ApplyURI(os.Getenv("MONGODB_URI")))
 
 func HandleRequest(ctx context.Context) error {
 	if err != nil {


### PR DESCRIPTION
[GODRIVER-2368](https://jira.mongodb.org/browse/GODRIVER-2368)
This is an example of AWS Lambda handler.
Tesed on Lambda.
Prefixed the filename with a `_` to prevent it from being compiled.