### PR TITLE
GODRIVER-2433 Support explicit encryption for Range Index

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -94,7 +94,7 @@ functions:
           go env
 
           # TODO(GODRIVER-2676): use libmongocrypt 1.7.0 once it is released.
-          LIBMONGOCRYPT_TAG="1.7.0-alpha0"
+          LIBMONGOCRYPT_TAG="1.7.0-alpha1"
           # Install libmongocrypt based on OS.
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include
@@ -106,7 +106,7 @@ functions:
              # TODO(GODRIVER-2676): replace this URL once libmongocrypt 1.7.0 is released with the following:
              # curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_TAG/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              # There is no tag URL for libmongocrypt pre-releases.
-             LIBMONGOCRYPT_COMMIT=a162f4871cface46bdade94cdf7e3ad9459297af
+             LIBMONGOCRYPT_COMMIT=2cd2f77ae806a3a4c12750b39b0be92b0ca3b2c1
              curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
              cd ..

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -135,6 +135,21 @@ func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue,
 		transformed.SetContentionFactor(*eo.ContentionFactor)
 	}
 
+	if eo.RangeOptions != nil {
+		var transformedRange mcopts.ExplicitRangeOptions
+		if eo.RangeOptions.Min != nil {
+			transformedRange.Min = &bsoncore.Value{Type: eo.RangeOptions.Min.Type, Data: eo.RangeOptions.Min.Value}
+		}
+		if eo.RangeOptions.Max != nil {
+			transformedRange.Max = &bsoncore.Value{Type: eo.RangeOptions.Max.Type, Data: eo.RangeOptions.Max.Value}
+		}
+		if eo.RangeOptions.Precision != nil {
+			transformedRange.Precision = eo.RangeOptions.Precision
+		}
+		transformedRange.Sparsity = eo.RangeOptions.Sparsity
+		transformed.SetRangeOptions(transformedRange)
+	}
+
 	subtype, data, err := ce.crypt.EncryptExplicit(ctx, bsoncore.Value{Type: val.Type, Data: val.Value}, transformed)
 	if err != nil {
 		return primitive.Binary{}, err

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -170,7 +170,7 @@ func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue,
 //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
 // $gt may also be $gte. $lt may also be $lte.
 // Only supported for queryType "rangePreview"
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ce *ClientEncryption) EncryptExpression(ctx context.Context, expr interface{}, opts ...*options.EncryptOptions) *SingleResult {
 	transformed := transformExplicitEncryptionOptions(opts...)
 

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -170,7 +170,7 @@ func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue,
 //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
 // $gt may also be $gte. $lt may also be $lte.
 // Only supported for queryType "rangePreview"
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ce *ClientEncryption) EncryptExpression(ctx context.Context, expr interface{}, opts ...*options.EncryptOptions) *SingleResult {
 	transformed := transformExplicitEncryptionOptions(opts...)
 

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -184,6 +184,11 @@ func (ce *ClientEncryption) EncryptExpression(ctx context.Context, expr interfac
 	if err != nil {
 		return err
 	}
+	if raw, ok := result.(*bson.Raw); ok {
+		// Avoid the cost of Unmarshal.
+		*raw = bson.Raw(encryptedExprDoc)
+		return nil
+	}
 	err = bson.Unmarshal([]byte(encryptedExprDoc), result)
 	if err != nil {
 		return err

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -122,6 +122,8 @@
 // This bug may result in data corruption.
 // Please use libmongocrypt 1.5.2 or higher when calling RewrapManyDataKey.
 //
+// - Go Driver v1.12.0 requires libmongocrypt v1.7.0 or higher.
+//
 // To install libmongocrypt, follow the instructions for your
 // operating system:
 //

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2287,7 +2287,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
-					opts := options.Find().SetSort(bson.M{"_id": 1})
+					opts := options.Find().SetSort(bson.D{{"_id", 1}})
 					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
 					assert.Nil(mt, err, "error in coll.Find: %v", err)
 					defer cursor.Close(context.Background())
@@ -2329,7 +2329,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
-					opts := options.Find().SetSort(bson.M{"_id": 1})
+					opts := options.Find().SetSort(bson.D{{"_id", 1}})
 					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
 					assert.Nil(mt, err, "error in coll.Find: %v", err)
 					defer cursor.Close(context.Background())
@@ -2366,7 +2366,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
-					opts := options.Find().SetSort(bson.M{"_id": 1})
+					opts := options.Find().SetSort(bson.D{{"_id", 1}})
 					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
 					assert.Nil(mt, err, "error in coll.Find: %v", err)
 					defer cursor.Close(context.Background())
@@ -2404,7 +2404,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
-					opts := options.Find().SetSort(bson.M{"_id": 1})
+					opts := options.Find().SetSort(bson.D{{"_id", 1}})
 					cursor, err := coll.Find(context.Background(), bson.M{"$expr": encryptedExpr}, opts)
 					assert.Nil(mt, err, "error in coll.Find: %v", err)
 					defer cursor.Close(context.Background())

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2282,11 +2282,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					// Encrypt.
 					var encryptedExpr bson.Raw
 					{
-						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
-						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
-						var err error
-						encryptedExpr, err = res.DecodeBytes()
-						assert.Nil(mt, err, "error in Decode: %v", err)
+						err := clientEncryption.EncryptExpression(context.Background(), expr, &encryptedExpr, eo)
+						assert.Nil(mt, err, "error in EncryptExpression: %v", err)
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
@@ -2327,11 +2324,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					// Encrypt.
 					var encryptedExpr bson.Raw
 					{
-						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
-						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
-						var err error
-						encryptedExpr, err = res.DecodeBytes()
-						assert.Nil(mt, err, "error in Decode: %v", err)
+						err := clientEncryption.EncryptExpression(context.Background(), expr, &encryptedExpr, eo)
+						assert.Nil(mt, err, "error in EncryptExpression: %v", err)
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
@@ -2367,11 +2361,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					// Encrypt.
 					var encryptedExpr bson.Raw
 					{
-						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
-						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
-						var err error
-						encryptedExpr, err = res.DecodeBytes()
-						assert.Nil(mt, err, "error in Decode: %v", err)
+						err := clientEncryption.EncryptExpression(context.Background(), expr, &encryptedExpr, eo)
+						assert.Nil(mt, err, "error in EncryptExpression: %v", err)
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")
@@ -2408,11 +2399,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					// Encrypt.
 					var encryptedExpr bson.Raw
 					{
-						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
-						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
-						var err error
-						encryptedExpr, err = res.DecodeBytes()
-						assert.Nil(mt, err, "error in Decode: %v", err)
+						err := clientEncryption.EncryptExpression(context.Background(), expr, &encryptedExpr, eo)
+						assert.Nil(mt, err, "error in EncryptExpression: %v", err)
 					}
 
 					coll := encryptedClient.Database("db").Collection("explicit_encryption")

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2059,6 +2059,430 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			_, err = encClient.Database("db").Collection("coll").InsertOne(context.Background(), bson.D{{"unencrypted", "test"}})
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 		})
+
+	rangeRunOpts := mtest.NewOptions().MinServerVersion("6.2").Topologies(mtest.ReplicaSet, mtest.LoadBalanced, mtest.ShardedReplicaSet)
+	mt.RunOpts("22. range explicit encryption", rangeRunOpts, func(mt *mtest.T) {
+		type testcase struct {
+			typeStr       string
+			field         string
+			typeBson      bsontype.Type
+			rangeOpts     options.RangeOptions
+			zero          bson.RawValue
+			six           bson.RawValue
+			thirty        bson.RawValue
+			twoHundred    bson.RawValue
+			twoHundredOne bson.RawValue
+		}
+
+		precision := int32(2)
+
+		tests := []testcase{
+			{
+				typeStr:  "DoubleNoPrecision",
+				field:    "encryptedDoubleNoPrecision",
+				typeBson: bson.TypeDouble,
+				rangeOpts: options.RangeOptions{
+					Sparsity: 1,
+				},
+				zero:          bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 0)},
+				six:           bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 6)},
+				thirty:        bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 30)},
+				twoHundred:    bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 200)},
+				twoHundredOne: bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 201)},
+			},
+			{
+				typeStr:  "DoublePrecision",
+				field:    "encryptedDoublePrecision",
+				typeBson: bson.TypeDouble,
+				rangeOpts: options.RangeOptions{
+					Min:       &bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 0)},
+					Max:       &bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 200)},
+					Sparsity:  1,
+					Precision: &precision,
+				},
+				zero:          bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 0)},
+				six:           bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 6)},
+				thirty:        bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 30)},
+				twoHundred:    bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 200)},
+				twoHundredOne: bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 201)},
+			},
+			{
+				typeStr:  "Date",
+				field:    "encryptedDate",
+				typeBson: bson.TypeDateTime,
+				rangeOpts: options.RangeOptions{
+					Min:      &bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 0)},
+					Max:      &bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 200)},
+					Sparsity: 1,
+				},
+				zero:          bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 0)},
+				six:           bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 6)},
+				thirty:        bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 30)},
+				twoHundred:    bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 200)},
+				twoHundredOne: bson.RawValue{Type: bson.TypeDateTime, Value: bsoncore.AppendDateTime(nil, 201)},
+			},
+			{
+				typeStr:  "Int",
+				field:    "encryptedInt",
+				typeBson: bson.TypeInt32,
+				rangeOpts: options.RangeOptions{
+					Min:      &bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 0)},
+					Max:      &bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 200)},
+					Sparsity: 1,
+				},
+				zero:          bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 0)},
+				six:           bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 6)},
+				thirty:        bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 30)},
+				twoHundred:    bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 200)},
+				twoHundredOne: bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 201)},
+			},
+			{
+				typeStr:  "Long",
+				field:    "encryptedLong",
+				typeBson: bson.TypeInt64,
+				rangeOpts: options.RangeOptions{
+					Min:      &bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 0)},
+					Max:      &bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 200)},
+					Sparsity: 1,
+				},
+				zero:          bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 0)},
+				six:           bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 6)},
+				thirty:        bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 30)},
+				twoHundred:    bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 200)},
+				twoHundredOne: bson.RawValue{Type: bson.TypeInt64, Value: bsoncore.AppendInt64(nil, 201)},
+			},
+		}
+
+		for _, test := range tests {
+			mt.Run(test.typeStr, func(mt *mtest.T) {
+				// Test Setup ... begin
+				encryptedFields := readJSONFile(mt, fmt.Sprintf("range-encryptedFields-%v.json", test.typeStr))
+				key1Document := readJSONFile(mt, "key1-document.json")
+				var key1ID primitive.Binary
+				{
+					subtype, data := key1Document.Lookup("_id").Binary()
+					key1ID = primitive.Binary{Subtype: subtype, Data: data}
+				}
+
+				testSetup := func() (*mongo.Client, *mongo.ClientEncryption) {
+					mtest.DropEncryptedCollection(mt, mt.Client.Database("db").Collection("explicit_encryption"), encryptedFields)
+					cco := options.CreateCollection().SetEncryptedFields(encryptedFields)
+					err := mt.Client.Database("db").CreateCollection(context.Background(), "explicit_encryption", cco)
+					assert.Nil(mt, err, "error on CreateCollection: %v", err)
+					err = mt.Client.Database("keyvault").Collection("datakeys").Drop(context.Background())
+					assert.Nil(mt, err, "error on Drop: %v", err)
+					keyVaultClient, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mtest.ClusterURI()))
+					assert.Nil(mt, err, "error on Connect: %v", err)
+					datakeysColl := keyVaultClient.Database("keyvault").Collection("datakeys", options.Collection().SetWriteConcern(mtest.MajorityWc))
+					_, err = datakeysColl.InsertOne(context.TODO(), key1Document)
+					assert.Nil(mt, err, "error on InsertOne: %v", err)
+					// Create a ClientEncryption.
+					ceo := options.ClientEncryption().
+						SetKeyVaultNamespace("keyvault.datakeys").
+						SetKmsProviders(fullKmsProvidersMap)
+					clientEncryption, err := mongo.NewClientEncryption(keyVaultClient, ceo)
+					assert.Nil(mt, err, "error on NewClientEncryption: %v", err)
+
+					// Create a MongoClient with AutoEncryptionOpts and bypassQueryAnalysis=true.
+					aeo := options.AutoEncryption().
+						SetKeyVaultNamespace("keyvault.datakeys").
+						SetKmsProviders(fullKmsProvidersMap).
+						SetBypassQueryAnalysis(true)
+					co := options.Client().SetAutoEncryptionOptions(aeo).ApplyURI(mtest.ClusterURI())
+					encryptedClient, err := mongo.Connect(context.Background(), co)
+					assert.Nil(mt, err, "error on Connect: %v", err)
+
+					// Insert 0, 6, 30, and 200.
+					coll := encryptedClient.Database("db").Collection("explicit_encryption")
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetRangeOptions(test.rangeOpts)
+					// Insert 0.
+					insertPayloadZero, err := clientEncryption.Encrypt(context.Background(), test.zero, eo)
+					assert.Nil(mt, err, "error in Encrypt: %v", err)
+					_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 0}, {test.field, insertPayloadZero}})
+					assert.Nil(mt, err, "error in InsertOne: %v", err)
+					// Insert 6.
+					insertPayloadSix, err := clientEncryption.Encrypt(context.Background(), test.six, eo)
+					assert.Nil(mt, err, "error in Encrypt: %v", err)
+					_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 1}, {test.field, insertPayloadSix}})
+					assert.Nil(mt, err, "error in InsertOne: %v", err)
+					// Insert 30.
+					insertPayloadThirty, err := clientEncryption.Encrypt(context.Background(), test.thirty, eo)
+					assert.Nil(mt, err, "error in Encrypt: %v", err)
+					_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 2}, {test.field, insertPayloadThirty}})
+					assert.Nil(mt, err, "error in InsertOne: %v", err)
+					// Insert 200.
+					insertPayloadTwoHundred, err := clientEncryption.Encrypt(context.Background(), test.twoHundred, eo)
+					assert.Nil(mt, err, "error in Encrypt: %v", err)
+					_, err = coll.InsertOne(context.Background(), bson.D{{"_id", 3}, {test.field, insertPayloadTwoHundred}})
+					assert.Nil(mt, err, "error in InsertOne: %v", err)
+
+					return encryptedClient, clientEncryption
+				}
+				// Test Setup ... end
+
+				// checkCursorResults checks documents returned by a cursor.
+				// Expects document i to have field `field` with value `values[i]`.
+				// Expects exactly len(values) documents to be returned.
+				checkCursorResults := func(cursor *mongo.Cursor, field string, values ...bson.RawValue) {
+					for i, v := range values {
+						assert.True(mt, cursor.Next(context.Background()), "expected Next true, got false. Expected document %v with value: %v", i, v)
+						got, err := cursor.Current.LookupErr(test.field)
+						assert.Nil(mt, err, "%v not found in document %v: %v", test.field, i, cursor.Current)
+						assert.Equal(mt, v, got, "expected %v, got %v in document %v", v, got, i)
+					}
+					assert.False(mt, cursor.Next(context.Background()), "expected Next false, got true with document: %v", cursor.Current)
+				}
+
+				mt.Run("Case 1: can decrypt a payload", func(mt *mtest.T) {
+					encryptedClient, clientEncryption := testSetup()
+					defer clientEncryption.Close(context.Background())
+					defer encryptedClient.Disconnect(context.Background())
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetRangeOptions(test.rangeOpts)
+					insertPayloadSix, err := clientEncryption.Encrypt(context.Background(), test.six, eo)
+					assert.Nil(mt, err, "error in Encrypt: %v", err)
+					got, err := clientEncryption.Decrypt(context.Background(), insertPayloadSix)
+					assert.Nil(mt, err, "error in Decrypt: %v", err)
+					assert.Equal(mt, test.six, got, "expected %v, got %v", test.six, got)
+				})
+
+				mt.Run("Case 2: can find encrypted range and return the maximum", func(mt *mtest.T) {
+					encryptedClient, clientEncryption := testSetup()
+					defer clientEncryption.Close(context.Background())
+					defer encryptedClient.Disconnect(context.Background())
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetQueryType("rangePreview").
+						SetRangeOptions(test.rangeOpts)
+
+					expr := bson.M{
+						"$and": bson.A{
+							bson.M{
+								test.field: bson.M{
+									"$gte": test.six,
+								},
+							},
+							bson.M{
+								test.field: bson.M{
+									"$lte": test.twoHundred,
+								},
+							},
+						},
+					}
+
+					// Encrypt.
+					var encryptedExpr bson.Raw
+					{
+						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
+						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
+						var err error
+						encryptedExpr, err = res.DecodeBytes()
+						assert.Nil(mt, err, "error in Decode: %v", err)
+					}
+
+					coll := encryptedClient.Database("db").Collection("explicit_encryption")
+					opts := options.Find().SetSort(bson.M{"_id": 1})
+					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
+					assert.Nil(mt, err, "error in coll.Find: %v", err)
+					defer cursor.Close(context.Background())
+
+					checkCursorResults(cursor, test.field, test.six, test.thirty, test.twoHundred)
+				})
+
+				mt.Run("Case 3: can find encrypted range and return the minimum", func(mt *mtest.T) {
+					encryptedClient, clientEncryption := testSetup()
+					defer clientEncryption.Close(context.Background())
+					defer encryptedClient.Disconnect(context.Background())
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetQueryType("rangePreview").
+						SetRangeOptions(test.rangeOpts)
+
+					expr := bson.M{
+						"$and": bson.A{
+							bson.M{
+								test.field: bson.M{
+									"$gte": test.zero,
+								},
+							},
+							bson.M{
+								test.field: bson.M{
+									"$lte": test.six,
+								},
+							},
+						},
+					}
+
+					// Encrypt.
+					var encryptedExpr bson.Raw
+					{
+						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
+						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
+						var err error
+						encryptedExpr, err = res.DecodeBytes()
+						assert.Nil(mt, err, "error in Decode: %v", err)
+					}
+
+					coll := encryptedClient.Database("db").Collection("explicit_encryption")
+					opts := options.Find().SetSort(bson.M{"_id": 1})
+					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
+					assert.Nil(mt, err, "error in coll.Find: %v", err)
+					defer cursor.Close(context.Background())
+
+					checkCursorResults(cursor, test.field, test.zero, test.six)
+				})
+
+				mt.Run("Case 4: can find encrypted range with an open range query", func(mt *mtest.T) {
+					encryptedClient, clientEncryption := testSetup()
+					defer clientEncryption.Close(context.Background())
+					defer encryptedClient.Disconnect(context.Background())
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetQueryType("rangePreview").
+						SetRangeOptions(test.rangeOpts)
+
+					expr := bson.M{
+						"$and": bson.A{
+							bson.M{
+								test.field: bson.M{
+									"$gt": test.thirty,
+								},
+							},
+						},
+					}
+
+					// Encrypt.
+					var encryptedExpr bson.Raw
+					{
+						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
+						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
+						var err error
+						encryptedExpr, err = res.DecodeBytes()
+						assert.Nil(mt, err, "error in Decode: %v", err)
+					}
+
+					coll := encryptedClient.Database("db").Collection("explicit_encryption")
+					opts := options.Find().SetSort(bson.M{"_id": 1})
+					cursor, err := coll.Find(context.Background(), encryptedExpr, opts)
+					assert.Nil(mt, err, "error in coll.Find: %v", err)
+					defer cursor.Close(context.Background())
+
+					checkCursorResults(cursor, test.field, test.twoHundred)
+				})
+
+				mt.Run("Case 5: can run an aggregation expression inside $expr", func(mt *mtest.T) {
+					encryptedClient, clientEncryption := testSetup()
+					defer clientEncryption.Close(context.Background())
+					defer encryptedClient.Disconnect(context.Background())
+					eo := options.Encrypt().
+						SetAlgorithm("RangePreview").
+						SetKeyID(key1ID).
+						SetContentionFactor(0).
+						SetQueryType("rangePreview").
+						SetRangeOptions(test.rangeOpts)
+
+					expr := bson.M{
+						"$and": bson.A{
+							bson.M{
+								"$lt": bson.A{
+									fmt.Sprintf("$%v", test.field),
+									test.thirty,
+								},
+							},
+						},
+					}
+
+					// Encrypt.
+					var encryptedExpr bson.Raw
+					{
+						res := clientEncryption.EncryptExpression(context.Background(), expr, eo)
+						assert.Nil(mt, res.Err(), "error in EncryptExpression: %v", res.Err())
+						var err error
+						encryptedExpr, err = res.DecodeBytes()
+						assert.Nil(mt, err, "error in Decode: %v", err)
+					}
+
+					coll := encryptedClient.Database("db").Collection("explicit_encryption")
+					opts := options.Find().SetSort(bson.M{"_id": 1})
+					cursor, err := coll.Find(context.Background(), bson.M{"$expr": encryptedExpr}, opts)
+					assert.Nil(mt, err, "error in coll.Find: %v", err)
+					defer cursor.Close(context.Background())
+
+					checkCursorResults(cursor, test.field, test.zero, test.six)
+				})
+
+				if test.field != "encryptedDoubleNoPrecision" {
+					mt.Run("Case 6: encrypting a document greater than the maximum errors", func(mt *mtest.T) {
+						encryptedClient, clientEncryption := testSetup()
+						defer clientEncryption.Close(context.Background())
+						defer encryptedClient.Disconnect(context.Background())
+						eo := options.Encrypt().
+							SetAlgorithm("RangePreview").
+							SetKeyID(key1ID).
+							SetContentionFactor(0).
+							SetRangeOptions(test.rangeOpts)
+
+						_, err := clientEncryption.Encrypt(context.Background(), test.twoHundredOne, eo)
+						assert.NotNil(mt, err, "expected error, but got none")
+					})
+
+					mt.Run("Case 7: encrypting a document of a different type errors", func(mt *mtest.T) {
+						encryptedClient, clientEncryption := testSetup()
+						defer clientEncryption.Close(context.Background())
+						defer encryptedClient.Disconnect(context.Background())
+						eo := options.Encrypt().
+							SetAlgorithm("RangePreview").
+							SetKeyID(key1ID).
+							SetContentionFactor(0).
+							SetRangeOptions(test.rangeOpts)
+
+						var val bson.RawValue
+						if test.field == "encryptedInt" {
+							val = bson.RawValue{Type: bson.TypeDouble, Value: bsoncore.AppendDouble(nil, 6)}
+						} else {
+							val = bson.RawValue{Type: bson.TypeInt32, Value: bsoncore.AppendInt32(nil, 6)}
+						}
+
+						_, err := clientEncryption.Encrypt(context.Background(), val, eo)
+						assert.NotNil(mt, err, "expected error, but got none")
+					})
+				}
+
+				if test.field != "encryptedDoubleNoPrecision" && test.field != "encryptedDoublePrecision" {
+					mt.Run("Case 8: setting precision errors if the type is not a double", func(mt *mtest.T) {
+						encryptedClient, clientEncryption := testSetup()
+						defer clientEncryption.Close(context.Background())
+						defer encryptedClient.Disconnect(context.Background())
+
+						// Copy rangeOpts and set precision.
+						ro := test.rangeOpts
+						ro.SetPrecision(2)
+						eo := options.Encrypt().
+							SetAlgorithm("RangePreview").
+							SetKeyID(key1ID).
+							SetContentionFactor(0).
+							SetRangeOptions(ro)
+
+						_, err := clientEncryption.Encrypt(context.Background(), test.six, eo)
+						assert.NotNil(mt, err, "expected error, but got none")
+					})
+				}
+			})
+		}
+	})
 }
 
 func getWatcher(mt *mtest.T, streamType mongo.StreamType, cpt *cseProseTest) watcher {

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2060,7 +2060,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 		})
 
