### PR TITLE
Make `rescanSRVInterval` configurable

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -125,6 +125,7 @@ type ClientOptions struct {
 	ServerSelectionTimeout   *time.Duration
 	SRVMaxHosts              *int
 	SRVServiceName           *string
+	RescanSRVInterval        *time.Duration
 	Timeout                  *time.Duration
 	TLSConfig                *tls.Config
 	WriteConcern             *writeconcern.WriteConcern
@@ -863,6 +864,12 @@ func (c *ClientOptions) SetSRVServiceName(srvName string) *ClientOptions {
 	return c
 }
 
+// SetRescanSRVInterval specifies a custom interval between SRV hosts rescan.
+func (c *ClientOptions) SetRescanSRVInterval(rescanSRVInterval time.Duration) *ClientOptions {
+	c.RescanSRVInterval = &rescanSRVInterval
+	return c
+}
+
 // MergeClientOptions combines the given *ClientOptions into a single *ClientOptions in a last one wins fashion.
 // The specified options are merged with the existing options on the client, with the specified options taking
 // precedence.
@@ -966,6 +973,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.SRVServiceName != nil {
 			c.SRVServiceName = opt.SRVServiceName
+		}
+		if opt.RescanSRVInterval != nil {
+			c.RescanSRVInterval = opt.RescanSRVInterval
 		}
 		if opt.Timeout != nil {
 			c.Timeout = opt.Timeout

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -142,12 +142,12 @@ func testPollingSRVRecordsSpec(t *testing.T, uri string) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 			require.NoError(t, err, "error constructing topology configs: %v", err)
+			cfg.RescanSRVInterval = time.Millisecond * 5
 
 			topo, err := New(cfg)
 			require.NoError(t, err, "Could not create the topology: %v", err)
 			mockRes := newMockResolver(tt.recordsToAdd, tt.recordsToRemove, tt.lookupFail, tt.lookupTimeout)
 			topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-			topo.rescanSRVInterval = time.Millisecond * 5
 			err = topo.Connect()
 			require.NoError(t, err, "Could not Connect to the topology: %v", err)
 
@@ -171,12 +171,12 @@ func TestPollSRVRecords(t *testing.T) {
 		uri := "mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 		cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 		require.NoError(t, err, "error constructing topology config: %v", err)
+		cfg.RescanSRVInterval = time.Millisecond * 5
 
 		topo, err := New(cfg)
 		require.NoError(t, err, "Could not create the topology: %v", err)
 		mockRes := newMockResolver(nil, nil, false, false)
 		topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-		topo.rescanSRVInterval = time.Millisecond * 5
 		err = topo.Connect()
 		require.NoError(t, err, "Could not Connect to the topology: %v", err)
 		topo.serversLock.Lock()
@@ -209,12 +209,12 @@ func TestPollSRVRecords(t *testing.T) {
 		uri := "mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 		cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 		require.NoError(t, err, "error constructing topology config: %v", err)
+		cfg.RescanSRVInterval = time.Millisecond * 5
 
 		topo, err := New(cfg)
 		require.NoError(t, err, "Could not create the topology: %v", err)
 		mockRes := newMockResolver([]*net.SRV{{"blah.bleh", 27019, 0, 0}, {"localhost.test.build.10gen.cc.", 27020, 0, 0}}, nil, false, false)
 		topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-		topo.rescanSRVInterval = time.Millisecond * 5
 		err = topo.Connect()
 		require.NoError(t, err, "Could not Connect to the topology: %v", err)
 
@@ -236,13 +236,13 @@ func TestPollSRVRecords(t *testing.T) {
 		uri := "mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 		cfg, err := NewConfig(options.Client().ApplyURI(uri), nil)
 		require.NoError(t, err, "error constructing topology config: %v", err)
+		cfg.RescanSRVInterval = time.Millisecond * 5
 
 		topo, err := New(cfg)
 		require.NoError(t, err, "Could not create the topology: %v", err)
 		mockRes := newMockResolver(nil, nil, false, false)
 		mockRes.fail = 1
 		topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-		topo.rescanSRVInterval = time.Millisecond * 5
 		err = topo.Connect()
 		require.NoError(t, err, "Could not Connect to the topology: %v", err)
 
@@ -289,7 +289,7 @@ func TestPollingSRVRecordsLoadBalanced(t *testing.T) {
 
 		topo := createLBTopology(t, "mongodb+srv://test3.test.build.10gen.cc")
 		topo.dnsResolver = dnsResolver
-		topo.rescanSRVInterval = time.Millisecond * 5
+		topo.cfg.RescanSRVInterval = time.Millisecond * 5
 		err := topo.Connect()
 		assert.Nil(t, err, "Connect error: %v", err)
 		defer func() {
@@ -298,7 +298,7 @@ func TestPollingSRVRecordsLoadBalanced(t *testing.T) {
 
 		// Wait for 2*rescanInterval and assert that polling was not done and the final host list only contains the
 		// original host.
-		time.Sleep(2 * topo.rescanSRVInterval)
+		time.Sleep(2 * topo.cfg.RescanSRVInterval)
 		lookupCalledTimes := atomic.LoadInt32(&mockResolver.ranLookup)
 		assert.Equal(t, int32(0), lookupCalledTimes, "expected SRV lookup to occur 0 times, got %d", lookupCalledTimes)
 		expectedHosts := []string{"localhost.test.build.10gen.cc:27017"}
@@ -315,13 +315,13 @@ func TestPollSRVRecordsMaxHosts(t *testing.T) {
 		uri := "mongodb+srv://test1.test.build.10gen.cc/?heartbeatFrequencyMS=100"
 		cfg, err := NewConfig(options.Client().ApplyURI(uri).SetSRVMaxHosts(srvMaxHosts), nil)
 		require.NoError(t, err, "error constructing topology config: %v", err)
+		cfg.RescanSRVInterval = time.Millisecond * 5
 
 		topo, err := New(cfg)
 		require.NoError(t, err, "Could not create the topology: %v", err)
 
 		mockRes := newMockResolver(recordsToAdd, recordsToRemove, false, false)
 		topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-		topo.rescanSRVInterval = time.Millisecond * 5
 		err = topo.Connect()
 		assert.Nil(t, err, "Connect error: %v", err)
 
@@ -387,13 +387,13 @@ func TestPollSRVRecordsServiceName(t *testing.T) {
 		uri := "mongodb+srv://test22.test.build.10gen.cc/?heartbeatFrequencyMS=100&srvServiceName=customname"
 		cfg, err := NewConfig(options.Client().ApplyURI(uri).SetSRVServiceName(srvServiceName), nil)
 		require.NoError(t, err, "error constructing topology config: %v", err)
+		cfg.RescanSRVInterval = time.Millisecond * 5
 
 		topo, err := New(cfg)
 		require.NoError(t, err, "Could not create the topology: %v", err)
 
 		mockRes := newMockResolver(recordsToAdd, recordsToRemove, false, false)
 		topo.dnsResolver = &dns.Resolver{mockRes.LookupSRV, mockRes.LookupTXT}
-		topo.rescanSRVInterval = time.Millisecond * 5
 		err = topo.Connect()
 		assert.Nil(t, err, "Connect error: %v", err)
 

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -23,6 +23,7 @@ import (
 )
 
 const defaultServerSelectionTimeout = 30 * time.Second
+const defaultRescanSRVInterval = 60 * time.Second
 
 // Config is used to construct a topology.
 type Config struct {
@@ -36,6 +37,7 @@ type Config struct {
 	SRVMaxHosts            int
 	SRVServiceName         string
 	LoadBalanced           bool
+	RescanSRVInterval      time.Duration
 }
 
 // ConvertToDriverAPIOptions converts a options.ServerAPIOptions instance to a driver.ServerAPIOptions.
@@ -67,6 +69,9 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 	// Set the default "ServerSelectionTimeout" to 30 seconds.
 	cfgp.ServerSelectionTimeout = defaultServerSelectionTimeout
 
+	// Set the default "RescanSRVInterval" to 60 seconds.
+	cfgp.RescanSRVInterval = defaultRescanSRVInterval
+
 	// Set the default "SeedList" to localhost.
 	cfgp.SeedList = []string{"localhost:27017"}
 
@@ -89,6 +94,11 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 
 	if co.SRVMaxHosts != nil {
 		cfgp.SRVMaxHosts = *co.SRVMaxHosts
+	}
+
+	// RescanSRVInterval
+	if co.RescanSRVInterval != nil {
+		cfgp.RescanSRVInterval = *co.RescanSRVInterval
 	}
 
 	// AppName


### PR DESCRIPTION
https://jira.mongodb.org/browse/GODRIVER-2525

## Summary
Allow customize `rescanSRVInterval` option (default: 60 seconds).

## Background & Motivation
We use `mongos` pool with HPA inside Kubernetes cluster. Mongo clients connect to `mongos` by SRV record.
In our configuration system DNS cache is around 5 seconds. Application SRV cache is 60 seconds (`rescanSRVInterval`). As result on quick `mongos` rollout must be slower then at least 65 seconds. Otherwise, you can get a situation where there are no live hosts in the SRV record used by the application.

To slow down rollout we use flag `minReadySeconds` but we want also reduce application cache TTL (`rescanSRVInterval`).