### PR TITLE
GODRIVER-2487 No useMultipleMongoses false in findOneAndUpdate errorResponse test.

### DIFF
--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.json
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.json
@@ -4,8 +4,7 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0",
-        "useMultipleMongoses": false
+        "id": "client0"
       }
     },
     {

--- a/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
+++ b/testdata/crud/unified/findOneAndUpdate-errorResponse.yml
@@ -5,7 +5,6 @@ schemaVersion: "1.12"
 createEntities:
   - client:
       id: &client0 client0
-      useMultipleMongoses: false
   - database:
       id: &database0 database0
       client: *client0


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2487

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Removes the `useMultipleMongoses: false` from the `findOneAndUpdate-errorResponse` test.

## Background & Motivation
<!--- Rationale for the pull request. -->
I mistakenly added the field in this [spec commit](https://github.com/mongodb/specifications/commit/9fec9df099d132df047650315411bc0a532f0cef). It's actually not needed as the test does not configure a failpoint 

