### PR TITLE
GODRIVER-2655 optimize ObjectIDFromHex a bit

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -82,13 +82,11 @@ func ObjectIDFromHex(s string) (ObjectID, error) {
 		return NilObjectID, ErrInvalidHex
 	}
 
-	b, err := hex.DecodeString(s)
+	var oid [12]byte
+	_, err := hex.Decode(oid[:], []byte(s))
 	if err != nil {
 		return NilObjectID, err
 	}
-
-	var oid [12]byte
-	copy(oid[:], b)
 
 	return oid, nil
 }

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -35,6 +35,13 @@ func BenchmarkHex(b *testing.B) {
 	}
 }
 
+func BenchmarkObjectIDFromHex(b *testing.B) {
+	id := NewObjectID().Hex()
+	for i := 0; i < b.N; i++ {
+		_, _ = ObjectIDFromHex(id)
+	}
+}
+
 func TestFromHex_RoundTrip(t *testing.T) {
 	before := NewObjectID()
 	after, err := ObjectIDFromHex(before.Hex())


### PR DESCRIPTION

## Summary
Similar to #1062 use Decode instead of DecodeString to reduce work done just a bit.

## Background & Motivation
Benchmark attached for current and new implementations gives the following results on my machine
```
BenchmarkObjectIDFromHex
BenchmarkObjectIDFromHex-10       	61378326	        19.35 ns/op
BenchmarkObjectIDFromHexNew
BenchmarkObjectIDFromHexNew-10    	66876584	        17.97 ns/op
```
It seems that string allocation is not happening in the current implementation as well, but there is a small improvement (not sure wether worth it to bother with the change at all)