### PR TITLE
GODRIVER-1668: specify database name empty error

### DIFF
--- a/bson/example_test.go
+++ b/bson/example_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2023-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bson_test
 
 import (

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -46,6 +46,8 @@ var (
 	ErrReplyDocumentMismatch = errors.New("number of documents returned does not match numberReturned field")
 	// ErrNonPrimaryReadPref is returned when a read is attempted in a transaction with a non-primary read preference.
 	ErrNonPrimaryReadPref = errors.New("read preference in a transaction must be primary")
+	// errDatabaseNameEmpty occurs when a database name is not provided.
+	errDatabaseNameEmpty = errors.New("database name cannot be empty")
 )
 
 const (
@@ -370,7 +372,7 @@ func (op Operation) Validate() error {
 		return InvalidOperationError{MissingField: "Deployment"}
 	}
 	if op.Database == "" {
-		return InvalidOperationError{MissingField: "Database"}
+		return errDatabaseNameEmpty
 	}
 	if op.Client != nil && !writeconcern.AckWrite(op.WriteConcern) {
 		return errors.New("session provided for an unacknowledged write")

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -103,7 +103,7 @@ func TestOperation(t *testing.T) {
 		}{
 			{"CommandFn", &Operation{}, InvalidOperationError{MissingField: "CommandFn"}},
 			{"Deployment", &Operation{CommandFn: cmdFn}, InvalidOperationError{MissingField: "Deployment"}},
-			{"Database", &Operation{CommandFn: cmdFn, Deployment: d}, InvalidOperationError{MissingField: "Database"}},
+			{"Database", &Operation{CommandFn: cmdFn, Deployment: d}, errDatabaseNameEmpty},
 			{"<nil>", &Operation{CommandFn: cmdFn, Deployment: d, Database: "test"}, nil},
 		}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

addressing this ticket https://jira.mongodb.org/browse/GODRIVER-1668 

improving error message when the database name is empty.


## Background & Motivation

after spending a quiet amount of time debugging the misleading error message, which could have been detected immediately if there where better error messages.