### PR TITLE
GODRIVER-2565 Abort transaction before CommitLoop if context errored.

### DIFF
--- a/mongo/session.go
+++ b/mongo/session.go
@@ -206,9 +206,20 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 			return res, err
 		}
 
+		// Check if callback intentionally aborted and, if so, return immediately
+		// with no error.
 		err = s.clientSession.CheckAbortTransaction()
 		if err != nil {
-			return res, nil
+			return res, err
+		}
+
+		// If context has errored, run AbortTransaction and return, as the CommitLoop
+		// has no chance of succeeding.
+		if ctx.Err() != nil {
+			// Wrap the user-provided Context in a new one that behaves like context.Background() for deadlines and
+			// cancellations, but forwards Value requests to the original one.
+			_ = s.AbortTransaction(internal.NewBackgroundContext(ctx))
+			return nil, ctx.Err()
 		}
 
 	CommitLoop:

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -215,6 +215,11 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 
 		// If context has errored, run AbortTransaction and return, as the CommitLoop
 		// has no chance of succeeding.
+		//
+		// Aborting after a failed CommitTransaction is dangerous. Failed transaction
+		// commits may unpin the session server-side, and subsequent transaction aborts
+		// may run on a new mongos which could end up with commit and abort being executed
+		// simultaneously.
 		if ctx.Err() != nil {
 			// Wrap the user-provided Context in a new one that behaves like context.Background() for deadlines and
 			// cancellations, but forwards Value requests to the original one.

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -210,7 +210,7 @@ func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx Sessi
 		// with no error.
 		err = s.clientSession.CheckAbortTransaction()
 		if err != nil {
-			return res, err
+			return res, nil
 		}
 
 		// If context has errored, run AbortTransaction and return, as the CommitLoop


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2565

## Summary
<!--- A summary of the changes propsed by this pull request. -->
If the context has errored right before the `CommitLoop` in `WithTransaction`, run `AbortTransaction` and return the context error.

## Background & Motivation
<!--- Rationale for the pull request. -->
This behavior is not specified in the convenient transactions API, as it has to do with contexts (see [DRIVERS-2471](https://jira.mongodb.org/browse/DRIVERS-2471)). If the context has errored after the callback but before `CommitLoop`, there is no chance the transaction commit will succeed, and resources will be left open server-side. We should run `AbortTransaction` in this case as a best effort to clean up server-side.

