### PR TITLE
Add POC for reply callback

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // CommandStartedEvent represents an event generated when a command is sent to a server.
@@ -58,9 +59,10 @@ type CommandFailedEvent struct {
 
 // CommandMonitor represents a monitor that is triggered for different events.
 type CommandMonitor struct {
-	Started   func(context.Context, *CommandStartedEvent)
-	Succeeded func(context.Context, *CommandSucceededEvent)
-	Failed    func(context.Context, *CommandFailedEvent)
+	Started       func(context.Context, *CommandStartedEvent)
+	Succeeded     func(context.Context, *CommandSucceededEvent)
+	Failed        func(context.Context, *CommandFailedEvent)
+	ReplyCallback func(context.Context, *bsoncore.Document) bson.Raw
 }
 
 // strings for pool command monitoring reasons

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1757,9 +1757,7 @@ func defaultReplyCallback(ctx context.Context, rsp *bsoncore.Document) bson.Raw 
 // publishFinishedEvent publishes either a CommandSucceededEvent or a CommandFailedEvent to the operation's command
 // monitor if possible. If success/failure events aren't being monitored, no events are published.
 func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInformation) {
-	fmt.Println("publishFinishedEvent")
 	if op.CommandMonitor == nil {
-		fmt.Println(1)
 		return
 	}
 
@@ -1773,7 +1771,6 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		success = true
 	}
 	if (success && op.CommandMonitor.Succeeded == nil) || (!success && op.CommandMonitor.Failed == nil) {
-		fmt.Println(2)
 		return
 	}
 
@@ -1803,7 +1800,6 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 			CommandFinishedEvent: finished,
 		}
 		op.CommandMonitor.Succeeded(ctx, successEvent)
-		fmt.Println(3)
 		return
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Add a "ReplyCallback" field to the CommandMonitor struct to give users the option of altering the response of a request before it is propagated to the CommandSucceeded event.

A use case for this would look something like the following:

```go
package main

import (
	"context"
	"log"

	"go.mongodb.org/mongo-driver/bson"
	"go.mongodb.org/mongo-driver/event"
	"go.mongodb.org/mongo-driver/mongo"
	"go.mongodb.org/mongo-driver/mongo/options"
	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
)

func main() {
	cmdMonitor := new(event.CommandMonitor)

	cmdMonitor.ReplyCallback = func(ctx context.Context, rsp *bsoncore.Document) bson.Raw { 
                 return nil 
        }
	cmdMonitor.Succeeded = func(context.Context, *event.CommandSucceededEvent) {}

	ctx := context.Background()

	clientOptions := options.Client().ApplyURI("mongodb://localhost:27017").SetMonitor(cmdMonitor)
	client, err := mongo.Connect(ctx, clientOptions)
	if err != nil {
		log.Fatal(err)
	}

	if err = client.Ping(ctx, nil); err != nil {
		log.Fatal(err)
	}
}
```

## Background & Motivation
<!--- Rationale for the pull request. -->

A user is suggesting adding a "Finished" event to the CommandMonitor in PR #1106. The user's solution may be the best solution, this PR is to explore alternatives.


