### PR TITLE
GODRIVER-2604 Add `ErrServerSelectionTimeout` and `WaitQueueTimeoutError` to `IsTimeout`.

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -112,6 +112,12 @@ func IsTimeout(err error) bool {
 		if err == driver.ErrDeadlineWouldBeExceeded {
 			return true
 		}
+		if err == topology.ErrServerSelectionTimeout {
+			return true
+		}
+		if _, ok := err.(topology.WaitQueueTimeoutError); ok {
+			return true
+		}
 		if ce, ok := err.(CommandError); ok && ce.IsMaxTimeMSExpiredError() {
 			return true
 		}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2604 

## Summary
<!--- A summary of the changes propsed by this pull request. -->
Adds more timeout errors to the `mongo.IsTimeout` error helper and updates the according test.

## Background & Motivation
<!--- Rationale for the pull request. -->
`mongo.IsTimeout` is our way of grouping timeout errors; there are some lower level errors that were not included in that helper that would be good to include.
