### PR TITLE
GODRIVER-2679 Elaborate on DNS issues docs and confusing DNS error.

### DIFF
--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -94,10 +94,13 @@
 //
 // # Potential DNS Issues
 //
-// Building with Go 1.11+ and using connection strings with the "mongodb+srv"[1] scheme is
+// Building with Go 1.11+ and using connection strings with the "mongodb+srv"[1] scheme is unfortunately
 // incompatible with some DNS servers in the wild due to the change introduced in
-// https://github.com/golang/go/issues/10622. If you receive an error with the message "cannot
-// unmarshal DNS message" while running an operation, we suggest you use a different DNS server.
+// https://github.com/golang/go/issues/10622. You may receive an error with the message "cannot unmarshal DNS message"
+// while running an operation when using DNS servers that non-compliantly compress SRV records. Old versions of kube-dns
+// and the native DNS resolver (systemd-resolver) on Ubuntu 18.04 are known to be non-compliant in this manner. We suggest
+// using a different DNS server (8.8.8.8 is the common default), and, if that's not possible, avoiding the "mongodb+srv"
+// scheme.
 //
 // # Client Side Encryption
 //

--- a/x/mongo/driver/dns/dns.go
+++ b/x/mongo/driver/dns/dns.go
@@ -80,7 +80,9 @@ func (r *Resolver) fetchSeedlistFromSRV(host string, srvName string, stopOnErr b
 		srvName = "mongodb"
 	}
 	_, addresses, err := r.LookupSRV(srvName, "tcp", host)
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), "cannot unmarshal DNS message") {
+		return nil, fmt.Errorf("see https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Potential_DNS_Issues: %w", err)
+	} else if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2679

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Elaborates on the ["Potential DNS Issues"](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Potential_DNS_Issues) section of our documentation with more explicit workarounds. Wraps the ambiguous `cannot unmarshal DNS message` error from `LookupSRV` with a link to that documentation.

## Background & Motivation
<!--- Rationale for the pull request. -->
Go driver users connecting to their clusters with SRV-schemed connection strings are still running into the infamous `cannot unmarshal DNS message` error due to non-compliant SRV servers and resolvers in the wild (i.e. Ubuntu 18.04's native DNS resolver `systemd`). This is not an issue we can fix in the Go driver, but we should elaborate on our documentation internally and wrap the error to point to our documentation.

