### PR TITLE
GODRIVER-2684 Deprecate D.Map.

### DIFF
--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -197,6 +197,9 @@ type MaxKey struct{}
 type D []E
 
 // Map creates a map from the elements of the D.
+//
+// Deprecated: Converting directly from a D to an M will not be supported in Go Driver 2.0. Instead,
+// users should marshal the D to BSON using bson.Marshal and unmarshal it to M using bson.Unmarshal.
 func (d D) Map() M {
 	m := make(M, len(d))
 	for _, e := range d {


### PR DESCRIPTION
[GODRIVER-2684](https://jira.mongodb.org/browse/GODRIVER-2684)

## Summary
Deprecate `bson.D.Map`. Recommend that users marshal a `bson.D` as BSON and unmarshal it as a `bson.M` to achieve the same `D`-to-`M` conversion.

## Background & Motivation
Using the `bson.D.Map` method often results in unexpected output because the method only shallow-converts the `D` to an `M`. Updating the method to recursively convert a `D` to an `M` requires a lot of reflection logic and would be a backward-breaking change in Go Driver 1.x. The only use case for converting a `D` to an `M` that we have observed is to marshal the D to an intuitive JSON representation (i.e. key-value instead of an array of tuples). In Go Driver 2.0, encoding to the intuitive JSON representation will be supported natively (see [GODRIVER-1765](https://jira.mongodb.org/browse/GODRIVER-1765)), so the `Map` method will have no known use cases.

