### PR TITLE
GODRIVER-2643 update virtual environment source

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -140,15 +140,7 @@ functions:
              export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install/mongo-c-driver/lib/pkgconfig
              export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
              export PATH="$PATH"
-
           EOT
-
-          # Check if the DRIVERS_TOOLS directory exists, if it does then run the evergreen setup scripts to export the
-          # PYTHON3_BINARY environment variable.
-          if [ -d "$DRIVERS_TOOLS" ]; then
-            . $DRIVERS_TOOLS/.evergreen/utils.sh
-            . $DRIVERS_TOOLS/.evergreen/find-python3.sh
-          fi
 
           # See what we variables we've set.
           cat expansion.yml
@@ -490,8 +482,6 @@ functions:
           export CSFLE_TLS_CA_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/ca-ec.pem"
           export CSFLE_TLS_CERTIFICATE_KEY_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/client-ec.pem"
 
-          # Check if the DRIVERS_TOOLS directory exists, if it does then run the evergreen setup scripts to export the
-          # PYTHON3_BINARY environment variable.
           . $DRIVERS_TOOLS/.evergreen/utils.sh
           . $DRIVERS_TOOLS/.evergreen/find-python3.sh
 
@@ -623,9 +613,18 @@ functions:
   run-valid-ocsp-server:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          find_python3 -m venv ./venv
+          . ./activate-ocspvenv.sh
+
+          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+
+          export PYTHON="$(find_python3)" # Uniform python lookup utility.
+          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+
+          $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -642,9 +641,18 @@ functions:
   run-revoked-ocsp-server:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          find_python3 -m venv ./venv
+          . ./activate-ocspvenv.sh
+
+          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+
+          export PYTHON="$(find_python3)" # Uniform python lookup utility.
+          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+
+          $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -663,9 +671,18 @@ functions:
   run-valid-delegate-ocsp-server:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          find_python3 -m venv ./venv
+          . ./activate-ocspvenv.sh
+
+          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+
+          export PYTHON="$(find_python3)" # Uniform python lookup utility.
+          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+
+          $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -682,9 +699,18 @@ functions:
   run-revoked-delegate-ocsp-server:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          find_python3 -m venv ./venv
+          . ./activate-ocspvenv.sh
+
+          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+
+          export PYTHON="$(find_python3)" # Uniform python lookup utility.
+          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+
+          $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -2163,8 +2189,6 @@ axes:
         run_on: ubuntu1804-test
         variables:
           GO_DIST: "/opt/golang/go1.18"
-            #PYTHON3_BINARY: "$(find_python3)"
-            #PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
@@ -2210,10 +2234,15 @@ task_groups:
               exit 1
             fi
 
+            . $DRIVERS_TOOLS/.evergreen/utils.sh
+            . $DRIVERS_TOOLS/.evergreen/find-python3.sh
+
+            export PYTHON="$(find_python3)" # Uniform python lookup utility.
+
             # Download the enterprise server download for current platform to $MONGODB_BINARIES.
             # This is required for tests that need mongocryptd.
             # $MONGODB_BINARIES is added to the $PATH in fetch-source.
-            find_python3 $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            $PYTHON $DRIVERS_TOOLS/.evergreen/mongodl.py \
                 --component archive \
                 --version ${SERVERLESS_MONGODB_VERSION} \
                 --edition enterprise \
@@ -2221,7 +2250,7 @@ task_groups:
                 --strip-path-components 2
 
             # Download the crypt_shared dynamic library for the current platform.
-            find_python3 $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            $PYTHON $DRIVERS_TOOLS/.evergreen/mongodl.py \
               --component crypt_shared \
               --version ${SERVERLESS_MONGODB_VERSION} \
               --edition enterprise \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -141,7 +141,6 @@ functions:
              export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
              export PATH="$PATH"
           EOT
-
           # See what we variables we've set.
           cat expansion.yml
     # Load the expansion file to make an evergreen variable with the current unique version

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -934,6 +934,7 @@ functions:
   start-kms-mock-server:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
