### PR TITLE
Ignore third-party files on adding licenses

### DIFF
--- a/etc/add_license.sh
+++ b/etc/add_license.sh
@@ -16,6 +16,13 @@ add_copyright() {
         return
     fi
 
+    # Check if first 14 bytes matches the word "// Copied from"
+     local line=$(head -c 14 $1)
+     if [ "$line" == "// Copied from" ]; then
+ 	echo "$1 has a third-party copyright notice" >&2
+ 	return
+     fi
+
     echo "$copyright" | cat - $1 > temp && mv temp $1
 }
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Ignore third-party files when adding licenses to files in the Go Driver.

## Background & Motivation
<!--- Rationale for the pull request. -->
The etc/add-license.sh script will try to add the copyright notice to third-party imports, which is not necessary.
