### PR TITLE
fix: D map for child properties

### DIFF
--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -197,11 +197,56 @@ type MaxKey struct{}
 type D []E
 
 // Map creates a map from the elements of the D.
-func (d D) Map() M {
-	m := make(M, len(d))
-	for _, e := range d {
-		m[e.Key] = e.Value
+
+func mapByA(doc A) []interface{} {
+	var arr []interface{}
+
+	for _, value := range doc {
+		switch v := value.(type) {
+		case D:
+			m := mapByD(v)
+			arr = append(arr, m)
+			continue
+
+		case A:
+			a := mapByA(v)
+			arr = append(arr, a)
+
+		default:
+			arr = append(arr, v)
+			continue
+		}
 	}
+
+	return arr
+}
+
+func mapByD(d interface{}) M {
+	m := make(map[string]interface{})
+
+	for _, e := range d.(D) {
+		m[e.Key] = e.Value
+
+		switch v := e.Value.(type) {
+		case A:
+			a := mapByA(v)
+			m[e.Key] = a
+			continue
+		case D:
+			newM := mapByD(v)
+			m[e.Key] = newM
+			continue
+		default:
+			m[e.Key] = e.Value
+			continue
+		}
+	}
+
+	return m
+}
+func (d D) Map() M {
+	m := mapByD(d)
+
 	return m
 }
 


### PR DESCRIPTION
### Summary
This commit fixes an issue in a property mapping for a data type called `D` in a system. The modification changes the original code to allow the creation of maps with nested child properties, which were not being mapped correctly before.

### Background
The original code contained a method called Map() that converts a D data type to an M map. The modification changes the original code to allow nested child properties to be correctly mapped and added to the resulting map.

### Motivation
The motivation behind this change appears to be to allow the system to handle nested child properties more effectively. The original problem was that the code was not correctly mapping these nested properties, and the change made to the mapByD() function fixes this problem, allowing the resulting map to correctly include these properties. With this correction, it is expected that the system will be able to manipulate and work with these properties in a more efficient and accurate way.