@@ -949,6 +950,7 @@ functions:
   start-kms-mock-server-require-client-cert:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2221,7 +2221,7 @@ task_groups:
                 --strip-path-components 2
 
             # Download the crypt_shared dynamic library for the current platform.
-             $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            find_python3 $DRIVERS_TOOLS/.evergreen/mongodl.py \
               --component crypt_shared \
               --version ${SERVERLESS_MONGODB_VERSION} \
               --edition enterprise \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,7 +175,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         shell: "bash"
         script: |
-          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/venv-utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
           export PYTHON3_BINARY="$(find_python3)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -978,7 +978,6 @@ functions:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-
           if [ "Windows_NT" = "$OS" ]; then
             kmstlsvenv/Scripts/python.exe -u kms_kmip_server.py \
               --port 5698 \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -733,7 +733,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
           mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -763,7 +763,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
           mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -803,7 +803,7 @@ functions:
             exit 0
           fi
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
           mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -891,7 +891,7 @@ functions:
           cp ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
           cd $AUTH_AWS_DIR
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
           cat <<EOF > setup.js
             const mongo_binaries = "$MONGODB_BINARIES";
             const project_dir = "$ECS_SRC_DIR";
@@ -906,7 +906,7 @@ functions:
           ${PREPARE_SHELL}
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
     - command: shell.exec
       params:
         background: true
@@ -921,7 +921,7 @@ functions:
           ${PREPARE_SHELL}
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          . ./activate_venv.sh
+          . ./activate-kmstlsvenv.sh
     - command: shell.exec
       params:
         background: true
@@ -932,22 +932,18 @@ functions:
   start-cse-servers:
     - command: shell.exec
       params:
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-
-          # only run this if virtualenv is installed
-          if ${PYTHON3_BINARY} -m venv ./venv; then
-            . ./activate_venv.sh
-          else
-            echo "Python module venv not found, skipping virtual environment setup..."
-          fi
+          . ./activate-kmstlsvenv.sh
     - command: shell.exec
       params:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
+
           if [ "Windows_NT" = "$OS" ]; then
             kmstlsvenv/Scripts/python.exe -u kms_kmip_server.py \
               --port 5698 \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -35,6 +35,7 @@ functions:
     - command: shell.exec
       params:
         working_dir: src/go.mongodb.org/mongo-driver
+        shell: "bash"
         script: |
           # Get the current unique version of this checkout.
           if [ "${is_patch}" = "true" ]; then
@@ -170,6 +171,22 @@ functions:
           # initialize submodules
           git submodule init
           git submodule update
+    - command: shell.exec
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        shell: "bash"
+        script: |
+          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
+          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+
+          export PYTHON3_BINARY="$(find_python3)"
+          venvcreate "$PYTHON3_BINARY" venv
+
+          echo "PYTHON3_BINARY: $PYTHON3_BINARY" >>expansion.yml
+    # Load the expansion file to make an evergreen variable with the current unique version
+    - command: expansions.update
+      params:
+        file: src/go.mongodb.org/mongo-driver/expansion.yml
 
   install-linters:
     - command: shell.exec
@@ -482,13 +499,7 @@ functions:
           export CSFLE_TLS_CA_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/ca-ec.pem"
           export CSFLE_TLS_CERTIFICATE_KEY_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/client-ec.pem"
 
-          . $DRIVERS_TOOLS/.evergreen/utils.sh
-          . $DRIVERS_TOOLS/.evergreen/find-python3.sh
-
-          export PYTHON="$(find_python3)"
-          venvcreate "$PYTHON" venv
-
-          $PYTHON -m venv ./venv
+          ${PYTHON3_BINARY} -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install boto3
 
           # Set the PYTHON environment variable to point to the active python3 binary. This is used by the
