### PR TITLE
GODRIVER-2650 Fix incorrect X509 certificate being used as username for authentication.

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -752,7 +752,8 @@ func (c *ClientOptions) SetTimeout(d time.Duration) *ClientOptions {
 // "tlsPrivateKeyFile". The "tlsCertificateKeyFile" option specifies a path to the client certificate and private key,
 // which must be concatenated into one file. The "tlsCertificateFile" and "tlsPrivateKey" combination specifies separate
 // paths to the client certificate and private key, respectively. Note that if "tlsCertificateKeyFile" is used, the
-// other two options must not be specified.
+// other two options must not be specified. Only the subject name of the first certificate is honored as the username
+// for X509 auth in a file with multiple certs.
 //
 // 3. "tlsCertificateKeyFilePassword" (or "sslClientCertificateKeyPassword"): Specify the password to decrypt the client
 // private key file (e.g. "tlsCertificateKeyFilePassword=password").
@@ -1049,8 +1050,8 @@ func addClientCertFromConcatenatedFile(cfg *tls.Config, certKeyFile, keyPassword
 	return addClientCertFromBytes(cfg, data, keyPassword)
 }
 
-// addClientCertFromBytes adds a client certificate to the configuration given a path to the
-// containing file and returns the certificate's subject name.
+// addClientCertFromBytes adds client certificates to the configuration given a path to the
+// containing file and returns the subject name in the first certificate.
 func addClientCertFromBytes(cfg *tls.Config, data []byte, keyPasswd string) (string, error) {
 	var currentBlock *pem.Block
 	var certDecodedBlock []byte
@@ -1067,6 +1068,8 @@ func addClientCertFromBytes(cfg *tls.Config, data []byte, keyPasswd string) (str
 		if currentBlock.Type == "CERTIFICATE" {
 			certBlock := data[start : len(data)-len(remaining)]
 			certBlocks = append(certBlocks, certBlock)
+			// Assign the certDecodedBlock when it is never set,
+			// so only the first certificate is honored in a file with multiple certs.
 			if certDecodedBlock == nil {
 				certDecodedBlock = currentBlock.Bytes
 			}

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -1067,7 +1067,9 @@ func addClientCertFromBytes(cfg *tls.Config, data []byte, keyPasswd string) (str
 		if currentBlock.Type == "CERTIFICATE" {
 			certBlock := data[start : len(data)-len(remaining)]
 			certBlocks = append(certBlocks, certBlock)
-			certDecodedBlock = currentBlock.Bytes
+			if certDecodedBlock == nil {
+				certDecodedBlock = currentBlock.Bytes
+			}
 			start += len(certBlock)
 		} else if strings.HasSuffix(currentBlock.Type, "PRIVATE KEY") {
 			isEncrypted := x509.IsEncryptedPEMBlock(currentBlock) || strings.Contains(currentBlock.Type, "ENCRYPTED PRIVATE KEY")

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -578,6 +578,7 @@ func TestClientOptions(t *testing.T) {
 				"mongodb://localhost/?ssl=true&authMechanism=mongodb-x509&sslClientCertificateKeyFile=testdata/one-pk-multiple-certs.pem",
 				baseClient().SetAuth(Credential{
 					AuthMechanism: "mongodb-x509", AuthSource: "$external",
+					// Subject name in the first certificate is used as the username for X509 auth.
 					Username: `C=US,ST=New York,L=New York City,O=MongoDB,OU=Drivers,CN=localhost`,
 				}).SetTLSConfig(&tls.Config{Certificates: make([]tls.Certificate, 1)}),
 			},

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -573,6 +573,14 @@ func TestClientOptions(t *testing.T) {
 				"mongodb://localhost/?tlsCertificateKeyFile=testdata/one-pk-multiple-certs.pem",
 				baseClient().SetTLSConfig(&tls.Config{Certificates: make([]tls.Certificate, 1)}),
 			},
+			{
+				"GODRIVER-2650 X509 certificate",
+				"mongodb://localhost/?ssl=true&authMechanism=mongodb-x509&sslClientCertificateKeyFile=testdata/one-pk-multiple-certs.pem",
+				baseClient().SetAuth(Credential{
+					AuthMechanism: "mongodb-x509", AuthSource: "$external",
+					Username: `C=US,ST=New York,L=New York City,O=MongoDB,OU=Drivers,CN=localhost`,
+				}).SetTLSConfig(&tls.Config{Certificates: make([]tls.Certificate, 1)}),
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
GODRIVER-2650

## Summary
Extract the subject from the first certificate instead of the last.

## Background & Motivation
The Subject of the last certificate was returned as the username for X509 auth after [GODRIVER-2263](https://jira.mongodb.org/browse/GODRIVER-2263), which did not match the order of loading a PEM file with multiple certs.
As the ticket suggests, this change updates the certificate subject string if the `certDecodeBlock` is never set.