### PR TITLE
GODRIVER-2580 Test crypt_shared with older server versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1639,12 +1639,12 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
+          REQUESTED_CRYPT_SHARED_VERSION: "latest-major"
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
-          REQUESTED_CRYPT_SHARED_VERSION: "latest-major"
 
   - name: test-replicaset-auth-nossl
     tags: ["test", "replicaset", "authssl"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -240,6 +240,7 @@ functions:
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           LOAD_BALANCER=${LOAD_BALANCER} \
+          REQUESTED_CRYPT_SHARED_VERSION=${REQUESTED_CRYPT_SHARED_VERSION} \
           sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
@@ -1629,6 +1630,21 @@ tasks:
           # Don't use the crypt_shared library, which should cause all of the tests to fall
           # back to using mongocryptd instead of crypt_shared.
           SKIP_CRYPT_SHARED_LIB: "true"
+
+  - name: test-replicaset-auth-ssl-crypt_shared_latest_major
+    tags: ["test", "replicaset", "authssl", "mongocryptd"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "replica_set"
+          AUTH: "auth"
+          SSL: "ssl"
+      - func: run-tests
+        vars:
+          TOPOLOGY: "replica_set"
+          AUTH: "auth"
+          SSL: "ssl"
+          REQUESTED_CRYPT_SHARED_VERSION: "latest-major"
 
   - name: test-replicaset-auth-nossl
     tags: ["test", "replicaset", "authssl"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -240,7 +240,6 @@ functions:
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           LOAD_BALANCER=${LOAD_BALANCER} \
-          REQUESTED_CRYPT_SHARED_VERSION=${REQUESTED_CRYPT_SHARED_VERSION} \
           sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
@@ -1630,21 +1629,6 @@ tasks:
           # Don't use the crypt_shared library, which should cause all of the tests to fall
           # back to using mongocryptd instead of crypt_shared.
           SKIP_CRYPT_SHARED_LIB: "true"
-
-  - name: test-replicaset-auth-ssl-crypt_shared_latest_major
-    tags: ["test", "replicaset", "authssl", "mongocryptd"]
-    commands:
-      - func: bootstrap-mongo-orchestration
-        vars:
-          TOPOLOGY: "replica_set"
-          AUTH: "auth"
-          SSL: "ssl"
-          REQUESTED_CRYPT_SHARED_VERSION: "latest-major"
-      - func: run-tests
-        vars:
-          TOPOLOGY: "replica_set"
-          AUTH: "auth"
-          SSL: "ssl"
 
   - name: test-replicaset-auth-nossl
     tags: ["test", "replicaset", "authssl"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -158,7 +158,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2465 $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -158,7 +158,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2465 $DRIVERS_TOOLS
+            git clone https://github.com/kevinAlbs/drivers-evergreen-tools.git --branch D2465-simplified $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,9 @@ build-aws-ecs-test:
 
 .PHONY: evg-test
 evg-test:
-	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s -p 1 ./... >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionSpec >> test.suite
+	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration -run TestClientSideEncryptionProse >> test.suite
+	# go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s -p 1 ./... >> test.suite
 
 .PHONY: evg-test-atlas
 evg-test-atlas:


### PR DESCRIPTION
GODRIVER-2580
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->
- Test latest release of crypt_shared with all server versions.

## Background & Motivation
<!--- Rationale for the pull request. -->
Full patch build: https://spruce.mongodb.com/version/637d22343066150e9a32cbfd
See DRIVERS-2465.

