### PR TITLE
GODRIVER-2674 Add Duration and deprecate DurationNanos

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -8,6 +8,7 @@ package event // import "go.mongodb.org/mongo-driver/event"
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -32,10 +33,10 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
-	DurationNanos int64
-	CommandName   string
-	RequestID     int64
-	ConnectionID  string
+	Duration     time.Duration
+	CommandName  string
+	RequestID    int64
+	ConnectionID string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
 	ServerConnectionID *int32
@@ -157,18 +158,18 @@ type ServerHeartbeatStartedEvent struct {
 
 // ServerHeartbeatSucceededEvent is an event generated when the heartbeat succeeds.
 type ServerHeartbeatSucceededEvent struct {
-	DurationNanos int64
-	Reply         description.Server
-	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool   // If this heartbeat was awaitable
+	Duration     time.Duration
+	Reply        description.Server
+	ConnectionID string // The address this heartbeat was sent to with a unique identifier
+	Awaited      bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatFailedEvent is an event generated when the heartbeat fails.
 type ServerHeartbeatFailedEvent struct {
-	DurationNanos int64
-	Failure       error
-	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
-	Awaited       bool   // If this heartbeat was awaitable
+	Duration     time.Duration
+	Failure      error
+	ConnectionID string // The address this heartbeat was sent to with a unique identifier
+	Awaited      bool   // If this heartbeat was awaitable
 }
 
 // ServerMonitor represents a monitor that is triggered for different server events. The client

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -33,10 +33,12 @@ type CommandStartedEvent struct {
 
 // CommandFinishedEvent represents a generic command finishing.
 type CommandFinishedEvent struct {
-	Duration     time.Duration
-	CommandName  string
-	RequestID    int64
-	ConnectionID string
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	CommandName   string
+	RequestID     int64
+	ConnectionID  string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return
 	// this value (e.g. on MDB < 4.2), it is unset.
 	ServerConnectionID *int32
@@ -158,18 +160,22 @@ type ServerHeartbeatStartedEvent struct {
 
 // ServerHeartbeatSucceededEvent is an event generated when the heartbeat succeeds.
 type ServerHeartbeatSucceededEvent struct {
-	Duration     time.Duration
-	Reply        description.Server
-	ConnectionID string // The address this heartbeat was sent to with a unique identifier
-	Awaited      bool   // If this heartbeat was awaitable
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	Reply         description.Server
+	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerHeartbeatFailedEvent is an event generated when the heartbeat fails.
 type ServerHeartbeatFailedEvent struct {
-	Duration     time.Duration
-	Failure      error
-	ConnectionID string // The address this heartbeat was sent to with a unique identifier
-	Awaited      bool   // If this heartbeat was awaitable
+	// Deprecated: Use Duration instead.
+	DurationNanos int64
+	Duration      time.Duration
+	Failure       error
+	ConnectionID  string // The address this heartbeat was sent to with a unique identifier
+	Awaited       bool   // If this heartbeat was awaitable
 }
 
 // ServerMonitor represents a monitor that is triggered for different server events. The client

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -33,8 +33,10 @@ import (
 const defaultMaxDocumentLen = 10_000
 
 // Security-sensitive commands that should be ignored in command monitoring by default.
-var securitySensitiveCommands = []string{"authenticate", "saslStart", "saslContinue", "getnonce",
-	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb"}
+var securitySensitiveCommands = []string{
+	"authenticate", "saslStart", "saslContinue", "getnonce",
+	"createUser", "updateUser", "copydbgetnonce", "copydbsaslstart", "copydb",
+}
 
 // clientEntity is a wrapper for a mongo.Client object that also holds additional information required during test
 // execution.
@@ -357,7 +359,7 @@ func (c *clientEntity) processFailedEvent(_ context.Context, evt *event.CommandF
 	bsonBuilder := bsoncore.NewDocumentBuilder().
 		AppendString("name", "CommandFailedEvent").
 		AppendDouble("observedAt", getSecondsSinceEpoch()).
-		AppendInt64("durationNanos", evt.DurationNanos).
+		AppendInt64("duration", int64(evt.Duration)).
 		AppendString("commandName", evt.CommandName).
 		AppendInt64("requestId", evt.RequestID).
 		AppendString("connectionId", evt.ConnectionID).

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -359,7 +359,7 @@ func (c *clientEntity) processFailedEvent(_ context.Context, evt *event.CommandF
 	bsonBuilder := bsoncore.NewDocumentBuilder().
 		AppendString("name", "CommandFailedEvent").
 		AppendDouble("observedAt", getSecondsSinceEpoch()).
-		AppendInt64("duration", int64(evt.Duration)).
+		AppendInt64("durationNanos", evt.Duration.Nanoseconds()).
 		AppendString("commandName", evt.CommandName).
 		AppendInt64("requestId", evt.RequestID).
 		AppendString("connectionId", evt.ConnectionID).

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -648,7 +648,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		if err == nil {
 			// roundtrip using either the full roundTripper or a special one for when the moreToCome
 			// flag is set
-			var roundTrip = op.roundTrip
+			roundTrip := op.roundTrip
 			if moreToCome {
 				roundTrip = op.moreToComeRoundTrip
 			}
@@ -1050,8 +1050,8 @@ func (op Operation) createWireMessage(
 	dst []byte,
 	desc description.SelectedServer,
 	maxTimeMS uint64,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	// If topology is not LoadBalanced, API version is not declared, and wire version is unknown
 	// or less than 6, use OP_QUERY. Otherwise, use OP_MSG.
 	if desc.Kind != description.LoadBalanced && op.ServerAPI == nil &&
@@ -1143,8 +1143,8 @@ func (op Operation) createQueryWireMessage(maxTimeMS uint64, dst []byte, desc de
 }
 
 func (op Operation) createMsgWireMessage(ctx context.Context, maxTimeMS uint64, dst []byte, desc description.SelectedServer,
-	conn Connection) ([]byte, startedInformation, error) {
-
+	conn Connection,
+) ([]byte, startedInformation, error) {
 	var info startedInformation
 	var flags wiremessage.MsgFlag
 	var wmindex int32
@@ -1873,7 +1873,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		CommandName:        info.cmdName,
 		RequestID:          int64(info.requestID),
 		ConnectionID:       info.connID,
-		DurationNanos:      info.duration.Nanoseconds(),
+		Duration:           info.duration,
 		ServerConnectionID: info.serverConnID,
 		ServiceID:          info.serviceID,
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1874,6 +1874,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		RequestID:          int64(info.requestID),
 		ConnectionID:       info.connID,
 		Duration:           info.duration,
+		DurationNanos:      info.duration.Nanoseconds(),
 		ServerConnectionID: info.serverConnID,
 		ServiceID:          info.serviceID,
 	}

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -742,18 +742,18 @@ func (s *Server) check() (description.Server, error) {
 		}
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
-		durationNanos = time.Since(start).Nanoseconds()
+		duration = time.Since(start)
 		if err == nil {
 			// Use the description from the connection handshake as the value for this check.
 			s.rttMonitor.addSample(s.conn.helloRTT)
 			descPtr = &s.conn.desc
 			if !isNilConn {
-				s.publishServerHeartbeatSucceededEvent(s.conn.ID(), durationNanos, s.conn.desc, false)
+				s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, s.conn.desc, false)
 			}
 		} else {
 			err = unwrapConnectionError(err)
 			if !isNilConn {
-				s.publishServerHeartbeatFailedEvent(s.conn.ID(), durationNanos, err, false)
+				s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, false)
 			}
 		}
 	} else {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -942,10 +942,11 @@ func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
 	await bool,
 ) {
 	serverHeartbeatSucceeded := &event.ServerHeartbeatSucceededEvent{
-		Duration:     duration,
-		Reply:        desc,
-		ConnectionID: connectionID,
-		Awaited:      await,
+		DurationNanos: duration.Nanoseconds(),
+		Duration:      duration,
+		Reply:         desc,
+		ConnectionID:  connectionID,
+		Awaited:       await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatSucceeded != nil {
@@ -960,10 +961,11 @@ func (s *Server) publishServerHeartbeatFailedEvent(connectionID string,
 	await bool,
 ) {
 	serverHeartbeatFailed := &event.ServerHeartbeatFailedEvent{
-		Duration:     duration,
-		Failure:      err,
-		ConnectionID: connectionID,
-		Awaited:      await,
+		DurationNanos: duration.Nanoseconds(),
+		Duration:      duration,
+		Failure:       err,
+		ConnectionID:  connectionID,
+		Awaited:       await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatFailed != nil {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -730,7 +730,7 @@ func (s *Server) createBaseOperation(conn driver.Connection) *operation.Hello {
 func (s *Server) check() (description.Server, error) {
 	var descPtr *description.Server
 	var err error
-	var durationNanos int64
+	var duration time.Duration
 
 	start := time.Now()
 	if s.conn == nil || s.conn.closed() || s.checkWasCancelled() {
@@ -796,19 +796,19 @@ func (s *Server) check() (description.Server, error) {
 			s.conn.setSocketTimeout(s.cfg.heartbeatTimeout)
 			err = baseOperation.Execute(s.heartbeatCtx)
 		}
-		durationNanos = time.Since(start).Nanoseconds()
+		duration = time.Since(start)
 
 		if err == nil {
 			tempDesc := baseOperation.Result(s.address)
 			descPtr = &tempDesc
-			s.publishServerHeartbeatSucceededEvent(s.conn.ID(), durationNanos, tempDesc, s.conn.getCurrentlyStreaming() || streamable)
+			s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, tempDesc, s.conn.getCurrentlyStreaming() || streamable)
 		} else {
 			// Close the connection here rather than below so we ensure we're not closing a connection that wasn't
 			// successfully created.
 			if s.conn != nil {
 				_ = s.conn.close()
 			}
-			s.publishServerHeartbeatFailedEvent(s.conn.ID(), durationNanos, err, s.conn.getCurrentlyStreaming() || streamable)
+			s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, s.conn.getCurrentlyStreaming() || streamable)
 		}
 	}
 
@@ -937,14 +937,15 @@ func (s *Server) publishServerHeartbeatStartedEvent(connectionID string, await b
 
 // publishes a ServerHeartbeatSucceededEvent to indicate hello has succeeded
 func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
-	durationNanos int64,
+	duration time.Duration,
 	desc description.Server,
-	await bool) {
+	await bool,
+) {
 	serverHeartbeatSucceeded := &event.ServerHeartbeatSucceededEvent{
-		DurationNanos: durationNanos,
-		Reply:         desc,
-		ConnectionID:  connectionID,
-		Awaited:       await,
+		Duration:     duration,
+		Reply:        desc,
+		ConnectionID: connectionID,
+		Awaited:      await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatSucceeded != nil {
@@ -954,14 +955,15 @@ func (s *Server) publishServerHeartbeatSucceededEvent(connectionID string,
 
 // publishes a ServerHeartbeatFailedEvent to indicate hello has failed
 func (s *Server) publishServerHeartbeatFailedEvent(connectionID string,
-	durationNanos int64,
+	duration time.Duration,
 	err error,
-	await bool) {
+	await bool,
+) {
 	serverHeartbeatFailed := &event.ServerHeartbeatFailedEvent{
-		DurationNanos: durationNanos,
-		Failure:       err,
-		ConnectionID:  connectionID,
-		Awaited:       await,
+		Duration:     duration,
+		Failure:      err,
+		ConnectionID: connectionID,
+		Awaited:      await,
 	}
 
 	if s != nil && s.cfg.serverMonitor != nil && s.cfg.serverMonitor.ServerHeartbeatFailed != nil {


### PR DESCRIPTION
[GODRIVER-2674](https://jira.mongodb.org/browse/GODRIVER-2674)

## Summary
* Deprecate field `event.CommandFinishedEvent.DurationNanos`. Suggest using `time.Duration` field `Duration` instead.
* Deprecate field `event.ServerHeartbeatFailedEvent.DurationNanos`. Suggest using `time.Duration` field `Duration` instead.
* Deprecate field `event.ServerHeartbeatSucceededEvent.DurationNanos`. Suggest using `time.Duration` field `Duration` instead.

## Background & Motivation
A Go `time.Duration` is much easier to work with than an `int64` that represents a duration in nanoseconds because `time.Duration` units are implicit and the Go `time` package provides lots of functions for inspecting and manipulating the duration values. In Go Driver 2.0, we plan to replace the `DurationNanos int64` fields with `Duration time.Duration` fields.

Resolves merge conflicts and test failures from https://github.com/mongodb/mongo-go-driver/pull/1120