### PR TITLE
GODRIVER-2577 Retry heartbeat on timeout to prevent pool cleanup in FAAS pause.

### DIFF
--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -181,7 +181,7 @@ func TestServerHeartbeatTimeout(t *testing.T) {
 					}
 				}),
 				WithHeartbeatInterval(func(time.Duration) time.Duration {
-					return 2 * time.Second
+					return 200 * time.Millisecond
 				}),
 			)
 			require.NoError(t, server.Connect(nil))


### PR DESCRIPTION
GODRIVER-2577

## Summary
This fix retries heartbeat on timeout errors to delay pool cleanup by one event loop.

## Background & Motivation
Pausing behavior in FAAS environment, e.g. AWS Lambda, causes connection timeout in heartbeat, which then clears the pool.
This fix retries heartbeats on timeout so only two continuous timeout errors will trigger a pool cleanup.
Its test case uses a proxy `net.Conn` to mimic timeout errors.