### PR TITLE
GODRIVER-2642 Enable the exportloopref linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   enable:
     - errcheck
     # - errorlint
+    - exportloopref
     - gocritic
     - goimports
     - gosimple


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2642

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Enables the `exportloopref` linter in `.golangci.yml`

## Background & Motivation
<!--- Rationale for the pull request. -->
Go has an ["issue"](https://github.com/golang/go/discussions/56010) with for loop variable semantics that allows easy, accidental errors when dereferencing or passing around values. This linter combined with the `paralleltest` should help catch more (not all) of these types of errors.

