### PR TITLE
GODRIVER-2681 Replace CompareTimestamp with Before, After and Compare methods.

### DIFF
--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -164,21 +164,14 @@ func (tp Timestamp) IsZero() bool {
 // Compare compares the time instant tp with tp2. If tp is before tp2, it returns -1; if tp is after
 // tp2, it returns +1; if they're the same, it returns 0.
 func (tp Timestamp) Compare(tp2 Timestamp) int {
-	if tp.Equal(tp2) {
+	switch {
+	case tp.Equal(tp2):
 		return 0
-	}
-
-	if tp.T > tp2.T {
-		return 1
-	}
-	if tp.T < tp2.T {
+	case tp.Before(tp2):
 		return -1
+	default:
+		return +1
 	}
-	// Compare I values because T values are equal
-	if tp.I > tp2.I {
-		return 1
-	}
-	return -1
 }
 
 // CompareTimestamp compares the time instant tp with tp2. If tp is before tp2, it returns -1; if tp is after

--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -181,8 +181,8 @@ func (tp Timestamp) Compare(tp2 Timestamp) int {
 	return -1
 }
 
-// CompareTimestamp returns an integer comparing two Timestamps, where T is compared first, followed by I.
-// Returns 0 if tp = tp2, 1 if tp > tp2, -1 if tp < tp2.
+// CompareTimestamp compares the time instant tp with tp2. If tp is before tp2, it returns -1; if tp is after
+// tp2, it returns +1; if they're the same, it returns 0.
 //
 // Deprecated: Use Timestamp.Compare instead.
 func CompareTimestamp(tp, tp2 Timestamp) int {

--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -141,6 +141,16 @@ type Timestamp struct {
 	I uint32
 }
 
+// After reports whether the time instant tp is after tp2.
+func (tp Timestamp) After(tp2 Timestamp) bool {
+	return tp.T > tp2.T || (tp.T == tp2.T && tp.I > tp2.I)
+}
+
+// Before reports whether the time instant tp is before tp2.
+func (tp Timestamp) Before(tp2 Timestamp) bool {
+	return tp.T < tp2.T || (tp.T == tp2.T && tp.I < tp2.I)
+}
+
 // Equal compares tp to tp2 and returns true if they are equal.
 func (tp Timestamp) Equal(tp2 Timestamp) bool {
 	return tp.T == tp2.T && tp.I == tp2.I
@@ -151,9 +161,9 @@ func (tp Timestamp) IsZero() bool {
 	return tp.T == 0 && tp.I == 0
 }
 
-// CompareTimestamp returns an integer comparing two Timestamps, where T is compared first, followed by I.
-// Returns 0 if tp = tp2, 1 if tp > tp2, -1 if tp < tp2.
-func CompareTimestamp(tp, tp2 Timestamp) int {
+// Compare compares the time instant tp with tp2. If tp is before tp2, it returns -1; if tp is after
+// tp2, it returns +1; if they're the same, it returns 0.
+func (tp Timestamp) Compare(tp2 Timestamp) int {
 	if tp.Equal(tp2) {
 		return 0
 	}
@@ -169,6 +179,14 @@ func CompareTimestamp(tp, tp2 Timestamp) int {
 		return 1
 	}
 	return -1
+}
+
+// CompareTimestamp returns an integer comparing two Timestamps, where T is compared first, followed by I.
+// Returns 0 if tp = tp2, 1 if tp > tp2, -1 if tp < tp2.
+//
+// Deprecated: Use Timestamp.Compare instead.
+func CompareTimestamp(tp, tp2 Timestamp) int {
+	return tp.Compare(tp2)
 }
 
 // MinKey represents the BSON minkey value.

--- a/bson/primitive/primitive_test.go
+++ b/bson/primitive/primitive_test.go
@@ -20,7 +20,7 @@ type zeroer interface {
 	IsZero() bool
 }
 
-func TestTimestampCompare(t *testing.T) {
+func TestCompareTimestamp(t *testing.T) {
 	testcases := []struct {
 		name     string
 		tp       Timestamp
@@ -38,6 +38,79 @@ func TestTimestampCompare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := CompareTimestamp(tc.tp, tc.tp2)
 			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTimestamp(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description     string
+		tp              Timestamp
+		tp2             Timestamp
+		expectedAfter   bool
+		expectedBefore  bool
+		expectedEqual   bool
+		expectedCompare int
+	}{
+		{
+			description:     "equal",
+			tp:              Timestamp{T: 12345, I: 67890},
+			tp2:             Timestamp{T: 12345, I: 67890},
+			expectedBefore:  false,
+			expectedAfter:   false,
+			expectedEqual:   true,
+			expectedCompare: 0,
+		},
+		{
+			description:     "T greater than",
+			tp:              Timestamp{T: 12345, I: 67890},
+			tp2:             Timestamp{T: 2345, I: 67890},
+			expectedBefore:  false,
+			expectedAfter:   true,
+			expectedEqual:   false,
+			expectedCompare: 1,
+		},
+		{
+			description:     "I greater than",
+			tp:              Timestamp{T: 12345, I: 67890},
+			tp2:             Timestamp{T: 12345, I: 7890},
+			expectedBefore:  false,
+			expectedAfter:   true,
+			expectedEqual:   false,
+			expectedCompare: 1,
+		},
+		{
+			description:     "T less than",
+			tp:              Timestamp{T: 12345, I: 67890},
+			tp2:             Timestamp{T: 112345, I: 67890},
+			expectedBefore:  true,
+			expectedAfter:   false,
+			expectedEqual:   false,
+			expectedCompare: -1,
+		},
+		{
+			description:     "I less than",
+			tp:              Timestamp{T: 12345, I: 67890},
+			tp2:             Timestamp{T: 12345, I: 167890},
+			expectedBefore:  true,
+			expectedAfter:   false,
+			expectedEqual:   false,
+			expectedCompare: -1,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expectedAfter, tc.tp.After(tc.tp2), "expected After results to be the same")
+			assert.Equal(t, tc.expectedBefore, tc.tp.Before(tc.tp2), "expected Before results to be the same")
+			assert.Equal(t, tc.expectedEqual, tc.tp.Equal(tc.tp2), "expected Equal results to be the same")
+			assert.Equal(t, tc.expectedCompare, tc.tp.Compare(tc.tp2), "expected Compare result to be the same")
 		})
 	}
 }


### PR DESCRIPTION
[GODRIVER-2681](https://jira.mongodb.org/browse/GODRIVER-2681)

## Summary
* Add `primitive.Timestamp` methods `Before`, `After`, and `Compare`.
* Deprecate the `primitive.CompareTimestamp` function.

## Background & Motivation
The [primitive.CompareTimestamp](https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.10.3/bson/primitive#CompareTimestamp) function is not a Go idiomatic API. Replace it with `primitive.Timestamp` methods `Before`, `After`, and `Compare` (inspired by Go's [time.Time](https://pkg.go.dev/time#Time) API). Deprecate `primitive.CompareTimestamp` and suggest using the new methods.