### PR TITLE
Fixed comment of Cursor.Next() and Cursor.TryNext() functions.

### DIFF
--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -112,8 +112,8 @@ func (c *Cursor) ID() int64 { return c.bc.ID() }
 // Next gets the next document for this cursor. It returns true if there were no errors and the cursor has not been
 // exhausted.
 //
-// Next blocks until a document is available, an error occurs, or ctx expires. If ctx expires, the
-// error will be set to cursor.Err(). In an error case, Next will return false.
+// Next blocks until a document is available or an error occurs. If the context expires, the cursor's error will 
+// be set to ctx.Err(). In case of an error, Next will return false.
 //
 // If Next returns false, subsequent calls will also return false.
 func (c *Cursor) Next(ctx context.Context) bool {
@@ -125,7 +125,7 @@ func (c *Cursor) Next(ctx context.Context) bool {
 // Next. See https://www.mongodb.com/docs/manual/core/tailable-cursors/ for more information about tailable cursors.
 //
 // TryNext returns false if the cursor is exhausted, an error occurs when getting results from the server, the next
-// document is not yet available, or ctx expires. If ctx expires, the error will be set to cursor.Err().
+// document is not yet available, or ctx expires. If the context  expires, the cursor's error will be set to ctx.Err().
 //
 // If TryNext returns false and an error occurred or the cursor has been exhausted (i.e. c.Err() != nil || c.ID() == 0),
 // subsequent attempts will also return false. Otherwise, it is safe to call TryNext again until a document is

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -112,7 +112,7 @@ func (c *Cursor) ID() int64 { return c.bc.ID() }
 // Next gets the next document for this cursor. It returns true if there were no errors and the cursor has not been
 // exhausted.
 //
-// Next blocks until a document is available or an error occurs. If the context expires, the cursor's error will 
+// Next blocks until a document is available or an error occurs. If the context expires, the cursor's error will
 // be set to ctx.Err(). In case of an error, Next will return false.
 //
 // If Next returns false, subsequent calls will also return false.

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -113,7 +113,7 @@ func (c *Cursor) ID() int64 { return c.bc.ID() }
 // exhausted.
 //
 // Next blocks until a document is available, an error occurs, or ctx expires. If ctx expires, the
-// error will be set to ctx.Err(). In an error case, Next will return false.
+// error will be set to cursor.Err(). In an error case, Next will return false.
 //
 // If Next returns false, subsequent calls will also return false.
 func (c *Cursor) Next(ctx context.Context) bool {
@@ -125,7 +125,7 @@ func (c *Cursor) Next(ctx context.Context) bool {
 // Next. See https://www.mongodb.com/docs/manual/core/tailable-cursors/ for more information about tailable cursors.
 //
 // TryNext returns false if the cursor is exhausted, an error occurs when getting results from the server, the next
-// document is not yet available, or ctx expires. If ctx expires, the error will be set to ctx.Err().
+// document is not yet available, or ctx expires. If ctx expires, the error will be set to cursor.Err().
 //
 // If TryNext returns false and an error occurred or the cursor has been exhausted (i.e. c.Err() != nil || c.ID() == 0),
 // subsequent attempts will also return false. Otherwise, it is safe to call TryNext again until a document is


### PR DESCRIPTION
GODRIVER-2777

## Summary
<!--- After researching the code, I believe there are typos in the comments of functions Cursor.Next() and Cursor.TryNext()
as we return cursor error in all places. -->

## Background & Motivation
<!--- Had a bug in the system and after research and debugging found out that Cursor.Next() function returns Cursor.Err() and that error is clearer than ctx.Err() -->