@@ -585,6 +596,7 @@ functions:
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         add_expansions_to_env: true
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
@@ -595,7 +607,7 @@ functions:
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
           MAKEFILE_TARGET=evg-test-serverless \
-            sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+            . ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   run-atlas-data-lake-test:
     - command: shell.exec
@@ -618,13 +630,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
-          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
-
-          export PYTHON="$(find_python3)"
-          venvcreate "$PYTHON" venv
-
-          $PYTHON -m venv ./venv
+          ${PYTHON3_BINARY} -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -646,13 +652,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
-          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
-
-          export PYTHON="$(find_python3)"
-          venvcreate "$PYTHON" venv
-
-          $PYTHON -m venv ./venv
+          ${PYTHON3_BINARY} -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -676,13 +676,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
-          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
-
-          export PYTHON="$(find_python3)"
-          venvcreate "$PYTHON" venv
-
-          $PYTHON -m venv ./venv
+          ${PYTHON3_BINARY} -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -704,13 +698,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          . ${DRIVERS_TOOLS}/.evergreen/utils.sh
-          . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
-
-          export PYTHON="$(find_python3)"
-          venvcreate "$PYTHON" venv
-
-          $PYTHON -m venv ./venv
+          ${PYTHON3_BINARY} -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -2225,15 +2213,10 @@ task_groups:
               exit 1
             fi
 
-            . $DRIVERS_TOOLS/.evergreen/utils.sh
-            . $DRIVERS_TOOLS/.evergreen/find-python3.sh
-
-            export PYTHON="$(find_python3)"
-
             # Download the enterprise server download for current platform to $MONGODB_BINARIES.
             # This is required for tests that need mongocryptd.
             # $MONGODB_BINARIES is added to the $PATH in fetch-source.
-            $PYTHON $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
                 --component archive \
                 --version ${SERVERLESS_MONGODB_VERSION} \
                 --edition enterprise \
@@ -2241,7 +2224,7 @@ task_groups:
                 --strip-path-components 2
 
             # Download the crypt_shared dynamic library for the current platform.
-            $PYTHON $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
               --component crypt_shared \
               --version ${SERVERLESS_MONGODB_VERSION} \
               --edition enterprise \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -140,7 +140,16 @@ functions:
              export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install/mongo-c-driver/lib/pkgconfig
              export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
              export PATH="$PATH"
+
           EOT
+
+          # Check if the DRIVERS_TOOLS directory exists, if it does then run the evergreen setup scripts to export the
+          # PYTHON3_BINARY environment variable.
+          if [ -d "$DRIVERS_TOOLS" ]; then
+            . $DRIVERS_TOOLS/.evergreen/utils.sh
+            . $DRIVERS_TOOLS/.evergreen/find-python3.sh
+          fi
+
           # See what we variables we've set.
           cat expansion.yml
     # Load the expansion file to make an evergreen variable with the current unique version
@@ -468,6 +477,7 @@ functions:
       type: test
       params:
         working_dir: src/go.mongodb.org/mongo-driver
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
@@ -480,7 +490,15 @@ functions:
           export CSFLE_TLS_CA_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/ca-ec.pem"
           export CSFLE_TLS_CERTIFICATE_KEY_FILE="$PROJECT_DIRECTORY/testdata/kmip-certs/client-ec.pem"
 
-          ${PYTHON3_BINARY} -m venv ./venv
+          # Check if the DRIVERS_TOOLS directory exists, if it does then run the evergreen setup scripts to export the
+          # PYTHON3_BINARY environment variable.
+          . $DRIVERS_TOOLS/.evergreen/utils.sh
+          . $DRIVERS_TOOLS/.evergreen/find-python3.sh
+
+          export PYTHON="$(find_python3)" # Uniform python lookup utility.
+          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+
+          $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install boto3
 
           # Set the PYTHON environment variable to point to the active python3 binary. This is used by the
@@ -607,7 +625,7 @@ functions:
       params:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          ${PYTHON3_BINARY} -m venv ./venv
