### PR TITLE
GODRIVER-2493 do not check encryptedFieldsMap in CreateEncryptedCollection

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -83,10 +83,6 @@ func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	}
 	ef := createOpts.EncryptedFields
 	if ef == nil {
-		// Otherwise, try to get EncryptedFields from EncryptedFieldsMap.
-		ef = db.getEncryptedFieldsFromMap(coll)
-	}
-	if ef == nil {
 		return nil, nil, errors.New("no EncryptedFields defined for the collection")
 	}
 


### PR DESCRIPTION
GODRIVER-2493
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
- do not check encryptedFieldsMap in CreateEncryptedCollection

## Background & Motivation

Implements https://github.com/mongodb/specifications/pull/1376
