### PR TITLE
GODRIVER-2709 Deprecate DefaultValueEncoders, DefaultValueDecoders, and PrimitiveCodecs.

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -48,6 +48,8 @@ func newDefaultStructCodec() *StructCodec {
 
 // DefaultValueDecoders is a namespace type for the default ValueDecoders used
 // when creating a registry.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 type DefaultValueDecoders struct{}
 
 // RegisterDefaultDecoders will register the decoder methods attached to DefaultValueDecoders with
@@ -56,6 +58,8 @@ type DefaultValueDecoders struct{}
 // There is no support for decoding map[string]interface{} because there is no decoder for
 // interface{}, so users must either register this decoder themselves or use the
 // EmptyInterfaceDecoder available in the bson package.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 	if rb == nil {
 		panic(errors.New("argument to RegisterDefaultDecoders must not be nil"))
@@ -132,6 +136,8 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 }
 
 // DDecodeValue is the ValueDecoderFunc for primitive.D instances.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) DDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || !val.CanSet() || val.Type() != tD {
 		return ValueDecoderError{Name: "DDecodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
@@ -235,6 +241,8 @@ func (dvd DefaultValueDecoders) booleanDecodeType(_ DecodeContext, vr bsonrw.Val
 }
 
 // BooleanDecodeValue is the ValueDecoderFunc for bool types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) BooleanDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || !val.CanSet() || val.Kind() != reflect.Bool {
 		return ValueDecoderError{Name: "BooleanDecodeValue", Kinds: []reflect.Kind{reflect.Bool}, Received: val}
@@ -333,6 +341,8 @@ func (DefaultValueDecoders) intDecodeType(dc DecodeContext, vr bsonrw.ValueReade
 }
 
 // IntDecodeValue is the ValueDecoderFunc for int types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) IntDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() {
 		return ValueDecoderError{
@@ -494,6 +504,8 @@ func (dvd DefaultValueDecoders) floatDecodeType(ec DecodeContext, vr bsonrw.Valu
 }
 
 // FloatDecodeValue is the ValueDecoderFunc for float types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) FloatDecodeValue(ec DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() {
 		return ValueDecoderError{
@@ -565,6 +577,8 @@ func (DefaultValueDecoders) javaScriptDecodeType(_ DecodeContext, vr bsonrw.Valu
 }
 
 // JavaScriptDecodeValue is the ValueDecoderFunc for the primitive.JavaScript type.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) JavaScriptDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tJavaScript {
 		return ValueDecoderError{Name: "JavaScriptDecodeValue", Types: []reflect.Type{tJavaScript}, Received: val}
@@ -620,6 +634,8 @@ func (DefaultValueDecoders) symbolDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 }
 
 // SymbolDecodeValue is the ValueDecoderFunc for the primitive.Symbol type.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) SymbolDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tSymbol {
 		return ValueDecoderError{Name: "SymbolDecodeValue", Types: []reflect.Type{tSymbol}, Received: val}
@@ -664,6 +680,8 @@ func (DefaultValueDecoders) binaryDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 }
 
 // BinaryDecodeValue is the ValueDecoderFunc for Binary.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) BinaryDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tBinary {
 		return ValueDecoderError{Name: "BinaryDecodeValue", Types: []reflect.Type{tBinary}, Received: val}
@@ -704,6 +722,8 @@ func (DefaultValueDecoders) undefinedDecodeType(_ DecodeContext, vr bsonrw.Value
 }
 
 // UndefinedDecodeValue is the ValueDecoderFunc for Undefined.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) UndefinedDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tUndefined {
 		return ValueDecoderError{Name: "UndefinedDecodeValue", Types: []reflect.Type{tUndefined}, Received: val}
@@ -765,6 +785,8 @@ func (dvd DefaultValueDecoders) objectIDDecodeType(_ DecodeContext, vr bsonrw.Va
 }
 
 // ObjectIDDecodeValue is the ValueDecoderFunc for primitive.ObjectID.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) ObjectIDDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tOID {
 		return ValueDecoderError{Name: "ObjectIDDecodeValue", Types: []reflect.Type{tOID}, Received: val}
@@ -808,6 +830,8 @@ func (DefaultValueDecoders) dateTimeDecodeType(_ DecodeContext, vr bsonrw.ValueR
 }
 
 // DateTimeDecodeValue is the ValueDecoderFunc for DateTime.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) DateTimeDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDateTime {
 		return ValueDecoderError{Name: "DateTimeDecodeValue", Types: []reflect.Type{tDateTime}, Received: val}
@@ -848,6 +872,8 @@ func (DefaultValueDecoders) nullDecodeType(_ DecodeContext, vr bsonrw.ValueReade
 }
 
 // NullDecodeValue is the ValueDecoderFunc for Null.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) NullDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tNull {
 		return ValueDecoderError{Name: "NullDecodeValue", Types: []reflect.Type{tNull}, Received: val}
@@ -891,6 +917,8 @@ func (DefaultValueDecoders) regexDecodeType(_ DecodeContext, vr bsonrw.ValueRead
 }
 
 // RegexDecodeValue is the ValueDecoderFunc for Regex.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) RegexDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRegex {
 		return ValueDecoderError{Name: "RegexDecodeValue", Types: []reflect.Type{tRegex}, Received: val}
@@ -935,6 +963,8 @@ func (DefaultValueDecoders) dBPointerDecodeType(_ DecodeContext, vr bsonrw.Value
 }
 
 // DBPointerDecodeValue is the ValueDecoderFunc for DBPointer.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) DBPointerDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDBPointer {
 		return ValueDecoderError{Name: "DBPointerDecodeValue", Types: []reflect.Type{tDBPointer}, Received: val}
@@ -978,6 +1008,8 @@ func (DefaultValueDecoders) timestampDecodeType(_ DecodeContext, vr bsonrw.Value
 }
 
 // TimestampDecodeValue is the ValueDecoderFunc for Timestamp.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) TimestampDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tTimestamp {
 		return ValueDecoderError{Name: "TimestampDecodeValue", Types: []reflect.Type{tTimestamp}, Received: val}
@@ -1020,6 +1052,8 @@ func (DefaultValueDecoders) minKeyDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 }
 
 // MinKeyDecodeValue is the ValueDecoderFunc for MinKey.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) MinKeyDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tMinKey {
 		return ValueDecoderError{Name: "MinKeyDecodeValue", Types: []reflect.Type{tMinKey}, Received: val}
