### PR TITLE
GODRIVER-2497 Always set causalConsistency=false for implicit sessions.

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -119,10 +119,7 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 
 	cs.sess = sessionFromContext(ctx)
 	if cs.sess == nil && cs.client.sessionPool != nil {
-		cs.sess, cs.err = session.NewClientSession(cs.client.sessionPool, cs.client.id, session.Implicit)
-		if cs.err != nil {
-			return nil, cs.Err()
-		}
+		cs.sess = session.NewImplicitClientSession(cs.client.sessionPool, cs.client.id)
 	}
 	if cs.err = cs.client.validSession(cs.sess); cs.err != nil {
 		closeImplicitSession(cs.sess)

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -400,7 +400,7 @@ func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) 
 		coreOpts.Snapshot = sopts.Snapshot
 	}
 
-	sess, err := session.NewClientSession(c.sessionPool, c.id, session.Explicit, coreOpts)
+	sess, err := session.NewClientSession(c.sessionPool, c.id, coreOpts)
 	if err != nil {
 		return nil, replaceErrors(err)
 	}
@@ -661,10 +661,7 @@ func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...
 		return ListDatabasesResult{}, err
 	}
 	if sess == nil && c.sessionPool != nil {
-		sess, err = session.NewClientSession(c.sessionPool, c.id, session.Implicit)
-		if err != nil {
-			return ListDatabasesResult{}, err
-		}
+		sess = session.NewImplicitClientSession(c.sessionPool, c.id)
 		defer sess.EndSession()
 	}
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -59,7 +59,7 @@ type aggregateParams struct {
 }
 
 func closeImplicitSession(sess *session.Client) {
-	if sess != nil && sess.SessionType == session.Implicit {
+	if sess != nil && sess.IsImplicit {
 		sess.EndSession()
 	}
 }
@@ -187,11 +187,7 @@ func (coll *Collection) BulkWrite(ctx context.Context, models []WriteModel,
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -255,11 +251,7 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -415,10 +407,7 @@ func (coll *Collection) delete(ctx context.Context, filter interface{}, deleteOn
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -546,11 +535,7 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -801,10 +786,7 @@ func aggregate(a aggregateParams) (cur *Cursor, err error) {
 		}
 	}()
 	if sess == nil && a.client.sessionPool != nil {
-		sess, err = session.NewClientSession(a.client.sessionPool, a.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(a.client.sessionPool, a.client.id)
 	}
 	if err = a.client.validSession(sess); err != nil {
 		return nil, err
@@ -950,10 +932,7 @@ func (coll *Collection) CountDocuments(ctx context.Context, filter interface{},
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return 0, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 	if err = coll.client.validSession(sess); err != nil {
@@ -1030,10 +1009,7 @@ func (coll *Collection) EstimatedDocumentCount(ctx context.Context,
 
 	var err error
 	if sess == nil && coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return 0, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -1099,10 +1075,7 @@ func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter i
 	sess := sessionFromContext(ctx)
 
 	if sess == nil && coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -1198,11 +1171,7 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		}
 	}()
 	if sess == nil && coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 	}
 
 	err = coll.client.validSession(sess)
@@ -1404,10 +1373,7 @@ func (coll *Collection) findAndModify(ctx context.Context, op *operation.FindAnd
 	sess := sessionFromContext(ctx)
 	var err error
 	if sess == nil && coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return &SingleResult{err: err}
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -1797,11 +1763,7 @@ func (coll *Collection) drop(ctx context.Context) error {
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(coll.client.sessionPool, coll.client.id, session.Implicit)
-		if err != nil {
-			return err
-		}
+		sess = session.NewImplicitClientSession(coll.client.sessionPool, coll.client.id)
 		defer sess.EndSession()
 	}
 

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -306,7 +306,7 @@ func (c *Cursor) addFromBatch(sliceVal reflect.Value, elemType reflect.Type, bat
 }
 
 func (c *Cursor) closeImplicitSession() {
-	if c.clientSession != nil && c.clientSession.SessionType == session.Implicit {
+	if c.clientSession != nil && c.clientSession.IsImplicit {
 		c.clientSession.EndSession()
 	}
 }

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -136,11 +136,7 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	cursorCommand bool, opts ...*options.RunCmdOptions) (*operation.Command, *session.Client, error) {
 	sess := sessionFromContext(ctx)
 	if sess == nil && db.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
-		if err != nil {
-			return nil, sess, err
-		}
+		sess = session.NewImplicitClientSession(db.client.sessionPool, db.client.id)
 	}
 
 	err := db.client.validSession(sess)
@@ -265,11 +261,7 @@ func (db *Database) Drop(ctx context.Context) error {
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && db.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
-		if err != nil {
-			return err
-		}
+		sess = session.NewImplicitClientSession(db.client.sessionPool, db.client.id)
 		defer sess.EndSession()
 	}
 
@@ -366,10 +358,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && db.client.sessionPool != nil {
-		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(db.client.sessionPool, db.client.id)
 	}
 
 	err = db.client.validSession(sess)
@@ -779,11 +768,7 @@ func (db *Database) CreateView(ctx context.Context, viewName, viewOn string, pip
 func (db *Database) executeCreateOperation(ctx context.Context, op *operation.Create) error {
 	sess := sessionFromContext(ctx)
 	if sess == nil && db.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
-		if err != nil {
-			return err
-		}
+		sess = session.NewImplicitClientSession(db.client.sessionPool, db.client.id)
 		defer sess.EndSession()
 	}
 

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -72,11 +72,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && iv.coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(iv.coll.client.sessionPool, iv.coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(iv.coll.client.sessionPool, iv.coll.client.id)
 	}
 
 	err := iv.coll.client.validSession(sess)
@@ -227,10 +223,7 @@ func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ..
 	sess := sessionFromContext(ctx)
 
 	if sess == nil && iv.coll.client.sessionPool != nil {
-		sess, err = session.NewClientSession(iv.coll.client.sessionPool, iv.coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(iv.coll.client.sessionPool, iv.coll.client.id)
 		defer sess.EndSession()
 	}
 
@@ -367,11 +360,7 @@ func (iv IndexView) drop(ctx context.Context, name string, opts ...*options.Drop
 
 	sess := sessionFromContext(ctx)
 	if sess == nil && iv.coll.client.sessionPool != nil {
-		var err error
-		sess, err = session.NewClientSession(iv.coll.client.sessionPool, iv.coll.client.id, session.Implicit)
-		if err != nil {
-			return nil, err
-		}
+		sess = session.NewImplicitClientSession(iv.coll.client.sessionPool, iv.coll.client.id)
 		defer sess.EndSession()
 	}
 

--- a/testdata/sessions/README.rst
+++ b/testdata/sessions/README.rst
@@ -37,6 +37,203 @@ Prose tests
 * ``client.startSession(snapshot = true, causalConsistency = true)``
 * Assert that an error was raised by driver
 
+2. Pool is LIFO
+~~~~~~~~~~~~~~~
+
+This test applies to drivers with session pools.
+
+* Call ``MongoClient.startSession`` twice to create two sessions, let us call them ``A`` and ``B``.
+* Call ``A.endSession``, then ``B.endSession``.
+* Call ``MongoClient.startSession``: the resulting session must have the same session ID as ``B``.
+* Call ``MongoClient.startSession`` again: the resulting session must have the same session ID  as ``A``.
+
+3. ``$clusterTime`` in commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Turn ``heartbeatFrequencyMS`` up to a very large number.
+* Register a command-started and a command-succeeded APM listener. If the driver has no APM support, inspect commands/replies in another idiomatic way, such as monkey-patching or a mock server.
+* Send a ``ping`` command to the server with the generic ``runCommand`` method.
+* Assert that the command passed to the command-started listener includes ``$clusterTime`` if and only if ``maxWireVersion`` >= 6.
+* Record the ``$clusterTime``, if any, in the reply passed to the command-succeeded APM listener.
+* Send another ``ping`` command.
+* Assert that ``$clusterTime`` in the command passed to the command-started listener, if any, equals the ``$clusterTime`` in the previous server reply. (Turning ``heartbeatFrequencyMS`` up prevents an intervening heartbeat from advancing the ``$clusterTime`` between these final two steps.)
+
+Repeat the above for:
+
+* An aggregate command from the ``aggregate`` helper method
+* A find command from the ``find`` helper method
+* An insert command from the ``insert_one`` helper method
+
+4. Explicit and implicit session arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Register a command-started APM listener. If the driver has no APM support, inspect commands in another idiomatic way, such as monkey-patching or a mock server.
+* Create ``client1``
+* Get ``database`` from ``client1``
+* Get ``collection`` from ``database``
+* Start ``session`` from ``client1``
+* Call ``collection.insertOne(session,...)``
+* Assert that the command passed to the command-started listener contained the session ``lsid`` from ``session``.
+* Call ``collection.insertOne(,...)`` (*without* a session argument)
+* Assert that the command passed to the command-started listener contained a session ``lsid``.
+
+Repeat the above for all methods that take a session parameter.
+
+5. Session argument is for the right client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Create ``client1`` and ``client2``
+* Get ``database`` from ``client1``
+* Get ``collection`` from ``database``
+* Start ``session`` from ``client2``
+* Call ``collection.insertOne(session,...)``
+* Assert that an error was reported because ``session`` was not started from ``client1``
+
+Repeat the above for all methods that take a session parameter.
+
+6. No further operations can be performed using a session after ``endSession`` has been called
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Start a ``session``
+* End the ``session``
+* Call ``collection.InsertOne(session, ...)``
+* Assert that the proper error was reported
+
+Repeat the above for all methods that take a session parameter.
+
+If your driver implements a platform dependent idiomatic disposal pattern, test
+that also (if the idiomatic disposal pattern calls ``endSession`` it would be
+sufficient to only test the disposal pattern since that ends up calling
+``endSession``).
+
+7. Authenticating as multiple users suppresses implicit sessions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Skip this test if your driver does not allow simultaneous authentication with multiple users.
+
+* Authenticate as two users
+* Call ``findOne`` with no explicit session
+* Capture the command sent to the server
+* Assert that the command sent to the server does not have an ``lsid`` field
+
+8. Client-side cursor that exhausts the results on the initial query immediately returns the implicit session to the pool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Insert two documents into a collection
+* Execute a find operation on the collection and iterate past the first document
+* Assert that the implicit session is returned to the pool. This can be done in several ways:
+
+  * Track in-use count in the server session pool and assert that the count has dropped to zero
+  * Track the lsid used for the find operation (e.g. with APM) and then do another operation and
+    assert that the same lsid is used as for the find operation.
+
+9. Client-side cursor that exhausts the results after a ``getMore`` immediately returns the implicit session to the pool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Insert five documents into a collection
+* Execute a find operation on the collection with batch size of 3
+* Iterate past the first four documents, forcing the final ``getMore`` operation
+* Assert that the implicit session is returned to the pool prior to iterating past the last document
+
+10. No remaining sessions are checked out after each functional test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At the end of every individual functional test of the driver, there SHOULD be an
+assertion that there are no remaining sessions checked out from the pool. This
+may require changes to existing tests to ensure that they close any explicit
+client sessions and any unexhausted cursors.
+
+11. For every combination of topology and readPreference, ensure that ``find`` and ``getMore`` both send the same session id
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Insert three documents into a collection
+* Execute a ``find`` operation on the collection with a batch size of 2
+* Assert that the server receives a non-zero lsid
+* Iterate through enough documents (3) to force a ``getMore``
+* Assert that the server receives a non-zero lsid equal to the lsid that ``find`` sent.
+
+12. Session pool can be cleared after forking without calling ``endSession``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Skip this test if your driver does not allow forking.
+
+* Create ClientSession
+* Record its lsid
+* Delete it (so the lsid is pushed into the pool)
+* Fork
+* In the parent, create a ClientSession and assert its lsid is the same.
+* In the child, create a ClientSession and assert its lsid is different.
+
+13. Existing sessions are not checked into a cleared pool after forking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Skip this test if your driver does not allow forking.
+
+* Create ClientSession
+* Record its lsid
+* Fork
+* In the parent, return the ClientSession to the pool, create a new ClientSession, and assert its lsid is the same.
+* In the child, return the ClientSession to the pool, create a new ClientSession, and assert its lsid is different.
+
+14. Implicit sessions only allocate their server session after a successful connection checkout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Create a MongoClient with the following options: ``maxPoolSize=1`` and ``retryWrites=true``. If testing against a sharded deployment, the test runner MUST ensure that the MongoClient connects to only a single mongos host.
+* Attach a command started listener that collects each command's lsid
+* Initiate the following concurrent operations
+
+  * ``insertOne({ }),``
+  * ``deleteOne({ }),``
+  * ``updateOne({ }, { $set: { a: 1 } }),``
+  * ``bulkWrite([{ updateOne: { filter: { }, update: { $set: { a: 1 } } } }]),``
+  * ``findOneAndDelete({ }),``
+  * ``findOneAndUpdate({ }, { $set: { a: 1 } }),``
+  * ``findOneAndReplace({ }, { a: 1 }),``
+  * ``find().toArray()``
+
+* Wait for all operations to complete successfully
+* Assert the following across at least 5 retries of the above test:
+
+  * Drivers MUST assert that exactly one session is used for all operations at
+    least once across the retries of this test.
+  * Note that it's possible, although rare, for >1 server session to be used
+    because the session is not released until after the connection is checked in.
+  * Drivers MUST assert that the number of allocated sessions is strictly less
+    than the number of concurrent operations in every retry of this test. In
+    this instance it would be less than (but NOT equal to) 8.
+
+15. ``lsid`` is added inside ``$query`` when using OP_QUERY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This test only applies to drivers that have not implemented OP_MSG and still use OP_QUERY.
+
+* For a command to a mongos that includes a readPreference, verify that the
+  ``lsid`` on query commands is added inside the ``$query`` field, and NOT as a
+  top-level field.
+
+16. Authenticating as a second user after starting a session results in a server error
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This test only applies to drivers that allow authentication to be changed on the fly.
+
+* Authenticate as the first user
+* Start a session by calling ``startSession``
+* Authenticate as a second user
+* Call ``findOne`` using the session as an explicit session
+* Assert that the driver returned an error because multiple users are authenticated
+
+17. Driver verifies that the session is owned by the current user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This test only applies to drivers that allow authentication to be changed on the fly.
+
+* Authenticate as user A
+* Start a session by calling ``startSession``
+* Logout user A
+* Authenticate as user B
+* Call ``findOne`` using the session as an explicit session
+* Assert that the driver returned an error because the session is owned by a different user
+
 Changelog
 =========
 
@@ -44,3 +241,4 @@ Changelog
 :2021-06-15: Added snapshot-session tests. Introduced legacy and unified folders.
 :2021-07-30: Use numbering for prose test
 :2022-02-11: Convert legacy tests to unified format
+:2022-06-13: Relocate prose test from spec document and apply new ordering

--- a/testdata/sessions/implicit-sessions-default-causal-consistency.json
+++ b/testdata/sessions/implicit-sessions-default-causal-consistency.json
@@ -1,0 +1,318 @@
+{
+  "description": "implicit sessions default causal consistency",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "implicit-cc-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionDefault",
+        "database": "database0",
+        "collectionName": "coll-default"
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionSnapshot",
+        "database": "database0",
+        "collectionName": "coll-snapshot",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "snapshot"
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionlinearizable",
+        "database": "database0",
+        "collectionName": "coll-linearizable",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "linearizable"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll-default",
+      "databaseName": "implicit-cc-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "default"
+        }
+      ]
+    },
+    {
+      "collectionName": "coll-snapshot",
+      "databaseName": "implicit-cc-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "snapshot"
+        }
+      ]
+    },
+    {
+      "collectionName": "coll-linearizable",
+      "databaseName": "implicit-cc-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "linearizable"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "readConcern is not sent on retried read in implicit session when readConcern level is not specified",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionDefault",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "default"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-default",
+                  "filter": {},
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-default",
+                  "filter": {},
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionSnapshot",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "snapshot"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-snapshot",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "snapshot",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-snapshot",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "snapshot",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "afterClusterTime is not sent on retried read in implicit session when readConcern level is linearizable",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionlinearizable",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "linearizable"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-linearizable",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "linearizable",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-linearizable",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "linearizable",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-cc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sessions/implicit-sessions-default-causal-consistency.yml
+++ b/testdata/sessions/implicit-sessions-default-causal-consistency.yml
@@ -1,0 +1,119 @@
+description: "implicit sessions default causal consistency"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+    topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName implicit-cc-tests
+  - collection:
+      id: &collectionDefault collectionDefault
+      database: *database0
+      collectionName: &collectionNameDefault coll-default
+  - collection:
+      id: &collectionSnapshot collectionSnapshot
+      database: *database0
+      collectionName: &collectionNameSnapshot coll-snapshot
+      collectionOptions:
+        readConcern: { level: snapshot }
+  - collection:
+      id: &collectionlinearizable collectionlinearizable
+      database: *database0
+      collectionName: &collectionNamelinearizable coll-linearizable
+      collectionOptions:
+        readConcern: { level: linearizable }
+
+initialData:
+  - collectionName: *collectionNameDefault
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: default }
+  - collectionName: *collectionNameSnapshot
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: snapshot }
+  - collectionName: *collectionNamelinearizable
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: linearizable }
+
+tests:
+  - description: "readConcern is not sent on retried read in implicit session when readConcern level is not specified"
+    operations:
+      - &failPointCommand
+        name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              errorCode: 11600 #InterruptedAtShutdown
+      - name: find
+        object: *collectionDefault
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: default }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventDefault
+              command:
+                find: *collectionNameDefault
+                filter: {}
+                readConcern: { $$exists: false }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventDefault
+
+  - description: "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - *failPointCommand
+      - name: find
+        object: *collectionSnapshot
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: snapshot }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventSnapshot
+              command:
+                find: *collectionNameSnapshot
+                filter: {}
+                readConcern:
+                  { level: snapshot, afterClusterTime: { $$exists: false } }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventSnapshot
+
+  - description: "afterClusterTime is not sent on retried read in implicit session when readConcern level is linearizable"
+    operations:
+      - *failPointCommand
+      - name: find
+        object: *collectionlinearizable
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: linearizable }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventLinearizable
+              command:
+                find: *collectionNamelinearizable
+                filter: {}
+                readConcern:
+                  { level: linearizable, afterClusterTime: { $$exists: false } }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventLinearizable

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -515,7 +515,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			// Set the server if it has not already been set and the session type is implicit. This will
 			// limit the number of implicit sessions to no greater than an application's maxPoolSize
 			// (ignoring operations that hold on to the session like cursors).
