### PR TITLE
fix: fixed a memory leak caused by the commandMonitor example closure.

### DIFF
--- a/event/examples_test.go
+++ b/event/examples_test.go
@@ -32,12 +32,20 @@ func ExampleCommandMonitor() {
 				startedCommands[evt.RequestID],
 				evt.Reply,
 			)
+			// Delete the elements of the closure collection immediately after use,
+			// otherwise you will experience a memory leak.
+			// The same goes for using concurrent map like sync.Map
+			delete(startedCommands, evt.RequestID)
 		},
 		Failed: func(_ context.Context, evt *event.CommandFailedEvent) {
 			log.Printf("Command: %v Failure: %v\n",
 				startedCommands[evt.RequestID],
 				evt.Failure,
 			)
+			// Delete the elements of the closure collection immediately after use,
+			// otherwise you will experience a memory leak.
+			// The same goes for using concurrent map like sync.Map
+			delete(startedCommands, evt.RequestID)
 		},
 	}
 	clientOpts := options.Client().ApplyURI("mongodb://localhost:27017").SetMonitor(cmdMonitor)

--- a/event/examples_test.go
+++ b/event/examples_test.go
@@ -41,9 +41,8 @@ func ExampleCommandMonitor() {
 				startedCommands[evt.RequestID],
 				evt.Failure,
 			)
-			// Delete the elements of the closure collection immediately after use,
-			// otherwise you will experience a memory leak.
-			// The same goes for using concurrent map like sync.Map
+
+			// Empty "startedCommands" for the request ID to avoid a memory leak.
 			delete(startedCommands, evt.RequestID)
 		},
 	}

--- a/event/examples_test.go
+++ b/event/examples_test.go
@@ -32,9 +32,8 @@ func ExampleCommandMonitor() {
 				startedCommands[evt.RequestID],
 				evt.Reply,
 			)
-			// Delete the elements of the closure collection immediately after use,
-			// otherwise you will experience a memory leak.
-			// The same goes for using concurrent map like sync.Map
+
+			// Empty "startedCommands" for the request ID to avoid a memory leak.
 			delete(startedCommands, evt.RequestID)
 		},
 		Failed: func(_ context.Context, evt *event.CommandFailedEvent) {


### PR DESCRIPTION
I use the CommandMonitor feature in my project and refer to the ExampleCommandMonitor example. However, there was a memory surge during the long run, and the problem was checked for a while because the closure did not clear the element in time, resulting in a memory surge leak. Specifically to complete an example, remind the user to clear in time.