@@ -1062,6 +1096,8 @@ func (DefaultValueDecoders) maxKeyDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 }
 
 // MaxKeyDecodeValue is the ValueDecoderFunc for MaxKey.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) MaxKeyDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tMaxKey {
 		return ValueDecoderError{Name: "MaxKeyDecodeValue", Types: []reflect.Type{tMaxKey}, Received: val}
@@ -1105,6 +1141,8 @@ func (dvd DefaultValueDecoders) decimal128DecodeType(_ DecodeContext, vr bsonrw.
 }
 
 // Decimal128DecodeValue is the ValueDecoderFunc for primitive.Decimal128.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) Decimal128DecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDecimal {
 		return ValueDecoderError{Name: "Decimal128DecodeValue", Types: []reflect.Type{tDecimal}, Received: val}
@@ -1164,6 +1202,8 @@ func (dvd DefaultValueDecoders) jsonNumberDecodeType(_ DecodeContext, vr bsonrw.
 }
 
 // JSONNumberDecodeValue is the ValueDecoderFunc for json.Number.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) JSONNumberDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tJSONNumber {
 		return ValueDecoderError{Name: "JSONNumberDecodeValue", Types: []reflect.Type{tJSONNumber}, Received: val}
@@ -1213,6 +1253,8 @@ func (dvd DefaultValueDecoders) urlDecodeType(_ DecodeContext, vr bsonrw.ValueRe
 }
 
 // URLDecodeValue is the ValueDecoderFunc for url.URL.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) URLDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tURL {
 		return ValueDecoderError{Name: "URLDecodeValue", Types: []reflect.Type{tURL}, Received: val}
@@ -1336,6 +1378,8 @@ func (dvd DefaultValueDecoders) MapDecodeValue(dc DecodeContext, vr bsonrw.Value
 }
 
 // ArrayDecodeValue is the ValueDecoderFunc for array types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) ArrayDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Array {
 		return ValueDecoderError{Name: "ArrayDecodeValue", Kinds: []reflect.Kind{reflect.Array}, Received: val}
