### PR TITLE
GODRIVER-2730 Remove blocking channel in update recovering.

### DIFF
--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -474,19 +474,11 @@ func (s *Server) update() {
 	checkNow := s.checkNow
 	done := s.done
 
-	var doneOnce bool
 	defer func() {
-		if r := recover(); r != nil {
-			if doneOnce {
-				return
-			}
-			// We keep this goroutine alive attempting to read from the done channel.
-			<-done
-		}
+		_ = recover()
 	}()
 
 	closeServer := func() {
-		doneOnce = true
 		s.subLock.Lock()
 		for id, c := range s.subscribers {
 			close(c)


### PR DESCRIPTION
GODRIVER-2730

## Summary
Remove the channel reading in the `recover` block of the `Server.update()`.

## Background & Motivation
The channel reading exists from commit [94ae2dc](https://github.com/mongodb/mongo-go-driver/commit/94ae2dc59114fbf6dd39707929068adfa20a92e8#diff-f1adee6cee5a6c64fac82d534ca26f6565e80fb5c288ba7768bfb29463fd6c77R251-R254). The shortcut if-condition was added shortly after the initial commit to fix a deadlock in [550660b](https://github.com/mongodb/mongo-go-driver/commit/550660bb2a7f750c43524c0d2b9816b2e863bddd).

I can neither practically reproduce a deadlock by a panic as the ticket implies nor logically figure out any reason that may cause a deadlock if the `Server.Disconnect()`, where the `done` channel [is closed](https://github.com/mongodb/mongo-go-driver/blame/master/x/mongo/driver/topology/server.go#L242) and nowhere else the channel is written otherwise, is properly called. However, I think it is unnecessary to keep the `update` routine alive until `Server.Disconnect()` is called as the comment suggests when a panic occurs.

