### PR TITLE
GODRIVER-2657 Restrict getNonce spec tests to < 6.2.

### DIFF
--- a/testdata/command-monitoring/redacted-commands.json
+++ b/testdata/command-monitoring/redacted-commands.json
@@ -162,6 +162,11 @@
     },
     {
       "description": "getnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -293,6 +298,11 @@
     },
     {
       "description": "copydbgetnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -328,6 +338,11 @@
     },
     {
       "description": "copydbsaslstart",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -363,6 +378,11 @@
     },
     {
       "description": "copydb",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/testdata/command-monitoring/redacted-commands.yml
+++ b/testdata/command-monitoring/redacted-commands.yml
@@ -93,6 +93,8 @@ tests:
                 payload: { $$exists: false }
 
   - description: "getnonce"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *database
@@ -159,6 +161,8 @@ tests:
                 roles: { $$exists: false }
 
   - description: "copydbgetnonce"
+    runOnRequirements:
+    - maxServerVersion: 3.6.99 # copydbgetnonce was removed as of 4.0 via SERVER-32276
     operations:
       - name: runCommand
         object: *database
@@ -176,6 +180,8 @@ tests:
               command: { copydbgetnonce: { $$exists: false } }
 
   - description: "copydbsaslstart"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydbsaslstart was removed as of 4.2 via SERVER-36211
     operations:
       - name: runCommand
         object: *database
@@ -193,6 +199,8 @@ tests:
               command: { copydbsaslstart: { $$exists: false } }
 
   - description: "copydb"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydb was removed as of 4.2 via SERVER-36257
     operations:
       - name: runCommand
         object: *database

--- a/testdata/unified-test-format/valid-pass/observeSensitiveCommands.json
+++ b/testdata/unified-test-format/valid-pass/observeSensitiveCommands.json
@@ -61,6 +61,11 @@
   "tests": [
     {
       "description": "getnonce is observed with observeSensitiveCommands=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -106,6 +111,11 @@
     },
     {
       "description": "getnonce is not observed with observeSensitiveCommands=false",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -127,6 +137,11 @@
     },
     {
       "description": "getnonce is not observed by default",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/testdata/unified-test-format/valid-pass/observeSensitiveCommands.yml
+++ b/testdata/unified-test-format/valid-pass/observeSensitiveCommands.yml
@@ -38,6 +38,8 @@ createEntities:
 
 tests:
   - description: "getnonce is observed with observeSensitiveCommands=true"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseObserveSensitiveCommands
@@ -57,6 +59,8 @@ tests:
                 nonce: { $$exists: false }
 
   - description: "getnonce is not observed with observeSensitiveCommands=false"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommands
@@ -68,6 +72,8 @@ tests:
         events: []
 
   - description: "getnonce is not observed by default"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommandsByDefault


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2657

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Syncs spec tests with [this commit](https://github.com/mongodb/specifications/commit/735a667672c758617821e3c5dda99c551e007375). 

## Background & Motivation
<!--- Rationale for the pull request. -->
Support for the `getNonce` command will be removed in server version 6.2. This updates spec tests that send `getNonce` to the server to only run on 6.1.99 and below. The only usage of `getNonce` we have otherwise is in the MongoDBCR authentication system, which we've ["deprecated"](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/auth/mongodbcr.go#L41-L42). The [mongdbcr_test.go](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/auth/mongodbcr_test.go) mocks connections for writing and reading messages, so `getNonce` is never actually sent to a server.