-			if op.Client != nil && op.Client.Server == nil && op.Client.SessionType == session.Implicit {
+			if op.Client != nil && op.Client.Server == nil && op.Client.IsImplicit {
 				if op.Client.Terminated {
 					return fmt.Errorf("unexpected nil session for a terminated implicit session")
 				}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -125,15 +125,15 @@ func TestOperation(t *testing.T) {
 		id, err := uuid.New()
 		noerr(t, err)
 
-		sess, err := session.NewClientSession(sessPool, id, session.Explicit)
+		sess, err := session.NewClientSession(sessPool, id)
 		noerr(t, err)
 
-		sessStartingTransaction, err := session.NewClientSession(sessPool, id, session.Explicit)
+		sessStartingTransaction, err := session.NewClientSession(sessPool, id)
 		noerr(t, err)
 		err = sessStartingTransaction.StartTransaction(nil)
 		noerr(t, err)
 
-		sessInProgressTransaction, err := session.NewClientSession(sessPool, id, session.Explicit)
+		sessInProgressTransaction, err := session.NewClientSession(sessPool, id)
 		noerr(t, err)
 		err = sessInProgressTransaction.StartTransaction(nil)
 		noerr(t, err)
@@ -269,7 +269,7 @@ func TestOperation(t *testing.T) {
 			id, err := uuid.New()
 			noerr(t, err)
 
-			sess, err := session.NewClientSession(sessPool, id, session.Explicit)
+			sess, err := session.NewClientSession(sessPool, id)
 			noerr(t, err)
 			err = sess.AdvanceClusterTime(older)
 			noerr(t, err)
@@ -364,7 +364,7 @@ func TestOperation(t *testing.T) {
 		id, err := uuid.New()
 		noerr(t, err)
 
-		sess, err := session.NewClientSession(sessPool, id, session.Explicit)
+		sess, err := session.NewClientSession(sessPool, id)
 		noerr(t, err)
 		Operation{Client: sess, Clock: clusterClock}.updateClusterTimes(clustertime)
 
@@ -386,7 +386,7 @@ func TestOperation(t *testing.T) {
 		id, err := uuid.New()
 		noerr(t, err)
 
-		sess, err := session.NewClientSession(sessPool, id, session.Explicit)
+		sess, err := session.NewClientSession(sessPool, id)
 		noerr(t, err)
 		if sess.OperationTime != nil {
 			t.Fatal("OperationTime should not be set on new session.")

--- a/x/mongo/driver/session/client_session_test.go
+++ b/x/mongo/driver/session/client_session_test.go
@@ -286,11 +286,11 @@ func TestClientSession(t *testing.T) {
 }
 
 func TestImplicitClientSession(t *testing.T) {
-        t.Parallel()
-        
+	t.Parallel()
+
 	t.Run("causal consistency is false", func(t *testing.T) {
-	    t.Parallel()
-	    
+		t.Parallel()
+
 		id, err := uuid.New()
 		require.NoError(t, err)
 

--- a/x/mongo/driver/session/client_session_test.go
+++ b/x/mongo/driver/session/client_session_test.go
@@ -52,7 +52,7 @@ func TestClientSession(t *testing.T) {
 
 	t.Run("TestAdvanceClusterTime", func(t *testing.T) {
 		id, _ := uuid.New()
-		sess, err := NewClientSession(&Pool{}, id, Explicit, sessionOpts)
+		sess, err := NewClientSession(&Pool{}, id, sessionOpts)
 		require.Nil(t, err, "Unexpected error")
 		err = sess.AdvanceClusterTime(clusterTime2)
 		require.Nil(t, err, "Unexpected error")
@@ -74,7 +74,7 @@ func TestClientSession(t *testing.T) {
 
 	t.Run("TestEndSession", func(t *testing.T) {
 		id, _ := uuid.New()
-		sess, err := NewClientSession(&Pool{}, id, Explicit, sessionOpts)
+		sess, err := NewClientSession(&Pool{}, id, sessionOpts)
 		require.Nil(t, err, "Unexpected error")
 		sess.EndSession()
 		err = sess.UpdateUseTime()
@@ -83,7 +83,7 @@ func TestClientSession(t *testing.T) {
 
 	t.Run("TestAdvanceOperationTime", func(t *testing.T) {
 		id, _ := uuid.New()
-		sess, err := NewClientSession(&Pool{}, id, Explicit, sessionOpts)
+		sess, err := NewClientSession(&Pool{}, id, sessionOpts)
 		require.Nil(t, err, "Unexpected error")
 
 		optime1 := &primitive.Timestamp{
@@ -121,7 +121,7 @@ func TestClientSession(t *testing.T) {
 
 	t.Run("TestTransactionState", func(t *testing.T) {
 		id, _ := uuid.New()
-		sess, err := NewClientSession(&Pool{}, id, Explicit, nil)
+		sess, err := NewClientSession(&Pool{}, id, nil)
 		require.Nil(t, err, "Unexpected error")
 
 		err = sess.CommitTransaction()
@@ -273,7 +273,7 @@ func TestClientSession(t *testing.T) {
 				}
 
 				id, _ := uuid.New()
-				sess, err := NewClientSession(&Pool{}, id, Explicit, sessOpts)
+				sess, err := NewClientSession(&Pool{}, id, sessOpts)
 				require.Nil(t, err, "unexpected NewClientSession error %v", err)
 
 				require.Equal(t, tc.expectedConsistent, sess.Consistent,
@@ -282,5 +282,15 @@ func TestClientSession(t *testing.T) {
 					"expected Snapshot to be %v, got %v", tc.expectedSnapshot, sess.Snapshot)
 			})
 		}
+	})
+}
+
+func TestImplicitClientSession(t *testing.T) {
+	t.Run("causal consistency is false", func(t *testing.T) {
+		id, err := uuid.New()
+		require.NoError(t, err)
+
+		c := NewImplicitClientSession(&Pool{}, id)
+		assert.False(t, c.Consistent, "expected causal consistency to be false for implicit sessions")
 	})
 }

--- a/x/mongo/driver/session/client_session_test.go
+++ b/x/mongo/driver/session/client_session_test.go
@@ -286,7 +286,11 @@ func TestClientSession(t *testing.T) {
 }
 
 func TestImplicitClientSession(t *testing.T) {
+        t.Parallel()
+        
 	t.Run("causal consistency is false", func(t *testing.T) {
+	    t.Parallel()
+	    
 		id, err := uuid.New()
 		require.NoError(t, err)
 


### PR DESCRIPTION
[GODRIVER-2497](https://jira.mongodb.org/browse/GODRIVER-2497)

## Summary
Create a new function `session.NewImplicitClientSession` for creating implicit client-side sessions that always sets `causalConsistency=false`. Simplify the existing `session.NewClientSession` function to always create explicit client-side sessions.

## Background & Motivation
The goal of [GODRIVER-2497](https://jira.mongodb.org/browse/GODRIVER-2497) is to always create implicit sessions with causal consistency disabled to fix a bug that can cause errors when operations are retried. Instead of adding additional conditional logic to the existing `session.NewClientSession` function, a safer and significantly simpler approach is to completely separate the logic for creating implicit and explicit client-side sessions.

Changes:
* Add a new `session.NewImplicitClientSession` function that creates implicit client-side sessions.
* Update all calls to create an implicit session to use the new `session.NewImplicitClientSession` function.
* Update the existing `session.NewClientSession` function to only create explicit client-side sessions. Remove the now-unnecessary `sessionType` argument.
* Replace `session.Client.SessionType` with `session.Client.IsImplicit` and update all conditional logic to use the new field. 
* Remove the `session.Type` type and `session.Implicit`/`session.Explicit` constants

Note that there are breaking changes to unstable APIs (in the "x/" directory) in this PR.