### PR TITLE
Fix typo in `bsoncodec.StringCodec` comment

### DIFF
--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
-// StringCodec is the Codec used for struct values.
+// StringCodec is the Codec used for string values.
 type StringCodec struct {
 	DecodeObjectIDAsHex bool
 }


### PR DESCRIPTION
This PR seeks to fix a typo in `bsoncodec.StringCodec` comment.