### PR TITLE
GODRIVER-2627 optimize latency selector

### DIFF
--- a/mongo/description/selector_test.go
+++ b/mongo/description/selector_test.go
@@ -230,6 +230,67 @@ func TestSelector_Sharded(t *testing.T) {
 	require.Equal([]Server{s}, result)
 }
 
+func BenchmarkLatencySelector(b *testing.B) {
+	bench := func(b *testing.B, serversHook func(servers []Server)) {
+		s := Server{
+			Addr:              address.Address("localhost:27017"),
+			HeartbeatInterval: time.Duration(10) * time.Second,
+			LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
+			LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
+			Kind:              Mongos,
+			WireVersion:       &VersionRange{Min: 0, Max: 5},
+			AverageRTTSet:     true,
+			AverageRTT:        time.Second,
+		}
+		servers := make([]Server, 100)
+		for i := 0; i < len(servers); i++ {
+			servers[i] = s
+		}
+		serversHook(servers)
+		//this will make base 1 sec latency < min (0.5) + conf (1)
+		//and high latency 2 higher than the threshold
+		servers[99].AverageRTT = 500 * time.Millisecond
+		c := Topology{
+			Kind:    Sharded,
+			Servers: servers,
+		}
+
+		b.ResetTimer()
+		b.RunParallel(func(p *testing.PB) {
+			b.ReportAllocs()
+			for p.Next() {
+				_, _ = LatencySelector(time.Second).SelectServer(c, c.Servers)
+			}
+		})
+	}
+	b.Run("AllFit", func(b *testing.B) {
+		bench(b, func(servers []Server) {
+			//noop
+		})
+	})
+	b.Run("AllButOneFit", func(b *testing.B) {
+		bench(b, func(servers []Server) {
+			servers[0].AverageRTT = 2 * time.Second
+		})
+
+	})
+	b.Run("HalfFit", func(b *testing.B) {
+		bench(b, func(servers []Server) {
+			for i := 0; i < len(servers); i += 2 {
+				servers[i].AverageRTT = 2 * time.Second
+			}
+		})
+	})
+	b.Run("OneFit", func(b *testing.B) {
+		bench(b, func(servers []Server) {
+			for i := 1; i < len(servers); i++ {
+				servers[i].AverageRTT = 2 * time.Second
+			}
+		})
+	})
+
+}
+
 func BenchmarkSelector_Sharded(b *testing.B) {
 	subject := readpref.Primary()
 

--- a/mongo/description/selector_test.go
+++ b/mongo/description/selector_test.go
@@ -236,26 +236,26 @@ func BenchmarkLatencySelector(b *testing.B) {
 		serversHook func(servers []Server)
 	}{
 		{
-			"AllFit",
-			func(servers []Server) {},
+			name:        "AllFit",
+			serversHook: func(servers []Server) {},
 		},
 		{
-			"AllButOneFit",
-			func(servers []Server) {
+			name: "AllButOneFit",
+			serversHook: func(servers []Server) {
 				servers[0].AverageRTT = 2 * time.Second
 			},
 		},
 		{
-			"HalfFit",
-			func(servers []Server) {
+			name: "HalfFit",
+			serversHook: func(servers []Server) {
 				for i := 0; i < len(servers); i += 2 {
 					servers[i].AverageRTT = 2 * time.Second
 				}
 			},
 		},
 		{
-			"OneFit",
-			func(servers []Server) {
+			name: "OneFit",
+			serversHook: func(servers []Server) {
 				for i := 1; i < len(servers); i++ {
 					servers[i].AverageRTT = 2 * time.Second
 				}

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -96,15 +96,21 @@ func (ls *latencySelector) SelectServer(t Topology, candidates []Server) ([]Serv
 
 		max := min + ls.latency
 
-		var result []Server
-		for _, candidate := range candidates {
+		viableIndexes := make([]int, 0, len(candidates))
+		for i, candidate := range candidates {
 			if candidate.AverageRTTSet {
 				if candidate.AverageRTT <= max {
-					result = append(result, candidate)
+					viableIndexes = append(viableIndexes, i)
 				}
 			}
 		}
-
+		if len(viableIndexes) == len(candidates) {
+			return candidates, nil
+		}
+		result := make([]Server, len(viableIndexes))
+		for i, idx := range viableIndexes {
+			result[i] = candidates[idx]
+		}
 		return result, nil
 	}
 }


### PR DESCRIPTION
## Summary
Optimize allocations in latency server selector.

## Background & Motivation
Similar to #1107 i try to optimize allocations in latency server selector. Benchmark provided without changes:
```
BenchmarkLatencySelector
BenchmarkLatencySelector/AllFit
BenchmarkLatencySelector/AllFit-10         	   64196	     17866 ns/op	  111273 B/op	       9 allocs/op
BenchmarkLatencySelector/AllButOneFit
BenchmarkLatencySelector/AllButOneFit-10   	   71056	     17038 ns/op	  111273 B/op	       9 allocs/op
BenchmarkLatencySelector/HalfFit
BenchmarkLatencySelector/HalfFit-10        	  124551	      9748 ns/op	   53928 B/op	       8 allocs/op
BenchmarkLatencySelector/OneFit
BenchmarkLatencySelector/OneFit-10         	 1471053	       825.6 ns/op	    1320 B/op	       3 allocs/op
PASS
```

And with proposed optimization:
```
BenchmarkLatencySelector
BenchmarkLatencySelector/AllFit
BenchmarkLatencySelector/AllFit-10         	 1868062	       686.8 ns/op	     904 B/op	       2 allocs/op
BenchmarkLatencySelector/AllButOneFit
BenchmarkLatencySelector/AllButOneFit-10   	  155904	      7382 ns/op	   41864 B/op	       3 allocs/op
BenchmarkLatencySelector/HalfFit
BenchmarkLatencySelector/HalfFit-10        	  277989	      4409 ns/op	   21384 B/op	       3 allocs/op
BenchmarkLatencySelector/OneFit
BenchmarkLatencySelector/OneFit-10         	 1247785	       966.7 ns/op	    1800 B/op	       3 allocs/op
PASS
```