@@ -1447,6 +1491,8 @@ func (dvd DefaultValueDecoders) SliceDecodeValue(dc DecodeContext, vr bsonrw.Val
 }
 
 // ValueUnmarshalerDecodeValue is the ValueDecoderFunc for ValueUnmarshaler implementations.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tValueUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tValueUnmarshaler)) {
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
@@ -1480,6 +1526,8 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 }
 
 // UnmarshalerDecodeValue is the ValueDecoderFunc for Unmarshaler implementations.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tUnmarshaler)) {
 		return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
@@ -1565,6 +1613,8 @@ func (dvd DefaultValueDecoders) EmptyInterfaceDecodeValue(dc DecodeContext, vr b
 }
 
 // CoreDocumentDecodeValue is the ValueDecoderFunc for bsoncore.Document.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (DefaultValueDecoders) CoreDocumentDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCoreDocument {
 		return ValueDecoderError{Name: "CoreDocumentDecodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
@@ -1671,6 +1721,8 @@ func (dvd DefaultValueDecoders) codeWithScopeDecodeType(dc DecodeContext, vr bso
 }
 
 // CodeWithScopeDecodeValue is the ValueDecoderFunc for CodeWithScope.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
 func (dvd DefaultValueDecoders) CodeWithScopeDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCodeWithScope {
 		return ValueDecoderError{Name: "CodeWithScopeDecodeValue", Types: []reflect.Type{tCodeWithScope}, Received: val}

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -58,10 +58,14 @@ func encodeElement(ec EncodeContext, dw bsonrw.DocumentWriter, e primitive.E) er
 
 // DefaultValueEncoders is a namespace type for the default ValueEncoders used
 // when creating a registry.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 type DefaultValueEncoders struct{}
 
 // RegisterDefaultEncoders will register the encoder methods attached to DefaultValueEncoders with
 // the provided RegistryBuilder.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 	if rb == nil {
 		panic(errors.New("argument to RegisterDefaultEncoders must not be nil"))
@@ -113,6 +117,8 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 }
 
 // BooleanEncodeValue is the ValueEncoderFunc for bool types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) BooleanEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Bool {
 		return ValueEncoderError{Name: "BooleanEncodeValue", Kinds: []reflect.Kind{reflect.Bool}, Received: val}
@@ -125,6 +131,8 @@ func fitsIn32Bits(i int64) bool {
 }
 
 // IntEncodeValue is the ValueEncoderFunc for int types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) IntEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	switch val.Kind() {
 	case reflect.Int8, reflect.Int16, reflect.Int32:
@@ -176,6 +184,8 @@ func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.Valu
 }
 
 // FloatEncodeValue is the ValueEncoderFunc for float types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) FloatEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	switch val.Kind() {
 	case reflect.Float32, reflect.Float64:
@@ -201,6 +211,8 @@ func (dve DefaultValueEncoders) StringEncodeValue(_ EncodeContext, vw bsonrw.Val
 }
 
 // ObjectIDEncodeValue is the ValueEncoderFunc for primitive.ObjectID.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) ObjectIDEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tOID {
 		return ValueEncoderError{Name: "ObjectIDEncodeValue", Types: []reflect.Type{tOID}, Received: val}
@@ -209,6 +221,8 @@ func (dve DefaultValueEncoders) ObjectIDEncodeValue(_ EncodeContext, vw bsonrw.V
 }
 
 // Decimal128EncodeValue is the ValueEncoderFunc for primitive.Decimal128.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) Decimal128EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDecimal {
 		return ValueEncoderError{Name: "Decimal128EncodeValue", Types: []reflect.Type{tDecimal}, Received: val}
@@ -217,6 +231,8 @@ func (dve DefaultValueEncoders) Decimal128EncodeValue(_ EncodeContext, vw bsonrw
 }
 
 // JSONNumberEncodeValue is the ValueEncoderFunc for json.Number.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) JSONNumberEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tJSONNumber {
 		return ValueEncoderError{Name: "JSONNumberEncodeValue", Types: []reflect.Type{tJSONNumber}, Received: val}
@@ -237,6 +253,8 @@ func (dve DefaultValueEncoders) JSONNumberEncodeValue(ec EncodeContext, vw bsonr
 }
 
 // URLEncodeValue is the ValueEncoderFunc for url.URL.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) URLEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tURL {
 		return ValueEncoderError{Name: "URLEncodeValue", Types: []reflect.Type{tURL}, Received: val}
