### PR TITLE
GODRIVER-2653 Improve reliability of the CSOT server selection prose tests by increasing timeouts.

### DIFF
--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -85,52 +85,60 @@ func TestCSOTProse(t *testing.T) {
 			"insert", "expected a second insert event, got %v", started[1].CommandName)
 	})
 	mt.Run("8. server selection", func(mt *mtest.T) {
-		cliOpts := options.Client().ApplyURI("mongodb://invalid/?serverSelectionTimeoutMS=10")
+		cliOpts := options.Client().ApplyURI("mongodb://invalid/?serverSelectionTimeoutMS=100")
 		mtOpts := mtest.NewOptions().ClientOptions(cliOpts).CreateCollection(false)
 		mt.RunOpts("serverSelectionTimeoutMS honored if timeoutMS is not set", mtOpts, func(mt *mtest.T) {
+			mt.Parallel()
+
 			callback := func(ctx context.Context) {
 				err := mt.Client.Ping(ctx, nil)
 				assert.NotNil(mt, err, "expected Ping error, got nil")
 			}
 
-			// Assert that Ping fails within 15ms due to server selection timeout.
-			assert.Soon(mt, callback, 15*time.Millisecond)
+			// Assert that Ping fails within 150ms due to server selection timeout.
+			assert.Soon(mt, callback, 150*time.Millisecond)
 		})
 
-		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=10&serverSelectionTimeoutMS=20")
+		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=100&serverSelectionTimeoutMS=200")
 		mtOpts = mtest.NewOptions().ClientOptions(cliOpts).CreateCollection(false)
 		mt.RunOpts("timeoutMS honored for server selection if it's lower than serverSelectionTimeoutMS", mtOpts, func(mt *mtest.T) {
+			mt.Parallel()
+
 			callback := func(ctx context.Context) {
 				err := mt.Client.Ping(ctx, nil)
 				assert.NotNil(mt, err, "expected Ping error, got nil")
 			}
 
-			// Assert that Ping fails within 15ms due to timeout.
-			assert.Soon(mt, callback, 15*time.Millisecond)
+			// Assert that Ping fails within 150ms due to timeout.
+			assert.Soon(mt, callback, 150*time.Millisecond)
 		})
 
-		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=20&serverSelectionTimeoutMS=10")
+		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=200&serverSelectionTimeoutMS=100")
 		mtOpts = mtest.NewOptions().ClientOptions(cliOpts).CreateCollection(false)
 		mt.RunOpts("serverSelectionTimeoutMS honored for server selection if it's lower than timeoutMS", mtOpts, func(mt *mtest.T) {
+			mt.Parallel()
+
 			callback := func(ctx context.Context) {
 				err := mt.Client.Ping(ctx, nil)
 				assert.NotNil(mt, err, "expected Ping error, got nil")
 			}
 
-			// Assert that Ping fails within 15ms due to server selection timeout.
-			assert.Soon(mt, callback, 15*time.Millisecond)
+			// Assert that Ping fails within 150ms due to server selection timeout.
+			assert.Soon(mt, callback, 150*time.Millisecond)
 		})
 
-		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=0&serverSelectionTimeoutMS=10")
+		cliOpts = options.Client().ApplyURI("mongodb://invalid/?timeoutMS=0&serverSelectionTimeoutMS=100")
 		mtOpts = mtest.NewOptions().ClientOptions(cliOpts).CreateCollection(false)
 		mt.RunOpts("serverSelectionTimeoutMS honored for server selection if timeoutMS=0", mtOpts, func(mt *mtest.T) {
+			mt.Parallel()
+
 			callback := func(ctx context.Context) {
 				err := mt.Client.Ping(ctx, nil)
 				assert.NotNil(mt, err, "expected Ping error, got nil")
 			}
 
-			// Assert that Ping fails within 15ms due to server selection timeout.
-			assert.Soon(mt, callback, 15*time.Millisecond)
+			// Assert that Ping fails within 150ms due to server selection timeout.
+			assert.Soon(mt, callback, 150*time.Millisecond)
 		})
 	})
 }


### PR DESCRIPTION
[GODRIVER-2653](https://jira.mongodb.org/browse/GODRIVER-2653)

## Summary
Increase the timeouts and expected operation durations used in the CSOT server selection prose tests by 10x.

## Background & Motivation
The [CSOT server selection prose tests](https://github.com/mongodb/specifications/blob/02c6e3fa7dbc3a64e5312ef820e0f1779069cadb/source/client-side-operations-timeout/tests/README.rst#server-selection) implemented in the Go Driver frequently fail on macOS due to too strict timing requirements. Increase the timeouts to increase the reliability of the tests.