### PR TITLE
GODRIVER-2672 Return ServerError with "TransientTransactionError" label for server selection timeouts.

### DIFF
--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -19,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
 func setupDb(name string, opts ...*options.DatabaseOptions) *Database {
@@ -104,6 +105,9 @@ func TestDatabase(t *testing.T) {
 
 			err = client.Ping(bgCtx, nil)
 			assert.NotNil(t, err, "expected error, got nil")
+			assert.True(t, IsTransientTransactionError(err), `expected error to include the "TransientTransactionError" label`)
+			var sse topology.ServerSelectionError
+			assert.True(t, errors.As(err, &sse), `expected error to be a "topology.ServerSelectionError"`)
 			var serverErr ServerError
 			assert.True(t, errors.As(err, &serverErr), `expected error to implement the "ServerError" interface`)
 			assert.True(t, serverErr.HasErrorLabel("TransientTransactionError"), `expected error to include the "TransientTransactionError" label`)

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -108,9 +108,9 @@ func TestDatabase(t *testing.T) {
 			assert.True(t, IsTransientTransactionError(err), `expected error to include the "TransientTransactionError" label`)
 			var sse topology.ServerSelectionError
 			assert.True(t, errors.As(err, &sse), `expected error to be a "topology.ServerSelectionError"`)
-			var serverErr ServerError
-			assert.True(t, errors.As(err, &serverErr), `expected error to implement the "ServerError" interface`)
-			assert.True(t, serverErr.HasErrorLabel("TransientTransactionError"), `expected error to include the "TransientTransactionError" label`)
+			var le LabeledError
+			assert.True(t, errors.As(err, &le), `expected error to implement the "ServerError" interface`)
+			assert.True(t, le.HasErrorLabel("TransientTransactionError"), `expected error to include the "TransientTransactionError" label`)
 		})
 	})
 	t.Run("nil document error", func(t *testing.T) {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -139,16 +139,6 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// IsTransientTransactionError returns true if err contains a "TransientTransactionError" label
-func IsTransientTransactionError(err error) bool {
-	if le, ok := err.(LabeledError); ok {
-		if le.HasErrorLabel(driver.TransientTransactionError) {
-			return true
-		}
-	}
-	return false
-}
-
 // unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
 func unwrap(err error) error {
 	u, ok := err.(interface {

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -68,29 +68,6 @@ type labeledError interface {
 	HasErrorLabel(string) bool
 }
 
-// LabeledError wraps the error and implements the interface of mongo.LabeledError for errors with labels.
-type LabeledError struct {
-	error
-	Labels []string
-}
-
-// HasErrorLabel returns true if the error contains the specified label.
-func (e LabeledError) HasErrorLabel(label string) bool {
-	if e.Labels != nil {
-		for _, l := range e.Labels {
-			if l == label {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// Unwrap returns the underlying error.
-func (e LabeledError) Unwrap() error {
-	return e.error
-}
-
 // InvalidOperationError is returned from Validate and indicates that a required field is missing
 // from an instance of Operation.
 type InvalidOperationError struct{ MissingField string }
@@ -344,9 +321,10 @@ func (op Operation) getServerAndConnection(ctx context.Context) (Server, Connect
 	if err != nil {
 		if op.Client != nil &&
 			!(op.Client.Committing || op.Client.Aborting) && op.Client.TransactionRunning() {
-			err = LabeledError{
-				error:  err,
-				Labels: []string{TransientTransactionError},
+			err = Error{
+				Message: err.Error(),
+				Labels:  []string{TransientTransactionError},
+				Wrapped: err,
 			}
 		}
 		return nil, nil, err

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 // ConnectionError represents a connection error.
@@ -66,11 +65,6 @@ func (e ServerSelectionError) Error() string {
 // Unwrap returns the underlying error.
 func (e ServerSelectionError) Unwrap() error {
 	return e.Wrapped
-}
-
-// HasErrorLabel returns true if the specified label is TransientTransactionError.
-func (e ServerSelectionError) HasErrorLabel(label string) bool {
-	return label == driver.TransientTransactionError
 }
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 // ConnectionError represents a connection error.
@@ -65,6 +66,26 @@ func (e ServerSelectionError) Error() string {
 // Unwrap returns the underlying error.
 func (e ServerSelectionError) Unwrap() error {
 	return e.Wrapped
+}
+
+// HasErrorCode always returns false.
+func (e ServerSelectionError) HasErrorCode(code int) bool {
+	return false
+}
+
+// HasErrorLabel returns true if the specified label is TransientTransactionError.
+func (e ServerSelectionError) HasErrorLabel(label string) bool {
+	return label == driver.TransientTransactionError
+}
+
+// HasErrorMessage returns true if the specified message is the error message of TransientTransactionError.
+func (e ServerSelectionError) HasErrorMessage(message string) bool {
+	return message == e.Error()
+}
+
+// HasErrorCodeWithMessage always returns false.
+func (e ServerSelectionError) HasErrorCodeWithMessage(code int, message string) bool {
+	return false
 }
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -68,24 +68,9 @@ func (e ServerSelectionError) Unwrap() error {
 	return e.Wrapped
 }
 
-// HasErrorCode always returns false.
-func (e ServerSelectionError) HasErrorCode(code int) bool {
-	return false
-}
-
 // HasErrorLabel returns true if the specified label is TransientTransactionError.
 func (e ServerSelectionError) HasErrorLabel(label string) bool {
 	return label == driver.TransientTransactionError
-}
-
-// HasErrorMessage returns true if the specified message is the error message of TransientTransactionError.
-func (e ServerSelectionError) HasErrorMessage(message string) bool {
-	return message == e.Error()
-}
-
-// HasErrorCodeWithMessage always returns false.
-func (e ServerSelectionError) HasErrorCodeWithMessage(code int, message string) bool {
-	return false
 }
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool


### PR DESCRIPTION
GODRIVER-2672

## Summary
Return `mongo.ServerError` with the "TransientTransactionError" label for server selection timeouts.

## Background & Motivation
As per the request of a "TransientTransactionError" label described in [the spec](https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst#transienttransactionerror), add a `mongo.ServerSelectionError` type, which wraps `topology.ServerSelectionError`, to implement the `mongo.ServerError` interface.

I don't think this is a breaking change because, originally, we return a `topology.ServerSelectionError`, a type under the "x" API, which is not encouraged to be used by driver users.