@@ -343,6 +361,8 @@ func (dve DefaultValueEncoders) mapEncodeValue(ec EncodeContext, dw bsonrw.Docum
 }
 
 // ArrayEncodeValue is the ValueEncoderFunc for array types.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) ArrayEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Array {
 		return ValueEncoderError{Name: "ArrayEncodeValue", Kinds: []reflect.Kind{reflect.Array}, Received: val}
@@ -515,6 +535,8 @@ func (dve DefaultValueEncoders) EmptyInterfaceEncodeValue(ec EncodeContext, vw b
 }
 
 // ValueMarshalerEncodeValue is the ValueEncoderFunc for ValueMarshaler implementations.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement ValueMarshaler
 	switch {
@@ -541,6 +563,8 @@ func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bs
 }
 
 // MarshalerEncodeValue is the ValueEncoderFunc for Marshaler implementations.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement Marshaler
 	switch {
@@ -567,6 +591,8 @@ func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.
 }
 
 // ProxyEncodeValue is the ValueEncoderFunc for Proxy implementations.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement Proxy
 	switch {
@@ -603,6 +629,8 @@ func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.Val
 }
 
 // JavaScriptEncodeValue is the ValueEncoderFunc for the primitive.JavaScript type.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) JavaScriptEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tJavaScript {
 		return ValueEncoderError{Name: "JavaScriptEncodeValue", Types: []reflect.Type{tJavaScript}, Received: val}
@@ -612,6 +640,8 @@ func (DefaultValueEncoders) JavaScriptEncodeValue(_ EncodeContext, vw bsonrw.Val
 }
 
 // SymbolEncodeValue is the ValueEncoderFunc for the primitive.Symbol type.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) SymbolEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tSymbol {
 		return ValueEncoderError{Name: "SymbolEncodeValue", Types: []reflect.Type{tSymbol}, Received: val}
@@ -621,6 +651,8 @@ func (DefaultValueEncoders) SymbolEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 }
 
 // BinaryEncodeValue is the ValueEncoderFunc for Binary.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) BinaryEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tBinary {
 		return ValueEncoderError{Name: "BinaryEncodeValue", Types: []reflect.Type{tBinary}, Received: val}
@@ -631,6 +663,8 @@ func (DefaultValueEncoders) BinaryEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 }
 
 // UndefinedEncodeValue is the ValueEncoderFunc for Undefined.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) UndefinedEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tUndefined {
 		return ValueEncoderError{Name: "UndefinedEncodeValue", Types: []reflect.Type{tUndefined}, Received: val}
@@ -640,6 +674,8 @@ func (DefaultValueEncoders) UndefinedEncodeValue(_ EncodeContext, vw bsonrw.Valu
 }
 
 // DateTimeEncodeValue is the ValueEncoderFunc for DateTime.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) DateTimeEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDateTime {
 		return ValueEncoderError{Name: "DateTimeEncodeValue", Types: []reflect.Type{tDateTime}, Received: val}
@@ -649,6 +685,8 @@ func (DefaultValueEncoders) DateTimeEncodeValue(_ EncodeContext, vw bsonrw.Value
 }
 
 // NullEncodeValue is the ValueEncoderFunc for Null.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) NullEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tNull {
 		return ValueEncoderError{Name: "NullEncodeValue", Types: []reflect.Type{tNull}, Received: val}
@@ -658,6 +696,8 @@ func (DefaultValueEncoders) NullEncodeValue(_ EncodeContext, vw bsonrw.ValueWrit
 }
 
 // RegexEncodeValue is the ValueEncoderFunc for Regex.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) RegexEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRegex {
 		return ValueEncoderError{Name: "RegexEncodeValue", Types: []reflect.Type{tRegex}, Received: val}
@@ -669,6 +709,8 @@ func (DefaultValueEncoders) RegexEncodeValue(_ EncodeContext, vw bsonrw.ValueWri
 }
 
 // DBPointerEncodeValue is the ValueEncoderFunc for DBPointer.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) DBPointerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDBPointer {
 		return ValueEncoderError{Name: "DBPointerEncodeValue", Types: []reflect.Type{tDBPointer}, Received: val}
@@ -680,6 +722,8 @@ func (DefaultValueEncoders) DBPointerEncodeValue(_ EncodeContext, vw bsonrw.Valu
 }
 
 // TimestampEncodeValue is the ValueEncoderFunc for Timestamp.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) TimestampEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tTimestamp {
 		return ValueEncoderError{Name: "TimestampEncodeValue", Types: []reflect.Type{tTimestamp}, Received: val}
