### PR TITLE
GODRIVER-2649 Add TODOs for passing readConcern correctly for RunCommand.

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -173,6 +173,10 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	default:
 		op = operation.NewCommand(runCmdDoc)
 	}
+
+	// TODO(GODRIVER-2649): ReadConcern(db.readConcern) will not actually pass the database's
+	// read concern. Remove this note once readConcern is correctly passed to the operation
+	// level.
 	return op.Session(sess).CommandMonitor(db.client.monitor).
 		ServerSelector(readSelect).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).ReadConcern(db.readConcern).

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -77,7 +77,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		return errors.New("the Command operation must have a Deployment set before Execute can be called")
 	}
 
-	// TODO(GODRIVER-2469): Actually pass readConcern to underlying driver.Operation.
+	// TODO(GODRIVER-2649): Actually pass readConcern to underlying driver.Operation.
 	return driver.Operation{
 		CommandFn: func(dst []byte, desc description.SelectedServer) ([]byte, error) {
 			return append(dst, c.command[4:len(c.command)-1]...), nil

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -77,6 +77,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		return errors.New("the Command operation must have a Deployment set before Execute can be called")
 	}
 
+	// TODO(GODRIVER-2469): Actually pass readConcern to underlying driver.Operation.
 	return driver.Operation{
 		CommandFn: func(dst []byte, desc description.SelectedServer) ([]byte, error) {
 			return append(dst, c.command[4:len(c.command)-1]...), nil


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2649

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Adds a TODO to reference backward-breaking change GODRIVER-2649.

## Background & Motivation
<!--- Rationale for the pull request. -->
`readConcern` is not being passed from `command.go` down to the underlying `driver.Operation`. This means calling `ReadConcern` on a `Command` as we do in `database.go` [here](https://github.com/mongodb/mongo-go-driver/blob/master/mongo/database.go#L178) is a noop.

