### PR TITLE
GODRIVER-2676 set libmongocrypt test dep to 1.7.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -95,8 +95,7 @@ functions:
           go version
           go env
 
-          # TODO(GODRIVER-2676): use libmongocrypt 1.7.0 once it is released.
-          LIBMONGOCRYPT_TAG="1.7.0-alpha2"
+          LIBMONGOCRYPT_TAG="1.7.0"
           # Install libmongocrypt based on OS.
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include
@@ -105,11 +104,7 @@ functions:
              mkdir libmongocrypt-all
              cd libmongocrypt-all
              # The following URL is published from the upload-all task in the libmongocrypt Evergreen project.
-             # TODO(GODRIVER-2676): replace this URL once libmongocrypt 1.7.0 is released with the following:
-             # curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_TAG/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
-             # There is no tag URL for libmongocrypt pre-releases.
-             LIBMONGOCRYPT_COMMIT=1a28503fed3dbf7bf4cde649debb750666d72c4c
-             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/master/$LIBMONGOCRYPT_COMMIT/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
+             curl https://mciuploads.s3.amazonaws.com/libmongocrypt/all/$LIBMONGOCRYPT_TAG/libmongocrypt-all.tar.gz -o libmongocrypt-all.tar.gz
              tar -xf libmongocrypt-all.tar.gz
              cd ..
              cp libmongocrypt-all/windows-test/bin/mongocrypt.dll c:/libmongocrypt/bin


### PR DESCRIPTION
GODRIVER-2676
## Summary
- update test dependency of libmongocrypt to 1.7.0

## Background & Motivation
libmongocrypt 1.7.0 was [recently released](https://github.com/mongodb/libmongocrypt/releases/tag/1.7.0) and contains support for Range Index.

