### PR TITLE
GODRIVER-2749 Deprecate all `Merge*Options` functions.

### DIFF
--- a/bson/bsonoptions/byte_slice_codec_options.go
+++ b/bson/bsonoptions/byte_slice_codec_options.go
@@ -23,6 +23,9 @@ func (bs *ByteSliceCodecOptions) SetEncodeNilAsEmpty(b bool) *ByteSliceCodecOpti
 }
 
 // MergeByteSliceCodecOptions combines the given *ByteSliceCodecOptions into a single *ByteSliceCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeByteSliceCodecOptions(opts ...*ByteSliceCodecOptions) *ByteSliceCodecOptions {
 	bs := ByteSliceCodec()
 	for _, opt := range opts {

--- a/bson/bsonoptions/empty_interface_codec_options.go
+++ b/bson/bsonoptions/empty_interface_codec_options.go
@@ -23,6 +23,9 @@ func (e *EmptyInterfaceCodecOptions) SetDecodeBinaryAsSlice(b bool) *EmptyInterf
 }
 
 // MergeEmptyInterfaceCodecOptions combines the given *EmptyInterfaceCodecOptions into a single *EmptyInterfaceCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeEmptyInterfaceCodecOptions(opts ...*EmptyInterfaceCodecOptions) *EmptyInterfaceCodecOptions {
 	e := EmptyInterfaceCodec()
 	for _, opt := range opts {

--- a/bson/bsonoptions/map_codec_options.go
+++ b/bson/bsonoptions/map_codec_options.go
@@ -46,6 +46,9 @@ func (t *MapCodecOptions) SetEncodeKeysWithStringer(b bool) *MapCodecOptions {
 }
 
 // MergeMapCodecOptions combines the given *MapCodecOptions into a single *MapCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeMapCodecOptions(opts ...*MapCodecOptions) *MapCodecOptions {
 	s := MapCodec()
 	for _, opt := range opts {

--- a/bson/bsonoptions/slice_codec_options.go
+++ b/bson/bsonoptions/slice_codec_options.go
@@ -23,6 +23,9 @@ func (s *SliceCodecOptions) SetEncodeNilAsEmpty(b bool) *SliceCodecOptions {
 }
 
 // MergeSliceCodecOptions combines the given *SliceCodecOptions into a single *SliceCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeSliceCodecOptions(opts ...*SliceCodecOptions) *SliceCodecOptions {
 	s := SliceCodec()
 	for _, opt := range opts {

--- a/bson/bsonoptions/string_codec_options.go
+++ b/bson/bsonoptions/string_codec_options.go
@@ -26,6 +26,9 @@ func (t *StringCodecOptions) SetDecodeObjectIDAsHex(b bool) *StringCodecOptions 
 }
 
 // MergeStringCodecOptions combines the given *StringCodecOptions into a single *StringCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeStringCodecOptions(opts ...*StringCodecOptions) *StringCodecOptions {
 	s := &StringCodecOptions{&defaultDecodeOIDAsHex}
 	for _, opt := range opts {

--- a/bson/bsonoptions/struct_codec_options.go
+++ b/bson/bsonoptions/struct_codec_options.go
@@ -57,6 +57,9 @@ func (t *StructCodecOptions) SetAllowUnexportedFields(b bool) *StructCodecOption
 }
 
 // MergeStructCodecOptions combines the given *StructCodecOptions into a single *StructCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeStructCodecOptions(opts ...*StructCodecOptions) *StructCodecOptions {
 	s := &StructCodecOptions{
 		OverwriteDuplicatedInlinedFields: &defaultOverwriteDuplicatedInlinedFields,

--- a/bson/bsonoptions/time_codec_options.go
+++ b/bson/bsonoptions/time_codec_options.go
@@ -23,6 +23,9 @@ func (t *TimeCodecOptions) SetUseLocalTimeZone(b bool) *TimeCodecOptions {
 }
 
 // MergeTimeCodecOptions combines the given *TimeCodecOptions into a single *TimeCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeTimeCodecOptions(opts ...*TimeCodecOptions) *TimeCodecOptions {
 	t := TimeCodec()
 	for _, opt := range opts {

--- a/bson/bsonoptions/uint_codec_options.go
+++ b/bson/bsonoptions/uint_codec_options.go
@@ -23,6 +23,9 @@ func (u *UIntCodecOptions) SetEncodeToMinSize(b bool) *UIntCodecOptions {
 }
 
 // MergeUIntCodecOptions combines the given *UIntCodecOptions into a single *UIntCodecOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeUIntCodecOptions(opts ...*UIntCodecOptions) *UIntCodecOptions {
 	u := UIntCodec()
 	for _, opt := range opts {

--- a/mongo/integration/mtest/setup_options.go
+++ b/mongo/integration/mtest/setup_options.go
@@ -25,6 +25,9 @@ func (so *SetupOptions) SetURI(uri string) *SetupOptions {
 }
 
 // MergeSetupOptions combines the given *SetupOptions into a single *Options in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeSetupOptions(opts ...*SetupOptions) *SetupOptions {
 	op := NewSetupOptions()
 	for _, opt := range opts {

--- a/mongo/integration/unified/options.go
+++ b/mongo/integration/unified/options.go
@@ -27,6 +27,9 @@ func (op *Options) SetRunKillAllSessions(killAllSessions bool) *Options {
 }
 
 // MergeOptions combines the given *Options into a single *Options in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeOptions(opts ...*Options) *Options {
 	op := NewOptions()
 	for _, opt := range opts {

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -139,6 +139,9 @@ func (ao *AggregateOptions) SetCustom(c bson.M) *AggregateOptions {
 
 // MergeAggregateOptions combines the given AggregateOptions instances into a single AggregateOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeAggregateOptions(opts ...*AggregateOptions) *AggregateOptions {
 	aggOpts := Aggregate()
 	for _, ao := range opts {

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -166,6 +166,9 @@ func (a *AutoEncryptionOptions) SetBypassQueryAnalysis(bypass bool) *AutoEncrypt
 }
 
 // MergeAutoEncryptionOptions combines the argued AutoEncryptionOptions in a last-one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeAutoEncryptionOptions(opts ...*AutoEncryptionOptions) *AutoEncryptionOptions {
 	aeo := AutoEncryption()
 	for _, opt := range opts {

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -67,6 +67,9 @@ func (b *BulkWriteOptions) SetLet(let interface{}) *BulkWriteOptions {
 
 // MergeBulkWriteOptions combines the given BulkWriteOptions instances into a single BulkWriteOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeBulkWriteOptions(opts ...*BulkWriteOptions) *BulkWriteOptions {
 	b := BulkWrite()
 	for _, opt := range opts {

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -157,6 +157,9 @@ func (cso *ChangeStreamOptions) SetCustomPipeline(cp bson.M) *ChangeStreamOption
 
 // MergeChangeStreamOptions combines the given ChangeStreamOptions instances into a single ChangeStreamOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeChangeStreamOptions(opts ...*ChangeStreamOptions) *ChangeStreamOptions {
 	csOpts := ChangeStream()
 	for _, cso := range opts {

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -122,6 +122,9 @@ func BuildTLSConfig(tlsOpts map[string]interface{}) (*tls.Config, error) {
 }
 
 // MergeClientEncryptionOptions combines the argued ClientEncryptionOptions in a last-one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeClientEncryptionOptions(opts ...*ClientEncryptionOptions) *ClientEncryptionOptions {
 	ceo := ClientEncryption()
 	for _, opt := range opts {

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -876,6 +876,9 @@ func (c *ClientOptions) SetSRVServiceName(srvName string) *ClientOptions {
 // MergeClientOptions combines the given *ClientOptions into a single *ClientOptions in a last one wins fashion.
 // The specified options are merged with the existing options on the client, with the specified options taking
 // precedence.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 	c := Client()
 

--- a/mongo/options/collectionoptions.go
+++ b/mongo/options/collectionoptions.go
@@ -63,6 +63,9 @@ func (c *CollectionOptions) SetRegistry(r *bsoncodec.Registry) *CollectionOption
 
 // MergeCollectionOptions combines the given CollectionOptions instances into a single *CollectionOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeCollectionOptions(opts ...*CollectionOptions) *CollectionOptions {
 	c := Collection()
 

--- a/mongo/options/countoptions.go
+++ b/mongo/options/countoptions.go
@@ -89,6 +89,9 @@ func (co *CountOptions) SetSkip(i int64) *CountOptions {
 }
 
 // MergeCountOptions combines the given CountOptions instances into a single CountOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeCountOptions(opts ...*CountOptions) *CountOptions {
 	countOpts := Count()
 	for _, co := range opts {

--- a/mongo/options/createcollectionoptions.go
+++ b/mongo/options/createcollectionoptions.go
@@ -234,6 +234,9 @@ func (c *CreateCollectionOptions) SetClusteredIndex(clusteredIndex interface{}) 
 
 // MergeCreateCollectionOptions combines the given CreateCollectionOptions instances into a single
 // CreateCollectionOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeCreateCollectionOptions(opts ...*CreateCollectionOptions) *CreateCollectionOptions {
 	cc := CreateCollection()
 
@@ -309,6 +312,9 @@ func (c *CreateViewOptions) SetCollation(collation *Collation) *CreateViewOption
 
 // MergeCreateViewOptions combines the given CreateViewOptions instances into a single CreateViewOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeCreateViewOptions(opts ...*CreateViewOptions) *CreateViewOptions {
 	cv := CreateView()
 

--- a/mongo/options/datakeyoptions.go
+++ b/mongo/options/datakeyoptions.go
@@ -79,6 +79,9 @@ func (dk *DataKeyOptions) SetKeyMaterial(keyMaterial []byte) *DataKeyOptions {
 }
 
 // MergeDataKeyOptions combines the argued DataKeyOptions in a last-one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeDataKeyOptions(opts ...*DataKeyOptions) *DataKeyOptions {
 	dko := DataKey()
 	for _, opt := range opts {

--- a/mongo/options/dboptions.go
+++ b/mongo/options/dboptions.go
@@ -63,6 +63,9 @@ func (d *DatabaseOptions) SetRegistry(r *bsoncodec.Registry) *DatabaseOptions {
 
 // MergeDatabaseOptions combines the given DatabaseOptions instances into a single DatabaseOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeDatabaseOptions(opts ...*DatabaseOptions) *DatabaseOptions {
 	d := Database()
 

--- a/mongo/options/deleteoptions.go
+++ b/mongo/options/deleteoptions.go
@@ -62,6 +62,9 @@ func (do *DeleteOptions) SetLet(let interface{}) *DeleteOptions {
 }
 
 // MergeDeleteOptions combines the given DeleteOptions instances into a single DeleteOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeDeleteOptions(opts ...*DeleteOptions) *DeleteOptions {
 	dOpts := Delete()
 	for _, do := range opts {

--- a/mongo/options/distinctoptions.go
+++ b/mongo/options/distinctoptions.go
@@ -57,6 +57,9 @@ func (do *DistinctOptions) SetMaxTime(d time.Duration) *DistinctOptions {
 
 // MergeDistinctOptions combines the given DistinctOptions instances into a single DistinctOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeDistinctOptions(opts ...*DistinctOptions) *DistinctOptions {
 	distinctOpts := Distinct()
 	for _, do := range opts {

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -121,6 +121,9 @@ func (ro *RangeOptions) SetPrecision(precision int32) *RangeOptions {
 }
 
 // MergeEncryptOptions combines the argued EncryptOptions in a last-one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeEncryptOptions(opts ...*EncryptOptions) *EncryptOptions {
 	eo := Encrypt()
 	for _, opt := range opts {

--- a/mongo/options/estimatedcountoptions.go
+++ b/mongo/options/estimatedcountoptions.go
@@ -46,6 +46,9 @@ func (eco *EstimatedDocumentCountOptions) SetMaxTime(d time.Duration) *Estimated
 
 // MergeEstimatedDocumentCountOptions combines the given EstimatedDocumentCountOptions instances into a single
 // EstimatedDocumentCountOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeEstimatedDocumentCountOptions(opts ...*EstimatedDocumentCountOptions) *EstimatedDocumentCountOptions {
 	e := EstimatedDocumentCount()
 	for _, opt := range opts {

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -251,6 +251,9 @@ func (f *FindOptions) SetSort(sort interface{}) *FindOptions {
 }
 
 // MergeFindOptions combines the given FindOptions instances into a single FindOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeFindOptions(opts ...*FindOptions) *FindOptions {
 	fo := Find()
 	for _, opt := range opts {
@@ -549,6 +552,9 @@ func (f *FindOneOptions) SetSort(sort interface{}) *FindOneOptions {
 
 // MergeFindOneOptions combines the given FindOneOptions instances into a single FindOneOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeFindOneOptions(opts ...*FindOneOptions) *FindOneOptions {
 	fo := FindOne()
 	for _, opt := range opts {
@@ -742,6 +748,9 @@ func (f *FindOneAndReplaceOptions) SetLet(let interface{}) *FindOneAndReplaceOpt
 
 // MergeFindOneAndReplaceOptions combines the given FindOneAndReplaceOptions instances into a single
 // FindOneAndReplaceOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeFindOneAndReplaceOptions(opts ...*FindOneAndReplaceOptions) *FindOneAndReplaceOptions {
 	fo := FindOneAndReplace()
 	for _, opt := range opts {
@@ -922,6 +931,9 @@ func (f *FindOneAndUpdateOptions) SetLet(let interface{}) *FindOneAndUpdateOptio
 
 // MergeFindOneAndUpdateOptions combines the given FindOneAndUpdateOptions instances into a single
 // FindOneAndUpdateOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeFindOneAndUpdateOptions(opts ...*FindOneAndUpdateOptions) *FindOneAndUpdateOptions {
 	fo := FindOneAndUpdate()
 	for _, opt := range opts {
@@ -1062,6 +1074,9 @@ func (f *FindOneAndDeleteOptions) SetLet(let interface{}) *FindOneAndDeleteOptio
 
 // MergeFindOneAndDeleteOptions combines the given FindOneAndDeleteOptions instances into a single
 // FindOneAndDeleteOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeFindOneAndDeleteOptions(opts ...*FindOneAndDeleteOptions) *FindOneAndDeleteOptions {
 	fo := FindOneAndDelete()
 	for _, opt := range opts {

--- a/mongo/options/gridfsoptions.go
+++ b/mongo/options/gridfsoptions.go
@@ -85,6 +85,9 @@ func (b *BucketOptions) SetReadPreference(rp *readpref.ReadPref) *BucketOptions 
 }
 
 // MergeBucketOptions combines the given BucketOptions instances into a single BucketOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeBucketOptions(opts ...*BucketOptions) *BucketOptions {
 	b := GridFSBucket()
 
@@ -144,6 +147,9 @@ func (u *UploadOptions) SetMetadata(doc interface{}) *UploadOptions {
 }
 
 // MergeUploadOptions combines the given UploadOptions instances into a single UploadOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeUploadOptions(opts ...*UploadOptions) *UploadOptions {
 	u := GridFSUpload()
 
@@ -192,6 +198,9 @@ func (n *NameOptions) SetRevision(r int32) *NameOptions {
 }
 
 // MergeNameOptions combines the given NameOptions instances into a single *NameOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeNameOptions(opts ...*NameOptions) *NameOptions {
 	n := GridFSName()
 	n.Revision = &DefaultRevision
@@ -296,6 +305,9 @@ func (f *GridFSFindOptions) SetSort(sort interface{}) *GridFSFindOptions {
 
 // MergeGridFSFindOptions combines the given GridFSFindOptions instances into a single GridFSFindOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeGridFSFindOptions(opts ...*GridFSFindOptions) *GridFSFindOptions {
 	fo := GridFSFind()
 	for _, opt := range opts {

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -77,6 +77,9 @@ func (c *CreateIndexesOptions) SetCommitQuorumVotingMembers() *CreateIndexesOpti
 
 // MergeCreateIndexesOptions combines the given CreateIndexesOptions into a single CreateIndexesOptions in a last one
 // wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeCreateIndexesOptions(opts ...*CreateIndexesOptions) *CreateIndexesOptions {
 	c := CreateIndexes()
 	for _, opt := range opts {
@@ -123,6 +126,9 @@ func (d *DropIndexesOptions) SetMaxTime(duration time.Duration) *DropIndexesOpti
 
 // MergeDropIndexesOptions combines the given DropIndexesOptions into a single DropIndexesOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeDropIndexesOptions(opts ...*DropIndexesOptions) *DropIndexesOptions {
 	c := DropIndexes()
 	for _, opt := range opts {
@@ -174,6 +180,9 @@ func (l *ListIndexesOptions) SetMaxTime(d time.Duration) *ListIndexesOptions {
 
 // MergeListIndexesOptions combines the given ListIndexesOptions instances into a single *ListIndexesOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeListIndexesOptions(opts ...*ListIndexesOptions) *ListIndexesOptions {
 	c := ListIndexes()
 	for _, opt := range opts {
@@ -409,6 +418,9 @@ func (i *IndexOptions) SetHidden(hidden bool) *IndexOptions {
 }
 
 // MergeIndexOptions combines the given IndexOptions into a single IndexOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeIndexOptions(opts ...*IndexOptions) *IndexOptions {
 	i := Index()
 

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -38,6 +38,9 @@ func (ioo *InsertOneOptions) SetComment(comment interface{}) *InsertOneOptions {
 
 // MergeInsertOneOptions combines the given InsertOneOptions instances into a single InsertOneOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeInsertOneOptions(opts ...*InsertOneOptions) *InsertOneOptions {
 	ioOpts := InsertOne()
 	for _, ioo := range opts {
@@ -98,6 +101,9 @@ func (imo *InsertManyOptions) SetOrdered(b bool) *InsertManyOptions {
 
 // MergeInsertManyOptions combines the given InsertManyOptions instances into a single InsertManyOptions in a last one
 // wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeInsertManyOptions(opts ...*InsertManyOptions) *InsertManyOptions {
 	imOpts := InsertMany()
 	for _, imo := range opts {

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -45,6 +45,9 @@ func (lc *ListCollectionsOptions) SetAuthorizedCollections(b bool) *ListCollecti
 
 // MergeListCollectionsOptions combines the given ListCollectionsOptions instances into a single *ListCollectionsOptions
 // in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeListCollectionsOptions(opts ...*ListCollectionsOptions) *ListCollectionsOptions {
 	lc := ListCollections()
 	for _, opt := range opts {

--- a/mongo/options/listdatabasesoptions.go
+++ b/mongo/options/listdatabasesoptions.go
@@ -37,6 +37,9 @@ func (ld *ListDatabasesOptions) SetAuthorizedDatabases(b bool) *ListDatabasesOpt
 
 // MergeListDatabasesOptions combines the given ListDatabasesOptions instances into a single *ListDatabasesOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeListDatabasesOptions(opts ...*ListDatabasesOptions) *ListDatabasesOptions {
 	ld := ListDatabases()
 	for _, opt := range opts {

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -85,6 +85,9 @@ func (ro *ReplaceOptions) SetLet(l interface{}) *ReplaceOptions {
 
 // MergeReplaceOptions combines the given ReplaceOptions instances into a single ReplaceOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeReplaceOptions(opts ...*ReplaceOptions) *ReplaceOptions {
 	rOpts := Replace()
 	for _, ro := range opts {

--- a/mongo/options/rewrapdatakeyoptions.go
+++ b/mongo/options/rewrapdatakeyoptions.go
@@ -35,6 +35,9 @@ func (rmdko *RewrapManyDataKeyOptions) SetMasterKey(masterKey interface{}) *Rewr
 
 // MergeRewrapManyDataKeyOptions combines the given RewrapManyDataKeyOptions instances into a single
 // RewrapManyDataKeyOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeRewrapManyDataKeyOptions(opts ...*RewrapManyDataKeyOptions) *RewrapManyDataKeyOptions {
 	rmdkOpts := RewrapManyDataKey()
 	for _, rmdko := range opts {

--- a/mongo/options/runcmdoptions.go
+++ b/mongo/options/runcmdoptions.go
@@ -27,6 +27,9 @@ func (rc *RunCmdOptions) SetReadPreference(rp *readpref.ReadPref) *RunCmdOptions
 }
 
 // MergeRunCmdOptions combines the given RunCmdOptions instances into one *RunCmdOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeRunCmdOptions(opts ...*RunCmdOptions) *RunCmdOptions {
 	rc := RunCmd()
 	for _, opt := range opts {

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -98,6 +98,9 @@ func (s *SessionOptions) SetSnapshot(b bool) *SessionOptions {
 
 // MergeSessionOptions combines the given SessionOptions instances into a single SessionOptions in a last-one-wins
 // fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeSessionOptions(opts ...*SessionOptions) *SessionOptions {
 	s := Session()
 	for _, opt := range opts {

--- a/mongo/options/transactionoptions.go
+++ b/mongo/options/transactionoptions.go
@@ -76,6 +76,9 @@ func (t *TransactionOptions) SetMaxCommitTime(mct *time.Duration) *TransactionOp
 
 // MergeTransactionOptions combines the given TransactionOptions instances into a single TransactionOptions in a
 // last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeTransactionOptions(opts ...*TransactionOptions) *TransactionOptions {
 	t := Transaction()
 	for _, opt := range opts {

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -95,6 +95,9 @@ func (uo *UpdateOptions) SetLet(l interface{}) *UpdateOptions {
 }
 
 // MergeUpdateOptions combines the given UpdateOptions instances into a single UpdateOptions in a last-one-wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeUpdateOptions(opts ...*UpdateOptions) *UpdateOptions {
 	uOpts := Update()
 	for _, uo := range opts {

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
@@ -137,6 +137,9 @@ func (rmdko *RewrapManyDataKeyOptions) SetMasterKey(masterKey bsoncore.Document)
 
 // MergeRewrapManyDataKeyOptions combines the given RewrapManyDataKeyOptions instances into a single
 // RewrapManyDataKeyOptions in a last one wins fashion.
+//
+// Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
+// single options struct instead.
 func MergeRewrapManyDataKeyOptions(opts ...*RewrapManyDataKeyOptions) *RewrapManyDataKeyOptions {
 	rmdkOpts := RewrapManyDataKey()
 	for _, rmdko := range opts {


### PR DESCRIPTION
[GODRIVER-2749](https://jira.mongodb.org/browse/GODRIVER-2749)

## Summary
Deprecate all `Merge*Options` functions. Suggest using a single options struct instead.

## Background & Motivation
We currently maintain 50+ `Merge*Options` functions that contain 1,000+ lines of code (plus tests). The sole purpose of those functions is to merge `*Options` structs together so that users can provide 2 or more options structs in APIs with a variadic options parameter. However, the vast majority of users only provide 0 or 1 options structs. Deprecate all `Merge*Options` functions in preparation to remove them in Go Driver 2.0.

