### PR TITLE
add CommandFinishedEvent to monitor without response copies

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -59,6 +59,7 @@ type CommandFailedEvent struct {
 // CommandMonitor represents a monitor that is triggered for different events.
 type CommandMonitor struct {
 	Started   func(context.Context, *CommandStartedEvent)
+	Finished  func(context.Context, *CommandFinishedEvent)
 	Succeeded func(context.Context, *CommandSucceededEvent)
 	Failed    func(context.Context, *CommandFailedEvent)
 }


### PR DESCRIPTION
## Summary
Add new event for monitoring to subscribe to operation finishes without heavy info about failure or success

## Background & Motivation
In our busy service publishFinishedEvent func does ~100GB of allocations in 2 hours and possesses the 4th place by allocations. AFAIU these allocations are rooted to the copies of server responses which we do not use. How about allowing to subscribe to operation finish event without the details about success or failure?

![image](https://user-images.githubusercontent.com/462800/198020002-16037bf9-ab44-4456-aaa6-a8c813974839.png)


