### PR TITLE
GODRIVER-2769 add context to SingleResult

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1362,7 +1362,7 @@ func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 	findOpts = append(findOpts, options.Find().SetLimit(-1))
 
 	cursor, err := coll.Find(ctx, filter, findOpts...)
-	return &SingleResult{cur: cursor, reg: coll.registry, err: replaceErrors(err)}
+	return &SingleResult{ctx: ctx, cur: cursor, reg: coll.registry, err: replaceErrors(err)}
 }
 
 func (coll *Collection) findAndModify(ctx context.Context, op *operation.FindAndModify) *SingleResult {
@@ -1413,7 +1413,7 @@ func (coll *Collection) findAndModify(ctx context.Context, op *operation.FindAnd
 		return &SingleResult{err: err}
 	}
 
-	return &SingleResult{rdr: bson.Raw(op.Result().Value), reg: coll.registry}
+	return &SingleResult{ctx: ctx, rdr: bson.Raw(op.Result().Value), reg: coll.registry}
 }
 
 // FindOneAndDelete executes a findAndModify command to delete at most one document in the collection. and returns the

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -207,6 +207,7 @@ func (db *Database) RunCommand(ctx context.Context, runCommand interface{}, opts
 	// RunCommand can be used to run a write, thus execute may return a write error
 	_, convErr := processWriteError(err)
 	return &SingleResult{
+		ctx: ctx,
 		err: convErr,
 		rdr: bson.Raw(op.Result()),
 		reg: db.registry,

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -122,7 +122,7 @@ func (sr *SingleResult) Err() error {
 	return sr.err
 }
 
-// WithContext specifies a context for this SingleResult.
+// WithContext specifies a context for a SingleResult.
 func (sr *SingleResult) WithContext(ctx context.Context) *SingleResult {
 	sr.ctx = ctx
 

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -121,10 +121,3 @@ func (sr *SingleResult) Err() error {
 
 	return sr.err
 }
-
-// WithContext specifies a context for a SingleResult.
-func (sr *SingleResult) WithContext(ctx context.Context) *SingleResult {
-	sr.ctx = ctx
-
-	return sr
-}

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -22,6 +22,7 @@ var ErrNoDocuments = errors.New("mongo: no documents in result")
 // SingleResult methods will return that error. If the operation did not return any documents, all SingleResult methods
 // will return ErrNoDocuments.
 type SingleResult struct {
+	ctx context.Context
 	err error
 	cur *Cursor
 	rdr bson.Raw
@@ -95,9 +96,9 @@ func (sr *SingleResult) setRdrContents() error {
 	case sr.rdr != nil:
 		return nil
 	case sr.cur != nil:
-		defer sr.cur.Close(context.TODO())
+		defer sr.cur.Close(sr.ctx)
 
-		if !sr.cur.Next(context.TODO()) {
+		if !sr.cur.Next(sr.ctx) {
 			if err := sr.cur.Err(); err != nil {
 				return err
 			}
@@ -119,4 +120,11 @@ func (sr *SingleResult) Err() error {
 	sr.err = sr.setRdrContents()
 
 	return sr.err
+}
+
+// WithContext specifies a context for this SingleResult.
+func (sr *SingleResult) WithContext(ctx context.Context) *SingleResult {
+	sr.ctx = ctx
+
+	return sr
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2769

## Summary
<!--- A summary of the changes proposed by this pull request. -->
This PR adds a context.Context field to mongo.SingleResult to safeguard user expectations when setting timeout logic on contexts passed to operations that return a single result.

## Background & Motivation
<!--- Rationale for the pull request. -->
The motivation for this proposal is to avoid indefinitely blocking the mongo.SingleResult cursor on operations that set timeout logic.