+          find_python3 -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -626,7 +644,7 @@ functions:
       params:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          ${PYTHON3_BINARY} -m venv ./venv
+          find_python3 -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -647,7 +665,7 @@ functions:
       params:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          ${PYTHON3_BINARY} -m venv ./venv
+          find_python3 -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -666,7 +684,7 @@ functions:
       params:
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-          ${PYTHON3_BINARY} -m venv ./venv
+          find_python3 -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
     - command: shell.exec
       params:
@@ -730,10 +748,11 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-kmstlsvenv.sh
+          . ./activate-authawsvenv.sh
           mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -760,10 +779,11 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-kmstlsvenv.sh
+          . ./activate-authawsvenv.sh
           mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -796,6 +816,7 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
           if [ "${SKIP_EC2_AUTH_TEST}" = "true" ]; then
@@ -803,7 +824,7 @@ functions:
             exit 0
           fi
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-kmstlsvenv.sh
+          . ./activate-authawsvenv.sh
           mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -878,6 +899,7 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
           if [ "${SKIP_ECS_AUTH_TEST}" = "true" ]; then
@@ -891,7 +913,7 @@ functions:
           cp ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
           cd $AUTH_AWS_DIR
-          . ./activate-kmstlsvenv.sh
+          . ./activate-authawsvenv.sh
           cat <<EOF > setup.js
             const mongo_binaries = "$MONGODB_BINARIES";
             const project_dir = "$ECS_SRC_DIR";
@@ -938,6 +960,7 @@ functions:
 
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
           . ./activate-kmstlsvenv.sh
+
     - command: shell.exec
       params:
         background: true
@@ -2140,7 +2163,8 @@ axes:
         run_on: ubuntu1804-test
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
+            #PYTHON3_BINARY: "$(find_python3)"
+            #PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
@@ -2189,7 +2213,7 @@ task_groups:
             # Download the enterprise server download for current platform to $MONGODB_BINARIES.
             # This is required for tests that need mongocryptd.
             # $MONGODB_BINARIES is added to the $PATH in fetch-source.
-            ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            find_python3 $DRIVERS_TOOLS/.evergreen/mongodl.py \
                 --component archive \
                 --version ${SERVERLESS_MONGODB_VERSION} \
                 --edition enterprise \
@@ -2197,7 +2221,7 @@ task_groups:
                 --strip-path-components 2
 
             # Download the crypt_shared dynamic library for the current platform.
-            ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
+             $DRIVERS_TOOLS/.evergreen/mongodl.py \
               --component crypt_shared \
               --version ${SERVERLESS_MONGODB_VERSION} \
               --edition enterprise \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2118,21 +2118,18 @@ axes:
         variables:
           GCC_PATH: "/cygdrive/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"
           GO_DIST: "C:\\golang\\go1.18"
-          PYTHON3_BINARY: "C:/python/Python38/python.exe"
           VENV_BIN_DIR: "Scripts"
       - id: "ubuntu1604-64-go-1-18"
         display_name: "Ubuntu 16.04"
         run_on: ubuntu1604-build
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
         batchtime: 1440 # Run at most once per 24 hours.
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: python3
 
   # OSes that require >= 4.0 for SSL
   - id: os-ssl-40
@@ -2145,7 +2142,6 @@ axes:
         variables:
           GCC_PATH: "/cygdrive/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"
           GO_DIST: "C:\\golang\\go1.18"
-          PYTHON3_BINARY: "C:/python/Python38/python.exe"
           VENV_BIN_DIR: "Scripts"
       - id: "ubuntu1804-64-go-1-18"
         display_name: "Ubuntu 18.04"
@@ -2159,7 +2155,6 @@ axes:
         batchtime: 1440 # Run at most once per 24 hours.
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: python3
 
   # OCSP linux tasks need to run against this OS since stapling is disabled on Ubuntu 18.04 (SERVER-51364)
   - id: ocsp-rhel-70
