### PR TITLE
GODRIVER-2628 optimize allocations in selectServerFromDescription

### DIFF
--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -542,10 +542,19 @@ func (t *Topology) selectServerFromDescription(desc description.Topology,
 		return desc.Servers, nil
 	}
 
-	var allowed []description.Server
-	for _, s := range desc.Servers {
+	allowedIndexes := make([]int, 0, len(desc.Servers))
+	for i, s := range desc.Servers {
 		if s.Kind != description.Unknown {
-			allowed = append(allowed, s)
+			allowedIndexes = append(allowedIndexes, i)
+		}
+	}
+	var allowed []description.Server
+	if len(allowedIndexes) == len(desc.Servers) {
+		allowed = desc.Servers
+	} else {
+		allowed = make([]description.Server, len(allowedIndexes))
+		for i, idx := range allowedIndexes {
+			allowed[i] = desc.Servers[idx]
 		}
 	}
 

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -835,3 +835,60 @@ func serverKindFromString(t *testing.T, s string) description.ServerKind {
 
 	return description.Unknown
 }
+
+func BenchmarkSelectServerFromDescription(b *testing.B) {
+	bench := func(b *testing.B, serversHook func(servers []description.Server)) {
+		s := description.Server{
+			Addr:              address.Address("localhost:27017"),
+			HeartbeatInterval: time.Duration(10) * time.Second,
+			LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
+			LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
+			Kind:              description.Mongos,
+			WireVersion:       &description.VersionRange{Min: 0, Max: 5},
+		}
+		servers := make([]description.Server, 100)
+		for i := 0; i < len(servers); i++ {
+			servers[i] = s
+		}
+		serversHook(servers)
+		desc := description.Topology{
+			Servers: servers,
+		}
+
+		timeout := make(chan time.Time)
+		b.ResetTimer()
+		b.RunParallel(func(p *testing.PB) {
+			b.ReportAllocs()
+			for p.Next() {
+				var c Topology
+				_, _ = c.selectServerFromDescription(desc, newServerSelectionState(selectNone, timeout))
+			}
+		})
+	}
+	b.Run("AllFit", func(b *testing.B) {
+		bench(b, func(servers []description.Server) {
+			//noop
+		})
+	})
+	b.Run("AllButOneFit", func(b *testing.B) {
+		bench(b, func(servers []description.Server) {
+			servers[0].Kind = description.Unknown
+		})
+
+	})
+	b.Run("HalfFit", func(b *testing.B) {
+		bench(b, func(servers []description.Server) {
+			for i := 0; i < len(servers); i += 2 {
+				servers[i].Kind = description.Unknown
+			}
+		})
+	})
+	b.Run("OneFit", func(b *testing.B) {
+		bench(b, func(servers []description.Server) {
+			for i := 1; i < len(servers); i++ {
+				servers[i].Kind = description.Unknown
+			}
+		})
+	})
+
+}

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -842,26 +842,26 @@ func BenchmarkSelectServerFromDescription(b *testing.B) {
 		serversHook func(servers []description.Server)
 	}{
 		{
-			"AllFit",
-			func(servers []description.Server) {},
+			name:        "AllFit",
+			serversHook: func(servers []description.Server) {},
 		},
 		{
-			"AllButOneFit",
-			func(servers []description.Server) {
+			name: "AllButOneFit",
+			serversHook: func(servers []description.Server) {
 				servers[0].Kind = description.Unknown
 			},
 		},
 		{
-			"HalfFit",
-			func(servers []description.Server) {
+			name: "HalfFit",
+			serversHook: func(servers []description.Server) {
 				for i := 0; i < len(servers); i += 2 {
 					servers[i].Kind = description.Unknown
 				}
 			},
 		},
 		{
-			"OneFit",
-			func(servers []description.Server) {
+			name: "OneFit",
+			serversHook: func(servers []description.Server) {
 				for i := 1; i < len(servers); i++ {
 					servers[i].Kind = description.Unknown
 				}

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -837,58 +837,66 @@ func serverKindFromString(t *testing.T, s string) description.ServerKind {
 }
 
 func BenchmarkSelectServerFromDescription(b *testing.B) {
-	bench := func(b *testing.B, serversHook func(servers []description.Server)) {
-		s := description.Server{
-			Addr:              address.Address("localhost:27017"),
-			HeartbeatInterval: time.Duration(10) * time.Second,
-			LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
-			LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
-			Kind:              description.Mongos,
-			WireVersion:       &description.VersionRange{Min: 0, Max: 5},
-		}
-		servers := make([]description.Server, 100)
-		for i := 0; i < len(servers); i++ {
-			servers[i] = s
-		}
-		serversHook(servers)
-		desc := description.Topology{
-			Servers: servers,
-		}
+	for _, bcase := range []struct {
+		name        string
+		serversHook func(servers []description.Server)
+	}{
+		{
+			"AllFit",
+			func(servers []description.Server) {},
+		},
+		{
+			"AllButOneFit",
+			func(servers []description.Server) {
+				servers[0].Kind = description.Unknown
+			},
+		},
+		{
+			"HalfFit",
+			func(servers []description.Server) {
+				for i := 0; i < len(servers); i += 2 {
+					servers[i].Kind = description.Unknown
+				}
+			},
+		},
+		{
+			"OneFit",
+			func(servers []description.Server) {
+				for i := 1; i < len(servers); i++ {
+					servers[i].Kind = description.Unknown
+				}
+			},
+		},
+	} {
+		bcase := bcase
 
-		timeout := make(chan time.Time)
-		b.ResetTimer()
-		b.RunParallel(func(p *testing.PB) {
-			b.ReportAllocs()
-			for p.Next() {
-				var c Topology
-				_, _ = c.selectServerFromDescription(desc, newServerSelectionState(selectNone, timeout))
+		b.Run(bcase.name, func(b *testing.B) {
+			s := description.Server{
+				Addr:              address.Address("localhost:27017"),
+				HeartbeatInterval: time.Duration(10) * time.Second,
+				LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
+				LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
+				Kind:              description.Mongos,
+				WireVersion:       &description.VersionRange{Min: 0, Max: 5},
 			}
+			servers := make([]description.Server, 100)
+			for i := 0; i < len(servers); i++ {
+				servers[i] = s
+			}
+			bcase.serversHook(servers)
+			desc := description.Topology{
+				Servers: servers,
+			}
+
+			timeout := make(chan time.Time)
+			b.ResetTimer()
+			b.RunParallel(func(p *testing.PB) {
+				b.ReportAllocs()
+				for p.Next() {
+					var c Topology
+					_, _ = c.selectServerFromDescription(desc, newServerSelectionState(selectNone, timeout))
+				}
+			})
 		})
 	}
-	b.Run("AllFit", func(b *testing.B) {
-		bench(b, func(servers []description.Server) {
-			//noop
-		})
-	})
-	b.Run("AllButOneFit", func(b *testing.B) {
-		bench(b, func(servers []description.Server) {
-			servers[0].Kind = description.Unknown
-		})
-
-	})
-	b.Run("HalfFit", func(b *testing.B) {
-		bench(b, func(servers []description.Server) {
-			for i := 0; i < len(servers); i += 2 {
-				servers[i].Kind = description.Unknown
-			}
-		})
-	})
-	b.Run("OneFit", func(b *testing.B) {
-		bench(b, func(servers []description.Server) {
-			for i := 1; i < len(servers); i++ {
-				servers[i].Kind = description.Unknown
-			}
-		})
-	})
-
 }


### PR DESCRIPTION
GODRIVER-2628 

## Summary
Optimize allocations in selectServerFromDescription

## Background & Motivation
Same way as in #1108 and #1107 I want to reduce allocations in selectServerFromDescription func which flat allocations in my case are > 100GB and which possess the very first place by flat allocations in my long running job.

Benchmark attached without changes to the code:
```
BenchmarkSelectServerFromDescription
BenchmarkSelectServerFromDescription/AllFit
BenchmarkSelectServerFromDescription/AllFit-10         	   63248	     17195 ns/op	  111265 B/op	       8 allocs/op
BenchmarkSelectServerFromDescription/AllButOneFit
BenchmarkSelectServerFromDescription/AllButOneFit-10   	   65990	     18173 ns/op	  111265 B/op	       8 allocs/op
BenchmarkSelectServerFromDescription/HalfFit
BenchmarkSelectServerFromDescription/HalfFit-10        	  110966	      9053 ns/op	   53920 B/op	       7 allocs/op
BenchmarkSelectServerFromDescription/OneFit
BenchmarkSelectServerFromDescription/OneFit-10         	 3362158	       351.3 ns/op	     416 B/op	       1 allocs/op
PASS
```

And with changes:
```
BenchmarkSelectServerFromDescription
BenchmarkSelectServerFromDescription/AllFit
BenchmarkSelectServerFromDescription/AllFit-10         	 2548441	       480.4 ns/op	     896 B/op	       1 allocs/op
BenchmarkSelectServerFromDescription/AllButOneFit
BenchmarkSelectServerFromDescription/AllButOneFit-10   	  159066	      6740 ns/op	   41856 B/op	       2 allocs/op
BenchmarkSelectServerFromDescription/HalfFit
BenchmarkSelectServerFromDescription/HalfFit-10        	  295821	      3710 ns/op	   21376 B/op	       2 allocs/op
BenchmarkSelectServerFromDescription/OneFit
BenchmarkSelectServerFromDescription/OneFit-10         	 1814713	       639.6 ns/op	    1312 B/op	       2 allocs/op
PASS
```
