### PR TITLE
GODRIVER-2755 guard abort transaction

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -413,6 +414,7 @@ func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) 
 		clientSession: sess,
 		client:        c,
 		deployment:    c.deployment,
+		abortMu:       sync.Mutex{},
 	}, nil
 }
 

--- a/mongo/integration/transaction_prose_test.go
+++ b/mongo/integration/transaction_prose_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+	xsession "go.mongodb.org/mongo-driver/x/mongo/driver/session"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestTransactionProse(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().Topologies(mtest.LoadBalanced).CreateClient(false))
+	defer mt.Close()
+
+	mt.Run("Abort transactions concurrently", func(mt *mtest.T) {
+		const concurrencyCount = 100
+
+		// Start a new ClientSession with default options and start a transaction.
+		session, err := mt.Client.StartSession()
+		if err != nil {
+			log.Fatalf("error starting session: %v", err)
+		}
+
+		if err = session.StartTransaction(); err != nil {
+			log.Fatalf("error starting transaction: %v", err)
+		}
+
+		abortTransactionCount := 0          // number of times abortTransaction was called
+		abortTransactionErrors := []error{} // errors returned by abortTransaction
+
+		ctx := context.Background()
+
+		err = mongo.WithSession(ctx, session, func(sc mongo.SessionContext) error {
+			// Within the transaction, insert a document into a
+			// collection.
+			if _, err := mt.Coll.InsertOne(sc, bson.D{{"x", 1}}); err != nil {
+				return err
+			}
+
+			// After the insert operation, concurrently abort the
+			// transaction 100 times.
+			g, _ := errgroup.WithContext(sc)
+			for i := 0; i < concurrencyCount; i++ {
+				g.Go(func() error {
+					if err := session.AbortTransaction(sc); err != nil {
+						abortTransactionErrors = append(abortTransactionErrors, err)
+
+						return err
+					}
+
+					abortTransactionCount++
+
+					return nil
+				})
+			}
+
+			return g.Wait()
+		})
+
+		// Assert that only one of the abortTransaction operations
+		// succeeds
+		if abortTransactionCount != 1 {
+			mt.Fatalf("expected abortTransactionCount to be 1, got %d", abortTransactionCount)
+		}
+
+		// There should be "concurrencyCount - 1" errors in
+		// abortTransactionErrors.
+		if len(abortTransactionErrors) != concurrencyCount-1 {
+			mt.Fatalf("expected %d errors, got %d", concurrencyCount-1, len(abortTransactionErrors))
+		}
+
+		// Assert that 99 operations raise an error containing the
+		// message "Cannot call abortTransaction after calling
+		// commitTransaction".
+		for _, err := range abortTransactionErrors {
+			if !errors.Is(err, xsession.ErrAbortTwice) {
+				mt.Fatalf("expected error %v, got %v", xsession.ErrAbortTwice, err)
+			}
+		}
+
+		session.EndSession(ctx)
+	})
+}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2755

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Guard the session's "abortTransaction" method with a mutex, avoiding calling "abortTransaction" concurrently.

## Background & Motivation
<!--- Rationale for the pull request. -->
A user reported the following stack trace when aborting a transaction:

