### PR TITLE
GODRIVER-2778 Reduce memory usage on compressed loads.

### DIFF
--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -57,7 +57,8 @@ func (c *connection) WriteWireMessage(_ context.Context, wm []byte) error {
 }
 
 // ReadWireMessage returns the next response in the connection's list of responses.
-func (c *connection) ReadWireMessage(_ context.Context, dst []byte) ([]byte, error) {
+func (c *connection) ReadWireMessage(_ context.Context) ([]byte, error) {
+	var dst []byte
 	if len(c.responses) == 0 {
 		return dst, errors.New("no responses remaining")
 	}

--- a/mongo/integration/mtest/wiremessage_helpers.go
+++ b/mongo/integration/mtest/wiremessage_helpers.go
@@ -54,7 +54,7 @@ func parseOpCompressed(wm []byte) (wiremessage.OpCode, []byte, error) {
 		return originalOpcode, nil, errors.New("failed to read compressor ID")
 	}
 
-	compressedMsg, wm, ok := wiremessage.ReadCompressedCompressedMessage(wm, int32(len(wm)))
+	compressedMsg, _, ok := wiremessage.ReadCompressedCompressedMessage(wm, int32(len(wm)))
 	if !ok {
 		return originalOpcode, nil, errors.New("failed to read compressed message")
 	}

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -59,7 +59,7 @@ type Server interface {
 // Connection represents a connection to a MongoDB server.
 type Connection interface {
 	WriteWireMessage(context.Context, []byte) error
-	ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error)
+	ReadWireMessage(ctx context.Context) ([]byte, error)
 	Description() description.Server
 
 	// Close closes any underlying connection and returns or frees any resources held by the

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -40,8 +40,7 @@ func (c *ChannelConn) WriteWireMessage(ctx context.Context, wm []byte) error {
 }
 
 // ReadWireMessage implements the driver.Connection interface.
-func (c *ChannelConn) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
-	dst = dst[:0]
+func (c *ChannelConn) ReadWireMessage(ctx context.Context) ([]byte, error) {
 	var wm []byte
 	var err error
 	select {
@@ -49,13 +48,7 @@ func (c *ChannelConn) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, 
 	case err = <-c.ReadErr:
 	case <-ctx.Done():
 	}
-	if l := len(wm); l > 0 {
-		if l > cap(dst) {
-			dst = make([]byte, 0, l)
-		}
-		dst = append(dst, wm...)
-	}
-	return dst, err
+	return wm, err
 }
 
 // Description implements the driver.Connection interface.

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -740,7 +740,6 @@ func (m *mockServerSelector) SelectServer(description.Topology, []description.Se
 type mockConnection struct {
 	// parameters
 	pWriteWM []byte
-	pReadDst []byte
 
 	// returns
 	rWriteErr     error
@@ -770,8 +769,7 @@ func (m *mockConnection) WriteWireMessage(_ context.Context, wm []byte) error {
 	return m.rWriteErr
 }
 
-func (m *mockConnection) ReadWireMessage(_ context.Context, dst []byte) ([]byte, error) {
-	m.pReadDst = dst
+func (m *mockConnection) ReadWireMessage(_ context.Context) ([]byte, error) {
 	return m.rReadWM, m.rReadErr
 }
 

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -82,7 +82,7 @@ func (s TransactionState) String() string {
 type LoadBalancedTransactionConnection interface {
 	// Functions copied over from driver.Connection.
 	WriteWireMessage(context.Context, []byte) error
-	ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error)
+	ReadWireMessage(ctx context.Context) ([]byte, error)
 	Description() description.Server
 	Close() error
 	ID() string

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -379,9 +379,9 @@ func (c *connection) write(ctx context.Context, wm []byte) (err error) {
 }
 
 // readWireMessage reads a wiremessage from the connection. The dst parameter will be overwritten.
-func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
+func (c *connection) readWireMessage(ctx context.Context) ([]byte, error) {
 	if atomic.LoadInt64(&c.state) != connConnected {
-		return dst, ConnectionError{ConnectionID: c.id, message: "connection is closed"}
+		return nil, ConnectionError{ConnectionID: c.id, message: "connection is closed"}
 	}
 
 	var deadline time.Time
@@ -399,7 +399,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 		return nil, ConnectionError{ConnectionID: c.id, Wrapped: err, message: "failed to set read deadline"}
 	}
 
-	dst, errMsg, err := c.read(ctx, dst)
+	dst, errMsg, err := c.read(ctx)
 	if err != nil {
 		// We closeConnection the connection because we don't know if there are other bytes left to read.
 		c.close()
@@ -407,7 +407,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 		if err == io.EOF {
 			message = "socket was unexpectedly closed"
 		}
-		return dst, ConnectionError{
+		return nil, ConnectionError{
 			ConnectionID: c.id,
 			Wrapped:      transformNetworkError(ctx, err, contextDeadlineUsed),
 			message:      message,
@@ -417,7 +417,7 @@ func (c *connection) readWireMessage(ctx context.Context, dst []byte) ([]byte, e
 	return dst, nil
 }
 
-func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, errMsg string, err error) {
+func (c *connection) read(ctx context.Context) (bytesRead []byte, errMsg string, err error) {
 	go c.cancellationListener.Listen(ctx, c.cancellationListenerCallback)
 	defer func() {
 		// If the context is cancelled after we finish reading the server response, the cancellation listener could fire
@@ -439,7 +439,7 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 	// reading messages from an exhaust cursor.
 	_, err = io.ReadFull(c.nc, sizeBuf[:])
 	if err != nil {
-		return dst, "incomplete read of message header", err
+		return nil, "incomplete read of message header", err
 	}
 
 	// read the length as an int32
@@ -452,16 +452,10 @@ func (c *connection) read(ctx context.Context, dst []byte) (bytesRead []byte, er
 		maxMessageSize = defaultMaxMessageSize
 	}
 	if uint32(size) > maxMessageSize {
-		return dst, errResponseTooLarge.Error(), errResponseTooLarge
+		return nil, errResponseTooLarge.Error(), errResponseTooLarge
 	}
 
-	if int(size) > cap(dst) {
-		// Since we can't grow this slice without allocating, just allocate an entirely new slice.
-		dst = make([]byte, 0, size)
-	}
-	// We need to ensure we don't accidentally read into a subsequent wire message, so we set the
-	// size to read exactly this wire message.
-	dst = dst[:size]
+	dst := make([]byte, size)
 	copy(dst, sizeBuf[:])
 
 	_, err = io.ReadFull(c.nc, dst[4:])
@@ -564,8 +558,8 @@ func (c initConnection) LocalAddress() address.Address {
 func (c initConnection) WriteWireMessage(ctx context.Context, wm []byte) error {
 	return c.writeWireMessage(ctx, wm)
 }
-func (c initConnection) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
-	return c.readWireMessage(ctx, dst)
+func (c initConnection) ReadWireMessage(ctx context.Context) ([]byte, error) {
+	return c.readWireMessage(ctx)
 }
 func (c initConnection) SetStreaming(streaming bool) {
 	c.setStreaming(streaming)
@@ -608,13 +602,13 @@ func (c *Connection) WriteWireMessage(ctx context.Context, wm []byte) error {
 
 // ReadWireMessage handles reading a wire message from the underlying connection. The dst parameter
 // will be overwritten with the new wire message.
-func (c *Connection) ReadWireMessage(ctx context.Context, dst []byte) ([]byte, error) {
+func (c *Connection) ReadWireMessage(ctx context.Context) ([]byte, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.connection == nil {
-		return dst, ErrConnectionClosed
+		return nil, ErrConnectionClosed
 	}
-	return c.connection.readWireMessage(ctx, dst)
+	return c.connection.readWireMessage(ctx)
 }
 
 // CompressWireMessage handles compressing the provided wire message using the underlying

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -476,7 +476,7 @@ func TestConnection(t *testing.T) {
 			t.Run("closed connection", func(t *testing.T) {
 				conn := &connection{id: "foobar"}
 				want := ConnectionError{ConnectionID: "foobar", message: "connection is closed"}
-				_, got := conn.readWireMessage(context.Background(), []byte{})
+				_, got := conn.readWireMessage(context.Background())
 				if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 					t.Errorf("errors do not match. got %v; want %v", got, want)
 				}
@@ -510,7 +510,7 @@ func TestConnection(t *testing.T) {
 						}
 						tnc := &testNetConn{deadlineerr: errors.New("set readDeadline error")}
 						conn := &connection{id: "foobar", nc: tnc, readTimeout: tc.timeout, state: connConnected}
-						_, got := conn.readWireMessage(ctx, []byte{})
+						_, got := conn.readWireMessage(ctx)
 						if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 							t.Errorf("errors do not match. got %v; want %v", got, want)
 						}
@@ -529,7 +529,7 @@ func TestConnection(t *testing.T) {
 					conn.cancellationListener = listener
 
 					want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "incomplete read of message header"}
-					_, got := conn.readWireMessage(context.Background(), []byte{})
+					_, got := conn.readWireMessage(context.Background())
 					if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 						t.Errorf("errors do not match. got %v; want %v", got, want)
 					}
@@ -546,7 +546,7 @@ func TestConnection(t *testing.T) {
 					conn.cancellationListener = listener
 
 					want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: "incomplete read of full message"}
-					_, got := conn.readWireMessage(context.Background(), []byte{})
+					_, got := conn.readWireMessage(context.Background())
 					if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 						t.Errorf("errors do not match. got %v; want %v", got, want)
 					}
@@ -582,7 +582,7 @@ func TestConnection(t *testing.T) {
 							conn.cancellationListener = listener
 
 							want := ConnectionError{ConnectionID: "foobar", Wrapped: err, message: err.Error()}
-							_, got := conn.readWireMessage(context.Background(), nil)
+							_, got := conn.readWireMessage(context.Background())
 							if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 								t.Errorf("errors do not match. got %v; want %v", got, want)
 							}
@@ -598,7 +598,7 @@ func TestConnection(t *testing.T) {
 					listener := newTestCancellationListener(false)
 					conn.cancellationListener = listener
 
-					got, err := conn.readWireMessage(context.Background(), nil)
+					got, err := conn.readWireMessage(context.Background())
 					noerr(t, err)
 					if !cmp.Equal(got, want) {
 						t.Errorf("did not read full wire message. got %v; want %v", got, want)
@@ -635,7 +635,7 @@ func TestConnection(t *testing.T) {
 							wg.Add(1)
 							go func() {
 								defer wg.Done()
-								_, err = conn.readWireMessage(ctx, nil)
+								_, err = conn.readWireMessage(ctx)
 							}()
 
 							<-nc.operationStartedChan
@@ -657,7 +657,7 @@ func TestConnection(t *testing.T) {
 					conn.cancellationListener = listener
 
 					want := ConnectionError{ConnectionID: conn.id, Wrapped: context.Canceled, message: "unable to read server response"}
-					_, err := conn.readWireMessage(context.Background(), nil)
+					_, err := conn.readWireMessage(context.Background())
 					assert.Equal(t, want, err, "expected error %v, got %v", want, err)
 					assert.Equal(t, connDisconnected, conn.state, "expected connection state %v, got %v", connDisconnected,
 						conn.state)
@@ -718,7 +718,7 @@ func TestConnection(t *testing.T) {
 			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 				t.Errorf("errors do not match. got %v; want %v", got, want)
 			}
-			_, got = conn.ReadWireMessage(context.Background(), nil)
+			_, got = conn.ReadWireMessage(context.Background())
 			if !cmp.Equal(got, want, cmp.Comparer(compareErrors)) {
 				t.Errorf("errors do not match. got %v; want %v", got, want)
 			}


### PR DESCRIPTION
GODRIVER-2778

## Summary
1. Modified around `Operation.decompressWireMessage` to eliminate duplicate memory allocation;
2. Reused `zlib.Writer`;
3. Removed unused parameter of `ReadWireMessage` in the interface of `driver.Connection`.

## Background & Motivation
```
name                          old time/op    new time/op    delta
ClientRead/not_compressed-10    33.5µs ±17%    29.6µs ± 7%  -11.61%  (p=0.000 n=10+10)
ClientRead/snappy-10            37.2µs ±12%    34.9µs ± 8%     ~     (p=0.095 n=10+9)
ClientRead/zlib-10               130µs ± 1%      57µs ± 6%  -55.78%  (p=0.000 n=9+9)
ClientRead/zstd-10              46.3µs ±16%    48.5µs ±22%     ~     (p=0.436 n=10+10)

name                          old alloc/op   new alloc/op   delta
ClientRead/not_compressed-10    17.4kB ± 0%    17.4kB ± 0%     ~     (p=0.900 n=10+10)
ClientRead/snappy-10            25.3kB ± 0%    20.1kB ± 0%  -20.67%  (p=0.000 n=10+10)
ClientRead/zlib-10               882kB ± 0%      61kB ± 0%  -93.11%  (p=0.000 n=10+10)
ClientRead/zstd-10              84.0kB ± 0%    78.8kB ± 0%   -6.18%  (p=0.000 n=7+10)

name                          old allocs/op  new allocs/op  delta
ClientRead/not_compressed-10      73.0 ± 0%      73.0 ± 0%     ~     (all equal)
ClientRead/snappy-10              76.0 ± 0%      75.0 ± 0%   -1.32%  (p=0.000 n=9+10)
ClientRead/zlib-10                 118 ± 0%        90 ± 0%  -23.73%  (p=0.000 n=10+10)
ClientRead/zstd-10                 178 ± 0%       177 ± 0%   -0.56%  (p=0.000 n=9+9)
```

```
name                           old time/op    new time/op    delta
ClientWrite/not_compressed-10    40.6µs ±16%    39.9µs ±16%     ~     (p=0.529 n=10+10)
ClientWrite/snappy-10            47.8µs ±18%    42.5µs ±13%  -11.10%  (p=0.009 n=10+10)
ClientWrite/zlib-10               131µs ± 4%     136µs ± 1%   +3.21%  (p=0.043 n=10+9)
ClientWrite/zstd-10              55.4µs ±11%    50.2µs ± 5%   -9.46%  (p=0.006 n=10+9)

name                           old alloc/op   new alloc/op   delta
ClientWrite/not_compressed-10    19.3kB ± 0%    19.4kB ± 0%   +0.10%  (p=0.022 n=10+10)
ClientWrite/snappy-10            24.3kB ± 0%    24.2kB ± 0%   -0.42%  (p=0.001 n=10+10)
ClientWrite/zlib-10               884kB ± 0%      61kB ± 1%  -93.07%  (p=0.000 n=10+10)
ClientWrite/zstd-10              33.9kB ± 0%    33.8kB ± 0%   -0.14%  (p=0.000 n=10+7)

name                           old allocs/op  new allocs/op  delta
ClientWrite/not_compressed-10      57.0 ± 0%      57.0 ± 0%     ~     (all equal)
ClientWrite/snappy-10              60.0 ± 0%      59.0 ± 0%   -1.67%  (p=0.000 n=10+10)
ClientWrite/zlib-10                97.0 ± 0%      67.0 ± 0%  -30.93%  (p=0.000 n=10+9)
ClientWrite/zstd-10                 149 ± 0%       148 ± 0%   -0.67%  (p=0.000 n=10+9)
```

Memory usage of "ClientRead/snappy" shows a ~20% reduction because we have already allocated memory for the uncompressed wiremessage ([code](https://github.com/mongodb/mongo-go-driver/blob/d957e67225a9ea82f1c7159020b4f9fd7c8d441a/x/mongo/driver/compression.go#L83)).