### PR TITLE
GODRIVER-2782 Resolve updated revive v1.3.1 lint errors.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -198,7 +198,7 @@ functions:
 
           # Install linters. Use "go install" instead of "go get" to prevent modifying the go.mod
           # file.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
           go install github.com/walle/lll/...@latest
 
   upload-mo-artifacts:

--- a/benchmark/bson_struct.go
+++ b/benchmark/bson_struct.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func BSONFlatStructDecoding(ctx context.Context, tm TimerManager, iters int) error {
+func BSONFlatStructDecoding(_ context.Context, tm TimerManager, iters int) error {
 	r, err := loadSourceRaw(getProjectRoot(), perfDataDir, bsonDataDir, flatBSONData)
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func BSONFlatStructDecoding(ctx context.Context, tm TimerManager, iters int) err
 	return nil
 }
 
-func BSONFlatStructEncoding(ctx context.Context, tm TimerManager, iters int) error {
+func BSONFlatStructEncoding(_ context.Context, tm TimerManager, iters int) error {
 	r, err := loadSourceRaw(getProjectRoot(), perfDataDir, bsonDataDir, flatBSONData)
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func BSONFlatStructEncoding(ctx context.Context, tm TimerManager, iters int) err
 	return nil
 }
 
-func BSONFlatStructTagsEncoding(ctx context.Context, tm TimerManager, iters int) error {
+func BSONFlatStructTagsEncoding(_ context.Context, tm TimerManager, iters int) error {
 	r, err := loadSourceRaw(getProjectRoot(), perfDataDir, bsonDataDir, flatBSONData)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func BSONFlatStructTagsEncoding(ctx context.Context, tm TimerManager, iters int)
 	return nil
 }
 
-func BSONFlatStructTagsDecoding(ctx context.Context, tm TimerManager, iters int) error {
+func BSONFlatStructTagsDecoding(_ context.Context, tm TimerManager, iters int) error {
 	r, err := loadSourceRaw(getProjectRoot(), perfDataDir, bsonDataDir, flatBSONData)
 	if err != nil {
 		return err

--- a/benchmark/canary.go
+++ b/benchmark/canary.go
@@ -14,7 +14,7 @@ import (
 //
 // Deprecated: CanaryIncCase has no observable effect, so recent versions of the Go compiler may
 // bypass calls to it in the compiled binary. It should not be used in benchmarks.
-func CanaryIncCase(ctx context.Context, tm TimerManager, iters int) error {
+func CanaryIncCase(context.Context, TimerManager, int) error {
 	return nil
 }
 
@@ -22,6 +22,6 @@ func CanaryIncCase(ctx context.Context, tm TimerManager, iters int) error {
 //
 // Deprecated: GlobalCanaryIncCase has no observable effect, so recent versions of the Go compiler
 // may bypass calls to it in the compiled binary. It should not be used in benchmarks.
-func GlobalCanaryIncCase(ctx context.Context, tm TimerManager, iters int) error {
+func GlobalCanaryIncCase(context.Context, TimerManager, int) error {
 	return nil
 }

--- a/benchmark/multi.go
+++ b/benchmark/multi.go
@@ -76,11 +76,7 @@ func MultiFindMany(ctx context.Context, tm TimerManager, iters int) error {
 		return err
 	}
 
-	if err = db.Drop(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return db.Drop(ctx)
 }
 
 func multiInsertCase(ctx context.Context, tm TimerManager, iters int, data string) error {
@@ -126,11 +122,7 @@ func multiInsertCase(ctx context.Context, tm TimerManager, iters int, data strin
 		return errors.New("bulk operation did not complete")
 	}
 
-	if err = db.Drop(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return db.Drop(ctx)
 }
 
 func MultiInsertSmallDocument(ctx context.Context, tm TimerManager, iters int) error {

--- a/benchmark/single.go
+++ b/benchmark/single.go
@@ -119,11 +119,7 @@ func SingleFindOneByID(ctx context.Context, tm TimerManager, iters int) error {
 
 	tm.StopTimer()
 
-	if err = db.Drop(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return db.Drop(ctx)
 }
 
 func singleInsertCase(ctx context.Context, tm TimerManager, iters int, data string) error {
@@ -163,11 +159,7 @@ func singleInsertCase(ctx context.Context, tm TimerManager, iters int, data stri
 
 	tm.StopTimer()
 
-	if err = db.Drop(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return db.Drop(ctx)
 }
 
 func SingleInsertSmallDocument(ctx context.Context, tm TimerManager, iters int) error {

--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -24,7 +24,7 @@ func NewArrayCodec() *ArrayCodec {
 }
 
 // EncodeValue is the ValueEncoder for bsoncore.Array values.
-func (ac *ArrayCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (ac *ArrayCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCoreArray {
 		return ValueEncoderError{Name: "CoreArrayEncodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
 	}
@@ -34,7 +34,7 @@ func (ac *ArrayCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val r
 }
 
 // DecodeValue is the ValueDecoder for bsoncore.Array values.
-func (ac *ArrayCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (ac *ArrayCodec) DecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCoreArray {
 		return ValueDecoderError{Name: "CoreArrayDecodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
 	}

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -38,7 +38,7 @@ func NewByteSliceCodec(opts ...*bsonoptions.ByteSliceCodecOptions) *ByteSliceCod
 }
 
 // EncodeValue is the ValueEncoder for []byte.
-func (bsc *ByteSliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (bsc *ByteSliceCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tByteSlice {
 		return ValueEncoderError{Name: "ByteSliceEncodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
 	}
@@ -48,7 +48,7 @@ func (bsc *ByteSliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, 
 	return vw.WriteBinary(val.Interface().([]byte))
 }
 
-func (bsc *ByteSliceCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (bsc *ByteSliceCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tByteSlice {
 		return emptyValue, ValueDecoderError{
 			Name:     "ByteSliceDecodeValue",

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -188,7 +188,7 @@ func (dvd DefaultValueDecoders) DDecodeValue(dc DecodeContext, vr bsonrw.ValueRe
 	return nil
 }
 
-func (dvd DefaultValueDecoders) booleanDecodeType(dctx DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) booleanDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t.Kind() != reflect.Bool {
 		return emptyValue, ValueDecoderError{
 			Name:     "BooleanDecodeValue",
@@ -515,7 +515,7 @@ func (dvd DefaultValueDecoders) FloatDecodeValue(ec DecodeContext, vr bsonrw.Val
 // StringDecodeValue is the ValueDecoderFunc for string types.
 //
 // Deprecated: StringDecodeValue is not registered by default. Use StringCodec.DecodeValue instead.
-func (dvd DefaultValueDecoders) StringDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (dvd DefaultValueDecoders) StringDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	var str string
 	var err error
 	switch vr.Type() {
@@ -536,7 +536,7 @@ func (dvd DefaultValueDecoders) StringDecodeValue(dctx DecodeContext, vr bsonrw.
 	return nil
 }
 
-func (DefaultValueDecoders) javaScriptDecodeType(dctx DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) javaScriptDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tJavaScript {
 		return emptyValue, ValueDecoderError{
 			Name:     "JavaScriptDecodeValue",
@@ -579,7 +579,7 @@ func (dvd DefaultValueDecoders) JavaScriptDecodeValue(dctx DecodeContext, vr bso
 	return nil
 }
 
-func (DefaultValueDecoders) symbolDecodeType(dctx DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) symbolDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tSymbol {
 		return emptyValue, ValueDecoderError{
 			Name:     "SymbolDecodeValue",
@@ -634,7 +634,7 @@ func (dvd DefaultValueDecoders) SymbolDecodeValue(dctx DecodeContext, vr bsonrw.
 	return nil
 }
 
-func (DefaultValueDecoders) binaryDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) binaryDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tBinary {
 		return emptyValue, ValueDecoderError{
 			Name:     "BinaryDecodeValue",
@@ -678,7 +678,7 @@ func (dvd DefaultValueDecoders) BinaryDecodeValue(dc DecodeContext, vr bsonrw.Va
 	return nil
 }
 
-func (DefaultValueDecoders) undefinedDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) undefinedDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tUndefined {
 		return emptyValue, ValueDecoderError{
 			Name:     "UndefinedDecodeValue",
@@ -719,7 +719,7 @@ func (dvd DefaultValueDecoders) UndefinedDecodeValue(dc DecodeContext, vr bsonrw
 }
 
 // Accept both 12-byte string and pretty-printed 24-byte hex string formats.
-func (dvd DefaultValueDecoders) objectIDDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) objectIDDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tOID {
 		return emptyValue, ValueDecoderError{
 			Name:     "ObjectIDDecodeValue",
@@ -779,7 +779,7 @@ func (dvd DefaultValueDecoders) ObjectIDDecodeValue(dc DecodeContext, vr bsonrw.
 	return nil
 }
 
-func (DefaultValueDecoders) dateTimeDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) dateTimeDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tDateTime {
 		return emptyValue, ValueDecoderError{
 			Name:     "DateTimeDecodeValue",
@@ -822,7 +822,7 @@ func (dvd DefaultValueDecoders) DateTimeDecodeValue(dc DecodeContext, vr bsonrw.
 	return nil
 }
 
-func (DefaultValueDecoders) nullDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) nullDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tNull {
 		return emptyValue, ValueDecoderError{
 			Name:     "NullDecodeValue",
@@ -862,7 +862,7 @@ func (dvd DefaultValueDecoders) NullDecodeValue(dc DecodeContext, vr bsonrw.Valu
 	return nil
 }
 
-func (DefaultValueDecoders) regexDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) regexDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tRegex {
 		return emptyValue, ValueDecoderError{
 			Name:     "RegexDecodeValue",
@@ -905,7 +905,7 @@ func (dvd DefaultValueDecoders) RegexDecodeValue(dc DecodeContext, vr bsonrw.Val
 	return nil
 }
 
-func (DefaultValueDecoders) dBPointerDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) dBPointerDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tDBPointer {
 		return emptyValue, ValueDecoderError{
 			Name:     "DBPointerDecodeValue",
@@ -949,7 +949,7 @@ func (dvd DefaultValueDecoders) DBPointerDecodeValue(dc DecodeContext, vr bsonrw
 	return nil
 }
 
-func (DefaultValueDecoders) timestampDecodeType(dc DecodeContext, vr bsonrw.ValueReader, reflectType reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) timestampDecodeType(_ DecodeContext, vr bsonrw.ValueReader, reflectType reflect.Type) (reflect.Value, error) {
 	if reflectType != tTimestamp {
 		return emptyValue, ValueDecoderError{
 			Name:     "TimestampDecodeValue",
@@ -992,7 +992,7 @@ func (dvd DefaultValueDecoders) TimestampDecodeValue(dc DecodeContext, vr bsonrw
 	return nil
 }
 
-func (DefaultValueDecoders) minKeyDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) minKeyDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tMinKey {
 		return emptyValue, ValueDecoderError{
 			Name:     "MinKeyDecodeValue",
@@ -1034,7 +1034,7 @@ func (dvd DefaultValueDecoders) MinKeyDecodeValue(dc DecodeContext, vr bsonrw.Va
 	return nil
 }
 
-func (DefaultValueDecoders) maxKeyDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (DefaultValueDecoders) maxKeyDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tMaxKey {
 		return emptyValue, ValueDecoderError{
 			Name:     "MaxKeyDecodeValue",
@@ -1076,7 +1076,7 @@ func (dvd DefaultValueDecoders) MaxKeyDecodeValue(dc DecodeContext, vr bsonrw.Va
 	return nil
 }
 
-func (dvd DefaultValueDecoders) decimal128DecodeType(dctx DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) decimal128DecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tDecimal {
 		return emptyValue, ValueDecoderError{
 			Name:     "Decimal128DecodeValue",
@@ -1119,7 +1119,7 @@ func (dvd DefaultValueDecoders) Decimal128DecodeValue(dctx DecodeContext, vr bso
 	return nil
 }
 
-func (dvd DefaultValueDecoders) jsonNumberDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) jsonNumberDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tJSONNumber {
 		return emptyValue, ValueDecoderError{
 			Name:     "JSONNumberDecodeValue",
@@ -1178,7 +1178,7 @@ func (dvd DefaultValueDecoders) JSONNumberDecodeValue(dc DecodeContext, vr bsonr
 	return nil
 }
 
-func (dvd DefaultValueDecoders) urlDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) urlDecodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tURL {
 		return emptyValue, ValueDecoderError{
 			Name:     "URLDecodeValue",
@@ -1230,7 +1230,7 @@ func (dvd DefaultValueDecoders) URLDecodeValue(dc DecodeContext, vr bsonrw.Value
 // TimeDecodeValue is the ValueDecoderFunc for time.Time.
 //
 // Deprecated: TimeDecodeValue is not registered by default. Use TimeCodec.DecodeValue instead.
-func (dvd DefaultValueDecoders) TimeDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (dvd DefaultValueDecoders) TimeDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if vr.Type() != bsontype.DateTime {
 		return fmt.Errorf("cannot decode %v into a time.Time", vr.Type())
 	}
@@ -1251,7 +1251,7 @@ func (dvd DefaultValueDecoders) TimeDecodeValue(dc DecodeContext, vr bsonrw.Valu
 // ByteSliceDecodeValue is the ValueDecoderFunc for []byte.
 //
 // Deprecated: ByteSliceDecodeValue is not registered by default. Use ByteSliceCodec.DecodeValue instead.
-func (dvd DefaultValueDecoders) ByteSliceDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (dvd DefaultValueDecoders) ByteSliceDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if vr.Type() != bsontype.Binary && vr.Type() != bsontype.Null {
 		return fmt.Errorf("cannot decode %v into a []byte", vr.Type())
 	}
@@ -1447,7 +1447,7 @@ func (dvd DefaultValueDecoders) SliceDecodeValue(dc DecodeContext, vr bsonrw.Val
 }
 
 // ValueUnmarshalerDecodeValue is the ValueDecoderFunc for ValueUnmarshaler implementations.
-func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tValueUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tValueUnmarshaler)) {
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
@@ -1480,7 +1480,7 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(dc DecodeContext, vr
 }
 
 // UnmarshalerDecodeValue is the ValueDecoderFunc for Unmarshaler implementations.
-func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tUnmarshaler)) {
 		return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
 	}
@@ -1565,7 +1565,7 @@ func (dvd DefaultValueDecoders) EmptyInterfaceDecodeValue(dc DecodeContext, vr b
 }
 
 // CoreDocumentDecodeValue is the ValueDecoderFunc for bsoncore.Document.
-func (DefaultValueDecoders) CoreDocumentDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (DefaultValueDecoders) CoreDocumentDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCoreDocument {
 		return ValueDecoderError{Name: "CoreDocumentDecodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
 	}

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -113,7 +113,7 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 }
 
 // BooleanEncodeValue is the ValueEncoderFunc for bool types.
-func (dve DefaultValueEncoders) BooleanEncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) BooleanEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Bool {
 		return ValueEncoderError{Name: "BooleanEncodeValue", Kinds: []reflect.Kind{reflect.Bool}, Received: val}
 	}
@@ -176,7 +176,7 @@ func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.Valu
 }
 
 // FloatEncodeValue is the ValueEncoderFunc for float types.
-func (dve DefaultValueEncoders) FloatEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) FloatEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	switch val.Kind() {
 	case reflect.Float32, reflect.Float64:
 		return vw.WriteDouble(val.Float())
@@ -188,7 +188,7 @@ func (dve DefaultValueEncoders) FloatEncodeValue(ec EncodeContext, vw bsonrw.Val
 // StringEncodeValue is the ValueEncoderFunc for string types.
 //
 // Deprecated: StringEncodeValue is not registered by default. Use StringCodec.EncodeValue instead.
-func (dve DefaultValueEncoders) StringEncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) StringEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if val.Kind() != reflect.String {
 		return ValueEncoderError{
 			Name:     "StringEncodeValue",
@@ -201,7 +201,7 @@ func (dve DefaultValueEncoders) StringEncodeValue(ectx EncodeContext, vw bsonrw.
 }
 
 // ObjectIDEncodeValue is the ValueEncoderFunc for primitive.ObjectID.
-func (dve DefaultValueEncoders) ObjectIDEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) ObjectIDEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tOID {
 		return ValueEncoderError{Name: "ObjectIDEncodeValue", Types: []reflect.Type{tOID}, Received: val}
 	}
@@ -209,7 +209,7 @@ func (dve DefaultValueEncoders) ObjectIDEncodeValue(ec EncodeContext, vw bsonrw.
 }
 
 // Decimal128EncodeValue is the ValueEncoderFunc for primitive.Decimal128.
-func (dve DefaultValueEncoders) Decimal128EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) Decimal128EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDecimal {
 		return ValueEncoderError{Name: "Decimal128EncodeValue", Types: []reflect.Type{tDecimal}, Received: val}
 	}
@@ -237,7 +237,7 @@ func (dve DefaultValueEncoders) JSONNumberEncodeValue(ec EncodeContext, vw bsonr
 }
 
 // URLEncodeValue is the ValueEncoderFunc for url.URL.
-func (dve DefaultValueEncoders) URLEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) URLEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tURL {
 		return ValueEncoderError{Name: "URLEncodeValue", Types: []reflect.Type{tURL}, Received: val}
 	}
@@ -248,7 +248,7 @@ func (dve DefaultValueEncoders) URLEncodeValue(ec EncodeContext, vw bsonrw.Value
 // TimeEncodeValue is the ValueEncoderFunc for time.TIme.
 //
 // Deprecated: TimeEncodeValue is not registered by default. Use TimeCodec.EncodeValue instead.
-func (dve DefaultValueEncoders) TimeEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) TimeEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tTime {
 		return ValueEncoderError{Name: "TimeEncodeValue", Types: []reflect.Type{tTime}, Received: val}
 	}
@@ -260,7 +260,7 @@ func (dve DefaultValueEncoders) TimeEncodeValue(ec EncodeContext, vw bsonrw.Valu
 // ByteSliceEncodeValue is the ValueEncoderFunc for []byte.
 //
 // Deprecated: ByteSliceEncodeValue is not registered by default. Use ByteSliceCodec.EncodeValue instead.
-func (dve DefaultValueEncoders) ByteSliceEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) ByteSliceEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tByteSlice {
 		return ValueEncoderError{Name: "ByteSliceEncodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
 	}
@@ -515,7 +515,7 @@ func (dve DefaultValueEncoders) EmptyInterfaceEncodeValue(ec EncodeContext, vw b
 }
 
 // ValueMarshalerEncodeValue is the ValueEncoderFunc for ValueMarshaler implementations.
-func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement ValueMarshaler
 	switch {
 	case !val.IsValid():
@@ -541,7 +541,7 @@ func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(ec EncodeContext, vw b
 }
 
 // MarshalerEncodeValue is the ValueEncoderFunc for Marshaler implementations.
-func (dve DefaultValueEncoders) MarshalerEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement Marshaler
 	switch {
 	case !val.IsValid():
@@ -603,7 +603,7 @@ func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.Val
 }
 
 // JavaScriptEncodeValue is the ValueEncoderFunc for the primitive.JavaScript type.
-func (DefaultValueEncoders) JavaScriptEncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) JavaScriptEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tJavaScript {
 		return ValueEncoderError{Name: "JavaScriptEncodeValue", Types: []reflect.Type{tJavaScript}, Received: val}
 	}
@@ -612,7 +612,7 @@ func (DefaultValueEncoders) JavaScriptEncodeValue(ectx EncodeContext, vw bsonrw.
 }
 
 // SymbolEncodeValue is the ValueEncoderFunc for the primitive.Symbol type.
-func (DefaultValueEncoders) SymbolEncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) SymbolEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tSymbol {
 		return ValueEncoderError{Name: "SymbolEncodeValue", Types: []reflect.Type{tSymbol}, Received: val}
 	}
@@ -621,7 +621,7 @@ func (DefaultValueEncoders) SymbolEncodeValue(ectx EncodeContext, vw bsonrw.Valu
 }
 
 // BinaryEncodeValue is the ValueEncoderFunc for Binary.
-func (DefaultValueEncoders) BinaryEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) BinaryEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tBinary {
 		return ValueEncoderError{Name: "BinaryEncodeValue", Types: []reflect.Type{tBinary}, Received: val}
 	}
@@ -631,7 +631,7 @@ func (DefaultValueEncoders) BinaryEncodeValue(ec EncodeContext, vw bsonrw.ValueW
 }
 
 // UndefinedEncodeValue is the ValueEncoderFunc for Undefined.
-func (DefaultValueEncoders) UndefinedEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) UndefinedEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tUndefined {
 		return ValueEncoderError{Name: "UndefinedEncodeValue", Types: []reflect.Type{tUndefined}, Received: val}
 	}
@@ -640,7 +640,7 @@ func (DefaultValueEncoders) UndefinedEncodeValue(ec EncodeContext, vw bsonrw.Val
 }
 
 // DateTimeEncodeValue is the ValueEncoderFunc for DateTime.
-func (DefaultValueEncoders) DateTimeEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) DateTimeEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDateTime {
 		return ValueEncoderError{Name: "DateTimeEncodeValue", Types: []reflect.Type{tDateTime}, Received: val}
 	}
@@ -649,7 +649,7 @@ func (DefaultValueEncoders) DateTimeEncodeValue(ec EncodeContext, vw bsonrw.Valu
 }
 
 // NullEncodeValue is the ValueEncoderFunc for Null.
-func (DefaultValueEncoders) NullEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) NullEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tNull {
 		return ValueEncoderError{Name: "NullEncodeValue", Types: []reflect.Type{tNull}, Received: val}
 	}
@@ -658,7 +658,7 @@ func (DefaultValueEncoders) NullEncodeValue(ec EncodeContext, vw bsonrw.ValueWri
 }
 
 // RegexEncodeValue is the ValueEncoderFunc for Regex.
-func (DefaultValueEncoders) RegexEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) RegexEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRegex {
 		return ValueEncoderError{Name: "RegexEncodeValue", Types: []reflect.Type{tRegex}, Received: val}
 	}
@@ -669,7 +669,7 @@ func (DefaultValueEncoders) RegexEncodeValue(ec EncodeContext, vw bsonrw.ValueWr
 }
 
 // DBPointerEncodeValue is the ValueEncoderFunc for DBPointer.
-func (DefaultValueEncoders) DBPointerEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) DBPointerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDBPointer {
 		return ValueEncoderError{Name: "DBPointerEncodeValue", Types: []reflect.Type{tDBPointer}, Received: val}
 	}
@@ -680,7 +680,7 @@ func (DefaultValueEncoders) DBPointerEncodeValue(ec EncodeContext, vw bsonrw.Val
 }
 
 // TimestampEncodeValue is the ValueEncoderFunc for Timestamp.
-func (DefaultValueEncoders) TimestampEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) TimestampEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tTimestamp {
 		return ValueEncoderError{Name: "TimestampEncodeValue", Types: []reflect.Type{tTimestamp}, Received: val}
 	}
@@ -691,7 +691,7 @@ func (DefaultValueEncoders) TimestampEncodeValue(ec EncodeContext, vw bsonrw.Val
 }
 
 // MinKeyEncodeValue is the ValueEncoderFunc for MinKey.
-func (DefaultValueEncoders) MinKeyEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) MinKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMinKey {
 		return ValueEncoderError{Name: "MinKeyEncodeValue", Types: []reflect.Type{tMinKey}, Received: val}
 	}
@@ -700,7 +700,7 @@ func (DefaultValueEncoders) MinKeyEncodeValue(ec EncodeContext, vw bsonrw.ValueW
 }
 
 // MaxKeyEncodeValue is the ValueEncoderFunc for MaxKey.
-func (DefaultValueEncoders) MaxKeyEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) MaxKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMaxKey {
 		return ValueEncoderError{Name: "MaxKeyEncodeValue", Types: []reflect.Type{tMaxKey}, Received: val}
 	}
@@ -709,7 +709,7 @@ func (DefaultValueEncoders) MaxKeyEncodeValue(ec EncodeContext, vw bsonrw.ValueW
 }
 
 // CoreDocumentEncodeValue is the ValueEncoderFunc for bsoncore.Document.
-func (DefaultValueEncoders) CoreDocumentEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (DefaultValueEncoders) CoreDocumentEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCoreDocument {
 		return ValueEncoderError{Name: "CoreDocumentEncodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
 	}

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -34,7 +34,7 @@ func NewStringCodec(opts ...*bsonoptions.StringCodecOptions) *StringCodec {
 }
 
 // EncodeValue is the ValueEncoder for string types.
-func (sc *StringCodec) EncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (sc *StringCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if val.Kind() != reflect.String {
 		return ValueEncoderError{
 			Name:     "StringEncodeValue",
@@ -46,7 +46,7 @@ func (sc *StringCodec) EncodeValue(ectx EncodeContext, vw bsonrw.ValueWriter, va
 	return vw.WriteString(val.String())
 }
 
-func (sc *StringCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (sc *StringCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t.Kind() != reflect.String {
 		return emptyValue, ValueDecoderError{
 			Name:     "StringDecodeValue",

--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -44,7 +44,7 @@ func NewTimeCodec(opts ...*bsonoptions.TimeCodecOptions) *TimeCodec {
 	return &codec
 }
 
-func (tc *TimeCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (tc *TimeCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tTime {
 		return emptyValue, ValueDecoderError{
 			Name:     "TimeDecodeValue",
@@ -117,7 +117,7 @@ func (tc *TimeCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val re
 }
 
 // EncodeValue is the ValueEncoderFunc for time.TIme.
-func (tc *TimeCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (tc *TimeCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tTime {
 		return ValueEncoderError{Name: "TimeEncodeValue", Types: []reflect.Type{tTime}, Received: val}
 	}

--- a/bson/bsonrw/bsonrwtest/bsonrwtest.go
+++ b/bson/bsonrw/bsonrwtest/bsonrwtest.go
@@ -572,7 +572,7 @@ func (llvrw *ValueReaderWriter) WriteArray() (bsonrw.ArrayWriter, error) {
 }
 
 // WriteBinary implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteBinary(b []byte) error {
+func (llvrw *ValueReaderWriter) WriteBinary([]byte) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteBinary
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -582,7 +582,7 @@ func (llvrw *ValueReaderWriter) WriteBinary(b []byte) error {
 }
 
 // WriteBinaryWithSubtype implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteBinaryWithSubtype(b []byte, btype byte) error {
+func (llvrw *ValueReaderWriter) WriteBinaryWithSubtype([]byte, byte) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteBinaryWithSubtype
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -602,7 +602,7 @@ func (llvrw *ValueReaderWriter) WriteBoolean(bool) error {
 }
 
 // WriteCodeWithScope implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteCodeWithScope(code string) (bsonrw.DocumentWriter, error) {
+func (llvrw *ValueReaderWriter) WriteCodeWithScope(string) (bsonrw.DocumentWriter, error) {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteCodeWithScope
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -612,7 +612,7 @@ func (llvrw *ValueReaderWriter) WriteCodeWithScope(code string) (bsonrw.Document
 }
 
 // WriteDBPointer implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteDBPointer(ns string, oid primitive.ObjectID) error {
+func (llvrw *ValueReaderWriter) WriteDBPointer(string, primitive.ObjectID) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteDBPointer
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -622,7 +622,7 @@ func (llvrw *ValueReaderWriter) WriteDBPointer(ns string, oid primitive.ObjectID
 }
 
 // WriteDateTime implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteDateTime(dt int64) error {
+func (llvrw *ValueReaderWriter) WriteDateTime(int64) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteDateTime
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -672,7 +672,7 @@ func (llvrw *ValueReaderWriter) WriteInt64(int64) error {
 }
 
 // WriteJavascript implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteJavascript(code string) error {
+func (llvrw *ValueReaderWriter) WriteJavascript(string) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteJavascript
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -722,7 +722,7 @@ func (llvrw *ValueReaderWriter) WriteObjectID(primitive.ObjectID) error {
 }
 
 // WriteRegex implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteRegex(pattern string, options string) error {
+func (llvrw *ValueReaderWriter) WriteRegex(string, string) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteRegex
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -752,7 +752,7 @@ func (llvrw *ValueReaderWriter) WriteDocument() (bsonrw.DocumentWriter, error) {
 }
 
 // WriteSymbol implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteSymbol(symbol string) error {
+func (llvrw *ValueReaderWriter) WriteSymbol(string) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteSymbol
 	if llvrw.ErrAfter == llvrw.Invoked {
@@ -762,7 +762,7 @@ func (llvrw *ValueReaderWriter) WriteSymbol(symbol string) error {
 }
 
 // WriteTimestamp implements the bsonrw.ValueWriter interface.
-func (llvrw *ValueReaderWriter) WriteTimestamp(t uint32, i uint32) error {
+func (llvrw *ValueReaderWriter) WriteTimestamp(uint32, uint32) error {
 	llvrw.checkdepth()
 	llvrw.Invoked = WriteTimestamp
 	if llvrw.ErrAfter == llvrw.Invoked {

--- a/bson/bsonrw/value_reader_writer_test.go
+++ b/bson/bsonrw/value_reader_writer_test.go
@@ -385,7 +385,7 @@ func (llvrw *TestValueReaderWriter) WriteArray() (ArrayWriter, error) {
 	return llvrw, nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteBinary(b []byte) error {
+func (llvrw *TestValueReaderWriter) WriteBinary([]byte) error {
 	llvrw.invoked = llvrwWriteBinary
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -393,7 +393,7 @@ func (llvrw *TestValueReaderWriter) WriteBinary(b []byte) error {
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteBinaryWithSubtype(b []byte, btype byte) error {
+func (llvrw *TestValueReaderWriter) WriteBinaryWithSubtype([]byte, byte) error {
 	llvrw.invoked = llvrwWriteBinaryWithSubtype
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -409,7 +409,7 @@ func (llvrw *TestValueReaderWriter) WriteBoolean(bool) error {
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteCodeWithScope(code string) (DocumentWriter, error) {
+func (llvrw *TestValueReaderWriter) WriteCodeWithScope(string) (DocumentWriter, error) {
 	llvrw.invoked = llvrwWriteCodeWithScope
 	if llvrw.errAfter == llvrw.invoked {
 		return nil, llvrw.err
@@ -417,7 +417,7 @@ func (llvrw *TestValueReaderWriter) WriteCodeWithScope(code string) (DocumentWri
 	return llvrw, nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteDBPointer(ns string, oid primitive.ObjectID) error {
+func (llvrw *TestValueReaderWriter) WriteDBPointer(string, primitive.ObjectID) error {
 	llvrw.invoked = llvrwWriteDBPointer
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -425,7 +425,7 @@ func (llvrw *TestValueReaderWriter) WriteDBPointer(ns string, oid primitive.Obje
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteDateTime(dt int64) error {
+func (llvrw *TestValueReaderWriter) WriteDateTime(int64) error {
 	llvrw.invoked = llvrwWriteDateTime
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -465,7 +465,7 @@ func (llvrw *TestValueReaderWriter) WriteInt64(int64) error {
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteJavascript(code string) error {
+func (llvrw *TestValueReaderWriter) WriteJavascript(string) error {
 	llvrw.invoked = llvrwWriteJavascript
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -505,7 +505,7 @@ func (llvrw *TestValueReaderWriter) WriteObjectID(primitive.ObjectID) error {
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteRegex(pattern string, options string) error {
+func (llvrw *TestValueReaderWriter) WriteRegex(string, string) error {
 	llvrw.invoked = llvrwWriteRegex
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -529,7 +529,7 @@ func (llvrw *TestValueReaderWriter) WriteDocument() (DocumentWriter, error) {
 	return llvrw, nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteSymbol(symbol string) error {
+func (llvrw *TestValueReaderWriter) WriteSymbol(string) error {
 	llvrw.invoked = llvrwWriteSymbol
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err
@@ -537,7 +537,7 @@ func (llvrw *TestValueReaderWriter) WriteSymbol(symbol string) error {
 	return nil
 }
 
-func (llvrw *TestValueReaderWriter) WriteTimestamp(t uint32, i uint32) error {
+func (llvrw *TestValueReaderWriter) WriteTimestamp(uint32, uint32) error {
 	llvrw.invoked = llvrwWriteTimestamp
 	if llvrw.errAfter == llvrw.invoked {
 		return llvrw.err

--- a/bson/mgocompat/setter_getter.go
+++ b/bson/mgocompat/setter_getter.go
@@ -49,7 +49,7 @@ type Getter interface {
 }
 
 // SetterDecodeValue is the ValueDecoderFunc for Setter types.
-func SetterDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func SetterDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tSetter) && !reflect.PtrTo(val.Type()).Implements(tSetter)) {
 		return bsoncodec.ValueDecoderError{Name: "SetterDecodeValue", Types: []reflect.Type{tSetter}, Received: val}
 	}

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -18,7 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/internal/require"
 )
 
-func TestNew(t *testing.T) {
+func TestNew(*testing.T) {
 	// Ensure that objectid.NewObjectID() doesn't panic.
 	NewObjectID()
 }

--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -18,11 +18,6 @@ import (
 	"go.mongodb.org/mongo-driver/internal/require"
 )
 
-func TestNew(*testing.T) {
-	// Ensure that objectid.NewObjectID() doesn't panic.
-	NewObjectID()
-}
-
 func TestString(t *testing.T) {
 	id := NewObjectID()
 	require.Contains(t, id.String(), id.Hex())

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -38,7 +38,7 @@ func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder)
 }
 
 // RawValueEncodeValue is the ValueEncoderFunc for RawValue.
-func (PrimitiveCodecs) RawValueEncodeValue(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRawValue {
 		return bsoncodec.ValueEncoderError{Name: "RawValueEncodeValue", Types: []reflect.Type{tRawValue}, Received: val}
 	}
@@ -49,7 +49,7 @@ func (PrimitiveCodecs) RawValueEncodeValue(ec bsoncodec.EncodeContext, vw bsonrw
 }
 
 // RawValueDecodeValue is the ValueDecoderFunc for RawValue.
-func (PrimitiveCodecs) RawValueDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (PrimitiveCodecs) RawValueDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRawValue {
 		return bsoncodec.ValueDecoderError{Name: "RawValueDecodeValue", Types: []reflect.Type{tRawValue}, Received: val}
 	}
@@ -64,7 +64,7 @@ func (PrimitiveCodecs) RawValueDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw
 }
 
 // RawEncodeValue is the ValueEncoderFunc for Reader.
-func (PrimitiveCodecs) RawEncodeValue(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (PrimitiveCodecs) RawEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRaw {
 		return bsoncodec.ValueEncoderError{Name: "RawEncodeValue", Types: []reflect.Type{tRaw}, Received: val}
 	}
@@ -75,7 +75,7 @@ func (PrimitiveCodecs) RawEncodeValue(ec bsoncodec.EncodeContext, vw bsonrw.Valu
 }
 
 // RawDecodeValue is the ValueDecoderFunc for Reader.
-func (PrimitiveCodecs) RawDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (PrimitiveCodecs) RawDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRaw {
 		return bsoncodec.ValueDecoderError{Name: "RawDecodeValue", Types: []reflect.Type{tRaw}, Received: val}
 	}

--- a/internal/assert/assertions_test.go
+++ b/internal/assert/assertions_test.go
@@ -179,7 +179,7 @@ func (t *bufferT) Errorf(format string, args ...interface{}) {
 	t.buf.WriteString(decorate(fmt.Sprintf(format, args...)))
 }
 
-func TestStringEqual(t *testing.T) {
+func TestStringEqual(*testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -193,7 +193,7 @@ func TestStringEqual(t *testing.T) {
 	}
 }
 
-func TestEqualFormatting(t *testing.T) {
+func TestEqualFormatting(*testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -1074,7 +1074,7 @@ Diff:
 	Equal(t, expected, actual)
 }
 
-func TestTimeEqualityErrorFormatting(t *testing.T) {
+func TestTimeEqualityErrorFormatting(*testing.T) {
 	mockT := new(mockTestingT)
 
 	Equal(mockT, time.Second*2, time.Millisecond)
@@ -1140,7 +1140,7 @@ func (m *mockTestingT) Errorf(format string, args ...interface{}) {
 type mockFailNowTestingT struct {
 }
 
-func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
+func (m *mockFailNowTestingT) Errorf(string, ...interface{}) {}
 
 func (m *mockFailNowTestingT) FailNow() {}
 

--- a/internal/assert/assertions_test.go
+++ b/internal/assert/assertions_test.go
@@ -179,7 +179,7 @@ func (t *bufferT) Errorf(format string, args ...interface{}) {
 	t.buf.WriteString(decorate(fmt.Sprintf(format, args...)))
 }
 
-func TestStringEqual(*testing.T) {
+func TestStringEqual(_ *testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -193,7 +193,7 @@ func TestStringEqual(*testing.T) {
 	}
 }
 
-func TestEqualFormatting(*testing.T) {
+func TestEqualFormatting(_ *testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -1074,7 +1074,7 @@ Diff:
 	Equal(t, expected, actual)
 }
 
-func TestTimeEqualityErrorFormatting(*testing.T) {
+func TestTimeEqualityErrorFormatting(_ *testing.T) {
 	mockT := new(mockTestingT)
 
 	Equal(mockT, time.Second*2, time.Millisecond)

--- a/internal/aws/credentials/credentials_test.go
+++ b/internal/aws/credentials/credentials_test.go
@@ -137,7 +137,7 @@ func (*MockProvider) Retrieve() (Value, error) {
 	return Value{}, nil
 }
 
-func TestCredentialsIsExpired_Race(t *testing.T) {
+func TestCredentialsIsExpired_Race(_ *testing.T) {
 	creds := NewChainCredentials([]Provider{&MockProvider{}})
 
 	starter := make(chan struct{})

--- a/internal/aws/signer/v4/v4.go
+++ b/internal/aws/signer/v4/v4.go
@@ -353,6 +353,8 @@ const doubleSpace = "  "
 func stripExcessSpaces(vals []string) {
 	var j, k, l, m, spaces int
 	for i, str := range vals {
+		// revive:disable:empty-block
+
 		// Trim trailing spaces
 		for j = len(str) - 1; j >= 0 && str[j] == ' '; j-- {
 		}
@@ -360,6 +362,9 @@ func stripExcessSpaces(vals []string) {
 		// Trim leading spaces
 		for k = 0; k < j && str[k] == ' '; k++ {
 		}
+
+		// revive:enable:empty-block
+
 		str = str[k : j+1]
 
 		// Strip multiple spaces.

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -18,8 +18,8 @@ import (
 
 type mockLogSink struct{}
 
-func (mockLogSink) Info(level int, msg string, keysAndValues ...interface{})  {}
-func (mockLogSink) Error(err error, msg string, keysAndValues ...interface{}) {}
+func (mockLogSink) Info(int, string, ...interface{})    {}
+func (mockLogSink) Error(error, string, ...interface{}) {}
 
 func BenchmarkLogger(b *testing.B) {
 	b.ReportAllocs()

--- a/internal/testutil/ops.go
+++ b/internal/testutil/ops.go
@@ -37,13 +37,18 @@ func AutoInsertDocs(t *testing.T, writeConcern *writeconcern.WriteConcern, docs 
 
 // InsertDocs inserts the docs into the test cluster.
 func InsertDocs(t *testing.T, dbname, colname string, writeConcern *writeconcern.WriteConcern, docs ...bsoncore.Document) {
-	err := operation.NewInsert(docs...).Collection(colname).Database(dbname).
-		Deployment(Topology(t)).ServerSelector(description.WriteSelector()).Execute(context.Background())
+	err := operation.NewInsert(docs...).
+		Collection(colname).
+		Database(dbname).
+		Deployment(Topology(t)).
+		ServerSelector(description.WriteSelector()).
+		WriteConcern(writeConcern).
+		Execute(context.Background())
 	require.NoError(t, err)
 }
 
 // RunCommand runs an arbitrary command on a given database of target server
-func RunCommand(t *testing.T, s driver.Server, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
+func RunCommand(s driver.Server, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
 	op := operation.NewCommand(cmd).
 		Database(db).Deployment(driver.SingleServerDeployment{Server: s})
 	err := op.Execute(context.Background())

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1749,10 +1749,7 @@ func (coll *Collection) dropEncryptedCollection(ctx context.Context, ef interfac
 	}
 
 	// Drop the data collection.
-	if err := coll.drop(ctx); err != nil {
-		return err
-	}
-	return nil
+	return coll.drop(ctx)
 }
 
 // drop drops a collection without EncryptedFields.

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -320,7 +320,7 @@ func (we WriteError) HasErrorCode(code int) bool {
 
 // HasErrorLabel returns true if the error contains the specified label. WriteErrors do not contain labels,
 // so we always return false.
-func (we WriteError) HasErrorLabel(label string) bool {
+func (we WriteError) HasErrorLabel(string) bool {
 	return false
 }
 

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -620,11 +620,7 @@ func (b *Bucket) createIndexes(ctx context.Context) error {
 	if err = createNumericalIndexIfNotExists(ctx, filesIv, filesModel); err != nil {
 		return err
 	}
-	if err = createNumericalIndexIfNotExists(ctx, chunksIv, chunksModel); err != nil {
-		return err
-	}
-
-	return nil
+	return createNumericalIndexIfNotExists(ctx, chunksIv, chunksModel)
 }
 
 func (b *Bucket) checkFirstWrite(ctx context.Context) error {

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -42,12 +42,12 @@ type negateCodec struct {
 	ID int64 `bson:"_id"`
 }
 
-func (e *negateCodec) EncodeValue(ectx bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (e *negateCodec) EncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	return vw.WriteInt64(val.Int())
 }
 
 // DecodeValue negates the value of ID when reading
-func (e *negateCodec) DecodeValue(ectx bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+func (e *negateCodec) DecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	i, err := vr.ReadInt64()
 	if err != nil {
 		return err

--- a/mongo/integration/log_helpers_test.go
+++ b/mongo/integration/log_helpers_test.go
@@ -69,6 +69,7 @@ func (sink *testLogSink) Info(level int, msg string, keysAndValues ...interface{
 }
 
 func (sink *testLogSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	keysAndValues = append(keysAndValues, "error", err)
 	sink.Info(int(logger.LevelInfo), msg, keysAndValues)
 }
 
@@ -110,10 +111,6 @@ func newTruncValidator(mt *mtest.T, key string, cond func(string) error) truncVa
 			return fmt.Errorf("command is not a string")
 		}
 
-		if err := cond(cmdStr); err != nil {
-			return err
-		}
-
-		return nil
+		return cond(cmdStr)
 	}
 }

--- a/mongo/integration/mtest/opmsg_deployment.go
+++ b/mongo/integration/mtest/opmsg_deployment.go
@@ -51,8 +51,8 @@ type connection struct {
 
 var _ driver.Connection = &connection{}
 
-// WriteWireMessage is a no-op operation.
-func (c *connection) WriteWireMessage(_ context.Context, wm []byte) error {
+// WriteWireMessage is a no-op.
+func (c *connection) WriteWireMessage(context.Context, []byte) error {
 	return nil
 }
 

--- a/mongo/integration/unified/logger.go
+++ b/mongo/integration/unified/logger.go
@@ -56,7 +56,7 @@ func (log *Logger) Info(level int, msg string, args ...interface{}) {
 	// logging offset.
 	level = level + logger.DiffToInfo
 
-	logMessage, err := newLogMessage(level, args...)
+	logMessage, err := newLogMessage(level, msg, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -77,6 +77,7 @@ func (log *Logger) Info(level int, msg string, args ...interface{}) {
 // Error implements the logger.Sink interface's "Error" method for printing log
 // errors. In this case, if an error occurs we will simply treat it as
 // informational.
-func (log *Logger) Error(_ error, msg string, args ...interface{}) {
+func (log *Logger) Error(err error, msg string, args ...interface{}) {
+	args = append(args, "error", err)
 	log.Info(int(logger.LevelInfo), msg, args)
 }

--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -29,7 +29,7 @@ type logMessage struct {
 
 // newLogMessage will create a "logMessage" from the level and a slice of
 // arguments.
-func newLogMessage(level int, args ...interface{}) (*logMessage, error) {
+func newLogMessage(level int, msg string, args ...interface{}) (*logMessage, error) {
 	logMessage := new(logMessage)
 
 	// Iterate over the literal levels until we get the first
@@ -55,7 +55,7 @@ func newLogMessage(level int, args ...interface{}) (*logMessage, error) {
 	}
 
 	// Create a new document from the arguments.
-	actualD := bson.D{}
+	actualD := bson.D{{"message", msg}}
 	for i := 0; i < len(args); i += 2 {
 		actualD = append(actualD, bson.E{
 			Key:   args[i].(string),

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -374,8 +374,5 @@ func disableFailPointWithClient(ctx context.Context, fpName string, client *mong
 		{"configureFailPoint", fpName},
 		{"mode", "off"},
 	}
-	if err := client.Database("admin").RunCommand(ctx, cmd).Err(); err != nil {
-		return err
-	}
-	return nil
+	return client.Database("admin").RunCommand(ctx, cmd).Err()
 }

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -796,7 +796,7 @@ type testDialer struct {
 	Num int
 }
 
-func (testDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (testDialer) DialContext(context.Context, string, string) (net.Conn, error) {
 	return nil, nil
 }
 

--- a/x/bsonx/bsoncore/value.go
+++ b/x/bsonx/bsoncore/value.go
@@ -198,21 +198,14 @@ func (v Value) AsInt64OK() (int64, bool) {
 // AsFloat64 returns a BSON number as an float64. If the BSON type is not a numeric one, this method
 // will panic.
 //
-// TODO(skriptble): Add support for Decimal128.
-func (v Value) AsFloat64() float64 { return 0 }
+// TODO(GODRIVER-2751): Implement AsFloat64.
+// func (v Value) AsFloat64() float64
 
 // AsFloat64OK functions the same as AsFloat64 but returns a boolean instead of panicking. False
 // indicates an error.
 //
-// TODO(skriptble): Add support for Decimal128.
-func (v Value) AsFloat64OK() (float64, bool) { return 0, false }
-
-// Add will add this value to another. This is currently only implemented for strings and numbers.
-// If either value is a string, the other type is coerced into a string and added to the other.
-//
-// This method will alter v and will attempt to reuse the []byte of v. If the []byte is too small,
-// it will be expanded.
-func (v *Value) Add(v2 Value) error { return nil }
+// TODO(GODRIVER-2751): Implement AsFloat64OK.
+// func (v Value) AsFloat64OK() (float64, bool)
 
 // Equal compaes v to v2 and returns true if they are equal.
 func (v Value) Equal(v2 Value) bool {

--- a/x/mongo/driver/auth/auth_test.go
+++ b/x/mongo/driver/auth/auth_test.go
@@ -101,14 +101,12 @@ func compareResponses(t *testing.T, wm []byte, expectedPayload bsoncore.Document
 			stype, wm, ok = wiremessage.ReadMsgSectionType(wm)
 			if !ok {
 				t.Fatalf("wiremessage is too short to unmarshal")
-				break
 			}
 			switch stype {
 			case wiremessage.DocumentSequence:
 				_, _, wm, ok = wiremessage.ReadMsgSectionDocumentSequence(wm)
 				if !ok {
 					t.Fatalf("wiremessage is too short to unmarshal")
-					break loop
 				}
 			case wiremessage.SingleDocument:
 				actualPayload, wm, ok = wiremessage.ReadMsgSectionSingleDocument(wm)

--- a/x/mongo/driver/auth/gssapi_not_enabled.go
+++ b/x/mongo/driver/auth/gssapi_not_enabled.go
@@ -12,6 +12,6 @@ package auth
 // GSSAPI is the mechanism name for GSSAPI.
 const GSSAPI = "GSSAPI"
 
-func newGSSAPIAuthenticator(cred *Cred) (Authenticator, error) {
+func newGSSAPIAuthenticator(*Cred) (Authenticator, error) {
 	return nil, newAuthError("GSSAPI support not enabled during build (-tags gssapi)", nil)
 }

--- a/x/mongo/driver/auth/plain.go
+++ b/x/mongo/driver/auth/plain.go
@@ -46,7 +46,7 @@ func (c *plainSaslClient) Start() (string, []byte, error) {
 	return PLAIN, b, nil
 }
 
-func (c *plainSaslClient) Next(challenge []byte) ([]byte, error) {
+func (c *plainSaslClient) Next([]byte) ([]byte, error) {
 	return nil, newAuthError("unexpected server challenge", nil)
 }
 

--- a/x/mongo/driver/drivertest/channel_conn.go
+++ b/x/mongo/driver/drivertest/channel_conn.go
@@ -33,6 +33,8 @@ func (c *ChannelConn) WriteWireMessage(ctx context.Context, wm []byte) error {
 	copy(b, wm)
 	select {
 	case c.Written <- b:
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 		c.WriteErr = errors.New("could not write wiremessage to written channel")
 	}
@@ -47,6 +49,7 @@ func (c *ChannelConn) ReadWireMessage(ctx context.Context) ([]byte, error) {
 	case wm = <-c.ReadResp:
 	case err = <-c.ReadErr:
 	case <-ctx.Done():
+		err = ctx.Err()
 	}
 	return wm, err
 }

--- a/x/mongo/driver/integration/aggregate_test.go
+++ b/x/mongo/driver/integration/aggregate_test.go
@@ -47,7 +47,7 @@ func skipIfBelow32(ctx context.Context, t *testing.T, topo *topology.Topology) {
 	noerr(t, err)
 
 	versionCmd := bsoncore.BuildDocument(nil, bsoncore.AppendInt32Element(nil, "serverStatus", 1))
-	serverStatus, err := testutil.RunCommand(t, server, dbName, versionCmd)
+	serverStatus, err := testutil.RunCommand(server, dbName, versionCmd)
 	noerr(t, err)
 	version, err := serverStatus.LookupErr("version")
 	noerr(t, err)

--- a/x/mongo/driver/integration/scram_test.go
+++ b/x/mongo/driver/integration/scram_test.go
@@ -147,7 +147,7 @@ func runScramAuthTest(t *testing.T, credential options.Credential) error {
 	noerr(t, err)
 
 	cmd := bsoncore.BuildDocument(nil, bsoncore.AppendInt32Element(nil, "dbstats", 1))
-	_, err = testutil.RunCommand(t, server, testutil.DBName(t), cmd)
+	_, err = testutil.RunCommand(server, testutil.DBName(t), cmd)
 	return err
 }
 
@@ -169,7 +169,7 @@ func createScramUsers(t *testing.T, s driver.Server, cases []scramTestCase) erro
 			)),
 			bsoncore.AppendArrayElement(nil, "mechanisms", bsoncore.BuildArray(nil, values...)),
 		)
-		_, err := testutil.RunCommand(t, s, db, newUserCmd)
+		_, err := testutil.RunCommand(s, db, newUserCmd)
 		if err != nil {
 			return fmt.Errorf("Couldn't create user '%s' on db '%s': %v", c.username, testutil.DBName(t), err)
 		}

--- a/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
@@ -27,7 +27,7 @@ func (c *Context) NextOperation() (bsoncore.Document, error) {
 }
 
 // AddOperationResult feeds the result of a database operation to mongocrypt.
-func (c *Context) AddOperationResult(result bsoncore.Document) error {
+func (c *Context) AddOperationResult(bsoncore.Document) error {
 	panic(cseNotSupportedMsg)
 }
 
@@ -57,6 +57,6 @@ func (c *Context) Close() {
 }
 
 // ProvideKmsProviders provides the KMS providers when in the NeedKmsCredentials state.
-func (c *Context) ProvideKmsProviders(kmsProviders bsoncore.Document) error {
+func (c *Context) ProvideKmsProviders(bsoncore.Document) error {
 	panic(cseNotSupportedMsg)
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
@@ -34,6 +34,6 @@ func (kc *KmsContext) BytesNeeded() int32 {
 }
 
 // FeedResponse feeds the bytes received from the KMS to mongocrypt.
-func (kc *KmsContext) FeedResponse(response []byte) error {
+func (kc *KmsContext) FeedResponse([]byte) error {
 	panic(cseNotSupportedMsg)
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -28,42 +28,42 @@ func Version() string {
 }
 
 // NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
-func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
+func NewMongoCrypt(*options.MongoCryptOptions) (*MongoCrypt, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateEncryptionContext creates a Context to use for encryption.
-func (m *MongoCrypt) CreateEncryptionContext(db string, cmd bsoncore.Document) (*Context, error) {
+func (m *MongoCrypt) CreateEncryptionContext(string, bsoncore.Document) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateExplicitEncryptionExpressionContext creates a Context to use for explicit encryption of an expression.
-func (m *MongoCrypt) CreateExplicitEncryptionExpressionContext(doc bsoncore.Document, opts *options.ExplicitEncryptionOptions) (*Context, error) {
+func (m *MongoCrypt) CreateExplicitEncryptionExpressionContext(bsoncore.Document, *options.ExplicitEncryptionOptions) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateDecryptionContext creates a Context to use for decryption.
-func (m *MongoCrypt) CreateDecryptionContext(cmd bsoncore.Document) (*Context, error) {
+func (m *MongoCrypt) CreateDecryptionContext(bsoncore.Document) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateDataKeyContext creates a Context to use for creating a data key.
-func (m *MongoCrypt) CreateDataKeyContext(kmsProvider string, opts *options.DataKeyOptions) (*Context, error) {
+func (m *MongoCrypt) CreateDataKeyContext(string, *options.DataKeyOptions) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateExplicitEncryptionContext creates a Context to use for explicit encryption.
-func (m *MongoCrypt) CreateExplicitEncryptionContext(doc bsoncore.Document, opts *options.ExplicitEncryptionOptions) (*Context, error) {
+func (m *MongoCrypt) CreateExplicitEncryptionContext(bsoncore.Document, *options.ExplicitEncryptionOptions) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // RewrapDataKeyContext creates a Context to use for rewrapping a data key.
-func (m *MongoCrypt) RewrapDataKeyContext(filter []byte, opts *options.RewrapManyDataKeyOptions) (*Context, error) {
+func (m *MongoCrypt) RewrapDataKeyContext([]byte, *options.RewrapManyDataKeyOptions) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
 // CreateExplicitDecryptionContext creates a Context to use for explicit decryption.
-func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Context, error) {
+func (m *MongoCrypt) CreateExplicitDecryptionContext(bsoncore.Document) (*Context, error) {
 	panic(cseNotSupportedMsg)
 }
 
@@ -85,6 +85,6 @@ func (m *MongoCrypt) Close() {
 }
 
 // GetKmsProviders returns the originally configured KMS providers.
-func (m *MongoCrypt) GetKmsProviders(ctx context.Context) (bsoncore.Document, error) {
+func (m *MongoCrypt) GetKmsProviders(context.Context) (bsoncore.Document, error) {
 	panic(cseNotSupportedMsg)
 }

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -68,7 +68,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 
 }
 
-func (at *AbortTransaction) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (at *AbortTransaction) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 
 	dst = bsoncore.AppendInt32Element(dst, "abortTransaction", 1)
 	if at.recoveryToken != nil {

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -70,7 +70,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 
 }
 
-func (ct *CommitTransaction) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (ct *CommitTransaction) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 
 	dst = bsoncore.AppendInt32Element(dst, "commitTransaction", 1)
 	if ct.recoveryToken != nil {

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -138,7 +138,7 @@ func (c *Count) Execute(ctx context.Context) error {
 	return err
 }
 
-func (c *Count) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (c *Count) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendStringElement(dst, "count", c.collection)
 	if c.query != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "query", c.query)

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -106,7 +106,7 @@ func (dc *DropCollection) Execute(ctx context.Context) error {
 
 }
 
-func (dc *DropCollection) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (dc *DropCollection) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendStringElement(dst, "drop", dc.collection)
 	return dst, nil
 }

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -57,7 +57,7 @@ func (dd *DropDatabase) Execute(ctx context.Context) error {
 
 }
 
-func (dd *DropDatabase) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (dd *DropDatabase) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 
 	dst = bsoncore.AppendInt32Element(dst, "dropDatabase", 1)
 	return dst, nil

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -103,7 +103,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 
 }
 
-func (di *DropIndexes) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (di *DropIndexes) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendStringElement(dst, "dropIndexes", di.collection)
 	if di.index != nil {
 		dst = bsoncore.AppendStringElement(dst, "index", *di.index)

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -63,7 +63,7 @@ func (es *EndSessions) Execute(ctx context.Context) error {
 
 }
 
-func (es *EndSessions) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (es *EndSessions) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	if es.sessionIDs != nil {
 		dst = bsoncore.AppendArrayElement(dst, "endSessions", es.sessionIDs)
 	}

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -167,7 +167,7 @@ func (ld *ListDatabases) Execute(ctx context.Context) error {
 
 }
 
-func (ld *ListDatabases) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (ld *ListDatabases) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendInt32Element(dst, "listDatabases", 1)
 	if ld.filter != nil {
 

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -92,7 +92,7 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 
 }
 
-func (lc *ListCollections) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (lc *ListCollections) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendInt32Element(dst, "listCollections", 1)
 	if lc.filter != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "filter", lc.filter)

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -87,7 +87,7 @@ func (li *ListIndexes) Execute(ctx context.Context) error {
 
 }
 
-func (li *ListIndexes) command(dst []byte, desc description.SelectedServer) ([]byte, error) {
+func (li *ListIndexes) command(dst []byte, _ description.SelectedServer) ([]byte, error) {
 	dst = bsoncore.AppendStringElement(dst, "listIndexes", li.collection)
 	cursorIdx, cursorDoc := bsoncore.AppendDocumentStart(nil)
 

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -724,7 +724,7 @@ type mockDeployment struct {
 	}
 }
 
-func (m *mockDeployment) SelectServer(ctx context.Context, desc description.ServerSelector) (Server, error) {
+func (m *mockDeployment) SelectServer(_ context.Context, desc description.ServerSelector) (Server, error) {
 	m.params.selector = desc
 	return m.returns.server, m.returns.err
 }

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -1146,7 +1146,7 @@ func (wfc *writeFailConn) Write([]byte) (int, error) {
 	return 0, errors.New("Write error")
 }
 
-func (wfc *writeFailConn) SetWriteDeadline(t time.Time) error {
+func (wfc *writeFailConn) SetWriteDeadline(time.Time) error {
 	return nil
 }
 

--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -75,7 +75,7 @@ func (r *mockResolver) LookupSRV(service, proto, name string) (string, []*net.SR
 	return str, addresses, err
 }
 
-func (r *mockResolver) LookupTXT(name string) ([]string, error) { return nil, nil }
+func (r *mockResolver) LookupTXT(string) ([]string, error) { return nil, nil }
 
 var srvPollingTests = []struct {
 	name            string

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -583,7 +583,7 @@ func TestMinPoolSize(t *testing.T) {
 	}
 }
 
-func TestTopology_String_Race(*testing.T) {
+func TestTopology_String_Race(_ *testing.T) {
 	ch := make(chan bool)
 	topo := &Topology{
 		servers: make(map[address.Address]*Server),

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -583,7 +583,7 @@ func TestMinPoolSize(t *testing.T) {
 	}
 }
 
-func TestTopology_String_Race(t *testing.T) {
+func TestTopology_String_Race(*testing.T) {
 	ch := make(chan bool)
 	topo := &Topology{
 		servers: make(map[address.Address]*Server),


### PR DESCRIPTION
[GODRIVER-2782](https://jira.mongodb.org/browse/GODRIVER-2782)

## Summary
* Update pinned `golangci-lint` version to v1.52.2
* Resolve all lint errors caused by `golangci-lint` upgrading `revive` from v1.3.0 to v1.3.1.

## Background & Motivation
The latest version of the `golangci-lint` tool upgraded `revive` from v1.3.0 to v1.3.1 (see [PR](https://github.com/golangci/golangci-lint/pull/3702)), which adds some additional useful code checks.