@@ -2170,7 +2165,6 @@ axes:
         run_on: rhel70-build
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: "/opt/python/3.6/bin/python3"
 
   - id: os-aws-auth
     display_name: OS
@@ -2183,7 +2177,6 @@ axes:
           GCC_PATH: "/cygdrive/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"
           GO_DIST: "C:\\golang\\go1.18"
           SKIP_ECS_AUTH_TEST: true
-          PYTHON3_BINARY: "C:/python/Python38/python.exe"
       - id: "ubuntu1804-64-go-1-18"
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
@@ -2197,7 +2190,6 @@ axes:
           GO_DIST: "/opt/golang/go1.18"
           SKIP_ECS_AUTH_TEST: true
           SKIP_EC2_AUTH_TEST: true
-          PYTHON3_BINARY: python3
 
 task_groups:
   - name: serverless_task_group

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -621,20 +621,13 @@ functions:
   run-valid-ocsp-server:
     - command: shell.exec
       params:
+        background: true
         shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          ${PYTHON3_BINARY} -m venv ./venv
-          ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
-    - command: shell.exec
-      params:
-        background: true
-        script: |
-          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-
-          ./venv/${VENV_BIN_DIR|bin}/python ocsp_mock.py \
+          python ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
@@ -643,20 +636,13 @@ functions:
   run-revoked-ocsp-server:
     - command: shell.exec
       params:
+        background: true
         shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          ${PYTHON3_BINARY} -m venv ./venv
-          ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
-    - command: shell.exec
-      params:
-        background: true
-        script: |
-          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-
-          ./venv/${VENV_BIN_DIR|bin}/python ocsp_mock.py \
+          python ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ca.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ca.key \
@@ -667,20 +653,13 @@ functions:
   run-valid-delegate-ocsp-server:
     - command: shell.exec
       params:
+        background: true
         shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          ${PYTHON3_BINARY} -m venv ./venv
-          ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
-    - command: shell.exec
-      params:
-        background: true
-        script: |
-          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-
-          ./venv/${VENV_BIN_DIR|bin}/python ocsp_mock.py \
+          python ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \
@@ -689,20 +668,13 @@ functions:
   run-revoked-delegate-ocsp-server:
     - command: shell.exec
       params:
+        background: true
         shell: "bash"
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/ocsp
           . ./activate-ocspvenv.sh
 
-          ${PYTHON3_BINARY} -m venv ./venv
-          ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
-    - command: shell.exec
-      params:
-        background: true
-        script: |
-          cd ${DRIVERS_TOOLS}/.evergreen/ocsp
-
-          ./venv/${VENV_BIN_DIR|bin}/python ocsp_mock.py \
+          python ocsp_mock.py \
           --ca_file ${OCSP_ALGORITHM}/ca.pem \
           --ocsp_responder_cert ${OCSP_ALGORITHM}/ocsp-responder.crt \
           --ocsp_responder_key ${OCSP_ALGORITHM}/ocsp-responder.key \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -323,9 +323,10 @@ functions:
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         add_expansions_to_env: true
+        shell: "bash"
         script: |
           ${PREPARE_SHELL}
-          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          . ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   send-perf-data:
     - command: perf.send
@@ -485,8 +486,8 @@ functions:
           . $DRIVERS_TOOLS/.evergreen/utils.sh
           . $DRIVERS_TOOLS/.evergreen/find-python3.sh
 
-          export PYTHON="$(find_python3)" # Uniform python lookup utility.
-          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+          export PYTHON="$(find_python3)"
+          venvcreate "$PYTHON" venv
 
           $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install boto3
@@ -621,8 +622,8 @@ functions:
           . ${DRIVERS_TOOLS}/.evergreen/utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
-          export PYTHON="$(find_python3)" # Uniform python lookup utility.
-          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+          export PYTHON="$(find_python3)"
+          venvcreate "$PYTHON" venv
 
           $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
