### PR TITLE
GODRIVER-1605 Add SetBatchSize to mongo.Cursor

### DIFF
--- a/mongo/batch_cursor.go
+++ b/mongo/batch_cursor.go
@@ -35,8 +35,8 @@ type batchCursor interface {
 	// Close closes the cursor.
 	Close(context.Context) error
 
-	// SetBatchSize is a modifier method for modifying the batch size of the
-	// implementing cursor.
+	// The SetBatchSize method is a modifier function used to adjust the
+	// batch size of the cursor that implements it.
 	SetBatchSize(int32)
 }
 

--- a/mongo/batch_cursor.go
+++ b/mongo/batch_cursor.go
@@ -34,6 +34,10 @@ type batchCursor interface {
 
 	// Close closes the cursor.
 	Close(context.Context) error
+
+	// SetBatchSize is a modifier method for modifying the batch size of the
+	// implementing cursor.
+	SetBatchSize(int32)
 }
 
 // changeStreamCursor is the interface implemented by batch cursors that also provide the functionality for retrieving

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -311,6 +311,15 @@ func (c *Cursor) closeImplicitSession() {
 	}
 }
 
+// SetBatchSize sets the number of documents to be returned in each batch
+// fetched by the cursor's "Next" method. Note that a cursor returned by any
+// CRUD operation already has a pre-defined batch size. Therefore, this
+// modifier only takes effect after the first batch has been retrieved from
+// the server.
+func (c *Cursor) SetBatchSize(batchSize int32) {
+	c.bc.SetBatchSize(batchSize)
+}
+
 // BatchCursorFromCursor returns a driver.BatchCursor for the given Cursor. If there is no underlying
 // driver.BatchCursor, nil is returned.
 //

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -311,11 +311,10 @@ func (c *Cursor) closeImplicitSession() {
 	}
 }
 
-// SetBatchSize sets the number of documents to be returned in each batch
-// fetched by the cursor's "Next" method. Note that a cursor returned by any
-// CRUD operation already has a pre-defined batch size. Therefore, this
-// modifier only takes effect after the first batch has been retrieved from
-// the server.
+// SetBatchSize sets the number of documents to fetch from the database with
+// each iteration of the cursor's "Next" method. Note that some operations set
+// an initial cursor batch size, so this setting only affects subsequent
+// document batches fetched from the database.
 func (c *Cursor) SetBatchSize(batchSize int32) {
 	c.bc.SetBatchSize(batchSize)
 }

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -86,6 +86,8 @@ func (tbc *testBatchCursor) Close(context.Context) error {
 	return nil
 }
 
+func (tbc *testBatchCursor) SetBatchSize(int32) {}
+
 func TestCursor(t *testing.T) {
 	t.Run("loops until docs available", func(t *testing.T) {})
 	t.Run("returns false on context cancellation", func(t *testing.T) {})

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -331,7 +331,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		return
 	}
 