-	rangeRunOpts := mtest.NewOptions().MinServerVersion("6.2").Topologies(mtest.ReplicaSet, mtest.LoadBalanced, mtest.ShardedReplicaSet)
+	rangeRunOpts := mtest.NewOptions().MinServerVersion("6.2").Topologies(mtest.ReplicaSet, mtest.Sharded, mtest.LoadBalanced, mtest.ShardedReplicaSet)
 	mt.RunOpts("22. range explicit encryption", rangeRunOpts, func(mt *mtest.T) {
 		type testcase struct {
 			typeStr       string

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1577,10 +1577,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			assert.Nil(mt, err, "error on CreateCollection: %v", err)
 			err = mt.Client.Database("keyvault").Collection("datakeys").Drop(context.Background())
 			assert.Nil(mt, err, "error on Drop: %v", err)
-			keyVaultClient, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mtest.ClusterURI()))
+			keyVaultClient, err := mongo.Connect(context.Background(), options.Client().ApplyURI(mtest.ClusterURI()))
 			assert.Nil(mt, err, "error on Connect: %v", err)
 			datakeysColl := keyVaultClient.Database("keyvault").Collection("datakeys", options.Collection().SetWriteConcern(mtest.MajorityWc))
-			_, err = datakeysColl.InsertOne(context.TODO(), key1Document)
+			_, err = datakeysColl.InsertOne(context.Background(), key1Document)
 			assert.Nil(mt, err, "error on InsertOne: %v", err)
 			// Create a ClientEncryption.
 			ceo := options.ClientEncryption().
@@ -1782,7 +1782,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			wcMajority := writeconcern.New(writeconcern.WMajority(), writeconcern.WTimeout(1*time.Second))
 			wcMajorityCollectionOpts := options.Collection().SetWriteConcern(wcMajority)
 			wcmColl := cse.kvClient.Database(kvDatabase).Collection(dkCollection, wcMajorityCollectionOpts)
-			_, err = wcmColl.Indexes().CreateOne(context.TODO(), keyVaultIndex)
+			_, err = wcmColl.Indexes().CreateOne(context.Background(), keyVaultIndex)
 			assert.Nil(mt, err, "error creating keyAltNames index: %v", err)
 
 			// Using client_encryption, create a data key with a local KMS provider and the keyAltName "def".
@@ -2171,10 +2171,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					assert.Nil(mt, err, "error on CreateCollection: %v", err)
 					err = mt.Client.Database("keyvault").Collection("datakeys").Drop(context.Background())
 					assert.Nil(mt, err, "error on Drop: %v", err)
-					keyVaultClient, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(mtest.ClusterURI()))
+					keyVaultClient, err := mongo.Connect(context.Background(), options.Client().ApplyURI(mtest.ClusterURI()))
 					assert.Nil(mt, err, "error on Connect: %v", err)
 					datakeysColl := keyVaultClient.Database("keyvault").Collection("datakeys", options.Collection().SetWriteConcern(mtest.MajorityWc))