@@ -649,8 +650,8 @@ functions:
           . ${DRIVERS_TOOLS}/.evergreen/utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
-          export PYTHON="$(find_python3)" # Uniform python lookup utility.
-          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+          export PYTHON="$(find_python3)"
+          venvcreate "$PYTHON" venv
 
           $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
@@ -679,8 +680,8 @@ functions:
           . ${DRIVERS_TOOLS}/.evergreen/utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
-          export PYTHON="$(find_python3)" # Uniform python lookup utility.
-          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+          export PYTHON="$(find_python3)"
+          venvcreate "$PYTHON" venv
 
           $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
@@ -707,8 +708,8 @@ functions:
           . ${DRIVERS_TOOLS}/.evergreen/utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
-          export PYTHON="$(find_python3)" # Uniform python lookup utility.
-          venvcreate "$PYTHON" venv # No leaks or undocumented dependencies.
+          export PYTHON="$(find_python3)"
+          venvcreate "$PYTHON" venv
 
           $PYTHON -m venv ./venv
           ./venv/${VENV_BIN_DIR|bin}/pip3 install -r mock-ocsp-responder-requirements.txt
@@ -2148,7 +2149,6 @@ axes:
         run_on: ubuntu1804-build
         variables:
           GO_DIST: "/opt/golang/go1.18"
-          PYTHON3_BINARY: "/opt/python/3.8/bin/python3"
       - id: "osx-go-1-18"
         display_name: "MacOS 11.0"
         run_on: macos-1100
@@ -2229,7 +2229,7 @@ task_groups:
             . $DRIVERS_TOOLS/.evergreen/utils.sh
             . $DRIVERS_TOOLS/.evergreen/find-python3.sh
 
-            export PYTHON="$(find_python3)" # Uniform python lookup utility.
+            export PYTHON="$(find_python3)"
 
             # Download the enterprise server download for current platform to $MONGODB_BINARIES.
             # This is required for tests that need mongocryptd.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -35,7 +35,6 @@ functions:
     - command: shell.exec
       params:
         working_dir: src/go.mongodb.org/mongo-driver
-        shell: "bash"
         script: |
           # Get the current unique version of this checkout.
           if [ "${is_patch}" = "true" ]; then
@@ -339,10 +338,9 @@ functions:
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         add_expansions_to_env: true
-        shell: "bash"
         script: |
           ${PREPARE_SHELL}
-          . ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   send-perf-data:
     - command: perf.send
@@ -486,7 +484,6 @@ functions:
       type: test
       params:
         working_dir: src/go.mongodb.org/mongo-driver
-        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
@@ -596,7 +593,6 @@ functions:
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         add_expansions_to_env: true
-        shell: "bash"
         script: |
           ${PREPARE_SHELL}
 
@@ -607,7 +603,7 @@ functions:
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
           MAKEFILE_TARGET=evg-test-serverless \
-            . ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+            sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   run-atlas-data-lake-test:
     - command: shell.exec

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,7 +19,6 @@ export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install
 export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
 export GOFLAGS=-mod=vendor
 
-# ! add a note here
 . $DRIVERS_TOOLS/.evergreen/utils.sh
 . $DRIVERS_TOOLS/.evergreen/find-python3.sh
 
@@ -60,7 +59,6 @@ if [ ! -z $PYTHON3_BINARY ]; then
 
   # Set the PYTHON environment variable to point to the active python3 binary. This is used by the
   # set-temp-creds.sh script.
-  # ! is this block needed?
   if [ "Windows_NT" = "$OS" ]; then
     export PYTHON="$(pwd)/venv/Scripts/python"
   else

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,11 +19,6 @@ export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install
 export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
 export GOFLAGS=-mod=vendor
 
-#. $DRIVERS_TOOLS/.evergreen/utils.sh
-#. $DRIVERS_TOOLS/.evergreen/find-python3.sh
-#
-#export PYTHON3_BINARY="$(find_python3)"
-
 SSL=${SSL:-nossl}
 if [ "$SSL" != "nossl" -a -z "${SERVERLESS+x}" ]; then
     export MONGO_GO_DRIVER_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
