### PR TITLE
GODRIVER-2677 Limit the maximum number of items in pool.

### DIFF
--- a/x/mongo/driver/byteslicepool.go
+++ b/x/mongo/driver/byteslicepool.go
@@ -1,0 +1,57 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package driver
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type byteslicePool struct {
+	pool *sync.Pool
+	sem  *semaphore.Weighted
+}
+
+// newByteSlicePool creates a byte slices pool with a maximum number of items,
+// which is specified by the parameter, "size".
+func newByteSlicePool(size int) *byteslicePool {
+	return &byteslicePool{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				// Start with 1kb buffers.
+				b := make([]byte, 1024)
+				// Return a pointer as the static analysis tool suggests.
+				return &b
+			},
+		},
+		sem: semaphore.NewWeighted(int64(size)),
+	}
+}
+
+func (p *byteslicePool) Get(ctx context.Context) ([]byte, error) {
+	// Block until resources are available.
+	err := p.sem.Acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	return (*p.pool.Get().(*[]byte))[:0], nil
+}
+
+func (p *byteslicePool) Put(b []byte) {
+	p.sem.Release(1)
+	// Proper usage of a sync.Pool requires each entry to have approximately the same memory
+	// cost. To obtain this property when the stored type contains a variably-sized buffer,
+	// we add a hard limit on the maximum buffer to place back in the pool. We limit the
+	// size to 16MiB because that's the maximum wire message size supported by MongoDB.
+	//
+	// Comment copied from https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/fmt/print.go;l=147
+	if cap(b) <= 16*1024*1024 {
+		p.pool.Put(&b)
+	}
+}

--- a/x/mongo/driver/byteslicepool_test.go
+++ b/x/mongo/driver/byteslicepool_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/internal/assert"
+)
+
+func TestByteSlicePool(t *testing.T) {
+	t.Run("allocation", func(t *testing.T) {
+		var memoryPool = newByteSlicePool(1)
+		b, err := memoryPool.Get(context.Background())
+		assert.Nil(t, err, "allocation failed with error %v", err)
+		assert.Equal(t, false, memoryPool.sem.TryAcquire(1), "semaphore was not acquired correctly")
+		memoryPool.Put(b)
+		assert.Equal(t, true, memoryPool.sem.TryAcquire(1), "semaphore was not released correctly")
+	})
+}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -318,14 +317,8 @@ func (op Operation) Validate() error {
 	return nil
 }
 
