### PR TITLE
GODRIVER-2674 use time.Duration instead of durationNanos

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -8,6 +8,7 @@ package event // import "go.mongodb.org/mongo-driver/event"
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -32,10 +33,10 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
-	DurationNanos int64
-	CommandName   string
-	RequestID     int64
-	ConnectionID  string
+	Duration     time.Duration
+	CommandName  string
+	RequestID    int64
+	ConnectionID string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
 	ServerConnectionID *int32
@@ -157,18 +158,18 @@ type ServerHeartbeatStartedEvent struct {
 
 // ServerHeartbeatSucceededEvent is an event generated when the heartbeat succeeds.
 type ServerHeartbeatSucceededEvent struct {
-	DurationNanos int64
-	Reply         description.Server
-	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool   // If this heartbeat was awaitable
+	Duration     time.Duration
+	Reply        description.Server
+	ConnectionID string // The address this heartbeat was sent to with a unique identifier
+	Awaited      bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatFailedEvent is an event generated when the heartbeat fails.
 type ServerHeartbeatFailedEvent struct {
-	DurationNanos int64
-	Failure       error
-	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool   // If this heartbeat was awaitable
+	Duration     time.Duration
+	Failure      error
+	ConnectionID string // The address this heartbeat was sent to with a unique identifier
+	Awaited      bool   // If this heartbeat was awaitable
 }
 
 // ServerMonitor represents a monitor that is triggered for different server events. The client

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -33,10 +33,12 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
-	Duration     time.Duration
-	CommandName  string
-	RequestID    int64
-	ConnectionID string
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	CommandName   string
+	RequestID     int64
+	ConnectionID  string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
 	ServerConnectionID *int32
@@ -158,18 +160,22 @@ type ServerHeartbeatStartedEvent struct {
 
 // ServerHeartbeatSucceededEvent is an event generated when the heartbeat succeeds.
 type ServerHeartbeatSucceededEvent struct {
-	Duration     time.Duration
-	Reply        description.Server
-	ConnectionID string // The address this heartbeat was sent to with a unique identifier
-	Awaited      bool   // If this heartbeat was awaitable
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	Reply         description.Server
+	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatFailedEvent is an event generated when the heartbeat fails.
 type ServerHeartbeatFailedEvent struct {
-	Duration     time.Duration
-	Failure      error
-	ConnectionID string // The address this heartbeat was sent to with a unique identifier
-	Awaited      bool   // If this heartbeat was awaitable
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	Failure       error
+	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerMonitor represents a monitor that is triggered for different server events. The client

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -25,8 +25,10 @@ import (
 )
 
 // Security-sensitive commands that should be ignored in command monitoring by default.
-var securitySensitiveCommands = []string{"authenticate", "saslStart", "saslContinue", "getnonce",
-	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb"}
+var securitySensitiveCommands = []string{
+	"authenticate", "saslStart", "saslContinue", "getnonce",
+	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb",
+}
 
 // clientEntity is a wrapper for a mongo.Client object that also holds additional information required during test
 // execution.
@@ -291,7 +293,7 @@ func (c *clientEntity) processFailedEvent(_ context.Context, evt *event.CommandF
 	bsonBuilder := bsoncore.NewDocumentBuilder().
 		AppendString("name", "CommandFailedEvent").
 		AppendDouble("observedAt", getSecondsSinceEpoch()).
-		AppendInt64("durationNanos", evt.DurationNanos).
+		AppendInt64("duration", int64(evt.Duration)).
 		AppendString("commandName", evt.CommandName).
 		AppendInt64("requestId", evt.RequestID).
 		AppendString("connectionId", evt.ConnectionID).

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -580,7 +580,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		if err == nil {
 			// roundtrip using either the full roundTripper or a special one for when the moreToCome
 			// flag is set
-			var roundTrip = op.roundTrip
+			roundTrip := op.roundTrip
 			if moreToCome {
 				roundTrip = op.moreToComeRoundTrip
 			}
@@ -981,8 +981,8 @@ func (op Operation) createWireMessage(
 	dst []byte,
 	desc description.SelectedServer,
 	maxTimeMS uint64,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	// If topology is not LoadBalanced, API version is not declared, and wire version is unknown
 	// or less than 6, use OP_QUERY. Otherwise, use OP_MSG.
 	if desc.Kind != description.LoadBalanced && op.ServerAPI == nil &&
@@ -1074,8 +1074,8 @@ func (op Operation) createQueryWireMessage(maxTimeMS uint64, dst []byte, desc de
 }
 
 func (op Operation) createMsgWireMessage(ctx context.Context, maxTimeMS uint64, dst []byte, desc description.SelectedServer,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	var info startedInformation
 	var flags wiremessage.MsgFlag
 	var wmindex int32
@@ -1731,17 +1731,17 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		return
 	}
 
-	var durationNanos int64
+	var duration time.Duration
 	var emptyTime time.Time
 	if info.startTime != emptyTime {
-		durationNanos = time.Since(info.startTime).Nanoseconds()
+		duration = time.Since(info.startTime)
 	}
 
 	finished := event.CommandFinishedEvent{
 		CommandName:        info.cmdName,
 		RequestID:          int64(info.requestID),
 		ConnectionID:       info.connID,
-		DurationNanos:      durationNanos,
+		Duration:           duration,
 		ServerConnectionID: info.serverConnID,
 		ServiceID:          info.serviceID,
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1741,6 +1741,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		CommandName:        info.cmdName,
 		RequestID:          int64(info.requestID),
 		ConnectionID:       info.connID,
+		DurationNanos:      duration.Nanoseconds(),
 		Duration:           duration,
 		ServerConnectionID: info.serverConnID,
 		ServiceID:          info.serviceID,

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -906,10 +906,11 @@ func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
 	await bool,
 ) {
 	serverHeartbeatSucceeded := &event.ServerHeartbeatSucceededEvent{
-		Duration:     duration,
-		Reply:        desc,
-		ConnectionID: connectionID,
-		Awaited:      await,
+		DurationNanos: duration.Nanoseconds(),
+		Duration:      duration,
+		Reply:         desc,
+		ConnectionID:  connectionID,
+		Awaited:       await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatSucceeded != nil {
@@ -924,10 +925,11 @@ func (s *Server) publishServerHeartbeatFailedEvent(connectionID string,
 	await bool,
 ) {
 	serverHeartbeatFailed := &event.ServerHeartbeatFailedEvent{
-		Duration:     duration,
-		Failure:      err,
-		ConnectionID: connectionID,
-		Awaited:      await,
+		DurationNanos: duration.Nanoseconds(),
+		Duration:      duration,
+		Failure:       err,
+		ConnectionID:  connectionID,
+		Awaited:       await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatFailed != nil {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -705,7 +705,7 @@ func (s *Server) createBaseOperation(conn driver.Connection) *operation.Hello {
 func (s *Server) check() (description.Server, error) {
 	var descPtr *description.Server
 	var err error
-	var durationNanos int64
+	var duration time.Duration
 
 	// Create a new connection if this is the first check, the connection was closed after an error during the previous
 	// check, or the previous check was cancelled.
@@ -760,19 +760,19 @@ func (s *Server) check() (description.Server, error) {
 			s.conn.setSocketTimeout(s.cfg.heartbeatTimeout)
 			err = baseOperation.Execute(s.heartbeatCtx)
 		}
-		durationNanos = time.Since(start).Nanoseconds()
+		duration = time.Since(start)
 
 		if err == nil {
 			tempDesc := baseOperation.Result(s.address)
 			descPtr = &tempDesc
-			s.publishServerHeartbeatSucceededEvent(s.conn.ID(), durationNanos, tempDesc, s.conn.getCurrentlyStreaming() || streamable)
+			s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, tempDesc, s.conn.getCurrentlyStreaming() || streamable)
 		} else {
 			// Close the connection here rather than below so we ensure we're not closing a connection that wasn't
 			// successfully created.
 			if s.conn != nil {
 				_ = s.conn.close()
 			}
-			s.publishServerHeartbeatFailedEvent(s.conn.ID(), durationNanos, err, s.conn.getCurrentlyStreaming() || streamable)
+			s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, s.conn.getCurrentlyStreaming() || streamable)
 		}
 	}
 
@@ -901,14 +901,15 @@ func (s *Server) publishServerHeartbeatStartedEvent(connectionID string, await b
 
 // publishes a ServerHeartbeatSucceededEvent to indicate hello has succeeded
 func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
-	durationNanos int64,
+	duration time.Duration,
 	desc description.Server,
-	await bool) {
+	await bool,
+) {
 	serverHeartbeatSucceeded := &event.ServerHeartbeatSucceededEvent{
-		DurationNanos: durationNanos,
-		Reply:         desc,
-		ConnectionID:  connectionID,
-		Awaited:       await,
+		Duration:     duration,
+		Reply:        desc,
+		ConnectionID: connectionID,
+		Awaited:      await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatSucceeded != nil {
@@ -918,14 +919,15 @@ func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
 
 // publishes a ServerHeartbeatFailedEvent to indicate hello has failed
 func (s *Server) publishServerHeartbeatFailedEvent(connectionID string,
-	durationNanos int64,
+	duration time.Duration,
 	err error,
-	await bool) {
+	await bool,
+) {
 	serverHeartbeatFailed := &event.ServerHeartbeatFailedEvent{
-		DurationNanos: durationNanos,
-		Failure:       err,
-		ConnectionID:  connectionID,
-		Awaited:       await,
+		Duration:     duration,
+		Failure:      err,
+		ConnectionID: connectionID,
+		Awaited:      await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatFailed != nil {


### PR DESCRIPTION
Same as #1105

```
OK make fmt
OK make lint
make test: go.mongodb.org/mongo-driver/mongo/integration/unified: no such command: 'configureFailPoint'
(make test fails on master with same result)
make test-race: same result as make test
```