@@ -54,7 +49,6 @@ if [ ! -z ${PYTHON3_BINARY} ]; then
   export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
   export AWS_DEFAULT_REGION="us-east-1"
-
   ${PYTHON3_BINARY} -m venv ./venv
 
   # Set the PYTHON environment variable to point to the active python3 binary. This is used by the

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,10 +19,10 @@ export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install
 export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
 export GOFLAGS=-mod=vendor
 
-. $DRIVERS_TOOLS/.evergreen/utils.sh
-. $DRIVERS_TOOLS/.evergreen/find-python3.sh
-
-export PYTHON3_BINARY="$(find_python3)"
+#. $DRIVERS_TOOLS/.evergreen/utils.sh
+#. $DRIVERS_TOOLS/.evergreen/find-python3.sh
+#
+#export PYTHON3_BINARY="$(find_python3)"
 
 SSL=${SSL:-nossl}
 if [ "$SSL" != "nossl" -a -z "${SERVERLESS+x}" ]; then
@@ -50,12 +50,12 @@ fi
 # tasks) requires the use of apt-get, which we wish to avoid. So, we do not set
 # a python3 binary on Ubuntu 14.04. Setting AWS temp credentials for legacy
 # server version tasks is unneccesary, as temp credentials are only needed on 4.2+.
-if [ ! -z $PYTHON3_BINARY ]; then
+if [ ! -z ${PYTHON3_BINARY} ]; then
   export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
   export AWS_DEFAULT_REGION="us-east-1"
 
-  $PYTHON3_BINARY -m venv ./venv
+  ${PYTHON3_BINARY} -m venv ./venv
 
   # Set the PYTHON environment variable to point to the active python3 binary. This is used by the
   # set-temp-creds.sh script.

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,6 +19,12 @@ export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install
 export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
 export GOFLAGS=-mod=vendor
 
+# ! add a note here
+. $DRIVERS_TOOLS/.evergreen/utils.sh
+. $DRIVERS_TOOLS/.evergreen/find-python3.sh
+
+export PYTHON3_BINARY="$(find_python3)"
+
 SSL=${SSL:-nossl}
 if [ "$SSL" != "nossl" -a -z "${SERVERLESS+x}" ]; then
     export MONGO_GO_DRIVER_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
@@ -45,14 +51,16 @@ fi
 # tasks) requires the use of apt-get, which we wish to avoid. So, we do not set
 # a python3 binary on Ubuntu 14.04. Setting AWS temp credentials for legacy
 # server version tasks is unneccesary, as temp credentials are only needed on 4.2+.
-if [ ! -z ${PYTHON3_BINARY} ]; then
+if [ ! -z $PYTHON3_BINARY ]; then
   export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
   export AWS_DEFAULT_REGION="us-east-1"
-  ${PYTHON3_BINARY} -m venv ./venv
+
+  $PYTHON3_BINARY -m venv ./venv
 
   # Set the PYTHON environment variable to point to the active python3 binary. This is used by the
   # set-temp-creds.sh script.
+  # ! is this block needed?
   if [ "Windows_NT" = "$OS" ]; then
     export PYTHON="$(pwd)/venv/Scripts/python"
   else


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2643

## Summary
<!--- A summary of the changes proposed by this pull request. -->
replace use of [activate_venv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/e276a93e6477149362ca85881006a1fae99a9095/.evergreen/csfle/activate_venv.sh) with [activate-kmstlsvenv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/e276a93e6477149362ca85881006a1fae99a9095/.evergreen/csfle/activate-kmstlsvenv.sh).

## Background & Motivation
<!--- Rationale for the pull request. -->
The activate-kmstlsvenv.sh is a hygienic alternatives to activate_venv.sh that does not leak variables into the environment and does not depend on environment variables for its behavior. 

