### PR TITLE
GODRIVER-2734 Benchmark and reduce allocations in bson.Raw.String

### DIFF
--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -7,10 +7,10 @@
 package bsoncore
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 )
 
 // NewArrayLengthError creates and returns an error for when the length of an array exceeds the
@@ -53,7 +53,7 @@ func (a Array) DebugString() string {
 	if len(a) < 5 {
 		return "<malformed>"
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("Array")
 	length, rem, _ := ReadLength(a) // We know we have enough bytes to read the length
 	buf.WriteByte('(')
@@ -69,7 +69,7 @@ func (a Array) DebugString() string {
 			buf.WriteString(fmt.Sprintf("<malformed (%d)>", length))
 			break
 		}
-		fmt.Fprintf(&buf, "%s", elem.Value().DebugString())
+		buf.WriteString(elem.Value().DebugString())
 		if length != 1 {
 			buf.WriteByte(',')
 		}
@@ -85,7 +85,7 @@ func (a Array) String() string {
 	if len(a) < 5 {
 		return ""
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteByte('[')
 
 	length, rem, _ := ReadLength(a) // We know we have enough bytes to read the length
@@ -100,7 +100,7 @@ func (a Array) String() string {
 		if !ok {
 			return ""
 		}
-		fmt.Fprintf(&buf, "%s", elem.Value().String())
+		buf.WriteString(elem.Value().String())
 		if length > 1 {
 			buf.WriteByte(',')
 		}

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -7,11 +7,11 @@
 package bsoncore
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
@@ -237,7 +237,7 @@ func (d Document) DebugString() string {
 	if len(d) < 5 {
 		return "<malformed>"
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("Document")
 	length, rem, _ := ReadLength(d) // We know we have enough bytes to read the length
 	buf.WriteByte('(')
@@ -253,7 +253,7 @@ func (d Document) DebugString() string {
 			buf.WriteString(fmt.Sprintf("<malformed (%d)>", length))
 			break
 		}
-		fmt.Fprintf(&buf, "%s ", elem.DebugString())
+		buf.WriteString(elem.DebugString())
 	}
 	buf.WriteByte('}')
 
@@ -266,7 +266,7 @@ func (d Document) String() string {
 	if len(d) < 5 {
 		return ""
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteByte('{')
 
 	length, rem, _ := ReadLength(d) // We know we have enough bytes to read the length
@@ -285,7 +285,7 @@ func (d Document) String() string {
 		if !ok {
 			return ""
 		}
-		fmt.Fprintf(&buf, "%s", elem.String())
+		buf.WriteString(elem.String())
 		first = false
 	}
 	buf.WriteByte('}')

--- a/x/bsonx/bsoncore/element.go
+++ b/x/bsonx/bsoncore/element.go
@@ -129,7 +129,7 @@ func (e Element) String() string {
 	if !valid {
 		return ""
 	}
-	return fmt.Sprintf(`"%s": %v`, key, val)
+	return "\"" + string(key) + "\": " + val.String()
 }
 
 // DebugString outputs a human readable version of RawElement. It will attempt to stringify the


### PR DESCRIPTION
[GODRIVER-2734](https://jira.mongodb.org/browse/GODRIVER-2734)

## Summary
* Replace all uses of `bytes.Buffer` with `strings.Builder` in `bsoncore` where the function output is a string.
* Remove all uses of `fmt.Fprintf` and `fmt.Sprintf` where there is little or no string formatting added.
* Add a benchmark that exercises `bson.Raw.String` for various inputs.

## Background & Motivation
There are a number of simple optimizations we can make to [bsoncore.Document.String](https://github.com/mongodb/mongo-go-driver/blob/60cfd91eb66c2646de5034327c50208d13c05db3/x/bsonx/bsoncore/document.go#L265), [bsoncore.Array.String](https://github.com/mongodb/mongo-go-driver/blob/60cfd91eb66c2646de5034327c50208d13c05db3/x/bsonx/bsoncore/array.go#L84), and [bsoncore.Element.String](https://github.com/mongodb/mongo-go-driver/blob/60cfd91eb66c2646de5034327c50208d13c05db3/x/bsonx/bsoncore/element.go#L118) that can significantly reduce allocations. The most important optimization is to use a [strings.Builder](https://pkg.go.dev/strings#Builder) instead of a `bytes.Buffer` or the `fmt` package to build large strings because it prevents the need for an extra allocation when returning a string (see the [Builder.String code](https://cs.opensource.google/go/go/+/refs/tags/go1.19.5:src/strings/builder.go;l=47) for details). Historically those haven't been a major concern, but the logging implementation ([GODRIVER-1712](https://jira.mongodb.org/browse/GODRIVER-1712)) for command logging relies heavily on the bson.Raw.String function.

Benchmark stats comparing `master` to this branch run on a Macbook Pro 16" 2019 (2.6 GHz 6-Core Intel Core i7):
```
❯ benchstat old.txt new.txt                                                                                 
name                           old time/op    new time/op    delta
RawString/string-12               869ns ± 1%     478ns ± 1%  -45.02%  (p=0.000 n=9+9)
RawString/integer-12              610ns ± 1%     273ns ± 1%  -55.29%  (p=0.000 n=8+9)
RawString/float-12                760ns ± 0%     464ns ±10%  -38.97%  (p=0.000 n=8+10)
RawString/nested_document-12     2.32µs ±10%    0.87µs ± 1%  -62.78%  (p=0.000 n=10+8)
RawString/array_of_strings-12    3.05µs ±10%    1.91µs ± 1%  -37.51%  (p=0.000 n=10+9)
RawString/mixed_struct-12        7.57µs ± 2%    5.35µs ±18%  -29.34%  (p=0.000 n=10+10)

name                           old alloc/op   new alloc/op   delta
RawString/string-12              1.10kB ± 0%    0.78kB ± 0%  -29.20%  (p=0.000 n=10+10)
RawString/integer-12               320B ± 0%      144B ± 0%  -55.00%  (p=0.000 n=10+10)
RawString/float-12                 424B ± 0%      248B ± 0%  -41.51%  (p=0.000 n=10+10)
RawString/nested_document-12     2.42kB ± 0%    1.43kB ± 0%  -40.95%  (p=0.000 n=10+10)
RawString/array_of_strings-12    5.60kB ± 0%    4.10kB ± 0%  -26.80%  (p=0.000 n=10+10)
RawString/mixed_struct-12        19.2kB ± 0%    15.1kB ± 0%  -21.03%  (p=0.002 n=8+10)

name                           old allocs/op  new allocs/op  delta
RawString/string-12                12.0 ± 0%       7.0 ± 0%  -41.67%  (p=0.000 n=10+10)
RawString/integer-12               9.00 ± 0%      5.00 ± 0%  -44.44%  (p=0.000 n=10+10)
RawString/float-12                 11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.000 n=10+10)
RawString/nested_document-12       28.0 ± 0%      13.0 ± 0%  -53.57%  (p=0.000 n=10+10)
RawString/array_of_strings-12      34.0 ± 0%      23.0 ± 0%  -32.35%  (p=0.000 n=10+10)
RawString/mixed_struct-12          43.0 ± 0%      24.0 ± 0%  -44.19%  (p=0.000 n=10+10)
```

