### PR TITLE
GODRIVER-2688 Misc Updates to Logging

### DIFF
--- a/internal/logger/component.go
+++ b/internal/logger/component.go
@@ -108,12 +108,9 @@ func SerializeCommand(cmd Command, extraKeysAndValues ...interface{}) []interfac
 	}
 
 	// Add the "serviceId" if it is not nil.
-	var serviceIDStr string
 	if cmd.ServiceID != nil {
-		serviceIDStr = cmd.ServiceID.Hex()
+		keysAndValues = append(keysAndValues, "serviceId", cmd.ServiceID.Hex())
 	}
-
-	keysAndValues = append(keysAndValues, "serviceId", serviceIDStr)
 
 	return keysAndValues
 }

--- a/internal/logger/component.go
+++ b/internal/logger/component.go
@@ -104,15 +104,16 @@ func SerializeCommand(cmd Command, extraKeysAndValues ...interface{}) []interfac
 
 	// Add the "serverConnectionId" if it is not nil.
 	if cmd.ServerConnectionID != nil {
-		keysAndValues = append(keysAndValues,
-			"serverConnectionId", *cmd.ServerConnectionID)
+		keysAndValues = append(keysAndValues, "serverConnectionId", *cmd.ServerConnectionID)
 	}
 
 	// Add the "serviceId" if it is not nil.
+	var serviceIDStr string
 	if cmd.ServiceID != nil {
-		keysAndValues = append(keysAndValues,
-			"serviceId", cmd.ServiceID.Hex())
+		serviceIDStr = cmd.ServiceID.Hex()
 	}
+
+	keysAndValues = append(keysAndValues, "serviceId", serviceIDStr)
 
 	return keysAndValues
 }

--- a/internal/logger/io_sink.go
+++ b/internal/logger/io_sink.go
@@ -29,15 +29,18 @@ func NewIOSink(out io.Writer) *IOSink {
 
 func logCommandMessageStarted(log *log.Logger, kvMap map[string]interface{}) {
 	format := "Command %q started on database %q using a connection with " +
-		"server-generated ID %d to %s:%d. The requestID is %d and " +
-		"the operation ID is %d. Command: %s"
+		"driver-generated ID %q and server-generated ID %d to %s:%d " +
+		"with service ID %q. The requestID is %d and the operation " +
+		"ID is %d. Command: %s"
 
 	log.Printf(format,
 		kvMap["commandName"],
 		kvMap["databaseName"],
+		kvMap["driverConnectionId"],
 		kvMap["serverConnectionId"],
 		kvMap["serverHost"],
 		kvMap["serverPort"],
+		kvMap["serviceId"],
 		kvMap["requestId"],
 		kvMap["operationId"],
 		kvMap["command"])
@@ -45,29 +48,39 @@ func logCommandMessageStarted(log *log.Logger, kvMap map[string]interface{}) {
 }
 
 func logCommandMessageSucceeded(log *log.Logger, kvMap map[string]interface{}) {
-	format := "Command %q succeeded in %d ms using server-generated ID " +
-		"%d to %s:%d. The requestID is %d and the operation ID is " +
-		"%d. Command reply: %s"
+	format := "Command %q succeeded in %d ms using a connection with " +
+		"driver-generated ID %q and server-generated ID %d to %s:%d " +
+		"with service ID %q. The requestID is %d and the operation " +
+		"ID is %d. Command reply: %s"
 
 	log.Printf(format,
 		kvMap["commandName"],
-		kvMap["duration"],
+		kvMap["durationMS"],
+		kvMap["driverConnectionId"],
 		kvMap["serverConnectionId"],
 		kvMap["serverHost"],
 		kvMap["serverPort"],
+		kvMap["serviceId"],
 		kvMap["requestId"],
 		kvMap["operationId"],
 		kvMap["reply"])
 }
 
+/*
+  Command "{{commandName}}" failed in {{durationMS}} ms using a connection with driver-generated ID {{driverConnectionId}} and
+   server-generated ID {{serverConnectionId}} to {{serverHost}}:{{serverPort}} with service ID {{serviceId}}. The requestID is
+   {{requestId}} and the operation ID is {{operationId}}. Error: {{error}}
+*/
+
 func logCommandMessageFailed(log *log.Logger, kvMap map[string]interface{}) {
 	format := "Command %q failed in %d ms using a connection with " +
-		"server-generated ID %d to %s:%d. The requestID is %d and " +
-		"the operation ID is %d. Error: %s"
+		"driver-generated ID %q and server-generated ID %d to %s:%d " +
+		"with service ID %q. The requestID is %d and the operation " +
+		"ID is %d. Error: %s"
 
 	log.Printf(format,
 		kvMap["commandName"],
-		kvMap["duration"],
+		kvMap["durationMS"],
 		kvMap["serverConnectionID"],
 		kvMap["serverHost"],
 		kvMap["serverPort"],

--- a/internal/logger/io_sink.go
+++ b/internal/logger/io_sink.go
@@ -66,12 +66,6 @@ func logCommandMessageSucceeded(log *log.Logger, kvMap map[string]interface{}) {
 		kvMap["reply"])
 }
 
-/*
-  Command "{{commandName}}" failed in {{durationMS}} ms using a connection with driver-generated ID {{driverConnectionId}} and
-   server-generated ID {{serverConnectionId}} to {{serverHost}}:{{serverPort}} with service ID {{serviceId}}. The requestID is
-   {{requestId}} and the operation ID is {{operationId}}. Error: {{error}}
-*/
-
 func logCommandMessageFailed(log *log.Logger, kvMap map[string]interface{}) {
 	format := "Command %q failed in %d ms using a connection with " +
 		"driver-generated ID %q and server-generated ID %d to %s:%d " +

--- a/internal/logger/io_sink.go
+++ b/internal/logger/io_sink.go
@@ -33,6 +33,11 @@ func logCommandMessageStarted(log *log.Logger, kvMap map[string]interface{}) {
 		"with service ID %q. The requestID is %d and the operation " +
 		"ID is %d. Command: %s"
 
+	var serviceID string
+	if id, ok := kvMap["serviceId"].(string); ok {
+		serviceID = id
+	}
+
 	log.Printf(format,
 		kvMap["commandName"],
 		kvMap["databaseName"],
@@ -40,7 +45,7 @@ func logCommandMessageStarted(log *log.Logger, kvMap map[string]interface{}) {
 		kvMap["serverConnectionId"],
 		kvMap["serverHost"],
 		kvMap["serverPort"],
-		kvMap["serviceId"],
+		serviceID,
 		kvMap["requestId"],
 		kvMap["operationId"],
 		kvMap["command"])
@@ -53,6 +58,11 @@ func logCommandMessageSucceeded(log *log.Logger, kvMap map[string]interface{}) {
 		"with service ID %q. The requestID is %d and the operation " +
 		"ID is %d. Command reply: %s"
 
+	var serviceID string
+	if id, ok := kvMap["serviceId"].(string); ok {
+		serviceID = id
+	}
+
 	log.Printf(format,
 		kvMap["commandName"],
 		kvMap["durationMS"],
@@ -60,7 +70,7 @@ func logCommandMessageSucceeded(log *log.Logger, kvMap map[string]interface{}) {
 		kvMap["serverConnectionId"],
 		kvMap["serverHost"],
 		kvMap["serverPort"],
-		kvMap["serviceId"],
+		serviceID,
 		kvMap["requestId"],
 		kvMap["operationId"],
 		kvMap["reply"])

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1804,6 +1804,7 @@ func (op Operation) publishStartedEvent(ctx context.Context, info startedInforma
 				ServiceID:          info.serviceID,
 			},
 				"command", formattedCmd,
+				"driverConnectionId", info.connID,
 				"databaseName", op.Database)...)
 
 	}
@@ -1855,6 +1856,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 				ServiceID:          info.serviceID,
 			},
 				"durationMS", info.duration.Milliseconds(),
+				"driverConnectionId", info.connID,
 				"reply", formattedReply)...)
 	}
 
@@ -1876,6 +1878,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 				ServiceID:          info.serviceID,
 			},
 				"durationMS", info.duration.Milliseconds(),