-					_, err = datakeysColl.InsertOne(context.TODO(), key1Document)
+					_, err = datakeysColl.InsertOne(context.Background(), key1Document)
 					assert.Nil(mt, err, "error on InsertOne: %v", err)
 					// Create a ClientEncryption.
 					ceo := options.ClientEncryption().

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -243,14 +243,15 @@ func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 // customCrypt is a test implementation of the driver.Crypt interface. It keeps track of the number of times its
 // methods have been called.
 type customCrypt struct {
-	numEncryptCalls              int
-	numDecryptCalls              int
-	numCreateDataKeyCalls        int
-	numEncryptExplicitCalls      int
-	numDecryptExplicitCalls      int
-	numCloseCalls                int
-	numBypassAutoEncryptionCalls int
-	numRewrapDataKeyCalls        int
+	numEncryptCalls                   int
+	numDecryptCalls                   int
+	numCreateDataKeyCalls             int
+	numEncryptExplicitCalls           int
+	numEncryptExplicitExpressionCalls int
+	numDecryptExplicitCalls           int
+	numCloseCalls                     int
+	numBypassAutoEncryptionCalls      int
+	numRewrapDataKeyCalls             int
 }
 
 var (
@@ -308,6 +309,12 @@ func (c *customCrypt) CreateDataKey(_ context.Context, _ string, _ *mcopts.DataK
 func (c *customCrypt) EncryptExplicit(_ context.Context, _ bsoncore.Value, _ *mcopts.ExplicitEncryptionOptions) (byte, []byte, error) {
 	c.numEncryptExplicitCalls++
 	return 0, nil, nil
+}
+
+// EncryptExplicit implements the driver.Crypt interface.
+func (c *customCrypt) EncryptExplicitExpression(_ context.Context, _ bsoncore.Document, _ *mcopts.ExplicitEncryptionOptions) (bsoncore.Document, error) {
+	c.numEncryptExplicitExpressionCalls++
+	return nil, nil
 }
 
 // DecryptExplicit implements the driver.Crypt interface.
@@ -385,6 +392,8 @@ func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 			"expected 0 calls to CreateDataKey, got %v", cc.numCreateDataKeyCalls)
 		assert.Equal(mt, cc.numEncryptExplicitCalls, 0,
 			"expected 0 calls to EncryptExplicit, got %v", cc.numEncryptExplicitCalls)
+		assert.Equal(mt, cc.numEncryptExplicitExpressionCalls, 0,
+			"expected 0 calls to EncryptExplicitExpression, got %v", cc.numEncryptExplicitExpressionCalls)
 		assert.Equal(mt, cc.numDecryptExplicitCalls, 0,
 			"expected 0 calls to DecryptExplicit, got %v", cc.numDecryptExplicitCalls)
 		assert.Equal(mt, cc.numCloseCalls, 0,

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -7,6 +7,7 @@
 package options
 
 import (
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -17,6 +18,13 @@ const (
 	QueryTypeEquality string = "equality"
 )
 
+type RangeOptions struct {
+	Min       *bson.RawValue
+	Max       *bson.RawValue
+	Sparsity  int64
+	Precision *int32
+}
+
 // EncryptOptions represents options to explicitly encrypt a value.
 type EncryptOptions struct {
 	KeyID            *primitive.Binary
@@ -24,6 +32,7 @@ type EncryptOptions struct {
 	Algorithm        string
 	QueryType        string
 	ContentionFactor *int64
+	RangeOptions     *RangeOptions
 }
 
 // Encrypt creates a new EncryptOptions instance.
@@ -74,6 +83,41 @@ func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOpt
 	return e
 }
 
+// SetRangeOptions specifies the options to use for explicit encryption with range. It is only valid to set if algorithm is "rangePreview".
+// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+func (e *EncryptOptions) SetRangeOptions(ro RangeOptions) *EncryptOptions {
+	e.RangeOptions = &ro
+	return e
+}
+
+// SetMin sets the range index minimum value.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+func (ro *RangeOptions) SetMin(min bson.RawValue) *RangeOptions {
+	ro.Min = &min
+	return ro
+}
+
+// SetMax sets the range index maximum value.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+func (ro *RangeOptions) SetMax(max bson.RawValue) *RangeOptions {
+	ro.Max = &max
+	return ro
+}
+
+// SetSparsity sets the range index sparsity.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+func (ro *RangeOptions) SetSparsity(sparsity int64) *RangeOptions {
+	ro.Sparsity = sparsity
+	return ro
+}
+
+// SetPrecision sets the range index precision.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+func (ro *RangeOptions) SetPrecision(precision int32) *RangeOptions {
+	ro.Precision = &precision
+	return ro
+}
+
 // MergeEncryptOptions combines the argued EncryptOptions in a last-one wins fashion.
 func MergeEncryptOptions(opts ...*EncryptOptions) *EncryptOptions {
 	eo := Encrypt()
@@ -96,6 +140,9 @@ func MergeEncryptOptions(opts ...*EncryptOptions) *EncryptOptions {
 		}
 		if opt.ContentionFactor != nil {
 			eo.ContentionFactor = opt.ContentionFactor
+		}
+		if opt.RangeOptions != nil {
+			eo.RangeOptions = opt.RangeOptions
 		}
 	}
 

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -18,7 +18,7 @@ const (
 	QueryTypeEquality string = "equality"
 )
 
-// RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
+// RangeOptions specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
 // NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 type RangeOptions struct {
 	Min       *bson.RawValue

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -19,7 +19,7 @@ const (
 )
 
 // RangeOptions specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 type RangeOptions struct {
 	Min       *bson.RawValue
 	Max       *bson.RawValue
@@ -86,35 +86,35 @@ func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOpt
 }
 
 // SetRangeOptions specifies the options to use for explicit encryption with range. It is only valid to set if algorithm is "rangePreview".
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (e *EncryptOptions) SetRangeOptions(ro RangeOptions) *EncryptOptions {
 	e.RangeOptions = &ro
 	return e
 }
 
 // SetMin sets the range index minimum value.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMin(min bson.RawValue) *RangeOptions {
 	ro.Min = &min
 	return ro
 }
 
 // SetMax sets the range index maximum value.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMax(max bson.RawValue) *RangeOptions {
 	ro.Max = &max
 	return ro
 }
 
 // SetSparsity sets the range index sparsity.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetSparsity(sparsity int64) *RangeOptions {
 	ro.Sparsity = sparsity
 	return ro
 }
 
 // SetPrecision sets the range index precision.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetPrecision(precision int32) *RangeOptions {
 	ro.Precision = &precision
 	return ro

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -18,6 +18,8 @@ const (
 	QueryTypeEquality string = "equality"
 )
 
+// RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 type RangeOptions struct {
 	Min       *bson.RawValue
 	Max       *bson.RawValue
@@ -84,35 +86,35 @@ func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOpt
 }
 
 // SetRangeOptions specifies the options to use for explicit encryption with range. It is only valid to set if algorithm is "rangePreview".
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (e *EncryptOptions) SetRangeOptions(ro RangeOptions) *EncryptOptions {
 	e.RangeOptions = &ro
 	return e
 }
 
 // SetMin sets the range index minimum value.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMin(min bson.RawValue) *RangeOptions {
 	ro.Min = &min
 	return ro
 }
 
 // SetMax sets the range index maximum value.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMax(max bson.RawValue) *RangeOptions {
 	ro.Max = &max
 	return ro
 }
 
 // SetSparsity sets the range index sparsity.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetSparsity(sparsity int64) *RangeOptions {
 	ro.Sparsity = sparsity
 	return ro
 }
 
 // SetPrecision sets the range index precision.
-// NOTE: The Range algorithm is experimental only. It is not intended for public use.
+// NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetPrecision(precision int32) *RangeOptions {
 	ro.Precision = &precision
 	return ro

--- a/testdata/client-side-encryption-prose/range-encryptedFields-Date.json
+++ b/testdata/client-side-encryption-prose/range-encryptedFields-Date.json
@@ -1,0 +1,30 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDate",
+        "bsonType": "date",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$date": {
+              "$numberLong": "0"
+          }
+          },
+          "max": {
+            "$date": {
+              "$numberLong": "200"
+          }
+          }
+        }
+      }
+    ]
+}

