### PR TITLE
GODRIVER-2487 Add spec tests for `errorResponse`.

### DIFF
--- a/mongo/integration/unified/error.go
+++ b/mongo/integration/unified/error.go
@@ -26,6 +26,7 @@ type expectedError struct {
 	IncludedLabels []string       `bson:"errorLabelsContain"`
 	OmittedLabels  []string       `bson:"errorLabelsOmit"`
 	ExpectedResult *bson.RawValue `bson:"expectResult"`
+	ErrorResponse  *bson.Raw      `bson:"errorResponse"`
 }
 
 // verifyOperationError compares the expected error to the actual operation result. If the expected parameter is nil,
@@ -125,6 +126,19 @@ func verifyOperationError(ctx context.Context, expected *expectedError, result *
 			return fmt.Errorf("result comparison error: %v", err)
 		}
 	}
+
+	if expected.ErrorResponse != nil {
+		if details.raw == nil {
+			return fmt.Errorf("expected error response from the server, got none")
+		}
+
+		// Allow extra keys as error response functions like a root-level document.
+		gotValue := documentToRawValue(details.raw)
+		expectedValue := documentToRawValue(*expected.ErrorResponse)
+		if err := verifyValuesMatch(ctx, expectedValue, gotValue, true); err != nil {
+			return fmt.Errorf("error response comparison error: %v", err)
+		}
+	}
 	return nil
 }
 
@@ -133,6 +147,7 @@ type errorDetails struct {
 	codes     []int32
 	codeNames []string
 	labels    []string
+	raw       bson.Raw
 }
 
 // extractErrorDetails creates an errorDetails instance based on the provided error. It returns the details and an "ok"
@@ -145,22 +160,29 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 		details.codes = []int32{converted.Code}
 		details.codeNames = []string{converted.Name}
 		details.labels = converted.Labels
+		details.raw = converted.Raw
 	case mongo.WriteException:
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
+			// this could contain a raw error...
 		}
 		for _, we := range converted.WriteErrors {
 			details.codes = append(details.codes, int32(we.Code))
+			// this could contain a raw error...
 		}
 		details.labels = converted.Labels
+		details.raw = converted.Raw
 	case mongo.BulkWriteException:
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
+			// this could contain a raw error...
 		}
 		for _, we := range converted.WriteErrors {
 			details.codes = append(details.codes, int32(we.Code))
+			details.raw = we.Raw
+			// this could contain a raw error...
 		}
 		details.labels = converted.Labels
 	default:

--- a/mongo/integration/unified/error.go
+++ b/mongo/integration/unified/error.go
@@ -132,7 +132,7 @@ func verifyOperationError(ctx context.Context, expected *expectedError, result *
 			return fmt.Errorf("expected error response from the server, got none")
 		}
 
-		// Allow extra keys as error response functions like a root-level document.
+		// Allow extra keys as 'errorResponse' functions like a root-level document.
 		gotValue := documentToRawValue(details.raw)
 		expectedValue := documentToRawValue(*expected.ErrorResponse)
 		if err := verifyValuesMatch(ctx, expectedValue, gotValue, true); err != nil {

--- a/mongo/integration/unified/error.go
+++ b/mongo/integration/unified/error.go
@@ -165,11 +165,9 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
-			// this could contain a raw error...
 		}
 		for _, we := range converted.WriteErrors {
 			details.codes = append(details.codes, int32(we.Code))
-			// this could contain a raw error...
 		}
 		details.labels = converted.Labels
 		details.raw = converted.Raw
@@ -177,12 +175,10 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
-			// this could contain a raw error...
 		}
 		for _, we := range converted.WriteErrors {
 			details.codes = append(details.codes, int32(we.Code))
 			details.raw = we.Raw
-			// this could contain a raw error...
 		}
 		details.labels = converted.Labels
 	default:

--- a/mongo/integration/unified/schema_version.go
+++ b/mongo/integration/unified/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	supportedSchemaVersions = map[int]string{
-		1: "1.9",
+		1: "1.12",
 	}
 )
 

--- a/testdata/crud/unified/aggregate-merge-errorResponse.json
+++ b/testdata/crud/unified/aggregate-merge-errorResponse.json
@@ -43,7 +43,11 @@
       "description": "aggregate $merge DuplicateKey error is accessible",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.1"