+				"driverConnectionId", info.connID,
 				"failure", formattedReply)...)
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2688

## Summary
<!--- A summary of the changes proposed by this pull request. -->
These were the following changes to sync:

**For command log messages, when the user does not specify a port for a host and is therefore relying on the default 27017, the driver SHOULD include that default in log messages.** 

In the Go Driver, the host and the port are collected from the stringified version of an `address.Address`. The `address.Address.String()` method uses 27017 as the default port. Because of this, all command operations SHOULD include the default port in log messages.

**The suggested unstructured representations for command log messages have been slightly modified to match the CMAP log messages.** 

Updated via this PR.

**It's no longer a strict requirement that drivers support logging directly to a file. Instead, it is sufficient to provide a straightforward API that would allow a user to direct log messages to a file.** 

The Go Driver already supports logging to a directory using an io.Writer defined by the user via environment variables. See [this](https://github.com/mongodb/mongo-go-driver/blob/master/internal/logger/logger.go#L158-L165) block.

**Clarify that drivers MAY attempt to warn users about invalid values of environment variables, but MUST NOT throw an error.** 

The Go Driver already satisfies this requirement.

**Require that if a driver supports configuring logging both via environment variables and programmatically, the programmatic configuration should take precedence.** 

The Go Driver already satisfies this requirement. See [this](https://github.com/mongodb/mongo-go-driver/blob/master/internal/logger/logger.go#L186-L189) block.

## Background & Motivation
<!--- Rationale for the pull request. -->

The rationale for these changes can be found [here](https://github.com/mongodb/specifications/commit/e9b4c96f3ff9b639c61feb7ed149ed14b59aabb6#diff-7f64379b1a16e6523b603c763f5ac972da5fdf37ca5c9ef688bf75262fbdc2cfR331).