### PR TITLE
GODRIVER-2174 Bump minimum Go version to 1.13.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1777,13 +1777,13 @@ tasks:
         vars:
           MONGO_GO_DRIVER_COMPRESSOR: "snappy"
 
-  - name: go1.10-build
+  - name: go1.13-build
     tags: ["compile-check"]
     commands:
       - func: run-make
         vars:
           targets: "build"
-          BUILD_ENV: "PATH=/opt/golang/go1.10/bin:$PATH GOROOT=/opt/golang/go1.10"
+          BUILD_ENV: "PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
 
   # Build with whatever the latest Go version is that we're using for tests
   - name: build

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1782,7 +1782,7 @@ tasks:
     commands:
       - func: run-make
         vars:
-          targets: "build"
+          targets: "build-113"
           BUILD_ENV: "PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
 
   # Build with whatever the latest Go version is that we're using for tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1782,8 +1782,10 @@ tasks:
     commands:
       - func: run-make
         vars:
-          targets: "build-113"
-          BUILD_ENV: "PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
+          targets: "build"
+          # Use GO111MODULE=off to disable modules, as go versions less than
+          # 1.16 will complain about the retract directives in go.mod.
+          BUILD_ENV: "GO111MODULE=off PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
 
   # Build with whatever the latest Go version is that we're using for tests
   - name: build

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ build:
 .PHONY: build-113
 build-113:
 	# Remove retract directives from go.mod for go1.13 build, as versions less
-	# than 1.16 will error when building with retract. The same .sum file can be
-	# used, but must be named go.noretract.sum.
-	sed -e '/retract (/,/)/d' go.mod > go.noretract.mod
-	cp go.sum go.noretract.sum
-	go build -modfile=go.noretract.mod $(BUILD_TAGS) $(PKGS)
-	rm go.noretract.mod go.noretract.sum
+	# than 1.16 will error when building with retract.
+	mv go.mod go.retract.mod
+	sed -e '/retract (/,/)/d' go.retract.mod > go.mod
+	go build $(BUILD_TAGS) $(PKGS)
+	rm go.mod
+	mv go.retract.mod go.mod
 
 .PHONY: build-examples
 build-examples:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-113:
 	# Remove retract directives from go.mod for go1.13 build, as versions less
 	# than 1.16 will error when building with retract. The same .sum file can be
 	# used, but must be named go.noretract.sum.
-	pcregrep -M -v 'retract \([^\)]+\)' go.mod > go.noretract.mod
+	sed -e '/retract (/,/)/d' go.mod > go.noretract.mod
 	cp go.sum go.noretract.sum
 	go build -modfile=go.noretract.mod $(BUILD_TAGS) $(PKGS)
 	rm go.noretract.mod go.noretract.sum

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,16 @@ add-license:
 build:
 	go build $(BUILD_TAGS) $(PKGS)
 
+.PHONY: build-113
+build-113:
+	# Remove retract directives from go.mod for go1.13 build, as versions less
+	# than 1.16 will error when building with retract. The same .sum file can be
+	# used, but must be named go.noretract.sum.
+	pcregrep -M -v 'retract \([^\)]+\)' go.mod > go.noretract.mod
+	cp go.sum go.noretract.sum
+	go build -modfile=go.noretract.mod $(BUILD_TAGS) $(PKGS)
+	rm go.noretract.mod go.noretract.sum
+
 .PHONY: build-examples
 build-examples:
 	go build $(BUILD_TAGS) ./examples/... ./x/mongo/driver/examples/...

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,6 @@ add-license:
 build:
 	go build $(BUILD_TAGS) $(PKGS)
 
-.PHONY: build-113
-build-113:
-	# Remove retract directives from go.mod for go1.13 build, as versions less
-	# than 1.16 will error when building with retract.
-	mv go.mod go.retract.mod
-	sed -e '/retract (/,/)/d' go.retract.mod > go.mod
-	go build $(BUILD_TAGS) $(PKGS)
-	rm go.mod
-	mv go.retract.mod go.mod
-
 .PHONY: build-examples
 build-examples:
 	go build $(BUILD_TAGS) ./examples/... ./x/mongo/driver/examples/...

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The MongoDB supported driver for Go.
 -------------------------
 ## Requirements
 
-- Go 1.10 or higher if using the driver as a dependency. Go 1.18 or higher if building the driver yourself. We aim to support the latest versions of Go.
+- Go 1.13 or higher if using the driver as a dependency. Go 1.18 or higher if building the driver yourself. We aim to support the latest versions of Go.
 - MongoDB 3.6 and higher.
 
 -------------------------

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The MongoDB supported driver for Go.
 -------------------------
 ## Requirements
 
-- Go 1.13 or higher if using the driver as a dependency. Go 1.18 or higher if building the driver yourself. We aim to support the latest versions of Go.
+- Go 1.13 or higher. We aim to support the latest versions of Go.
+  - Go 1.18 or higher is required to run the driver test suite.
 - MongoDB 3.6 and higher.
 
 -------------------------

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before starting to write code, look for existing [tickets](https://jira.mongodb.
 The Go Driver team uses GitHub to manage and review all code changes. Patches should generally be made against the master (default) branch and include relevant tests, if
 applicable.
 
-Code should compile and tests should pass under all Go versions which the driver currently supports. Currently the Go Driver supports a minimum version of Go 1.10 and requires Go 1.18 for development. Please run the following Make targets to validate your changes:
+Code should compile and tests should pass under all Go versions which the driver currently supports. Currently the Go Driver supports a minimum version of Go 1.13 and requires Go 1.18 for development. Please run the following Make targets to validate your changes:
 - `make fmt`
 - `make lint` (requires [golangci-lint](https://github.com/golangci/golangci-lint) and [lll](https://github.com/walle/lll) to be installed and available in the `PATH`)
 - `make test`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mongodb.org/mongo-driver
 
-go 1.10
+go 1.13
 
 retract (
 	v1.10.0 // Contains a possible data corruption bug in RewrapManyDataKey when using libmongocrypt versions less than 1.5.2.


### PR DESCRIPTION
GODRIVER-2174

Bumps the minimum Go version from 1.10 to 1.13. 

The followup ticket GODRIVER-2603 will refactor old code that was built before we had access to 1.13.