```
panic: runtime error: invalid memory address or nil pointer dereference
--
goroutine 205012212 [running]:
runtime/debug.Stack()
/data/mci/6518126308abc1030d90b2652dd254f1/go/src/runtime/debug/stack.go:24 +0x65
github.com/10gen/baas/utils.WritePanic({0x4e4cd40, 0x8028790}, 0xc14b042c60)
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/http.go:303 +0x9c
github.com/10gen/baas/utils.Transactions.Abort.func1.1()
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/transaction.go:33 +0x16a
panic({0x4e4cd40, 0x8028790})
/data/mci/6518126308abc1030d90b2652dd254f1/go/src/runtime/panic.go:884 +0x212
go.mongodb.org/mongo-driver/x/mongo/driver/session.(*Client).ClearPinnedResources(0xc1491fdc70)
/root/go/pkg/mod/github.com/mongodb-forks/mongo-go-driver@v1.10.6-baas/x/mongo/driver/session/client_session.go:317 +0x8b
go.mongodb.org/mongo-driver/x/mongo/driver/session.(*Client).clearTransactionOpts(0x0?)
/root/go/pkg/mod/github.com/mongodb-forks/mongo-go-driver@v1.10.6-baas/x/mongo/driver/session/client_session.go:530 +0x8c
go.mongodb.org/mongo-driver/x/mongo/driver/session.(*Client).AbortTransaction(0xc192996f00?)
/root/go/pkg/mod/github.com/mongodb-forks/mongo-go-driver@v1.10.6-baas/x/mongo/driver/session/client_session.go:482 +0x85
go.mongodb.org/mongo-driver/mongo.(*sessionImpl).AbortTransaction(0xc14b698180, {0x5e8f598, 0xc14b698210})
/root/go/pkg/mod/github.com/mongodb-forks/mongo-go-driver@v1.10.6-baas/mongo/session.go:298 +0x466
github.com/10gen/baas/service/services/mongodb.mongoTransaction.Abort({{0x63, 0x46, 0x6a, 0x86, 0xa5, 0xf6, 0x16, 0xda, 0xaf, 0x96, ...}, ...}, ...)
/data/mci/6518126308abc1030d90b2652dd254f1/baas/service/services/mongodb/transaction.go:28 +0xb1
github.com/10gen/baas/utils.Transactions.Abort.func1(0xc14b042c60, 0xc14adc9a40?, {0x5e8f598?, 0xc14b698210?})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/transaction.go:37 +0x91
github.com/10gen/baas/utils.Transactions.Abort({0xc131563480?, 0x1, 0xc14b58ef90?}, {0x5e8f598, 0xc14b698210}, 0xa?)
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/transaction.go:40 +0x97
github.com/10gen/baas/api/common.ExecuteQuery.func3.2()
/data/mci/6518126308abc1030d90b2652dd254f1/baas/api/common/graphql.go:356 +0xa9
github.com/10gen/baas/api/common.ExecuteQuery.func3({0x5e8f598, 0xc14b698210}, {0x5eb3dd0?, 0xc14ad93500})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/api/common/graphql.go:390 +0x9b6
github.com/10gen/baas/api/common.ExecuteQuery.func4({0x5e8f598?, 0xc14b58ef90?}, {0x5eb3dd0?, 0xc14ad93500?})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/api/common/graphql.go:398 +0x102
github.com/10gen/baas/function/execution/vm.(*Context).RunAsync.func1({0x5e8f598, 0xc14b58ef90})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/function/execution/vm/execution.go:52 +0x5a
github.com/10gen/baas/function/execution/vm.(*eventLoop).processAsyncWorkQueue.func1.1.1({{0x5e8f598?, 0xc14b58ed20?}, 0xc0fca9ad50?, 0xc0ccb9a6e0?}, {0x5e8f598?, 0xc14b58ef90?})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/function/execution/vm/event_loop.go:491 +0x92
github.com/10gen/baas/function/execution/vm.(*eventLoop).processAsyncWorkQueue.func1.1({{0x5e8f598?, 0xc14b58ed20?}, 0xc0fca9ad50?, 0xc0ccb9a6e0?}, 0xc14a6a3000, {0x5e8f598, 0xc14b58ef90})
/data/mci/6518126308abc1030d90b2652dd254f1/baas/function/execution/vm/event_loop.go:493 +0x89
github.com/10gen/baas/function/execution/vm.(*eventLoop).processAsyncWorkQueue.func1()
/data/mci/6518126308abc1030d90b2652dd254f1/baas/function/execution/vm/event_loop.go:530 +0x1a5
github.com/10gen/baas/utils.PanicCapturingFuncWithCallback(0x219f5b7?, 0xc0832349b0?)
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/utils.go:251 +0x53
github.com/10gen/baas/utils.PanicCapturingFunc(0xc0b2b004b0?)
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/utils.go:207 +0x1b
created by github.com/10gen/baas/utils.PanicCapturingGo
/data/mci/6518126308abc1030d90b2652dd254f1/baas/utils/utils.go:257 +0x56
```

Since pinned connections are guarded on [L321](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/session/client_session.go#L321), it would appear that the client is calling "abortTransaction" multiple times concurrently. This exact error can be replicated by the prose test included in this PR. From the [specifications](https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#aborttransaction):

> If this session is already in the "transaction aborted" state, then drivers MUST raise an error containing the message "Cannot call abortTransaction twice".
