### PR TITLE
GODRIVER-2702 update bsoncore value string to preserve timestamp type

### DIFF
--- a/x/bsonx/bsoncore/value.go
+++ b/x/bsonx/bsoncore/value.go
@@ -323,7 +323,7 @@ func (v Value) String() string {
 		if !ok {
 			return ""
 		}
-		return fmt.Sprintf(`{"$timestamp":{"t":"%s","i":"%s"}}`, strconv.FormatUint(uint64(t), 10), strconv.FormatUint(uint64(i), 10))
+		return fmt.Sprintf(`{"$timestamp":{"t":%v,"i":%v}}`, t, i)
 	case bsontype.Int64:
 		i64, ok := v.Int64OK()
 		if !ok {

--- a/x/bsonx/bsoncore/value_test.go
+++ b/x/bsonx/bsoncore/value_test.go
@@ -17,8 +17,14 @@ import (
 )
 
 func TestValue(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Validate", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("invalid", func(t *testing.T) {
+			t.Parallel()
+
 			v := Value{Type: bsontype.Double, Data: []byte{0x01, 0x02, 0x03, 0x04}}
 			want := NewInsufficientBytesError(v.Data, v.Data)
 			got := v.Validate()
@@ -27,6 +33,8 @@ func TestValue(t *testing.T) {
 			}
 		})
 		t.Run("value", func(t *testing.T) {
+			t.Parallel()
+
 			v := Value{Type: bsontype.Double, Data: AppendDouble(nil, 3.14159)}
 			var want error
 			got := v.Validate()
@@ -35,7 +43,10 @@ func TestValue(t *testing.T) {
 			}
 		})
 	})
+
 	t.Run("IsNumber", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name  string
 			val   Value
@@ -50,7 +61,11 @@ func TestValue(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				isnum := tc.val.IsNumber()
 				if isnum != tc.isnum {
 					t.Errorf("IsNumber did not return the expected boolean. got %t; want %t", isnum, tc.isnum)
@@ -619,10 +634,19 @@ func TestValue(t *testing.T) {
 			nil,
 			[]interface{}{primitive.NewDecimal128(12345, 67890), true},
 		},
+		{
+			"Timestamp.String/Success", Value.String, Value{Type: bsontype.Timestamp, Data: AppendTimestamp(nil, 12345, 67890)},
+			nil,
+			[]interface{}{"{\"$timestamp\":{\"t\":12345,\"i\":67890}}"},
+		},
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			defer func() {
 				err := recover()
 				if !cmp.Equal(err, tc.panicErr, cmp.Comparer(compareErrors)) {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2702

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Update the "bsoncore.Value#String" method to preserve timestamp int/uint type during string conversion. This method is intended to express BSON as extended JSON and converting the timestamp (I,U) values is in antithesis to [specifications](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#conversion-table).

## Background & Motivation
<!--- Rationale for the pull request. -->

The "CommandStartedMessage" for command logging and monitoring has a field called "command" which is the "relaxed extJSON representation of the command." To accomplish this in the Go Driver, we use the "[bsoncore.Value#String](https://github.com/mongodb/mongo-go-driver/blob/master/x/bsonx/bsoncore/value.go#L228)" method to convert `cmdCopy` in the operation executor to a string before logging. However, "bsoncore.Value#String" does not preserve timestamp types and so decoding the resulting string will result in the following error:

```go
var doc bson.Raw
if err := bson.UnmarshalExtJSON([]byte(cmdCopy.String()), true, &doc); err != nil {
        // panic: error: $timestamp t value should be uint32, but instead is string
	panic(fmt.Sprintf("error: %v", err)) 
}
```

This use-case arises with the addition of the "$$matchAsDocument" and "$$matchAsRoot" operators to the driver test runners, [here](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#matchasdocument).
