### PR TITLE
GODRIVER-2493 Automatically create Queryable Encryption keys.

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -74,6 +74,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 }
 
 // CreateEncryptedCollection creates a new collection with the help of automatic generation of new encryption data keys for null keyIds.
+// It returns the created collection and the encrypted fields document used to create it.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	db *Database, coll string, createOpts *options.CreateCollectionOptions,
 	kmsProvider string, dkOpts *options.DataKeyOptions) (*Collection, bson.M, error) {

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2098,7 +2098,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			}`), true /* canonical */, &encryptedFields)
 			assert.Nil(mt, err, "Unmarshal error: %v", err)
 
-			coll, err := clientEnc.CreateEncryptedCollection(
+			coll, _, err := clientEnc.CreateEncryptedCollection(
 				context.Background(),
 				client.Database("db"),
 				"testing1", options.CreateCollection().SetEncryptedFields(encryptedFields),
@@ -2117,7 +2117,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				assert.Nil(mt, err, "error in Close")
 			}()
 
-			coll, err := clientEnc.CreateEncryptedCollection(
+			coll, _, err := clientEnc.CreateEncryptedCollection(
 				context.Background(),
 				client.Database("db"),
 				"testing1", options.CreateCollection(),
@@ -2144,7 +2144,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			}`), true /* canonical */, &encryptedFields)
 			assert.Nil(mt, err, "Unmarshal error: %v", err)
 
-			_, err = clientEnc.CreateEncryptedCollection(
+			_, _, err = clientEnc.CreateEncryptedCollection(
 				context.Background(),
 				client.Database("db"),
 				"testing1", options.CreateCollection().SetEncryptedFields(encryptedFields),
@@ -2170,17 +2170,15 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			}`), true /* canonical */, &encryptedFields)
 			assert.Nil(mt, err, "Unmarshal error: %v", err)
 
-			op := options.CreateCollection().SetEncryptedFields(encryptedFields)
-			coll, err := clientEnc.CreateEncryptedCollection(
+			coll, ef, err := clientEnc.CreateEncryptedCollection(
 				context.Background(),
 				client.Database("db"),
-				"testing1", op,
+				"testing1", options.CreateCollection().SetEncryptedFields(encryptedFields),
 				"local", nil,
 			)
 			assert.Nil(mt, err, "CreateCollection error: %v", err)
 
-			fields := op.EncryptedFields.(map[string]interface{})["fields"].(primitive.A)
-			keyid := fields[0].(map[string]interface{})["keyId"].(primitive.Binary)
+			keyid := ef["fields"].(bson.A)[0].(bson.M)["keyId"].(primitive.Binary)
 			rawValueType, rawValueData, err := bson.MarshalValue("123-45-6789")
 			assert.Nil(mt, err, "MarshalValue error: %v", err)
 			rawValue := bson.RawValue{Type: rawValueType, Value: rawValueData}


### PR DESCRIPTION
GODRIVER-2493

## Summary
- Add a new `CreateEncryptedCollection` method which automatically generates new encryption data keys for nil `keyIds`;
- Add test cases.

## Background & Motivation
https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#create-encrypted-collection-helper
https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#automatic-data-encryption-keys
