### PR TITLE
GODRIVER-2621 use batchtime for fuzz tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2000,7 +2000,6 @@ tasks:
               ./testgcpkms
 
   - name: "test-fuzz"
-    tags: ["test", "fuzz", "daily"]
     commands:
       - func: bootstrap-mongo-orchestration
       - func: run-fuzz-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2000,6 +2000,7 @@ tasks:
               ./testgcpkms
 
   - name: "test-fuzz"
+    tags: ["test", "fuzz", "daily"]
     commands:
       - func: bootstrap-mongo-orchestration
       - func: run-fuzz-tests
@@ -2407,6 +2408,7 @@ buildvariants:
     display_name: "Fuzz ${version} ${os-ssl-40}"
     tasks:
       - name: "test-fuzz"
+        batchtime: 1440 # Run at most once per 24 hours.
 
   - name: testgcpkms-variant
     display_name: "GCP KMS"


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2621

## Summary
Run the fuzz tests on PR CI at most once per 24 hours, instead of periodically.

## Background & Motivation
Periodic Builds  for fuzzing feed into the waterfall every night, which can be noisy. This solution resolves that noise. The periodic build will be removed after this PR is merged.
