### PR TITLE
GODRIVER-2682 Prepare to rename bson.NewFromIOReader to bson.ReadDocument.

### DIFF
--- a/bson/raw.go
+++ b/bson/raw.go
@@ -22,11 +22,19 @@ var ErrNilReader = errors.New("nil reader")
 // A Raw must be a full BSON document. Use the RawValue type for individual BSON values.
 type Raw []byte
 
-// NewFromIOReader reads in a document from the given io.Reader and constructs a Raw from
-// it.
-func NewFromIOReader(r io.Reader) (Raw, error) {
+// ReadDocument reads a BSON document from the io.Reader and returns it as a bson.Raw. If the
+// reader contains multiple BSON documents, only the first document is read.
+func ReadDocument(r io.Reader) (Raw, error) {
 	doc, err := bsoncore.NewDocumentFromReader(r)
 	return Raw(doc), err
+}
+
+// NewFromIOReader reads a BSON document from the io.Reader and returns it as a bson.Raw. If the
+// reader contains multiple BSON documents, only the first document is read.
+//
+// Deprecated: Use ReadDocument instead.
+func NewFromIOReader(r io.Reader) (Raw, error) {
+	return ReadDocument(r)
 }
 
 // Validate validates the document. This method only validates the first document in

--- a/bson/raw_test.go
+++ b/bson/raw_test.go
@@ -265,6 +265,7 @@ func TestRaw(t *testing.T) {
 		}
 	})
 	t.Run("ReadDocument", func(t *testing.T) {
+		t.Parallel()
 		testCases := []struct {
 			name       string
 			ioReader   io.Reader
@@ -339,6 +340,7 @@ func TestRaw(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				reader, err := ReadDocument(tc.ioReader)
 				require.Equal(t, err, tc.err)
 				require.True(t, bytes.Equal(tc.bsonReader, reader))

--- a/bson/raw_test.go
+++ b/bson/raw_test.go
@@ -339,8 +339,10 @@ func TestRaw(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
+			tc := tc // Capture range variable.
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
+
 				reader, err := ReadDocument(tc.ioReader)
 				require.Equal(t, err, tc.err)
 				require.True(t, bytes.Equal(tc.bsonReader, reader))

--- a/bson/raw_test.go
+++ b/bson/raw_test.go
@@ -264,7 +264,7 @@ func TestRaw(t *testing.T) {
 			})
 		}
 	})
-	t.Run("NewFromIOReader", func(t *testing.T) {
+	t.Run("ReadDocument", func(t *testing.T) {
 		testCases := []struct {
 			name       string
 			ioReader   io.Reader
@@ -339,7 +339,7 @@ func TestRaw(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				reader, err := NewFromIOReader(tc.ioReader)
+				reader, err := ReadDocument(tc.ioReader)
 				require.Equal(t, err, tc.err)
 				require.True(t, bytes.Equal(tc.bsonReader, reader))
 			})


### PR DESCRIPTION
[GODRIVER-2682](https://jira.mongodb.org/browse/GODRIVER-2682)

## Summary
Add a new function `bson.ReadDocument` that does exactly the same thing as `bson.NewFromIOReader`. Deprecate `bson.NewFromIOReader` in preparation to remove it in Go Driver 2.0.

## Background & Motivation
The function `bson.NewFromIOReader` is not intuitively named. Replace it with a new, more intuitive function `bson.ReadDocument` that behaves exactly the same and deprecate `bson.NewFromIOReader`.

