### PR TITLE
GODRIVER-2606 Deprecate unused code in preparation to remove it in Go Driver 2.0

### DIFF
--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -23,6 +23,8 @@ var (
 // Marshaler is an interface implemented by types that can marshal themselves
 // into a BSON document represented as bytes. The bytes returned must be a valid
 // BSON document if the error is nil.
+//
+// Deprecated: Use bson.Marshaler instead.
 type Marshaler interface {
 	MarshalBSON() ([]byte, error)
 }
@@ -31,6 +33,8 @@ type Marshaler interface {
 // themselves into a BSON value as bytes. The type must be the valid type for
 // the bytes returned. The bytes and byte type together must be valid if the
 // error is nil.
+//
+// Deprecated: Use bson.ValueMarshaler instead.
 type ValueMarshaler interface {
 	MarshalBSONValue() (bsontype.Type, []byte, error)
 }
@@ -39,6 +43,8 @@ type ValueMarshaler interface {
 // document representation of themselves. The BSON bytes can be assumed to be
 // valid. UnmarshalBSON must copy the BSON bytes if it wishes to retain the data
 // after returning.
+//
+// Deprecated: Use bson.Unmarshaler instead.
 type Unmarshaler interface {
 	UnmarshalBSON([]byte) error
 }
@@ -47,6 +53,8 @@ type Unmarshaler interface {
 // BSON value representation of themselves. The BSON bytes and type can be
 // assumed to be valid. UnmarshalBSONValue must copy the BSON value bytes if it
 // wishes to retain the data after returning.
+//
+// Deprecated: Use bson.ValueUnmarshaler instead.
 type ValueUnmarshaler interface {
 	UnmarshalBSONValue(bsontype.Type, []byte) error
 }

--- a/bson/bsonrw/extjson_reader.go
+++ b/bson/bsonrw/extjson_reader.go
@@ -16,11 +16,15 @@ import (
 )
 
 // ExtJSONValueReaderPool is a pool for ValueReaders that read ExtJSON.
+//
+// Deprecated: ExtJSONValueReaderPool will not be supported in Go Driver 2.0.
 type ExtJSONValueReaderPool struct {
 	pool sync.Pool
 }
 
 // NewExtJSONValueReaderPool instantiates a new ExtJSONValueReaderPool.
+//
+// Deprecated: ExtJSONValueReaderPool will not be supported in Go Driver 2.0.
 func NewExtJSONValueReaderPool() *ExtJSONValueReaderPool {
 	return &ExtJSONValueReaderPool{
 		pool: sync.Pool{
@@ -32,6 +36,8 @@ func NewExtJSONValueReaderPool() *ExtJSONValueReaderPool {
 }
 
 // Get retrieves a ValueReader from the pool and uses src as the underlying ExtJSON.
+//
+// Deprecated: ExtJSONValueReaderPool will not be supported in Go Driver 2.0.
 func (bvrp *ExtJSONValueReaderPool) Get(r io.Reader, canonical bool) (ValueReader, error) {
 	vr := bvrp.pool.Get().(*extJSONValueReader)
 	return vr.reset(r, canonical)
@@ -39,6 +45,8 @@ func (bvrp *ExtJSONValueReaderPool) Get(r io.Reader, canonical bool) (ValueReade
 
 // Put inserts a ValueReader into the pool. If the ValueReader is not a ExtJSON ValueReader nothing
 // is inserted into the pool and ok will be false.
+//
+// Deprecated: ExtJSONValueReaderPool will not be supported in Go Driver 2.0.
 func (bvrp *ExtJSONValueReaderPool) Put(vr ValueReader) (ok bool) {
 	bvr, ok := vr.(*extJSONValueReader)
 	if !ok {

--- a/bson/bsonrw/extjson_writer.go
+++ b/bson/bsonrw/extjson_writer.go
@@ -23,11 +23,15 @@ import (
 )
 
 // ExtJSONValueWriterPool is a pool for ExtJSON ValueWriters.
+//
+// Deprecated: ExtJSONValueWriterPool will not be supported in Go Driver 2.0.
 type ExtJSONValueWriterPool struct {
 	pool sync.Pool
 }
 
 // NewExtJSONValueWriterPool creates a new pool for ValueWriter instances that write to ExtJSON.
+//
+// Deprecated: ExtJSONValueWriterPool will not be supported in Go Driver 2.0.
 func NewExtJSONValueWriterPool() *ExtJSONValueWriterPool {
 	return &ExtJSONValueWriterPool{
 		pool: sync.Pool{
@@ -39,6 +43,8 @@ func NewExtJSONValueWriterPool() *ExtJSONValueWriterPool {
 }
 
 // Get retrieves a ExtJSON ValueWriter from the pool and resets it to use w as the destination.
+//
+// Deprecated: ExtJSONValueWriterPool will not be supported in Go Driver 2.0.
 func (bvwp *ExtJSONValueWriterPool) Get(w io.Writer, canonical, escapeHTML bool) ValueWriter {
 	vw := bvwp.pool.Get().(*extJSONValueWriter)
 	if writer, ok := w.(*SliceWriter); ok {
@@ -53,6 +59,8 @@ func (bvwp *ExtJSONValueWriterPool) Get(w io.Writer, canonical, escapeHTML bool)
 
 // Put inserts a ValueWriter into the pool. If the ValueWriter is not a ExtJSON ValueWriter, nothing
 // happens and ok will be false.
+//
+// Deprecated: ExtJSONValueWriterPool will not be supported in Go Driver 2.0.
 func (bvwp *ExtJSONValueWriterPool) Put(vw ValueWriter) (ok bool) {
 	bvw, ok := vw.(*extJSONValueWriter)
 	if !ok {

--- a/bson/bsonrw/value_reader.go
+++ b/bson/bsonrw/value_reader.go
@@ -28,11 +28,15 @@ var vrPool = sync.Pool{
 }
 
 // BSONValueReaderPool is a pool for ValueReaders that read BSON.
+//
+// Deprecated: BSONValueReaderPool will not be supported in Go Driver 2.0.
 type BSONValueReaderPool struct {
 	pool sync.Pool
 }
 
 // NewBSONValueReaderPool instantiates a new BSONValueReaderPool.
+//
+// Deprecated: BSONValueReaderPool will not be supported in Go Driver 2.0.
 func NewBSONValueReaderPool() *BSONValueReaderPool {
 	return &BSONValueReaderPool{
 		pool: sync.Pool{
@@ -44,6 +48,8 @@ func NewBSONValueReaderPool() *BSONValueReaderPool {
 }
 
 // Get retrieves a ValueReader from the pool and uses src as the underlying BSON.
+//
+// Deprecated: BSONValueReaderPool will not be supported in Go Driver 2.0.
 func (bvrp *BSONValueReaderPool) Get(src []byte) ValueReader {
 	vr := bvrp.pool.Get().(*valueReader)
 	vr.reset(src)
@@ -52,6 +58,8 @@ func (bvrp *BSONValueReaderPool) Get(src []byte) ValueReader {
 
 // Put inserts a ValueReader into the pool. If the ValueReader is not a BSON ValueReader nothing
 // is inserted into the pool and ok will be false.
+//
+// Deprecated: BSONValueReaderPool will not be supported in Go Driver 2.0.
 func (bvrp *BSONValueReaderPool) Put(vr ValueReader) (ok bool) {
 	bvr, ok := vr.(*valueReader)
 	if !ok {

--- a/bson/bsonrw/value_writer.go
+++ b/bson/bsonrw/value_writer.go
@@ -29,11 +29,15 @@ var vwPool = sync.Pool{
 }
 
 // BSONValueWriterPool is a pool for BSON ValueWriters.
+//
+// Deprecated: BSONValueWriterPool will not be supported in Go Driver 2.0.
 type BSONValueWriterPool struct {
 	pool sync.Pool
 }
 
 // NewBSONValueWriterPool creates a new pool for ValueWriter instances that write to BSON.
+//
+// Deprecated: BSONValueWriterPool will not be supported in Go Driver 2.0.
 func NewBSONValueWriterPool() *BSONValueWriterPool {
 	return &BSONValueWriterPool{
 		pool: sync.Pool{
@@ -45,6 +49,8 @@ func NewBSONValueWriterPool() *BSONValueWriterPool {
 }
 
 // Get retrieves a BSON ValueWriter from the pool and resets it to use w as the destination.
+//
+// Deprecated: BSONValueWriterPool will not be supported in Go Driver 2.0.
 func (bvwp *BSONValueWriterPool) Get(w io.Writer) ValueWriter {
 	vw := bvwp.pool.Get().(*valueWriter)
 
@@ -56,6 +62,8 @@ func (bvwp *BSONValueWriterPool) Get(w io.Writer) ValueWriter {
 }
 
 // GetAtModeElement retrieves a ValueWriterFlusher from the pool and resets it to use w as the destination.
+//
+// Deprecated: BSONValueWriterPool will not be supported in Go Driver 2.0.
 func (bvwp *BSONValueWriterPool) GetAtModeElement(w io.Writer) ValueWriterFlusher {
 	vw := bvwp.Get(w).(*valueWriter)
 	vw.push(mElement)
@@ -64,6 +72,8 @@ func (bvwp *BSONValueWriterPool) GetAtModeElement(w io.Writer) ValueWriterFlushe
 
 // Put inserts a ValueWriter into the pool. If the ValueWriter is not a BSON ValueWriter, nothing
 // happens and ok will be false.
+//
+// Deprecated: BSONValueWriterPool will not be supported in Go Driver 2.0.
 func (bvwp *BSONValueWriterPool) Put(vw ValueWriter) (ok bool) {
 	bvw, ok := vw.(*valueWriter)
 	if !ok {

--- a/bson/bsonrw/writer.go
+++ b/bson/bsonrw/writer.go
@@ -69,8 +69,13 @@ type BytesWriter interface {
 }
 
 // SliceWriter allows a pointer to a slice of bytes to be used as an io.Writer.
+//
+// Deprecated: SliceWriter will not be supported in Go Driver 2.0.
 type SliceWriter []byte
 
+// Write writes the bytes to the underlying slice.
+//
+// Deprecated: SliceWriter will not be supported in Go Driver 2.0.
 func (sw *SliceWriter) Write(p []byte) (int, error) {
 	written := len(p)
 	*sw = append(*sw, p...)

--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -8,7 +8,9 @@
 // a stringifier for the Type to enable easier debugging when working with BSON.
 package bsontype // import "go.mongodb.org/mongo-driver/bson/bsontype"
 
-// These constants uniquely refer to each BSON type.
+// BSON element types as described in https://bsonspec.org/spec.html.
+//
+// Deprecated: Use bson.Type* constants instead.
 const (
 	Double           Type = 0x01
 	String           Type = 0x02
@@ -31,7 +33,12 @@ const (
 	Decimal128       Type = 0x13
 	MinKey           Type = 0xFF
 	MaxKey           Type = 0x7F
+)
 
+// BSON binary element subtypes as described in https://bsonspec.org/spec.html.
+//
+// Deprecated: Use the bson.TypeBinary* constants instead.
+const (
 	BinaryGeneric     byte = 0x00
 	BinaryFunction    byte = 0x01
 	BinaryBinaryOld   byte = 0x02

--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -92,6 +92,8 @@ func ObjectIDFromHex(s string) (ObjectID, error) {
 }
 
 // IsValidObjectID returns true if the provided hex string represents a valid ObjectID and false if not.
+//
+// Deprecated: Use ObjectIDFromHex and check the error instead.
 func IsValidObjectID(s string) bool {
 	_, err := ObjectIDFromHex(s)
 	return err == nil

--- a/bson/types.go
+++ b/bson/types.go
@@ -10,7 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
-// These constants uniquely refer to each BSON type.
+// BSON element types as described in https://bsonspec.org/spec.html.
 const (
 	TypeDouble           = bsontype.Double
 	TypeString           = bsontype.String
@@ -33,4 +33,17 @@ const (
 	TypeDecimal128       = bsontype.Decimal128
 	TypeMinKey           = bsontype.MinKey
 	TypeMaxKey           = bsontype.MaxKey
+)
+
+// BSON binary element subtypes as described in https://bsonspec.org/spec.html.
+const (
+	TypeBinaryGeneric     = bsontype.BinaryGeneric
+	TypeBinaryFunction    = bsontype.BinaryFunction
+	TypeBinaryBinaryOld   = bsontype.BinaryBinaryOld
+	TypeBinaryUUIDOld     = bsontype.BinaryUUIDOld
+	TypeBinaryUUID        = bsontype.BinaryUUID
+	TypeBinaryMD5         = bsontype.BinaryMD5
+	TypeBinaryEncrypted   = bsontype.BinaryEncrypted
+	TypeBinaryColumn      = bsontype.BinaryColumn
+	TypeBinaryUserDefined = bsontype.BinaryUserDefined
 )

--- a/mongo/gridfs/download_stream.go
+++ b/mongo/gridfs/download_stream.go
@@ -84,6 +84,8 @@ type unmarshalFile struct {
 }
 
 // UnmarshalBSON implements the bson.Unmarshaler interface.
+//
+// Deprecated: Unmarshaling a File from BSON will not be supported in Go Driver 2.0.
 func (f *File) UnmarshalBSON(data []byte) error {
 	var temp unmarshalFile
 	if err := bson.Unmarshal(data, &temp); err != nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -33,6 +33,8 @@ type Dialer interface {
 // provided type into BSON bytes and append those bytes to the provided []byte.
 // The AppendBSON can return a non-nil error and non-nil []byte. The AppendBSON
 // method may also write incomplete BSON to the []byte.
+//
+// Deprecated: BSONAppender is unused and will be removed in Go Driver 2.0.
 type BSONAppender interface {
 	AppendBSON([]byte, interface{}) ([]byte, error)
 }
@@ -40,9 +42,13 @@ type BSONAppender interface {
 // BSONAppenderFunc is an adapter function that allows any function that
 // satisfies the AppendBSON method signature to be used where a BSONAppender is
 // used.
+//
+// Deprecated: BSONAppenderFunc is unused and will be removed in Go Driver 2.0.
 type BSONAppenderFunc func([]byte, interface{}) ([]byte, error)
 
 // AppendBSON implements the BSONAppender interface
+//
+// Deprecated: BSONAppenderFunc is unused and will be removed in Go Driver 2.0.
 func (baf BSONAppenderFunc) AppendBSON(dst []byte, val interface{}) ([]byte, error) {
 	return baf(dst, val)
 }

--- a/mongo/options/mongooptions.go
+++ b/mongo/options/mongooptions.go
@@ -31,6 +31,8 @@ type Collation struct {
 }
 
 // ToDocument converts the Collation to a bson.Raw.
+//
+// Deprecated: Marshaling a Collation to BSON will not be supported in Go Driver 2.0.
 func (co *Collation) ToDocument() bson.Raw {
 	idx, doc := bsoncore.AppendDocumentStart(nil)
 	if co.Locale != "" {
@@ -110,11 +112,17 @@ const (
 // ArrayFilters is used to hold filters for the array filters CRUD option. If a registry is nil, bson.DefaultRegistry
 // will be used when converting the filter interfaces to BSON.
 type ArrayFilters struct {
-	Registry *bsoncodec.Registry // The registry to use for converting filters. Defaults to bson.DefaultRegistry.
-	Filters  []interface{}       // The filters to apply
+	// Registry is the registry to use for converting filters. Defaults to bson.DefaultRegistry.
+	//
+	// Deprecated: Marshaling ArrayFilters to BSON will not be supported in Go Driver 2.0.
+	Registry *bsoncodec.Registry
+
+	Filters []interface{} // The filters to apply
 }
 
 // ToArray builds a []bson.Raw from the provided ArrayFilters.
+//
+// Deprecated: Marshaling ArrayFilters to BSON will not be supported in Go Driver 2.0.
 func (af *ArrayFilters) ToArray() ([]bson.Raw, error) {
 	registry := af.Registry
 	if registry == nil {
@@ -133,6 +141,8 @@ func (af *ArrayFilters) ToArray() ([]bson.Raw, error) {
 
 // ToArrayDocument builds a BSON array for the array filters CRUD option. If the registry for af is nil,
 // bson.DefaultRegistry will be used when converting the filter interfaces to BSON.
+//
+// Deprecated: Marshaling ArrayFilters to BSON will not be supported in Go Driver 2.0.
 func (af *ArrayFilters) ToArrayDocument() (bson.Raw, error) {
 	registry := af.Registry
 	if registry == nil {
@@ -154,12 +164,16 @@ func (af *ArrayFilters) ToArrayDocument() (bson.Raw, error) {
 
 // MarshalError is returned when attempting to transform a value into a document
 // results in an error.
+//
+// Deprecated: MarshalError is unused and will be removed in Go Driver 2.0.
 type MarshalError struct {
 	Value interface{}
 	Err   error
 }
 
 // Error implements the error interface.
+//
+// Deprecated: MarshalError is unused and will be removed in Go Driver 2.0.
 func (me MarshalError) Error() string {
 	return fmt.Sprintf("cannot transform type %s to a bson.Raw", reflect.TypeOf(me.Value))
 }

--- a/mongo/results.go
+++ b/mongo/results.go
@@ -201,6 +201,8 @@ type unmarshalIndexSpecification struct {
 }
 
 // UnmarshalBSON implements the bson.Unmarshaler interface.
+//
+// Deprecated: Unmarshaling an IndexSpecification from BSON will not be supported in Go Driver 2.0.
 func (i *IndexSpecification) UnmarshalBSON(data []byte) error {
 	var temp unmarshalIndexSpecification
 	if err := bson.Unmarshal(data, &temp); err != nil {
@@ -258,6 +260,9 @@ type unmarshalCollectionSpecification struct {
 }
 
 // UnmarshalBSON implements the bson.Unmarshaler interface.
+//
+// Deprecated: Unmarshaling a CollectionSpecification from BSON will not be supported in Go Driver
+// 2.0.
 func (cs *CollectionSpecification) UnmarshalBSON(data []byte) error {
 	var temp unmarshalCollectionSpecification
 	if err := bson.Unmarshal(data, &temp); err != nil {

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -140,6 +140,8 @@ func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 
 // AcknowledgedValue returns true if a BSON RawValue for a write concern represents an acknowledged write concern.
 // The element's value must be a document representing a write concern.
+//
+// Deprecated: AcknowledgedValue will not be supported in Go Driver 2.0.
 func AcknowledgedValue(rawv bson.RawValue) bool {
 	doc, ok := bsoncore.Value{Type: rawv.Type, Data: rawv.Value}.DocumentOK()
 	if !ok {


### PR DESCRIPTION
[GODRIVER-2606](https://jira.mongodb.org/browse/GODRIVER-2606)

## Summary
Deprecate unused code in preparation to remove it in Go Driver 2.0. Suggest replacements if there is one.

## Background & Motivation
There is a lot of functionality that appears totally unused in the Go Driver API. We've kept it around to maintain backward compatibility. Mark all of the seemingly unused types and functions as deprecated so we can reduce the negative impact of removing them in Go Driver 2.0.

### Buckets
Totally unused:
* `mongo.BSONAppender`
* `mongo.BSONAppenderFunc`
* `options.MarshalError`

No known use case:
* `options.Collation.ToDocument`
* `options.ArrayFilters.ToArray`
* `options.ArrayFilters.ToArrayDocument`
* `options.ArrayFilters.Registry`
* `bsonrw.SliceWriter`
* `writeconcern.AcknowledgedValue`

Used internally but no known use case externally:
* `mongo.CollectionSpecification.UnmarshalBSON`
* `gridfs.File.UnmarshalBSON`
* `mongo.IndexSpecification.UnmarshalBSON`
* `bsonrw.BSONValueReaderPool`
* `bsonrw.BSONValueReaderPool`
* `bsonrw.ExtJSONValueReaderPool`
* `bsonrw.ExtJSONValueWriterPool`

Duplicate:
* All BSON element type constants in the `bsontype` package. Also defined in the `bson` package.
* `primitive.IsValidObjectID`. Thin wrapper around error checking for `primitive.ObjectIDFromHex`.
* `bsoncodec.Marshaler`. Duplicated exactly in the `bson` package.
* `bsoncodec.Unmarshaler`. Duplicated exactly in the `bson` package.


