### PR TITLE
Add a common issues section for 'authentication failed' errors.

### DIFF
--- a/docs/common-issues.md
+++ b/docs/common-issues.md
@@ -1,5 +1,7 @@
 # Frequently Encountered Issues
 
+These are fixes or information for common issues encountered by Go Driver users. If none of these are helpful, [create a GODRIVER Jira ticket](https://jira.mongodb.org/secure/CreateIssue!default.jspa) and we'll try to troubleshoot your issue!
+
 ## `WriteXXX` can only write while positioned on a Element or Value but is positioned on a TopLevel
 
 The [`bson.Marshal`](https://pkg.go.dev/go.mongodb.org/mongo-driver/bson#Marshal) function requires a parameter that can be decoded into a BSON Document, i.e. a [`primitive.D`](https://github.com/mongodb/mongo-go-driver/blob/master/bson/bson.go#L31). Therefore the error message
@@ -49,4 +51,15 @@ if err := json.Unmarshal(jsonBytes, &m); err != nil {
 fmt.Printf("json: %v\n", m)
 ```
 
+## Authentication Failed
 
+When connecting to a MongoDB deployment with password authentication enabled, if your authentication information or configuration are incorrect, you may encounter an error message like:
+
+> connection() error occurred during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-256": (AuthenticationFailed) Authentication failed.
+
+That error can be caused by a number of issues. The error message intentionally omits the exact authentication failure reason (see the [OWASP Authentication and Error Messages guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#authentication-and-error-messages) for an explanation). Possible causes of the error include:
+- Incorrect password.
+- Incorrect username.
+- Incorrect authentication database (i.e. [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource)).
+
+If you encounter an `AuthenticationFailed` error like the one above, check that the username and password in your [connection string](https://www.mongodb.com/docs/manual/reference/connection-string/) or [SetAuth](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo/options#ClientOptions.SetAuth) call are correct. In most cases, [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource) does not need to be specified unless you are using a non-default authentication database (the default is "admin").


### PR DESCRIPTION
## Summary
A common issue that Go Driver users encounter is an "Authentication Failed" message. Add a section to the common issues doc for troubleshooting "Authentication Failed" errors.

Also add an overview paragraph at the beginning with a description of what's in the common issues doc and a link to create a GODRIVER Jira ticket in case users still need more help.

## Background & Motivation
The error message returned by an authentication failure intentionally omits the exact authentication failure reason (see the [OWASP Authentication and Error Messages guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#authentication-and-error-messages) for an explanation). Because of that, authentication failures can be non-intuitive to troubleshoot. Add a section to the common issues doc to help reduce confusion.

Inspired by feedback in [GODRIVER-2609](https://jira.mongodb.org/browse/GODRIVER-2609).

