### PR TITLE
GODRIVER-2748 Add "Public Technical Preview" note to CreateEncryptedCollection

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -75,7 +75,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 
 // CreateEncryptedCollection creates a new collection for Queryable Encryption with the help of automatic generation of new encryption data keys for null keyIds.
 // It returns the created collection and the encrypted fields document used to create it.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	db *Database, coll string, createOpts *options.CreateCollectionOptions,
 	kmsProvider string, masterKey interface{}) (*Collection, bson.M, error) {

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -75,6 +75,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 
 // CreateEncryptedCollection creates a new collection with the help of automatic generation of new encryption data keys for null keyIds.
 // It returns the created collection and the encrypted fields document used to create it.
+// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	db *Database, coll string, createOpts *options.CreateCollectionOptions,
 	kmsProvider string, masterKey interface{}) (*Collection, bson.M, error) {

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -73,7 +73,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 	return ce, nil
 }
 
-// CreateEncryptedCollection creates a new collection with the help of automatic generation of new encryption data keys for null keyIds.
+// CreateEncryptedCollection creates a new collection for Queryable Encryption with the help of automatic generation of new encryption data keys for null keyIds.
 // It returns the created collection and the encrypted fields document used to create it.
 // Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -229,7 +229,7 @@ func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue,
 // {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
 // $gt may also be $gte. $lt may also be $lte.
 // Only supported for queryType "rangePreview"
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ce *ClientEncryption) EncryptExpression(ctx context.Context, expr interface{}, result interface{}, opts ...*options.EncryptOptions) error {
 	transformed := transformExplicitEncryptionOptions(opts...)
 

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -151,7 +151,7 @@ func (a *AutoEncryptionOptions) SetTLSConfig(tlsOpts map[string]*tls.Config) *Au
 
 // SetEncryptedFieldsMap specifies a map from namespace to local EncryptedFieldsMap document.
 // EncryptedFieldsMap is used for Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{}) *AutoEncryptionOptions {
 	a.EncryptedFieldsMap = ef
 	return a
@@ -159,7 +159,7 @@ func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{})
 
 // SetBypassQueryAnalysis specifies whether or not query analysis should be used for automatic encryption.
 // Use this option when using explicit encryption with Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (a *AutoEncryptionOptions) SetBypassQueryAnalysis(bypass bool) *AutoEncryptionOptions {
 	a.BypassQueryAnalysis = &bypass
 	return a

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -19,7 +19,7 @@ const (
 )
 
 // RangeOptions specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 type RangeOptions struct {
 	Min       *bson.RawValue
 	Max       *bson.RawValue
@@ -86,35 +86,35 @@ func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOpt
 }
 
 // SetRangeOptions specifies the options to use for explicit encryption with range. It is only valid to set if algorithm is "rangePreview".
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (e *EncryptOptions) SetRangeOptions(ro RangeOptions) *EncryptOptions {
 	e.RangeOptions = &ro
 	return e
 }
 
 // SetMin sets the range index minimum value.
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMin(min bson.RawValue) *RangeOptions {
 	ro.Min = &min
 	return ro
 }
 
 // SetMax sets the range index maximum value.
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetMax(max bson.RawValue) *RangeOptions {
 	ro.Max = &max
 	return ro
 }
 
 // SetSparsity sets the range index sparsity.
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetSparsity(sparsity int64) *RangeOptions {
 	ro.Sparsity = sparsity
 	return ro
 }
 
 // SetPrecision sets the range index precision.
-// NOTE(kevinAlbs): The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
+// Beta: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 func (ro *RangeOptions) SetPrecision(precision int32) *RangeOptions {
 	ro.Precision = &precision
 	return ro

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -13,7 +13,7 @@ import (
 
 // These constants specify valid values for QueryType
 // QueryType is used for Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 const (
 	QueryTypeEquality string = "equality"
 )
@@ -61,7 +61,7 @@ func (e *EncryptOptions) SetKeyAltName(keyAltName string) *EncryptOptions {
 // - Unindexed
 // This is required.
 // Indexed and Unindexed are used for Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 	e.Algorithm = algorithm
 	return e
@@ -71,7 +71,7 @@ func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 // This should be one of the following:
 // - equality
 // QueryType is used for Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
 	e.QueryType = queryType
 	return e
@@ -79,7 +79,7 @@ func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
 
 // SetContentionFactor specifies the contention factor. It is only valid to set if algorithm is "Indexed".
 // ContentionFactor is used for Queryable Encryption.
-// Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
+// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOptions {
 	e.ContentionFactor = &contentionFactor
 	return e


### PR DESCRIPTION
GODRIVER-2748
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

# Summary
- Add "Public Technical Preview" note to CreateEncryptedCollection
- Note that CreateEncryptedCollection is specific to Queryable Encryption

# Background & Motivation

The API for ClientEncryption.CreateEncryptedCollection is specific to Queryable Encryption. Queryable Encryption API was determined to be marked as "Public Technical Preview" in DRIVERS-2349.

The "Public Technical Preview" note is copied from [encryptoptions.go](https://github.com/mongodb/mongo-go-driver/blob/c5146995ca4dcf539ac0d687c5f2d313b2b84f9b/mongo/options/encryptoptions.go#L16) for consistency.