@@ -691,6 +735,8 @@ func (DefaultValueEncoders) TimestampEncodeValue(_ EncodeContext, vw bsonrw.Valu
 }
 
 // MinKeyEncodeValue is the ValueEncoderFunc for MinKey.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) MinKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMinKey {
 		return ValueEncoderError{Name: "MinKeyEncodeValue", Types: []reflect.Type{tMinKey}, Received: val}
@@ -700,6 +746,8 @@ func (DefaultValueEncoders) MinKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 }
 
 // MaxKeyEncodeValue is the ValueEncoderFunc for MaxKey.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) MaxKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMaxKey {
 		return ValueEncoderError{Name: "MaxKeyEncodeValue", Types: []reflect.Type{tMaxKey}, Received: val}
@@ -709,6 +757,8 @@ func (DefaultValueEncoders) MaxKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 }
 
 // CoreDocumentEncodeValue is the ValueEncoderFunc for bsoncore.Document.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (DefaultValueEncoders) CoreDocumentEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCoreDocument {
 		return ValueEncoderError{Name: "CoreDocumentEncodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
@@ -720,6 +770,8 @@ func (DefaultValueEncoders) CoreDocumentEncodeValue(_ EncodeContext, vw bsonrw.V
 }
 
 // CodeWithScopeEncodeValue is the ValueEncoderFunc for CodeWithScope.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
 func (dve DefaultValueEncoders) CodeWithScopeEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCodeWithScope {
 		return ValueEncoderError{Name: "CodeWithScopeEncodeValue", Types: []reflect.Type{tCodeWithScope}, Received: val}

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -21,10 +21,16 @@ var primitiveCodecs PrimitiveCodecs
 
 // PrimitiveCodecs is a namespace for all of the default bsoncodec.Codecs for the primitive types
 // defined in this package.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 type PrimitiveCodecs struct{}
 
 // RegisterPrimitiveCodecs will register the encode and decode methods attached to PrimitiveCodecs
 // with the provided RegistryBuilder. if rb is nil, a new empty RegistryBuilder will be created.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder) {
 	if rb == nil {
 		panic(errors.New("argument to RegisterPrimitiveCodecs must not be nil"))
@@ -38,6 +44,9 @@ func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder)
 }
 
 // RawValueEncodeValue is the ValueEncoderFunc for RawValue.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRawValue {
 		return bsoncodec.ValueEncoderError{Name: "RawValueEncodeValue", Types: []reflect.Type{tRawValue}, Received: val}
@@ -49,6 +58,9 @@ func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.
 }
 
 // RawValueDecodeValue is the ValueDecoderFunc for RawValue.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 func (PrimitiveCodecs) RawValueDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRawValue {
 		return bsoncodec.ValueDecoderError{Name: "RawValueDecodeValue", Types: []reflect.Type{tRawValue}, Received: val}
@@ -64,6 +76,9 @@ func (PrimitiveCodecs) RawValueDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.
 }
 
 // RawEncodeValue is the ValueEncoderFunc for Reader.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 func (PrimitiveCodecs) RawEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRaw {
 		return bsoncodec.ValueEncoderError{Name: "RawEncodeValue", Types: []reflect.Type{tRaw}, Received: val}
@@ -75,6 +90,9 @@ func (PrimitiveCodecs) RawEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.Value
 }
 
 // RawDecodeValue is the ValueDecoderFunc for Reader.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
+// registered.
 func (PrimitiveCodecs) RawDecodeValue(_ bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRaw {
 		return bsoncodec.ValueDecoderError{Name: "RawDecodeValue", Types: []reflect.Type{tRaw}, Received: val}


### PR DESCRIPTION
[GODRIVER-2709](https://jira.mongodb.org/browse/GODRIVER-2709)

## Summary
Deprecate `DefaultValueEncoders`, `DefaultValueDecoders`, and `PrimitiveCodecs` and all exported methods of those types. Recommend that users call `bson.NewRegistry` to get a default registry instead.

## Background & Motivation
The only known use cases for using of the `DefaultValueEncoders`, `DefaultValueDecoders`, and `PrimitiveCodecs` types and methods is to create a default `Registry` of value encoders/decoders. That can already be accomplished by calling `bson.NewRegistry`, so the `DefaultValueEncoders`, `DefaultValueDecoders`, and `PrimitiveCodecs` types and methods are redundant and create confusion with users.

