### PR TITLE
GODRIVER-2630 Rename all instances of sessCtx to ctx and reformat Session documentation.

### DIFF
--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -752,8 +752,7 @@ func ExampleClient_StartSession_withTransaction() {
 		context.TODO(),
 		func(ctx mongo.SessionContext) (interface{}, error) {
 			// Use the mongo.SessionContext as the Context parameter for
-			// InsertOne and FindOne so both operations are run under the new
-			// Session.
+			// InsertOne and FindOne so both operations are run in the same transaction
 
 			coll := client.Database("db").Collection("coll")
 			res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -625,16 +625,17 @@ func ExampleWithSession() {
 	err = mongo.WithSession(
 		context.TODO(),
 		sess,
-		func(sessCtx mongo.SessionContext) error {
-			// Use sessCtx as the Context parameter for InsertOne and FindOne so
-			// both operations are run under the new Session.
+		func(ctx mongo.SessionContext) error {
+			// Use the mongo.SessionContext as the Context parameter for
+			// InsertOne and FindOne so both operations are run under the new
+			// Session.
 
 			if err := sess.StartTransaction(); err != nil {
 				return err
 			}
 
 			coll := client.Database("db").Collection("coll")
-			res, err := coll.InsertOne(sessCtx, bson.D{{"x", 1}})
+			res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})
 			if err != nil {
 				// Abort the transaction after an error. Use
 				// context.Background() to ensure that the abort can complete
@@ -646,7 +647,7 @@ func ExampleWithSession() {
 
 			var result bson.M
 			err = coll.FindOne(
-				sessCtx,
+				ctx,
 				bson.D{{"_id", res.InsertedID}},
 			).Decode(result)
 			if err != nil {
@@ -681,28 +682,29 @@ func ExampleClient_UseSessionWithOptions() {
 	err := client.UseSessionWithOptions(
 		context.TODO(),
 		opts,
-		func(sessCtx mongo.SessionContext) error {
-			// Use sessCtx as the Context parameter for InsertOne and FindOne so
-			// both operations are run under the new Session.
+		func(ctx mongo.SessionContext) error {
+			// Use the mongo.SessionContext as the Context parameter for
+			// InsertOne and FindOne so both operations are run under the new
+			// Session.
 
-			if err := sessCtx.StartTransaction(); err != nil {
+			if err := ctx.StartTransaction(); err != nil {
 				return err
 			}
 
 			coll := client.Database("db").Collection("coll")
-			res, err := coll.InsertOne(sessCtx, bson.D{{"x", 1}})
+			res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})
 			if err != nil {
 				// Abort the transaction after an error. Use
 				// context.Background() to ensure that the abort can complete
 				// successfully even if the context passed to mongo.WithSession
 				// is changed to have a timeout.
-				_ = sessCtx.AbortTransaction(context.Background())
+				_ = ctx.AbortTransaction(context.Background())
 				return err
 			}
 
 			var result bson.M
 			err = coll.FindOne(
-				sessCtx,
+				ctx,
 				bson.D{{"_id", res.InsertedID}},
 			).Decode(result)
 			if err != nil {
@@ -710,7 +712,7 @@ func ExampleClient_UseSessionWithOptions() {
 				// context.Background() to ensure that the abort can complete
 				// successfully even if the context passed to mongo.WithSession
 				// is changed to have a timeout.
-				_ = sessCtx.AbortTransaction(context.Background())
+				_ = ctx.AbortTransaction(context.Background())
 				return err
 			}
 			fmt.Println(result)
@@ -718,7 +720,7 @@ func ExampleClient_UseSessionWithOptions() {
 			// Use context.Background() to ensure that the commit can complete
 			// successfully even if the context passed to mongo.WithSession is
 			// changed to have a timeout.
-			return sessCtx.CommitTransaction(context.Background())
+			return ctx.CommitTransaction(context.Background())
 		})
 	if err != nil {
 		log.Fatal(err)
@@ -748,19 +750,20 @@ func ExampleClient_StartSession_withTransaction() {
 		SetReadPreference(readpref.PrimaryPreferred())
 	result, err := sess.WithTransaction(
 		context.TODO(),
-		func(sessCtx mongo.SessionContext) (interface{}, error) {
-			// Use sessCtx as the Context parameter for InsertOne and FindOne so
-			// both operations are run in a transaction.
+		func(ctx mongo.SessionContext) (interface{}, error) {
+			// Use the mongo.SessionContext as the Context parameter for
+			// InsertOne and FindOne so both operations are run under the new
+			// Session.
 
 			coll := client.Database("db").Collection("coll")
-			res, err := coll.InsertOne(sessCtx, bson.D{{"x", 1}})
+			res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})
 			if err != nil {
 				return nil, err
 			}
 
 			var result bson.M
 			err = coll.FindOne(
-				sessCtx,
+				ctx,
 				bson.D{{"_id", res.InsertedID}},
 			).Decode(result)
 			if err != nil {
@@ -784,16 +787,17 @@ func ExampleNewSessionContext() {
 		panic(err)
 	}
 	defer sess.EndSession(context.TODO())
-	sessCtx := mongo.NewSessionContext(context.TODO(), sess)
+	ctx := mongo.NewSessionContext(context.TODO(), sess)
 
-	// Start a transaction and sessCtx as the Context parameter to InsertOne and
-	// FindOne so both operations will be run in the transaction.
+	// Start a transaction and use the mongo.SessionContext as the Context
+	// parameter for InsertOne and FindOne so both operations are run in the
+	// transaction.
 	if err = sess.StartTransaction(); err != nil {
 		panic(err)
 	}
 
 	coll := client.Database("db").Collection("coll")
-	res, err := coll.InsertOne(sessCtx, bson.D{{"x", 1}})
+	res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})
 	if err != nil {
 		// Abort the transaction after an error. Use context.Background() to
 		// ensure that the abort can complete successfully even if the context
@@ -804,7 +808,7 @@ func ExampleNewSessionContext() {
 
 	var result bson.M
 	err = coll.FindOne(
-		sessCtx,
+		ctx,
 		bson.D{{"_id", res.InsertedID}},
 	).Decode(&result)
 	if err != nil {

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -301,10 +301,10 @@ func TestSessions(t *testing.T) {
 			assert.Nil(mt, err, "StartSession error: %v", err)
 			defer sess.EndSession(context.Background())
 
-			sessCtx := mongo.NewSessionContext(context.Background(), sess)
-			assert.Equal(mt, sess.ID(), sessCtx.ID(), "expected Session ID %v, got %v", sess.ID(), sessCtx.ID())
+			ctx := mongo.NewSessionContext(context.Background(), sess)
+			assert.Equal(mt, sess.ID(), ctx.ID(), "expected Session ID %v, got %v", sess.ID(), ctx.ID())
 
-			gotSess := mongo.SessionFromContext(sessCtx)
+			gotSess := mongo.SessionFromContext(ctx)
 			assert.NotNil(mt, gotSess, "expected SessionFromContext to return non-nil value, got nil")
 			assert.Equal(mt, sess.ID(), gotSess.ID(), "expected Session ID %v, got %v", sess.ID(), gotSess.ID())
 		})
@@ -323,8 +323,8 @@ func TestSessions(t *testing.T) {
 				return mongo.NewSessionContext(context.Background(), sess)
 			}
 
-			sessCtx := createSessionContext(mt)
-			sess := mongo.SessionFromContext(sessCtx)
+			ctx := createSessionContext(mt)
+			sess := mongo.SessionFromContext(ctx)
 			assert.NotNil(mt, sess, "expected SessionFromContext to return non-nil value, got nil")
 			defer sess.EndSession(context.Background())
 
@@ -333,14 +333,14 @@ func TestSessions(t *testing.T) {
 
 			numDocs := 2
 			for i := 0; i < numDocs; i++ {
-				_, err = mt.Coll.InsertOne(sessCtx, bson.D{{"x", 1}})
+				_, err = mt.Coll.InsertOne(ctx, bson.D{{"x", 1}})
 				assert.Nil(mt, err, "InsertOne error at index %d: %v", i, err)
 			}
 
 			// Assert that the collection count is 0 before committing and numDocs after. This tests that the InsertOne
 			// calls were actually executed in the transaction because the pre-commit count does not include them.
 			assertCollectionCount(mt, 0)
-			err = sess.CommitTransaction(sessCtx)
+			err = sess.CommitTransaction(ctx)
 			assert.Nil(mt, err, "CommitTransaction error: %v", err)
 			assertCollectionCount(mt, int64(numDocs))
 		})

--- a/mongo/integration/unified/session_operation_execution.go
+++ b/mongo/integration/unified/session_operation_execution.go
@@ -103,7 +103,7 @@ func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan 
 		return fmt.Errorf("error unmarshalling arguments to transactionOptions: %v", err)
 	}
 
-	_, err = sess.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (interface{}, error) {
+	_, err = sess.WithTransaction(ctx, func(mongo.SessionContext) (interface{}, error) {
 		for idx, oper := range operations {
 			if err := oper.execute(ctx, loopDone); err != nil {
 				return nil, fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, err)

--- a/mongo/integration/unified/session_operation_execution.go
+++ b/mongo/integration/unified/session_operation_execution.go
@@ -103,7 +103,7 @@ func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan 
 		return fmt.Errorf("error unmarshalling arguments to transactionOptions: %v", err)
 	}
 
-	_, err = sess.WithTransaction(ctx, func(mongo.SessionContext) (interface{}, error) {
+	_, err = sess.WithTransaction(ctx, func(ctx mongo.SessionContext) (interface{}, error) {
 		for idx, oper := range operations {
 			if err := oper.execute(ctx, loopDone); err != nil {
 				return nil, fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, err)

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -84,53 +84,58 @@ func SessionFromContext(ctx context.Context) Session {
 // https://www.mongodb.com/docs/manual/core/transactions/.
 //
 // Implementations of Session are not safe for concurrent use by multiple goroutines.
-//
-// StartTransaction starts a new transaction, configured with the given options, on this session. This method will
-// return an error if there is already a transaction in-progress for this session.
-//
-// CommitTransaction commits the active transaction for this session. This method will return an error if there is no
-// active transaction for this session or the transaction has been aborted.
-//
-// AbortTransaction aborts the active transaction for this session. This method will return an error if there is no
-// active transaction for this session or the transaction has been committed or aborted.
-//
-// WithTransaction starts a transaction on this session and runs the fn callback. Errors with the
-// TransientTransactionError and UnknownTransactionCommitResult labels are retried for up to 120 seconds. Inside the
-// callback, sessCtx must be used as the Context parameter for any operations that should be part of the transaction. If
-// the ctx parameter already has a Session attached to it, it will be replaced by this session. The fn callback may be
-// run multiple times during WithTransaction due to retry attempts, so it must be idempotent. Non-retryable operation
-// errors or any operation errors that occur after the timeout expires will be returned without retrying. If the
-// callback fails, the driver will call AbortTransaction. Because this method must succeed to ensure that server-side
-// resources are properly cleaned up, context deadlines and cancellations will not be respected during this call. For a
-// usage example, see the Client.StartSession method documentation.
-//
-// ClusterTime, OperationTime, Client, and ID return the session's current cluster time, the session's current operation
-// time, the Client associated with the session, and the ID document associated with the session, respectively. The ID
-// document for a session is in the form {"id": <BSON binary value>}.
-//
-// EndSession method should abort any existing transactions and close the session.
-//
-// AdvanceClusterTime advances the cluster time for a session. This method will return an error if the session has ended.
-//
-// AdvanceOperationTime advances the operation time for a session. This method will return an error if the session has
-// ended.
 type Session interface {
-	// Functions to modify session state.
+	// StartTransaction starts a new transaction, configured with the given options, on this
+	// session. This method returns an error if there is already a transaction in-progress for this
+	// session.
 	StartTransaction(...*options.TransactionOptions) error
+
+	// AbortTransaction aborts the active transaction for this session. This method returns an error
+	// if there is no active transaction for this session or if the transaction has been committed
+	// or aborted.
 	AbortTransaction(context.Context) error
+
+	// CommitTransaction commits the active transaction for this session. This method returns an
+	// error if there is no active transaction for this session or if the transaction has been
+	// aborted.
 	CommitTransaction(context.Context) error
-	WithTransaction(ctx context.Context, fn func(sessCtx SessionContext) (interface{}, error),
+
+	// WithTransaction starts a transaction on this session and runs the fn callback. Errors with
+	// the TransientTransactionError and UnknownTransactionCommitResult labels are retried for up to
+	// 120 seconds. Inside the callback, the SessionContext must be used as the Context parameter
+	// for any operations that should be part of the transaction. If the ctx parameter already has a
+	// Session attached to it, it will be replaced by this session. The fn callback may be run
+	// multiple times during WithTransaction due to retry attempts, so it must be idempotent.
+	// Non-retryable operation errors or any operation errors that occur after the timeout expires
+	// will be returned without retrying. If the callback fails, the driver will call
+	// AbortTransaction. Because this method must succeed to ensure that server-side resources are
+	// properly cleaned up, context deadlines and cancellations will not be respected during this
+	// call. For a usage example, see the Client.StartSession method documentation.
+	WithTransaction(ctx context.Context, fn func(ctx SessionContext) (interface{}, error),
 		opts ...*options.TransactionOptions) (interface{}, error)
+
+	// EndSession aborts any existing transactions and close the session.
 	EndSession(context.Context)
 
-	// Functions to retrieve session properties.
+	// ClusterTime returns the current cluster time document associated with the session.
 	ClusterTime() bson.Raw
+
+	// OperationTime returns the current operation time document associated with the session.
 	OperationTime() *primitive.Timestamp
+
+	// Client the Client associated with the session.
 	Client() *Client
+
+	// ID returns the current ID document associated with the session. The ID document is in the
+	// form {"id": <BSON binary value>}.
 	ID() bson.Raw
 
-	// Functions to modify mutable session properties.
+	// AdvanceClusterTime advances the cluster time for a session. This method returns an error if
+	// the session has ended.
 	AdvanceClusterTime(bson.Raw) error
+
+	// AdvanceOperationTime advances the operation time for a session. This method returns an error
+	// if the session has ended.
 	AdvanceOperationTime(*primitive.Timestamp) error
 
 	session()
@@ -175,7 +180,7 @@ func (s *sessionImpl) EndSession(ctx context.Context) {
 }
 
 // WithTransaction implements the Session interface.
-func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(sessCtx SessionContext) (interface{}, error),
+func (s *sessionImpl) WithTransaction(ctx context.Context, fn func(ctx SessionContext) (interface{}, error),
 	opts ...*options.TransactionOptions) (interface{}, error) {
 	timeout := time.NewTimer(withTransactionTimeout)
 	defer timeout.Stop()


### PR DESCRIPTION
[GODRIVER-2630](https://jira.mongodb.org/browse/GODRIVER-2630)

## Summary
Rename all instances of `sessCtx mongo.SessionContext` to `ctx mongo.SessionContext`.

## Background & Motivation
We currently document in the [Go Driver Code Example Reference](https://docs.google.com/document/d/1FtUKxOaEmdFf4d3HcXAVIGed2awuwIWdkWc0YQIwPvk/edit#) that examples should always use variable name `ctx` for the callback function signatures when using the `mongo.WithSession` and `Session.WithTransaction` functions.

The reason for that guideline is that it helps prevent a common error of using the outer context (i.e. the one from outside the callback func that doesn't contain the session/transaction information) instead of the inner context from the callback func. Naming the variable `ctx` shadows the context from outside the callback func, preventing that error (assuming users are using the common `ctx` context variable name).

However, the Go Driver code, Godocs, and example code still uses the `sessCtx` variable name. Update all `sessCtx` variable names to `ctx` to match the Go Driver Code Example Reference doc.

Also, the `mongo.Session` interface documentation is difficult to read because the docs for every function in the interface are part of the main type documentation. Update the documentation on the `mongo.Session` interface to put the documentation relevant to each function next to the function instead of all together on the `mongo.Session` doc (see an example of that pattern on the [http.ResponseWriter](https://pkg.go.dev/net/http#ResponseWriter) interface).