-	numToReturn, ok := calcGetMoreBatchSize(ctx, *bc)
+	numToReturn, ok := calcGetMoreBatchSize(*bc)
 	if !ok {
 		if err := bc.Close(ctx); err != nil {
 			bc.err = err

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -311,7 +311,7 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 // calcGetMoreBatchSize returns the number of documents that should be returned in
 // the response of a "getMore" operation given the limit, batchSize, and number
 // of documents already returned.
-func calcGetMoreBatchSize(ctx context.Context, bc BatchCursor) (int32, bool) {
+func calcGetMoreBatchSize(bc BatchCursor) (int32, bool) {
 	gmBatchSize := bc.batchSize
 
 	// Account for legacy operations that don't support setting a limit.

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -318,13 +318,8 @@ func (bc *BatchCursor) getMoreBatchSize(ctx context.Context) (int32, bool, error
 	if bc.limit != 0 && bc.numReturned+bc.batchSize >= bc.limit {
 		gmBatchSize = bc.limit - bc.numReturned
 		if gmBatchSize <= 0 {
-			err := bc.Close(ctx)
-			if err != nil {
-				return 0, false, err
-			}
+			return gmBatchSize, false, bc.Close(ctx)
 		}
-
-		return gmBatchSize, false, nil
 	}
 
 	return gmBatchSize, true, nil

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -308,9 +308,10 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 	}.Execute(ctx)
 }
 
-// calcGetMoreBatchSize returns the number of documents that should be returned in
-// the response of a "getMore" operation given the limit, batchSize, and number
-// of documents already returned.
+// calcGetMoreBatchSize calculates the number of documents to return in the
+// response of a "getMore" operation based on the given limit, batchSize, and
+// number of documents already returned. Returns false if a non-trivial limit is
+// lower than or equal to the number of documents already returned.
 func calcGetMoreBatchSize(bc BatchCursor) (int32, bool) {
 	gmBatchSize := bc.batchSize
 

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -308,10 +308,10 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 	}.Execute(ctx)
 }
 
-// getMoreBatchSize returns the number of documents that should be returned in
+// calcGetMoreBatchSize returns the number of documents that should be returned in
 // the response of a "getMore" operation given the limit, batchSize, and number
 // of documents already returned.
-func (bc *BatchCursor) getMoreBatchSize(ctx context.Context) (int32, bool) {
+func calcGetMoreBatchSize(ctx context.Context, bc BatchCursor) (int32, bool) {
 	gmBatchSize := bc.batchSize
 
 	// Account for legacy operations that don't support setting a limit.
@@ -331,7 +331,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		return
 	}
 
-	numToReturn, ok := bc.getMoreBatchSize(ctx)
+	numToReturn, ok := calcGetMoreBatchSize(ctx, *bc)
 	if !ok {
 		if err := bc.Close(ctx); err != nil {
 			bc.err = err

--- a/x/mongo/driver/batch_cursor_test.go
+++ b/x/mongo/driver/batch_cursor_test.go
@@ -7,13 +7,19 @@
 package driver
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/internal/assert"
 )
 
 func TestBatchCursor(t *testing.T) {
+	t.Parallel()
+
 	t.Run("setBatchSize", func(t *testing.T) {
+		t.Parallel()
+
 		var size int32
 		bc := &BatchCursor{
 			batchSize: size,
@@ -23,5 +29,58 @@ func TestBatchCursor(t *testing.T) {
 		size = int32(4)
 		bc.SetBatchSize(size)
 		assert.Equal(t, size, bc.batchSize, "expected batchSize %v, got %v", size, bc.batchSize)
+	})
+
+	t.Run("getMoreBatchSize", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tcase := range []struct {
+			name                               string
+			size, limit, numReturned, expected int32
+			expectedError                      error
+		}{
+			{
+				name:     "empty",
+				expected: 0,
+			},
+			{
+				name:     "batchSize NEQ 0",
+				size:     4,
+				expected: 4,
+			},
+			{
+				name:     "limit NEQ 0",
+				limit:    4,
+				expected: 0,
+			},
+			{
+				name:        "limit NEQ and batchSize + numReturned EQ limit",
+				size:        4,
+				limit:       8,
+				numReturned: 4,
+				expected:    4,
+			},
+		} {
+			tcase := tcase
+			t.Run(tcase.name, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+
+				bc := &BatchCursor{
+					limit:     tcase.limit,
+					batchSize: tcase.size,
+				}
+
+				bc.SetBatchSize(tcase.size)
+
+				size, err := bc.getMoreBatchSize(ctx)
+				if !errors.Is(err, tcase.expectedError) {
+					t.Errorf("expected error %v, got %v", tcase.expectedError, err)
+				}
+
+				assert.Equal(t, tcase.expected, size, "expected batchSize %v, got %v",
+					tcase.expected, size)
+			})
+		}
 	})
 }

--- a/x/mongo/driver/batch_cursor_test.go
+++ b/x/mongo/driver/batch_cursor_test.go
@@ -73,7 +73,7 @@ func TestBatchCursor(t *testing.T) {
 
 				bc.SetBatchSize(tcase.size)
 
-				size, err := bc.getMoreBatchSize(ctx)
+				size, _, err := bc.getMoreBatchSize(ctx)
 				if !errors.Is(err, tcase.expectedError) {
 					t.Errorf("expected error %v, got %v", tcase.expectedError, err)
 				}

--- a/x/mongo/driver/batch_cursor_test.go
+++ b/x/mongo/driver/batch_cursor_test.go
@@ -7,7 +7,6 @@
 package driver
 
 import (
-	"context"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/internal/assert"
@@ -74,7 +73,6 @@ func TestBatchCursor(t *testing.T) {
 			tcase := tcase
 			t.Run(tcase.name, func(t *testing.T) {
 				t.Parallel()
-				ctx := context.Background()
 
 				bc := &BatchCursor{
 					limit:       tcase.limit,
@@ -84,7 +82,7 @@ func TestBatchCursor(t *testing.T) {
 
 				bc.SetBatchSize(tcase.size)
 
-				size, ok := calcGetMoreBatchSize(ctx, *bc)
+				size, ok := calcGetMoreBatchSize(*bc)
 
 				assert.Equal(t, tcase.expected, size, "expected batchSize %v, got %v", tcase.expected, size)
 				assert.Equal(t, tcase.ok, ok, "expected ok %v, got %v", tcase.ok, ok)

--- a/x/mongo/driver/list_collections_batch_cursor.go
+++ b/x/mongo/driver/list_collections_batch_cursor.go
@@ -127,3 +127,8 @@ func (*ListCollectionsBatchCursor) projectNameElement(rawDoc bsoncore.Document) 
 	filteredDoc = bsoncore.BuildDocument(filteredDoc, filteredElems)
 	return filteredDoc, nil
 }
+
+// SetBatchSize sets the batchSize for future getMores.
+func (lcbc *ListCollectionsBatchCursor) SetBatchSize(size int32) {
+	lcbc.bc.SetBatchSize(size)
+}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-1605

## Summary
<!--- A summary of the changes proposed by this pull request. -->
The "SetBatchSize" method can be used to override the batch size of a mongo.Cursor instance. This allows users to customize the batch size according to their needs.

## Background & Motivation
<!--- Rationale for the pull request. -->
The cursor's "Next" method executes a [getMore](https://www.mongodb.com/docs/v6.0/reference/command/getMore/) operation with a specific batch size. However, there may be cases where it is necessary to override the default batch size in order to prevent cursor operations from timing out. The Go Driver supports this use case by allowing the batch size to be overridden.
