### PR TITLE
Use SHA256 instead of SHA1 in oss-fuzz to resolve gosec warning.

### DIFF
--- a/cmd/build-oss-fuzz-corpus/main.go
+++ b/cmd/build-oss-fuzz-corpus/main.go
@@ -4,11 +4,13 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// Entry point for the MongoDB Go Driver integration into the Google "oss-fuzz" project
+// (https://github.com/google/oss-fuzz).
 package main
 
 import (
 	"archive/zip"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -80,7 +82,9 @@ func seedExtJSON(zw *zip.Writer, extJSON string, extJSONType string, desc string
 		log.Fatalf("failed to convert JSON to bytes: %v", err)
 	}
 
-	zipFile := fmt.Sprintf("%x", sha1.Sum(jbytes))
+	// Use a SHA256 hash of the BSON bytes for the filename. This isn't an oss-fuzz requirement, it
+	// just simplifies file naming.
+	zipFile := fmt.Sprintf("%x", sha256.Sum256(jbytes))
 
 	f, err := zw.Create(zipFile)
 	if err != nil {


### PR DESCRIPTION
## Summary
Use `"crypto/sha256"` instead of `"crypto/sha1"` to generate filenames for the oss-fuzz integration.

## Background & Motivation
The gosec linter currently warns about using the `"crypto/sha1"` package:
> G505: Blocklisted import crypto/sha1: weak cryptographic primitive

The oss-fuzz integration doesn't rely on the filenames being SHA1 hashes, so use SHA256 instead to resolve the gosec linter warnings. Updates the integration added in https://github.com/mongodb/mongo-go-driver/pull/1170.