--- a/testdata/client-side-encryption-prose/range-encryptedFields-DoubleNoPrecision.json
+++ b/testdata/client-side-encryption-prose/range-encryptedFields-DoubleNoPrecision.json
@@ -1,0 +1,21 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDoubleNoPrecision",
+        "bsonType": "double",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/testdata/client-side-encryption-prose/range-encryptedFields-DoublePrecision.json
+++ b/testdata/client-side-encryption-prose/range-encryptedFields-DoublePrecision.json
@@ -1,0 +1,30 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDoublePrecision",
+        "bsonType": "double",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberDouble": "0.0"
+          },
+          "max": {
+            "$numberDouble": "199.9"
+          },
+          "precision": {
+            "$numberInt": "2"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/testdata/client-side-encryption-prose/range-encryptedFields-Int.json
+++ b/testdata/client-side-encryption-prose/range-encryptedFields-Int.json
@@ -1,0 +1,27 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedInt",
+        "bsonType": "int",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberInt": "0"
+          },
+          "max": {
+            "$numberInt": "200"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/testdata/client-side-encryption-prose/range-encryptedFields-Long.json
+++ b/testdata/client-side-encryption-prose/range-encryptedFields-Long.json
@@ -1,0 +1,27 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedLong",
+        "bsonType": "long",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberLong": "0"
+          },
+          "max": {
+            "$numberLong": "200"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -65,6 +65,8 @@ type Crypt interface {
 	CreateDataKey(ctx context.Context, kmsProvider string, opts *options.DataKeyOptions) (bsoncore.Document, error)
 	// EncryptExplicit encrypts the given value with the given options.
 	EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *options.ExplicitEncryptionOptions) (byte, []byte, error)
+	// EncryptExplicitExpression encrypts the given expression with the given options.
+	EncryptExplicitExpression(ctx context.Context, val bsoncore.Document, opts *options.ExplicitEncryptionOptions) (bsoncore.Document, error)
 	// DecryptExplicit decrypts the given encrypted value.
 	DecryptExplicit(ctx context.Context, subtype byte, data []byte) (bsoncore.Value, error)
 	// Close cleans up any resources associated with the Crypt instance.
@@ -213,6 +215,27 @@ func (c *crypt) EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *o
 
 	sub, data := res.Lookup("v").Binary()
 	return sub, data, nil
+}
+
+// EncryptExplicitExpression encrypts the given expression with the given options.
+func (c *crypt) EncryptExplicitExpression(ctx context.Context, expr bsoncore.Document, opts *options.ExplicitEncryptionOptions) (bsoncore.Document, error) {
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendDocumentElement(doc, "v", expr)
+	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
+
+	cryptCtx, err := c.mongoCrypt.CreateExplicitEncryptionExpressionContext(doc, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cryptCtx.Close()
+
+	res, err := c.executeStateMachine(ctx, cryptCtx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedExpr := res.Lookup("v").Document()
+	return encryptedExpr, nil
 }
 
 // DecryptExplicit decrypts the given encrypted value.

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -35,6 +35,11 @@ func (m *MongoCrypt) CreateEncryptionContext(db string, cmd bsoncore.Document) (
 	panic(cseNotSupportedMsg)
 }
 
+// CreateExplicitEncryptionExpressionContext creates a Context to use for explicit encryption of an expression.
+func (m *MongoCrypt) CreateExplicitEncryptionExpressionContext(doc bsoncore.Document, opts *options.ExplicitEncryptionOptions) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
 // CreateDecryptionContext creates a Context to use for decryption.
 func (m *MongoCrypt) CreateDecryptionContext(cmd bsoncore.Document) (*Context, error) {
 	panic(cseNotSupportedMsg)

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
@@ -56,6 +56,15 @@ type ExplicitEncryptionOptions struct {
 	Algorithm        string
 	QueryType        string
 	ContentionFactor *int64
+	RangeOptions     *ExplicitRangeOptions
+}
+
+// ExplicitRangeOptions specifies options for the range index.
+type ExplicitRangeOptions struct {
+	Min       *bsoncore.Value
+	Max       *bsoncore.Value
+	Sparsity  int64
+	Precision *int32
 }
 
 // ExplicitEncryption creates a new ExplicitEncryptionOptions instance.
@@ -90,6 +99,12 @@ func (eeo *ExplicitEncryptionOptions) SetQueryType(queryType string) *ExplicitEn
 // SetContentionFactor specifies the contention factor.
 func (eeo *ExplicitEncryptionOptions) SetContentionFactor(contentionFactor int64) *ExplicitEncryptionOptions {
 	eeo.ContentionFactor = &contentionFactor
+	return eeo
+}
+
+// SetRangeOptions specifies the range options.
+func (eeo *ExplicitEncryptionOptions) SetRangeOptions(ro ExplicitRangeOptions) *ExplicitEncryptionOptions {
+	eeo.RangeOptions = &ro
 	return eeo
 }
 


### PR DESCRIPTION
GODRIVER-2433

# Summary
- Add `RangeOptions`.
- Add `ClientEncryption.EncryptExpression()`.
- Add prose test for explicit encryption with range.
- Document requirement of libmongocrypt 1.7.0.

# Background & Motivation

See https://github.com/mongodb/specifications/pull/1355.

The API is marked experimental due to [this comment](https://jira.mongodb.org/browse/DRIVERS-2286?focusedCommentId=4975162&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4975162).

The libmongocrypt API is also described in [mongocrypt.h](https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h#L949)
