### PR TITLE
GODRIVER-2746 replace CreateEncryptedCollection DataKeyOpts with masterKey

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -77,7 +77,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 // It returns the created collection and the encrypted fields document used to create it.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	db *Database, coll string, createOpts *options.CreateCollectionOptions,
-	kmsProvider string, dkOpts *options.DataKeyOptions) (*Collection, bson.M, error) {
+	kmsProvider string, masterKey interface{}) (*Collection, bson.M, error) {
 	if createOpts == nil {
 		return nil, nil, errors.New("nil CreateCollectionOptions")
 	}
@@ -111,6 +111,10 @@ func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 				if f, ok := field.(bson.M); !ok {
 					continue
 				} else if v, ok := f["keyId"]; ok && v == nil {
+					dkOpts := options.DataKey()
+					if masterKey != nil {
+						dkOpts.SetMasterKey(masterKey)
+					}
 					keyid, err := ce.CreateDataKey(ctx, kmsProvider, dkOpts)
 					if err != nil {
 						createOpts.EncryptedFields = m


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2746

## Summary
<!--- A summary of the changes proposed by this pull request. -->
- replace CreateEncryptedCollection DataKeyOpts with masterKey

## Background & Motivation
<!--- Rationale for the pull request. -->
Implements change proposed in https://github.com/mongodb/specifications/pull/1377

