### PR TITLE
GODRIVER-2779 Reduce memory allocations in bson slice codec

### DIFF
--- a/bson/bsoncodec/slice_codec_test.go
+++ b/bson/bsoncodec/slice_codec_test.go
@@ -5,19 +5,22 @@ import (
 	"strings"
 	"testing"
 
-	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func BenchmarkSliceCodec_EncodeValue(b *testing.B) {
 	codec := NewSliceCodec()
 	eContext := EncodeContext{}
-	vw := &valueWriterMock{}
 	dataToEncode := []byte(strings.Repeat("t", 4096))
 	val := reflect.ValueOf(&dataToEncode).Elem()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		vw := &bsonrwtest.ValueReaderWriter{}
 		err := codec.EncodeValue(eContext, vw, val)
 		if err != nil {
 			b.Fatal(err)
@@ -29,12 +32,17 @@ func BenchmarkSliceCodec_EncodeValue(b *testing.B) {
 func BenchmarkSliceCodec_DecodeValue(b *testing.B) {
 	codec := NewSliceCodec()
 	dContext := DecodeContext{}
-	vr := &valueReaderMock{}
+	dataToDecode := bsoncore.AppendBinary(nil, bsontype.BinaryGeneric, []byte(strings.Repeat("t", 4096)))
+
 	var buf []byte
 	val := reflect.ValueOf(&buf).Elem()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		vr := &bsonrwtest.ValueReaderWriter{BSONType: bsontype.Binary, Return: bsoncore.Value{
+			Type: bsontype.Binary,
+			Data: dataToDecode,
+		}}
 		err := codec.DecodeValue(dContext, vr, val)
 		if err != nil {
 			b.Fatal(err)
@@ -43,24 +51,34 @@ func BenchmarkSliceCodec_DecodeValue(b *testing.B) {
 	b.ReportAllocs()
 }
 
-type valueWriterMock struct {
-	bsonrw.ValueWriter
-}
+func TestSliceCodec_DecodeValue(t *testing.T) {
+	t.Parallel()
+	codec := NewSliceCodec()
 
-func (m *valueWriterMock) WriteBinary(_ []byte) error {
-	return nil
-}
+	t.Run("decode binary", func(t *testing.T) {
+		expected := []byte("test bytes")
+		vr := &bsonrwtest.ValueReaderWriter{BSONType: bsontype.Binary, Return: bsoncore.Value{
+			Type: bsontype.Binary,
+			Data: bsoncore.AppendBinary(nil, bsontype.BinaryGeneric, expected),
+		}}
 
-type valueReaderMock struct {
-	bsonrw.ValueReader
-}
+		actual := []byte("dummy")
+		val := reflect.ValueOf(&actual).Elem()
+		err := codec.DecodeValue(DecodeContext{}, vr, val)
+		require.NoError(t, err)
 
-func (m *valueReaderMock) Type() bsontype.Type {
-	return bsontype.Binary
-}
+		assert.Equal(t, expected, actual)
+	})
 
-var dataToDecode = []byte(strings.Repeat("t", 4096))
+	t.Run("decode string", func(t *testing.T) {
+		expected := "test string"
+		vr := &bsonrwtest.ValueReaderWriter{BSONType: bsontype.String, Return: expected}
 
-func (m *valueReaderMock) ReadBinary() (b []byte, btype byte, err error) {
-	return dataToDecode, bsontype.BinaryGeneric, nil
+		actual := []byte("dummy")
+		val := reflect.ValueOf(&actual).Elem()
+		err := codec.DecodeValue(DecodeContext{}, vr, val)
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, string(actual))
+	})
 }

--- a/bson/bsoncodec/slice_codec_test.go
+++ b/bson/bsoncodec/slice_codec_test.go
@@ -1,0 +1,66 @@
+package bsoncodec
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+)
+
+func BenchmarkSliceCodec_EncodeValue(b *testing.B) {
+	codec := NewSliceCodec()
+	eContext := EncodeContext{}
+	vw := &valueWriterMock{}
+	dataToEncode := []byte(strings.Repeat("t", 4096))
+	val := reflect.ValueOf(&dataToEncode).Elem()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := codec.EncodeValue(eContext, vw, val)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkSliceCodec_DecodeValue(b *testing.B) {
+	codec := NewSliceCodec()
+	dContext := DecodeContext{}
+	vr := &valueReaderMock{}
+	var buf []byte
+	val := reflect.ValueOf(&buf).Elem()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := codec.DecodeValue(dContext, vr, val)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+}
+
+type valueWriterMock struct {
+	bsonrw.ValueWriter
+}
+
+func (m *valueWriterMock) WriteBinary(_ []byte) error {
+	return nil
+}
+
+type valueReaderMock struct {
+	bsonrw.ValueReader
+}
+
+func (m *valueReaderMock) Type() bsontype.Type {
+	return bsontype.Binary
+}
+
+var dataToDecode = []byte(strings.Repeat("t", 4096))
+
+func (m *valueReaderMock) ReadBinary() (b []byte, btype byte, err error) {
+	return dataToDecode, bsontype.BinaryGeneric, nil
+}


### PR DESCRIPTION
## Summary
Memory allocations in the bson slice codec has been reduced.
```
name                       old time/op    new time/op    delta
SliceCodec_EncodeValue-10    56.9µs ± 0%     0.5µs ± 1%  -99.15%  (p=0.008 n=5+5)
SliceCodec_DecodeValue-10     185µs ± 0%       0µs ± 1%  -99.92%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
SliceCodec_EncodeValue-10    16.6kB ± 0%     4.1kB ± 0%  -75.23%  (p=0.008 n=5+5)
SliceCodec_DecodeValue-10    98.3kB ± 0%     0.1kB ± 0%  -99.93%  (p=0.008 n=5+5)

name                       old allocs/op  new allocs/op  delta
SliceCodec_EncodeValue-10     4.11k ± 0%     0.00k ± 0%  -99.95%  (p=0.008 n=5+5)
SliceCodec_DecodeValue-10     4.10k ± 0%     0.00k ± 0%  -99.93%  (p=0.008 n=5+5)
```

## Background & Motivation
There is a problem with using bson.Unmarshal()/bson.Marshal() for documents with a big blob because it makes a lot of memory allocations.

pprof for bson.Unmarshal()
```
Type: alloc_space
Time: Mar 7, 2023 at 8:30pm (+07)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 4779.27MB, 99.22% of 4816.80MB total
Dropped 58 nodes (cum <= 24.08MB)
Showing top 10 nodes out of 21
      flat  flat%   sum%        cum   cum%
 4220.60MB 87.62% 87.62%  4220.60MB 87.62%  reflect.Value.Slice
  201.43MB  4.18% 91.80%  4445.05MB 92.28%  go.mongodb.org/mongo-driver/bson/bsoncodec.(*SliceCodec).DecodeValue
  177.12MB  3.68% 95.48%   354.23MB  7.35%  go.mongodb.org/mongo-driver/x/mongo/driver.Operation.roundTrip
  177.12MB  3.68% 99.16%   177.12MB  3.68%  go.mongodb.org/mongo-driver/x/mongo/driver/topology.(*connection).read
    2.51MB 0.052% 99.21%  4814.30MB 99.95%  main.(*MongoObjectStorage).FilterObject
    0.50MB  0.01% 99.22%   357.24MB  7.42%  go.mongodb.org/mongo-driver/x/mongo/driver.Operation.Execute
         0     0% 99.22%  4814.30MB 99.95%  gitlab.ptsecurity.com/cybsi/cloud/pkg/flow.(*GoroutineGroup).run
         0     0% 99.22%  4445.55MB 92.29%  go.mongodb.org/mongo-driver/bson.(*Decoder).Decode
         0     0% 99.22%  4453.05MB 92.45%  go.mongodb.org/mongo-driver/bson.Unmarshal (inline)
         0     0% 99.22%  4453.05MB 92.45%  go.mongodb.org/mongo-driver/bson.UnmarshalWithRegistry
```
The struct which I used. 
```
type Object struct {
	Type    int
	Context json.RawMessage <- 4kb json
}
```
