### PR TITLE
further optimize selectByKind for special case of all fitting servers

### DIFF
--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -304,6 +304,9 @@ func selectByKind(candidates []Server, kind ServerKind) []Server {
 			viableIndexes = append(viableIndexes, i)
 		}
 	}
+	if len(viableIndexes) == len(candidates) {
+		return candidates
+	}
 	result := make([]Server, len(viableIndexes))
 	for i, idx := range viableIndexes {
 		result[i] = candidates[idx]


### PR DESCRIPTION
## Summary
Further optimize selectByKind for the special case of all servers fitting our query kind.

## Background & Motivation
In #1059 by @qingyang-hu selectByKind was already optimized. I added to the benchmark parameter for the percent of applicable servers and without that optimization results are the following:
```
BenchmarkSelector_Sharded
BenchmarkSelector_Sharded/AllFit
BenchmarkSelector_Sharded/AllFit-10         	   75529	     16778 ns/op	  111288 B/op	       9 allocs/op
BenchmarkSelector_Sharded/AllButOneFit
BenchmarkSelector_Sharded/AllButOneFit-10   	   74986	     16482 ns/op	  111288 B/op	       9 allocs/op
BenchmarkSelector_Sharded/HalfFit
BenchmarkSelector_Sharded/HalfFit-10        	  125223	      9684 ns/op	   53944 B/op	       8 allocs/op
BenchmarkSelector_Sharded/OneFit
BenchmarkSelector_Sharded/OneFit-10         	 3367720	       343.1 ns/op	     440 B/op	       2 allocs/op
```

With current code:
```
BenchmarkSelector_Sharded
BenchmarkSelector_Sharded/AllFit
BenchmarkSelector_Sharded/AllFit-10         	  178857	      7063 ns/op	   41880 B/op	       3 allocs/op
BenchmarkSelector_Sharded/AllButOneFit
BenchmarkSelector_Sharded/AllButOneFit-10   	  150439	      7979 ns/op	   41880 B/op	       3 allocs/op
BenchmarkSelector_Sharded/HalfFit
BenchmarkSelector_Sharded/HalfFit-10        	  288954	      3932 ns/op	   21400 B/op	       3 allocs/op
BenchmarkSelector_Sharded/OneFit
BenchmarkSelector_Sharded/OneFit-10         	 1761706	       717.4 ns/op	    1336 B/op	       3 allocs/op
```

And with my suggested optimization (since we believe that it is our case and it is only partially covered with the previous PR)
```
BenchmarkSelector_Sharded
BenchmarkSelector_Sharded/AllFit
BenchmarkSelector_Sharded/AllFit-10         	 2517913	       495.1 ns/op	     920 B/op	       2 allocs/op
BenchmarkSelector_Sharded/AllButOneFit
BenchmarkSelector_Sharded/AllButOneFit-10   	  177531	      6777 ns/op	   41880 B/op	       3 allocs/op
BenchmarkSelector_Sharded/HalfFit
BenchmarkSelector_Sharded/HalfFit-10        	  318038	      5002 ns/op	   21400 B/op	       3 allocs/op
BenchmarkSelector_Sharded/OneFit
BenchmarkSelector_Sharded/OneFit-10         	 1762570	       669.1 ns/op	    1336 B/op	       3 allocs/op
```
