### PR TITLE
pin golangci-lint v1.51.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -198,7 +198,7 @@ functions:
 
           # Install linters. Use "go install" instead of "go get" to prevent modifying the go.mod
           # file.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
           go install github.com/walle/lll/...@latest
 
   upload-mo-artifacts:


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Update the evergreen config file to pin golangci-lint v1.51.2 to avoid the static analysis lint failures that were introduced in the latest version.

## Background & Motivation
<!--- Rationale for the pull request. -->

