### PR TITLE
GODRIVER-2620 Fix hostname parsing for SRV polling.

### DIFF
--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -127,6 +127,7 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 func TestPollingSRVRecordsSpec(t *testing.T) {
 	for _, uri := range []string{
 		"mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
+                // Test with user:pass as a regression test for GODRIVER-2620
 		"mongodb+srv://user:pass@test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
 	} {
 		t.Run(uri, func(t *testing.T) {

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -127,7 +127,7 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 func TestPollingSRVRecordsSpec(t *testing.T) {
 	for _, tt := range srvPollingTests {
 		t.Run(tt.name, func(t *testing.T) {
-			uri := "mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
+			uri := "mongodb+srv://user:pass@test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 			cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 			require.NoError(t, err, "error constructing topology configs: %v", err)
 

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -127,7 +127,7 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 func TestPollingSRVRecordsSpec(t *testing.T) {
 	for _, uri := range []string{
 		"mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
-                // Test with user:pass as a regression test for GODRIVER-2620
+		// Test with user:pass as a regression test for GODRIVER-2620
 		"mongodb+srv://user:pass@test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
 	} {
 		t.Run(uri, func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestPollingSRVRecordsSpec(t *testing.T) {
 }
 
 func testPollingSRVRecordsSpec(t *testing.T, uri string) {
-    t.Helper()
+	t.Helper()
 	for _, tt := range srvPollingTests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -136,6 +136,7 @@ func TestPollingSRVRecordsSpec(t *testing.T) {
 }
 
 func testPollingSRVRecordsSpec(t *testing.T, uri string) {
+    t.Helper()
 	for _, tt := range srvPollingTests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -125,9 +125,19 @@ func compareHosts(t *testing.T, received []description.Server, expected []string
 }
 
 func TestPollingSRVRecordsSpec(t *testing.T) {
+	for _, uri := range []string{
+		"mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
+		"mongodb+srv://user:pass@test1.test.build.10gen.cc/?heartbeatFrequencyMS=100",
+	} {
+		t.Run(uri, func(t *testing.T) {
+			testPollingSRVRecordsSpec(t, uri)
+		})
+	}
+}
+
+func testPollingSRVRecordsSpec(t *testing.T, uri string) {
 	for _, tt := range srvPollingTests {
 		t.Run(tt.name, func(t *testing.T) {
-			uri := "mongodb+srv://user:pass@test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 			cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 			require.NoError(t, err, "error constructing topology configs: %v", err)
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -234,7 +236,22 @@ func (t *Topology) Connect() error {
 
 	t.serversLock.Unlock()
 	if t.pollingRequired {
-		go t.pollSRVRecords()
+		uri, err := url.Parse(t.cfg.URI)
+		if err != nil {
+			return err
+		}
+		// sanity check before passing the hostname to resolver
+		parsedHosts := strings.Split(uri.Host, ",")
+		if len(parsedHosts) != 1 {
+			return fmt.Errorf("URI with SRV must include one and only one hostname")
+		}
+		_, _, err = net.SplitHostPort(parsedHosts[0])
+		if err == nil {
+			// we were able to successfully extract a port from the host,
+			// but should not be able to when using SRV
+			return fmt.Errorf("URI with srv must not include a port number")
+		}
+		go t.pollSRVRecords(parsedHosts[0])
 		t.pollingwg.Add(1)
 	}
 
@@ -556,7 +573,7 @@ func (t *Topology) selectServerFromDescription(desc description.Topology,
 	return suitable, nil
 }
 
-func (t *Topology) pollSRVRecords() {
+func (t *Topology) pollSRVRecords(hosts string) {
 	defer t.pollingwg.Done()
 
 	serverConfig := newServerConfig(t.cfg.ServerOpts...)
@@ -572,13 +589,6 @@ func (t *Topology) pollSRVRecords() {
 			<-t.pollingDone
 		}
 	}()
-
-	// remove the scheme
-	uri := t.cfg.URI[14:]
-	hosts := uri
-	if idx := strings.IndexAny(uri, "/?@"); idx != -1 {
-		hosts = uri[:idx]
-	}
 
 	for {
 		select {

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -241,17 +241,16 @@ func (t *Topology) Connect() error {
 			return err
 		}
 		// sanity check before passing the hostname to resolver
-		parsedHosts := strings.Split(uri.Host, ",")
-		if len(parsedHosts) != 1 {
+		if parsedHosts := strings.Split(uri.Host, ","); len(parsedHosts) != 1 {
 			return fmt.Errorf("URI with SRV must include one and only one hostname")
 		}
-		_, _, err = net.SplitHostPort(parsedHosts[0])
+		_, _, err = net.SplitHostPort(uri.Host)
 		if err == nil {
 			// we were able to successfully extract a port from the host,
 			// but should not be able to when using SRV
 			return fmt.Errorf("URI with srv must not include a port number")
 		}
-		go t.pollSRVRecords(parsedHosts[0])
+		go t.pollSRVRecords(uri.Host)
 		t.pollingwg.Add(1)
 	}
 


### PR DESCRIPTION
[GODRIVER-2620](https://jira.mongodb.org/browse/GODRIVER-2620)

## Summary
Fix hostname parsing for SRV polling.

## Background & Motivation
The original code parses the SRV hostname incorrectly for any URI with a username and password. This PR extracts the hostname from a URI using the `net/url` package instead of manual parsing and finishes all sanity checks before passing the hostname.
However, I couldn't find a decent way to pass the errors from inside the polling out.
