### PR TITLE
GODRIVER-2333 Assert that Ping op succeeds  initial DNS spec tests

### DIFF
--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -67,7 +67,7 @@ func runSeedlistDiscoveryDirectory(mt *mtest.T, subdirectory string) {
 	}
 }
 
-// runSeedListDiscoverPingTest will create a new connection using the test URI and ping the server.
+// runSeedListDiscoverPingTest will create a new connection using the test URI and attempt to "ping" the server.
 func runSeedListDiscoveryPingTest(mt *mtest.T, tcase seedlistTest) {
 	mt.Parallel()
 
@@ -267,6 +267,13 @@ func getServerByAddress(address string, topo *topology.Topology) (description.Se
 	selectedServer, err := topo.SelectServer(context.Background(), selectByName)
 	if err != nil {
 		return description.Server{}, err
+	}
+
+	// If the selected server is a topology.SelectedServer, then we can get the description without creating a
+	// connect pool.
+	topologySelectedServer, ok := selectedServer.(*topology.SelectedServer)
+	if ok {
+		return topologySelectedServer.Description().Server, nil
 	}
 
 	selectedServerConnection, err := selectedServer.Connection(context.Background())

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -40,7 +40,7 @@ type seedlistTest struct {
 	NumHosts *int     `bson:"numHosts"`
 	Error    bool     `bson:"error"`
 	Options  bson.Raw `bson:"options"`
-	Ping     bool     `bson:"ping"`
+	Ping     *bool    `bson:"ping"`
 }
 
 func TestInitialDNSSeedlistDiscoverySpec(t *testing.T) {
@@ -73,8 +73,8 @@ func runSeedlistDiscoveryDirectory(mt *mtest.T, subdirectory string) {
 	}
 }
 
-// runSeedListDiscoverPingTest will create a new connection using the test URI and attempt to "ping" the server.
-func runSeedListDiscoveryPingTest(mt *mtest.T, clientOpts *options.ClientOptions) {
+// runSeedlistDiscoveryPingTest will create a new connection using the test URI and attempt to "ping" the server.
+func runSeedlistDiscoveryPingTest(mt *mtest.T, clientOpts *options.ClientOptions) {
 	ctx := context.Background()
 
 	client, err := mongo.Connect(ctx, clientOpts)
@@ -160,8 +160,8 @@ func runSeedlistDiscoveryTest(mt *mtest.T, file string) {
 		assert.Nil(mt, err, "error finding host %q: %v", host, err)
 	}
 
-	if test.Ping {
-		runSeedListDiscoveryPingTest(mt, opts)
+	if ping := test.Ping; ping == nil || *ping {
+		runSeedlistDiscoveryPingTest(mt, opts)
 	}
 }
 

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
@@ -11,3 +11,4 @@ options:
     loadBalanced: true
     ssl: true
     directConnection: false
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
@@ -9,5 +9,6 @@
   "options": {
     "loadBalanced": true,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: true
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/testdata/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
@@ -4,12 +4,11 @@
     "localhost.test.build.10gen.cc:27017"
   ],
   "hosts": [
-    "localhost:27017",
-    "localhost:27018",
-    "localhost:27019"
+    "mongo-rs-ssl1:27017"
   ],
   "options": {
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
@@ -4,7 +4,9 @@
     "localhost.test.build.10gen.cc:27017"
   ],
   "hosts": [
-    "mongo-rs-ssl1:27017"
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
   ],
   "options": {
     "ssl": true,

--- a/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/direct-connection-false.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     ssl: true
     directConnection: false
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -1,0 +1,22 @@
+{
+  "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "user": "b*b@f3tt=",
+    "password": "$4to@L8=MC",
+    "db": "mydb?"
+  },
+  "ping": false,
+  "comment": "Encoded user, pass, and DB parse correctly"
+}

--- a/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -1,22 +1,22 @@
 {
-   "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
-   "seeds": [
-     "localhost.test.build.10gen.cc:27017"
-   ],
-   "hosts": [
-     "localhost:27017",
-     "localhost:27018",
-     "localhost:27019"
-   ],
-   "options": {
-     "replicaSet": "repl0",
-     "ssl": true
-   },
-   "parsed_options": {
-     "user": "b*b@f3tt=",
-     "password": "$4to@L8=MC",
-     "db": "mydb?"
-   },
-   "ping": true,
-   "comment": "Encoded user, pass, and DB parse correctly"
- }
+  "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "user": "b*b@f3tt=",
+    "password": "$4to@L8=MC",
+    "db": "mydb?"
+  },
+  "ping": false,
+  "comment": "Encoded user, pass, and DB parse correctly"
+}

--- a/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -1,22 +1,22 @@
 {
-  "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
-  "seeds": [
-    "localhost.test.build.10gen.cc:27017"
-  ],
-  "hosts": [
-    "localhost:27017",
-    "localhost:27018",
-    "localhost:27019"
-  ],
-  "options": {
-    "replicaSet": "repl0",
-    "ssl": true
-  },
-  "parsed_options": {
-    "user": "b*b@f3tt=",
-    "password": "$4to@L8=MC",
-    "db": "mydb?"
-  },
-  "ping": false,
-  "comment": "Encoded user, pass, and DB parse correctly"
-}
+   "uri": "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0",
+   "seeds": [
+     "localhost.test.build.10gen.cc:27017"
+   ],
+   "hosts": [
+     "localhost:27017",
+     "localhost:27018",
+     "localhost:27019"
+   ],
+   "options": {
+     "replicaSet": "repl0",
+     "ssl": true
+   },
+   "parsed_options": {
+     "user": "b*b@f3tt=",
+     "password": "$4to@L8=MC",
+     "db": "mydb?"
+   },
+   "ping": true,
+   "comment": "Encoded user, pass, and DB parse correctly"
+ }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
@@ -1,0 +1,19 @@
+uri: "mongodb+srv://b*b%40f3tt%3D:%244to%40L8%3DMC@test3.test.build.10gen.cc/mydb%3F?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
+parsed_options:
+    user: "b*b@f3tt="
+    password: "$4to@L8=MC"
+    db: "mydb?"
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
+comment: Encoded user, pass, and DB parse correctly

--- a/testdata/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.json
@@ -11,5 +11,6 @@
   "options": {
     "loadBalanced": false,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: false
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "ssl": true
   },
+  "ping": true,
   "comment": "Is correct, as returned host name shared the URI root \"test.build.10gen.cc\"."
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.yml
@@ -8,4 +8,5 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true
 comment: Is correct, as returned host name shared the URI root "test.build.10gen.cc".

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-result-default-port.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-result-default-port.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-result-default-port.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-result-default-port.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/one-txt-record.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -12,5 +12,6 @@
   "options": {
     "ssl": true,
     "srvServiceName": "customname"
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     ssl: true
     srvServiceName: "customname"
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -13,5 +13,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
@@ -14,3 +14,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -9,5 +9,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -13,5 +13,6 @@
     "replicaSet": "repl0",
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/two-results-default-port.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/two-results-default-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/two-results-default-port.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/two-results-default-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": false
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: false
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "otherDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: otherDB
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.json
@@ -15,5 +15,6 @@
   },
   "parsed_options": {
     "auth_database": "adminDB"
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.yml
@@ -11,3 +11,4 @@ options:
     ssl: true
 parsed_options:
     auth_database: adminDB
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0",
+  "uri": "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
     "localhost.test.build.10gen.cc:27017",
     "localhost.test.build.10gen.cc:27018"
@@ -11,8 +11,12 @@
   ],
   "options": {
     "replicaSet": "repl0",
-    "srvMaxHosts": 0,
     "ssl": true
   },
-  "ping": true
+  "parsed_options": {
+    "user": "auser",
+    "password": "apass"
+  },
+  "ping": false,
+  "comment": "Should preserve auth credentials"
 }

--- a/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
@@ -1,0 +1,19 @@
+uri: "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
+parsed_options:
+    user: auser
+    password: apass
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
+comment: Should preserve auth credentials

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
@@ -11,3 +11,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
@@ -10,3 +10,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
@@ -5,5 +5,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
@@ -8,3 +8,4 @@ numHosts: 1
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -151,7 +151,6 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 	}
 
 	// Auth & Database & Password & Username
-	//  cs.Username != "" || cs.AuthMechanism == auth.MongoDBX509 || cs.AuthMechanism == auth.GSSAPI
 	if authenticatable(co.Auth) {
 		cred := &auth.Cred{
 			Username:    co.Auth.Username,


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2333

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Sync [mongo/specifications b2e35cb](             https://github.com/mongodb/specifications/tree/b2e35cb9e19ddb5bbfaea46d3126c3571819fdb2/source/initial-dns-seedlist-discovery/tests) to 

> Run a "ping" operation unless ping is false or error is true.

## Background & Motivation
This addition will potentially expose spec test misconfigurations by running an operation on the server defined by the test connection string, rather than simply listing hosts.
