### PR TITLE
GODRIVER-2753 Integration with oss-fuzz fuzzing service

### DIFF
--- a/cmd/build-oss-fuzz-corpus/main.go
+++ b/cmd/build-oss-fuzz-corpus/main.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -32,7 +33,7 @@ type validityTestCase struct {
 func findJSONFilesInDir(dir string) ([]string, error) {
 	files := make([]string, 0)
 
-	entries, err := os.ReadDir(dir)
+	entries, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2753

## Summary
This PR adds a cmd to build zip file of seed corpus for fuzzing to be used by oss-fuzz.

## Background & Motivation
Hi, I would like to help integrate this project into [OSS-Fuzz](https://github.com/google/oss-fuzz).

- As an initial step for integration I have created this PR: https://github.com/google/oss-fuzz/pull/9528, it contains necessary logic from an OSS-Fuzz perspective to integrate mongo-go-driver.

- OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, you can find more details in our [FAQ](https://google.github.io/oss-fuzz/faq/).

-  If you would like to integrate, the only thing I need is a list of email(s), it must be associated with a google account like gmail ([why?](https://google.github.io/oss-fuzz/faq/#why-do-you-require-a-google-account-for-authentication)). by doing that, the provided email(s) will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats.

- Notice the email(s) affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.
