### PR TITLE
GODRIVER-2739 Support Optional Inserted Ids in CSFLE Unified Tests

### DIFF
--- a/testdata/client-side-encryption/unified/rewrapManyDataKey.json
+++ b/testdata/client-side-encryption/unified/rewrapManyDataKey.json
@@ -321,7 +321,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -503,7 +506,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -687,7 +693,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -873,7 +882,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1055,7 +1067,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1218,7 +1233,10 @@
               "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },

--- a/testdata/client-side-encryption/unified/rewrapManyDataKey.yml
+++ b/testdata/client-side-encryption/unified/rewrapManyDataKey.yml
@@ -130,6 +130,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -182,6 +183,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -236,6 +238,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -285,6 +288,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -334,6 +338,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -381,6 +386,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
       - name: find
         object: *collection0
         arguments:


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2739

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Add "insertedIds" matching for bulk write response "insertedIds". The Go Driver does not implement this optional feature, so this PR is just to keep the specs up-to-date.

## Background & Motivation
<!--- Rationale for the pull request. -->
The rewrap many data key CSFLE unified spec tests omit the optional insertIds property on the BulkWriteResult. This causes failures for drivers that have the optional field and assert exact equality of the result object in the unified tests.

