### PR TITLE
Change CommadFailedEvent.Failure type to error

### DIFF
--- a/event/examples_test.go
+++ b/event/examples_test.go
@@ -34,7 +34,7 @@ func ExampleCommandMonitor() {
 			)
 		},
 		Failed: func(_ context.Context, evt *event.CommandFailedEvent) {
-			log.Printf("Command: %v Failure: %v\n",
+			log.Printf("Command: %v Failure: %e\n",
 				startedCommands[evt.RequestID],
 				evt.Failure,
 			)

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -53,7 +53,7 @@ type CommandSucceededEvent struct {
 // CommandFailedEvent represents an event generated when a command's execution fails.
 type CommandFailedEvent struct {
 	CommandFinishedEvent
-	Failure string
+	Failure error
 }
 
 // CommandMonitor represents a monitor that is triggered for different events.

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -340,7 +340,7 @@ func TestClient(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Setup a client and skip the test based on server version.
 				var started []*event.CommandStartedEvent
-				var failureReasons []string
+				var failureReasons []error
 				cmdMonitor := &event.CommandMonitor{
 					Started: func(_ context.Context, evt *event.CommandStartedEvent) {
 						if evt.CommandName == "endSessions" {
@@ -391,7 +391,7 @@ func TestClient(t *testing.T) {
 				numEventsExpected := int(math.Ceil(divisionResult))
 				assert.Equal(t, len(started), numEventsExpected, "expected %d started events, got %d", numEventsExpected,
 					len(started))
-				assert.Equal(t, len(failureReasons), 0, "endSessions errors: %v", failureReasons)
+				assert.Equal(t, len(failureReasons), 0, "endSessions errors: %e", failureReasons)
 
 				for i := 0; i < numEventsExpected; i++ {
 					sentArray := started[i].Command.Lookup("endSessions").Array()

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -25,8 +25,10 @@ import (
 )
 
 // Security-sensitive commands that should be ignored in command monitoring by default.
-var securitySensitiveCommands = []string{"authenticate", "saslStart", "saslContinue", "getnonce",
-	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb"}
+var securitySensitiveCommands = []string{
+	"authenticate", "saslStart", "saslContinue", "getnonce",
+	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb",
+}
 
 // clientEntity is a wrapper for a mongo.Client object that also holds additional information required during test
 // execution.
@@ -295,7 +297,7 @@ func (c *clientEntity) processFailedEvent(_ context.Context, evt *event.CommandF
 		AppendString("commandName", evt.CommandName).
 		AppendInt64("requestId", evt.RequestID).
 		AppendString("connectionId", evt.ConnectionID).
-		AppendString("failure", evt.Failure)
+		AppendString("failure", evt.Failure.Error())
 	if evt.ServiceID != nil {
 		bsonBuilder.AppendString("serviceId", evt.ServiceID.String())
 	}

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -385,7 +385,7 @@ func stringifyEventsForClient(client *clientEntity) string {
 
 	str.WriteString("\nFailed Events\n\n")
 	for _, evt := range client.failedEvents() {
-		str.WriteString(fmt.Sprintf("[%s] CommandName: %s, Failure: %s\n", evt.ConnectionID, evt.CommandName, evt.Failure))
+		str.WriteString(fmt.Sprintf("[%s] CommandName: %s, Failure: %e\n", evt.ConnectionID, evt.CommandName, evt.Failure))
 	}
 
 	str.WriteString("\nPool Events\n\n")

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -580,7 +580,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		if err == nil {
 			// roundtrip using either the full roundTripper or a special one for when the moreToCome
 			// flag is set
-			var roundTrip = op.roundTrip
+			roundTrip := op.roundTrip
 			if moreToCome {
 				roundTrip = op.moreToComeRoundTrip
 			}
@@ -981,8 +981,8 @@ func (op Operation) createWireMessage(
 	dst []byte,
 	desc description.SelectedServer,
 	maxTimeMS uint64,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	// If topology is not LoadBalanced, API version is not declared, and wire version is unknown
 	// or less than 6, use OP_QUERY. Otherwise, use OP_MSG.
 	if desc.Kind != description.LoadBalanced && op.ServerAPI == nil &&
@@ -1074,8 +1074,8 @@ func (op Operation) createQueryWireMessage(maxTimeMS uint64, dst []byte, desc de
 }
 
 func (op Operation) createMsgWireMessage(ctx context.Context, maxTimeMS uint64, dst []byte, desc description.SelectedServer,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	var info startedInformation
 	var flags wiremessage.MsgFlag
 	var wmindex int32
@@ -1761,7 +1761,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 	}
 
 	failedEvent := &event.CommandFailedEvent{
-		Failure:              info.cmdErr.Error(),
+		Failure:              info.cmdErr,
 		CommandFinishedEvent: finished,
 	}
 	op.CommandMonitor.Failed(ctx, failedEvent)

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -208,7 +208,7 @@ func TestServerConnectionTimeout(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	var serverTestTable = []struct {
+	serverTestTable := []struct {
 		name            string
 		connectionError bool
 		networkError    bool
@@ -769,7 +769,7 @@ func TestServer(t *testing.T) {
 			assert.True(t, ok, "expected type %T, got %T", event.ServerHeartbeatFailedEvent{}, publishedEvents[1])
 			assert.Equal(t, failed.ConnectionID, s.conn.ID(), "expected connectionID to match")
 			assert.False(t, failed.Awaited, "expected awaited to be false")
-			assert.True(t, errors.Is(failed.Failure, readErr), "expected Failure to be %v, got: %v", readErr, failed.Failure)
+			assert.True(t, errors.Is(failed.Failure, readErr), "expected Failure to be %e, got: %e", readErr, failed.Failure)
 		})
 	})
 	t.Run("WithServerAppName", func(t *testing.T) {


### PR DESCRIPTION
\+ gofmt

To get string, `.Error()` can be called on error.

`ServerHeartbeatFailedEvent.Failure` is already of type error.

<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Background & Motivation
I wanted to use `error` value. Couldn't. `ServerHeartbeatFailedEvent.Failure` already uses error.