+          "minServerVersion": "5.1",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
         }
       ],
       "operations": [

--- a/testdata/crud/unified/aggregate-merge-errorResponse.json
+++ b/testdata/crud/unified/aggregate-merge-errorResponse.json
@@ -1,0 +1,86 @@
+{
+  "description": "aggregate-merge-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1
+        },
+        {
+          "_id": 2,
+          "x": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "aggregate $merge DuplicateKey error is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$documents": [
+                  {
+                    "_id": 2,
+                    "x": 1
+                  }
+                ]
+              },
+              {
+                "$merge": {
+                  "into": "test",
+                  "whenMatched": "fail"
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "errorCode": 11000,
+            "errorResponse": {
+              "keyPattern": {
+                "_id": 1
+              },
+              "keyValue": {
+                "_id": 2
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/aggregate-merge-errorResponse.yml
+++ b/testdata/crud/unified/aggregate-merge-errorResponse.yml
@@ -1,0 +1,39 @@
+description: "aggregate-merge-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 1 }
+      - { _id: 2, x: 1 }
+
+tests:
+  - description: "aggregate $merge DuplicateKey error is accessible"
+    runOnRequirements:
+      - minServerVersion: "5.1" # SERVER-59097
+    operations:
+      - name: aggregate
+        object: *database0
+        arguments:
+          pipeline:
+            - { $documents: [ { _id: 2, x: 1 } ] }
+            - { $merge: { into: *collection0Name, whenMatched: "fail" } }
+        expectError:
+          errorCode: 11000 # DuplicateKey
+          errorResponse:
+            keyPattern: { _id: 1 }
+            keyValue: { _id: 2 }

--- a/testdata/crud/unified/aggregate-merge-errorResponse.yml
+++ b/testdata/crud/unified/aggregate-merge-errorResponse.yml
@@ -25,6 +25,9 @@ tests:
   - description: "aggregate $merge DuplicateKey error is accessible"
     runOnRequirements:
       - minServerVersion: "5.1" # SERVER-59097
+        # Exclude sharded topologies since the aggregate command fails with
+        # IllegalOperation(20) instead of DuplicateKey(11000)
+        topologies: [ single, replicaset ]
     operations:
       - name: aggregate
         object: *database0

--- a/testdata/crud/unified/bulkWrite-errorResponse.json
+++ b/testdata/crud/unified/bulkWrite-errorResponse.json
@@ -1,0 +1,87 @@
+{
+  "description": "bulkWrite-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "bulkWrite operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/bulkWrite-errorResponse.json
+++ b/testdata/crud/unified/bulkWrite-errorResponse.json
@@ -4,7 +4,8 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "useMultipleMongoses": false
       }
     },
     {

--- a/testdata/crud/unified/bulkWrite-errorResponse.yml
+++ b/testdata/crud/unified/bulkWrite-errorResponse.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0

--- a/testdata/crud/unified/bulkWrite-errorResponse.yml
+++ b/testdata/crud/unified/bulkWrite-errorResponse.yml
@@ -1,0 +1,44 @@
+description: "bulkWrite-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "bulkWrite operations support errorResponse assertions"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: &errorCode 8 # UnknownError
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: { _id: 1 }
+        expectError:
+          errorCode: *errorCode
+          errorResponse:
+            code: *errorCode

--- a/testdata/crud/unified/bulkWrite-errorResponse.yml
+++ b/testdata/crud/unified/bulkWrite-errorResponse.yml
@@ -15,6 +15,11 @@ createEntities:
       collectionName: &collection0Name test
 
 tests:
+  # This test intentionally executes only a single insert operation in the bulk
+  # write to make the error code and response assertions less ambiguous. That
+  # said, some drivers may still need to skip this test because the CRUD spec
+  # does not prescribe how drivers should formulate a BulkWriteException beyond
+  # collecting write and write concern errors.
   - description: "bulkWrite operations support errorResponse assertions"
     runOnRequirements:
       - minServerVersion: "4.0.0"

--- a/testdata/crud/unified/deleteOne-errorResponse.json
+++ b/testdata/crud/unified/deleteOne-errorResponse.json
@@ -1,0 +1,81 @@
+{
+  "description": "deleteOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "delete operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/deleteOne-errorResponse.json
+++ b/testdata/crud/unified/deleteOne-errorResponse.json
@@ -4,7 +4,8 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "useMultipleMongoses": false
       }
     },
     {

--- a/testdata/crud/unified/deleteOne-errorResponse.yml
+++ b/testdata/crud/unified/deleteOne-errorResponse.yml
@@ -1,0 +1,42 @@
+description: "deleteOne-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "delete operations support errorResponse assertions"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ delete ]
+              errorCode: &errorCode 8 # UnknownError
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+        expectError:
+          errorCode: *errorCode
+          errorResponse:
+            code: *errorCode

--- a/testdata/crud/unified/deleteOne-errorResponse.yml
+++ b/testdata/crud/unified/deleteOne-errorResponse.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0

--- a/testdata/crud/unified/deleteOne-errorResponse.yml
+++ b/testdata/crud/unified/deleteOne-errorResponse.yml
@@ -15,6 +15,9 @@ createEntities:
       collectionName: &collection0Name test
 
 tests:
+  # Some drivers may still need to skip this test because the CRUD spec does not
+  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # write or write concern error.
   - description: "delete operations support errorResponse assertions"
     runOnRequirements:
       - minServerVersion: "4.0.0"

--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.json
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.json
@@ -1,0 +1,132 @@
+{
+  "description": "findOneAndUpdate-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "foo"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndUpdate DuplicateKey error is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "unique": true
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "update": {
+              "$set": {
+                "x": "foo"
+              }
+            },
+            "upsert": true
+          },
+          "expectError": {
+            "errorCode": 11000,
+            "errorResponse": {
+              "keyPattern": {
+                "x": 1
+              },
+              "keyValue": {
+                "x": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate document validation errInfo is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "validator": {
+              "x": {
+                "$type": "string"
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "errorCode": 121,
+            "errorResponse": {
+              "errInfo": {
+                "failingDocumentId": 1,
+                "details": {
+                  "$$type": "object"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.json
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.json
@@ -4,7 +4,8 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "useMultipleMongoses": false
       }
     },
     {

--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
@@ -1,0 +1,69 @@
+description: "findOneAndUpdate-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: "foo" }
+
+tests:
+  - description: "findOneAndUpdate DuplicateKey error is accessible"
+    runOnRequirements:
+      - minServerVersion: "4.2" # SERVER-37124
+    operations:
+      - name: createIndex
+        object: *collection0
+        arguments:
+          keys: { x: 1 }
+          unique: true
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 2 }
+          update: { $set: { x: "foo" } }
+          upsert: true
+        expectError:
+          errorCode: 11000 # DuplicateKey
+          errorResponse:
+            keyPattern: { x: 1 }
+            keyValue: { x: "foo" }
+
+  - description: "findOneAndUpdate document validation errInfo is accessible"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          validator:
+            x: { $type: "string" }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 } }
+        expectError:
+          errorCode: 121 # DocumentValidationFailure
+          errorResponse:
+            # Avoid asserting the exact contents of errInfo as it may vary by
+            # server version. Likewise, this is why drivers do not model the
+            # document. The following is sufficient to test that validation
+            # details are accessible. See SERVER-20547 for more context.
+            errInfo:
+              failingDocumentId: 1
+              details: { $$type: "object" }

--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0

--- a/testdata/crud/unified/insertOne-errorResponse.json
+++ b/testdata/crud/unified/insertOne-errorResponse.json
@@ -1,0 +1,81 @@
+{
+  "description": "insertOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "insert operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/insertOne-errorResponse.json
+++ b/testdata/crud/unified/insertOne-errorResponse.json
@@ -4,7 +4,8 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "useMultipleMongoses": false
       }
     },
     {

--- a/testdata/crud/unified/insertOne-errorResponse.yml
+++ b/testdata/crud/unified/insertOne-errorResponse.yml
@@ -15,6 +15,9 @@ createEntities:
       collectionName: &collection0Name test
 
 tests:
+  # Some drivers may still need to skip this test because the CRUD spec does not
+  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # write or write concern error.
   - description: "insert operations support errorResponse assertions"
     runOnRequirements:
       - minServerVersion: "4.0.0"

--- a/testdata/crud/unified/insertOne-errorResponse.yml
+++ b/testdata/crud/unified/insertOne-errorResponse.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0

--- a/testdata/crud/unified/insertOne-errorResponse.yml
+++ b/testdata/crud/unified/insertOne-errorResponse.yml
@@ -1,0 +1,42 @@
+description: "insertOne-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "insert operations support errorResponse assertions"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: &errorCode 8 # UnknownError
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1 }
+        expectError:
+          errorCode: *errorCode
+          errorResponse:
+            code: *errorCode

--- a/testdata/crud/unified/updateOne-errorResponse.json
+++ b/testdata/crud/unified/updateOne-errorResponse.json
@@ -1,0 +1,86 @@
+{
+  "description": "updateOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "update operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/crud/unified/updateOne-errorResponse.json
+++ b/testdata/crud/unified/updateOne-errorResponse.json
@@ -4,7 +4,8 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "useMultipleMongoses": false
       }
     },
     {

--- a/testdata/crud/unified/updateOne-errorResponse.yml
+++ b/testdata/crud/unified/updateOne-errorResponse.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0

--- a/testdata/crud/unified/updateOne-errorResponse.yml
+++ b/testdata/crud/unified/updateOne-errorResponse.yml
@@ -15,6 +15,9 @@ createEntities:
       collectionName: &collection0Name test
 
 tests:
+  # Some drivers may still need to skip this test because the CRUD spec does not
+  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # write or write concern error.
   - description: "update operations support errorResponse assertions"
     runOnRequirements:
       - minServerVersion: "4.0.0"

--- a/testdata/crud/unified/updateOne-errorResponse.yml
+++ b/testdata/crud/unified/updateOne-errorResponse.yml
@@ -1,0 +1,43 @@
+description: "updateOne-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "update operations support errorResponse assertions"
+    runOnRequirements:
+      - minServerVersion: "4.0.0"
+        topologies: [ single, replicaset ]
+      - minServerVersion: "4.2.0"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ update ]
+              errorCode: &errorCode 8 # UnknownError
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 } }
+        expectError:
+          errorCode: *errorCode
+          errorResponse:
+            code: *errorCode


### PR DESCRIPTION
GODRIVER-2487

Adds spec tests for the new `errorResponse` field. Adds support for the `errorResponse` field in the unified test runner.

GODRIVER-2325 recently exposed the raw server reply in all errors returned from the server; this PR just accesses those `Raw` fields from the unified test runner.