-var memoryPool = sync.Pool{
-	New: func() interface{} {
-		// Start with 1kb buffers.
-		b := make([]byte, 1024)
-		// Return a pointer as the static analysis tool suggests.
-		return &b
-	},
-}
+// Create a pool of maximum 512 byte slices.
+var memoryPool = newByteSlicePool(512)
 
 // Execute runs this operation.
 func (op Operation) Execute(ctx context.Context) error {
@@ -425,17 +418,11 @@ func (op Operation) Execute(ctx context.Context) error {
 		conn = nil
 	}
 
-	wm := memoryPool.Get().(*[]byte)
+	wm, err := memoryPool.Get(context.Background())
+	if err != nil {
+		return errors.New("failed to allocate memory")
+	}
 	defer func() {
-		// Proper usage of a sync.Pool requires each entry to have approximately the same memory
-		// cost. To obtain this property when the stored type contains a variably-sized buffer,
-		// we add a hard limit on the maximum buffer to place back in the pool. We limit the
-		// size to 16MiB because that's the maximum wire message size supported by MongoDB.
-		//
-		// Comment copied from https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/fmt/print.go;l=147
-		if cap(*wm) > 16*1024*1024 {
-			return
-		}
 		memoryPool.Put(wm)
 	}()
 	for {
@@ -536,7 +523,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		}
 
 		var startedInfo startedInformation
-		*wm, startedInfo, err = op.createWireMessage(ctx, (*wm)[:0], desc, maxTimeMS, conn)
+		wm, startedInfo, err = op.createWireMessage(ctx, wm[:0], desc, maxTimeMS, conn)
 		if err != nil {
 			return err
 		}
@@ -551,12 +538,15 @@ func (op Operation) Execute(ctx context.Context) error {
 		op.publishStartedEvent(ctx, startedInfo)
 
 		// get the moreToCome flag information before we compress
-		moreToCome := wiremessage.IsMsgMoreToCome(*wm)
+		moreToCome := wiremessage.IsMsgMoreToCome(wm)
 
 		// compress wiremessage if allowed
 		if compressor, ok := conn.(Compressor); ok && op.canCompress(startedInfo.cmdName) {
-			b := memoryPool.Get().(*[]byte)
-			*b, err = compressor.CompressWireMessage(*wm, (*b)[:0])
+			b, err := memoryPool.Get(context.Background())
+			if err != nil {
+				return errors.New("failed to allocate memory")
+			}
+			b, err = compressor.CompressWireMessage(wm, b[:0])
 			memoryPool.Put(wm)
 			wm = b
 			if err != nil {
@@ -595,7 +585,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			if moreToCome {
 				roundTrip = op.moreToComeRoundTrip
 			}
-			res, *wm, err = roundTrip(ctx, conn, *wm)
+			res, wm, err = roundTrip(ctx, conn, wm)
 
 			if ep, ok := srvr.(ErrorProcessor); ok {
 				_ = ep.ProcessError(err, conn)
@@ -975,12 +965,15 @@ func (Operation) decompressWireMessage(wm []byte) ([]byte, error) {
 	}
 
 	// Copy msg, which is a subslice of wm. wm will be used to store the return value of the decompressed message.
-	b := memoryPool.Get().(*[]byte)
-	msglen := len(msg)
-	if len(*b) < msglen {
-		*b = make([]byte, msglen)
+	b, err := memoryPool.Get(context.Background())
+	if err != nil {
+		return nil, errors.New("failed to allocate memory")
 	}
-	copy(*b, msg)
+	msglen := len(msg)
+	if len(b) < msglen {
+		b = make([]byte, msglen)
+	}
+	copy(b, msg)
 	defer func() {
 		memoryPool.Put(b)
 	}()
@@ -993,7 +986,7 @@ func (Operation) decompressWireMessage(wm []byte) ([]byte, error) {
 		Compressor:       compressorID,
 		UncompressedSize: uncompressedSize,
 	}
-	uncompressed, err := DecompressPayload((*b)[0:msglen], opts)
+	uncompressed, err := DecompressPayload(b[0:msglen], opts)
 	if err != nil {
 		return nil, err
 	}

--- a/x/mongo/driver/operation_exhaust.go
+++ b/x/mongo/driver/operation_exhaust.go
@@ -18,13 +18,15 @@ func (op Operation) ExecuteExhaust(ctx context.Context, conn StreamerConnection)
 		return errors.New("exhaust read must be done with a connection that is currently streaming")
 	}
 
-	wm := memoryPool.Get().(*[]byte)
+	wm, err := memoryPool.Get(context.Background())
+	if err != nil {
+		return errors.New("failed to allocate memory")
+	}
 	defer func() {
 		memoryPool.Put(wm)
 	}()
 	var res []byte
-	var err error
-	res, *wm, err = op.readWireMessage(ctx, conn, (*wm)[:0])
+	res, wm, err = op.readWireMessage(ctx, conn, wm[:0])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
GODRIVER-2677

## Summary
Use a semaphore to limit the maximum number of items in the byte slice pool.

## Background & Motivation
I limited 512 slices in the pool. `Get()` blocks until a slice is returned to the pool when all are allocated. So the size of the pool shall not be bigger than 16MB * 512 ~= 8GB in theory considering the ticket indicates ~20GB of memory consumption.
I did not reset the capacity of returned byte slice because it would cause more allocations.

The benchstat from `benchmark/operation_test.go`:
```
name                           old time/op    new time/op    delta
ClientWrite/not_compressed-10    2.17ms ±16%    1.94ms ± 4%  -10.45%  (p=0.005 n=10+10)
ClientWrite/snappy-10            2.04ms ±18%    1.96ms ±10%     ~     (p=0.631 n=10+10)
ClientWrite/zlib-10              1.85ms ±12%    1.93ms ±11%     ~     (p=0.218 n=10+10)
ClientWrite/zstd-10              1.96ms ±10%    1.99ms ± 8%     ~     (p=0.684 n=10+10)

name                           old alloc/op   new alloc/op   delta
ClientWrite/not_compressed-10    27.9kB ± 2%    27.6kB ± 2%   -1.16%  (p=0.035 n=10+10)
ClientWrite/snappy-10            41.5kB ± 1%    41.2kB ± 1%     ~     (p=0.075 n=10+10)
ClientWrite/zlib-10               906kB ± 0%     907kB ± 0%   +0.11%  (p=0.000 n=9+9)
ClientWrite/zstd-10              67.0kB ± 0%    67.1kB ± 0%     ~     (p=0.165 n=10+10)

name                           old allocs/op  new allocs/op  delta
ClientWrite/not_compressed-10      79.9 ± 1%      81.0 ± 0%   +1.38%  (p=0.001 n=10+10)
ClientWrite/snappy-10              82.3 ± 2%      85.0 ± 0%   +3.28%  (p=0.000 n=10+9)
ClientWrite/zlib-10                 122 ± 0%       126 ± 0%   +2.95%  (p=0.000 n=6+10)
ClientWrite/zstd-10                 183 ± 0%       186 ± 1%   +1.58%  (p=0.000 n=9+10)
```

```
name                          old time/op    new time/op    delta
ClientRead/not_compressed-10     140µs ± 2%     153µs ± 5%   +9.15%  (p=0.000 n=9+9)
ClientRead/snappy-10             119µs ± 1%     170µs ±22%  +42.64%  (p=0.000 n=9+10)
ClientRead/zlib-10               218µs ± 6%     257µs ± 3%  +17.82%  (p=0.000 n=10+9)
ClientRead/zstd-10               117µs ± 1%     156µs ± 1%  +32.95%  (p=0.000 n=9+8)

name                          old alloc/op   new alloc/op   delta
ClientRead/not_compressed-10    29.0kB ± 0%    29.0kB ± 0%     ~     (p=0.753 n=10+10)
ClientRead/snappy-10            45.8kB ± 0%    45.7kB ± 0%   -0.10%  (p=0.012 n=10+10)
ClientRead/zlib-10               905kB ± 0%     905kB ± 0%   -0.02%  (p=0.009 n=10+10)
ClientRead/zstd-10               135kB ± 0%     136kB ± 0%   +0.08%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
ClientRead/not_compressed-10      83.0 ± 0%      85.0 ± 0%   +2.41%  (p=0.000 n=10+10)
ClientRead/snappy-10              87.0 ± 0%      90.0 ± 0%   +3.45%  (p=0.000 n=10+10)
ClientRead/zlib-10                 143 ± 0%       146 ± 0%   +2.10%  (p=0.000 n=7+9)
ClientRead/zstd-10                 191 ± 0%       194 ± 0%   +1.57%  (p=0.000 n=10+10)
```

The number of allocations increases, but it does not impact the size of allocations.
For the increase of reading time, my understanding is the overhead operation, which is relatively big compared with its base (reading time is in µs while writing time is in ms).
