### PR TITLE
GODRIVER-2661 Fix make targets that still refer to PKGS.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1045,6 +1045,7 @@ tasks:
   - name: sa-fmt
     tags: ["static-analysis"]
     commands:
+      - func: install-linters
       - func: run-make
         vars:
           targets: check-fmt

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-tests:
 
 .PHONY: check-fmt
 check-fmt:
-	etc/check_fmt.sh $(PKGS)
+	etc/check_fmt.sh
 
 # check-modules runs "go mod tidy" then "go mod vendor" and exits with a non-zero exit code if there
 # are any module or vendored modules changes. The intent is to confirm two properties:
@@ -57,7 +57,7 @@ doc:
 
 .PHONY: fmt
 fmt:
-	gofmt -l -s -w $(PKGS)
+	go fmt ./...
 
 .PHONY: lint
 lint:

--- a/etc/check_fmt.sh
+++ b/etc/check_fmt.sh
@@ -16,7 +16,7 @@ fi
 # E.g ignored lines:
 #     // "mongodb://ldap-user:ldap-pwd@localhost:27017/?authMechanism=PLAIN"
 #     // (https://www.mongodb.com/docs/manual/core/authentication-mechanisms-enterprise/#security-auth-ldap).
-lll_out="$(find "$@" -type f -name "*_examples_test.go" | lll -w 4 -l 80 -e '^\s*\/\/.+:\/\/' --files)"
+lll_out="$(find . -type f -name "*_examples_test.go" | lll -w 4 -l 80 -e '^\s*\/\/.+:\/\/' --files)"
 
 if [[ $lll_out ]]; then
   echo "lll check failed for:";

--- a/etc/check_fmt.sh
+++ b/etc/check_fmt.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# check_fmt gopackages...
-# Runs gofmt on given packages and checks that *_example_test.go files have wrapped lines.
+# check_fmt
+# Runs go fmt on all packages in the repo and checks that *_example_test.go files have wrapped lines.
 
-gofmt_out="$(gofmt -l -s "$@")"
+gofmt_out="$(go fmt ./...)"
 
 if [[ $gofmt_out ]]; then
-  echo "gofmt check failed for:";
+  echo "go fmt check failed for:";
   sed -e 's/^/ - /' <<< "$gofmt_out";
   exit 1;
 fi

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -752,7 +752,8 @@ func ExampleClient_StartSession_withTransaction() {
 		context.TODO(),
 		func(ctx mongo.SessionContext) (interface{}, error) {
 			// Use the mongo.SessionContext as the Context parameter for
-			// InsertOne and FindOne so both operations are run in the same transaction
+			// InsertOne and FindOne so both operations are run in the same
+			// transaction.
 
 			coll := client.Database("db").Collection("coll")
 			res, err := coll.InsertOne(ctx, bson.D{{"x", 1}})


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2661

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Changes the `fmt` and `check-fmt` make targets to use `go fmt` instead of `gofmt` and avoid usage of the now non-existent `PKGS` variable (removed in GODRIVER-2093). Installs linters for `sa-fmt` task that was [not actually running](https://evergreen.mongodb.com/lobster/evergreen/task/mongo_go_driver_static_analysis_sa_fmt_eff5307d71ecbc763735076f3e2f63b5d77ead2a_22_11_28_17_04_17/0/task#bookmarks=0%2C1987&l=1&shareLine=1955) the `lll` linter. Fixes an unwrapped comment in `crud_examples_test.go`.

## Background & Motivation
<!--- Rationale for the pull request. -->
`make fmt` and `make check-fmt` will currently fail and hang indefinitely, respectively. Since we encourage users to run `make fmt` for contributions and run `check-fmt` ourselves in the `sa-fmt` task, we should fix these targets.
