### PR TITLE
GODRIVER-2433 skip `fle2-Range-*-Correctness` tests on macOS

### DIFF
--- a/mongo/integration/client_side_encryption_spec_test.go
+++ b/mongo/integration/client_side_encryption_spec_test.go
@@ -12,6 +12,7 @@ package integration
 import (
 	"os"
 	"path"
+	"regexp"
 	"testing"
 )
 
@@ -54,6 +55,10 @@ func TestClientSideEncryptionSpec(t *testing.T) {
 
 	for _, fileName := range jsonFilesInDir(t, path.Join(dataPath, encryptionSpecName)) {
 		t.Run(fileName, func(t *testing.T) {
+			re := regexp.MustCompile(`fle2\-Range\-.*\-Correctness`)
+			if re.Match([]byte(fileName)) {
+				t.Skipf("Skipping test on macOS due to slow runtime.")
+			}
 			if fileName == "kmipKMS.json" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
 				t.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
 			}

--- a/mongo/integration/client_side_encryption_spec_test.go
+++ b/mongo/integration/client_side_encryption_spec_test.go
@@ -57,7 +57,7 @@ func TestClientSideEncryptionSpec(t *testing.T) {
 		t.Run(fileName, func(t *testing.T) {
 			re := regexp.MustCompile(`fle2\-Range\-.*\-Correctness`)
 			if re.Match([]byte(fileName)) {
-				t.Skipf("Skipping test on macOS due to slow runtime.")
+				t.Skipf("skipping test on macOS due to slow runtime")
 			}
 			if fileName == "kmipKMS.json" && "" == os.Getenv("KMS_MOCK_SERVERS_RUNNING") {
 				t.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")


### PR DESCRIPTION
GODRIVER-2433

## Summary
- skip `fle2-Range-*-Correctness` tests on macOS

## Background & Motivation

See https://github.com/mongodb/specifications/pull/1371