### PR TITLE
GODRIVER-2167 Deprecate frequently lossy AsInt32 and AsInt32OK functions

### DIFF
--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -267,10 +267,16 @@ func (rv RawValue) Int32OK() (int32, bool) { return convertToCoreValue(rv).Int32
 
 // AsInt32 returns a BSON number as an int32. If the BSON type is not a numeric one, this method
 // will panic.
+//
+// Deprecated: Use AsInt64 instead. If an int32 is required, convert the returned value to an int32
+// and perform any required overflow/underflow checking.
 func (rv RawValue) AsInt32() int32 { return convertToCoreValue(rv).AsInt32() }
 
 // AsInt32OK is the same as AsInt32, except that it returns a boolean instead of
 // panicking.
+//
+// Deprecated: Use AsInt64OK instead. If an int32 is required, convert the returned value to an
+// int32 and perform any required overflow/underflow checking.
 func (rv RawValue) AsInt32OK() (int32, bool) { return convertToCoreValue(rv).AsInt32OK() }
 
 // Timestamp returns the BSON timestamp value the Value represents. It panics if the value is a


### PR DESCRIPTION
[GODRIVER-2167](https://jira.mongodb.org/browse/GODRIVER-2167)

## Summary
Deprecate frequently lossy `AsInt32` and `AsInt32OK` functions.

## Background & Motivation
The BSON library currently includes 4 BSON-to-Go numeric value conversion functions that can cause silent data loss:
* `AsInt32`, `AsInt32OK`
* `AsInt64`, `AsInt64OK`

While converting BSON numeric types to a Go `int64` can cause data loss in some cases, it's generally only a problem for extremely large or extremely small values that most users never encounter (values >`9.2e+18` or <`-9.2e+18`). However, converting BSON numeric types to a Go `int32` can cause data loss for values that users may commonly encounter (values >`2,147,483,647` or <`-2,147,483,648`). As a result, using `AsInt32` or `AsInt32OK` is practically much less safe than `AsInt64` or `AsInt64OK`. Deprecate `AsInt32` and `AsInt32OK` and recommend people use `AsInt64` or `AsInt64OK` instead. If users really need an `int32`, they can convert the `int64` to an `int32` themselves and implement whatever overflow/underflow checking logic they require.

