### PR TITLE
GODRIVER-2761 Skip QE tests against latest servers

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -78,7 +78,6 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		},
 	}
 
-	runOpts := mtest.NewOptions().MinServerVersion("6.0").Topologies(mtest.ReplicaSet, mtest.LoadBalanced, mtest.ShardedReplicaSet)
 	mt.Run("1. custom key material test", func(mt *mtest.T) {
 		const (
 			dkCollection = "datakeys"
@@ -1534,6 +1533,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			})
 		}
 	})
+	runOpts := mtest.NewOptions().MinServerVersion("6.0").MaxServerVersion("6.2.99").Topologies(mtest.ReplicaSet, mtest.LoadBalanced, mtest.ShardedReplicaSet)
 	mt.RunOpts("12. explicit encryption", runOpts, func(mt *mtest.T) {
 		// Test Setup ... begin
 		encryptedFields := readJSONFile(mt, "encrypted-fields.json")

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -477,6 +477,7 @@ func TestFLE2DocsExample(t *testing.T) {
 	// FLE 2 is not supported on Standalone topology.
 	mtOpts := mtest.NewOptions().
 		MinServerVersion("6.0").
+		MaxServerVersion("6.2.99").
 		Enterprise(true).
 		CreateClient(false).
 		Topologies(mtest.ReplicaSet,

--- a/testdata/client-side-encryption/legacy/fle2-BypassQueryAnalysis.json
+++ b/testdata/client-side-encryption/legacy/fle2-BypassQueryAnalysis.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-BypassQueryAnalysis.yml
+++ b/testdata/client-side-encryption/legacy/fle2-BypassQueryAnalysis.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-Compact.json
+++ b/testdata/client-side-encryption/legacy/fle2-Compact.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-Compact.yml
+++ b/testdata/client-side-encryption/legacy/fle2-Compact.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-CreateCollection.json
+++ b/testdata/client-side-encryption/legacy/fle2-CreateCollection.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-CreateCollection.yml
+++ b/testdata/client-side-encryption/legacy/fle2-CreateCollection.yml
@@ -1,6 +1,8 @@
 # This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
     

--- a/testdata/client-side-encryption/legacy/fle2-DecryptExistingData.json
+++ b/testdata/client-side-encryption/legacy/fle2-DecryptExistingData.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-DecryptExistingData.yml
+++ b/testdata/client-side-encryption/legacy/fle2-DecryptExistingData.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2-Delete.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-jsonSchema.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFieldsMap-defaults.json
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFieldsMap-defaults.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-EncryptedFieldsMap-defaults.yml
+++ b/testdata/client-side-encryption/legacy/fle2-EncryptedFieldsMap-defaults.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2-FindOneAndUpdate.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-InsertFind-Indexed.json
+++ b/testdata/client-side-encryption/legacy/fle2-InsertFind-Indexed.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-InsertFind-Indexed.yml
+++ b/testdata/client-side-encryption/legacy/fle2-InsertFind-Indexed.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-InsertFind-Unindexed.json
+++ b/testdata/client-side-encryption/legacy/fle2-InsertFind-Unindexed.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-InsertFind-Unindexed.yml
+++ b/testdata/client-side-encryption/legacy/fle2-InsertFind-Unindexed.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-MissingKey.json
+++ b/testdata/client-side-encryption/legacy/fle2-MissingKey.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-MissingKey.yml
+++ b/testdata/client-side-encryption/legacy/fle2-MissingKey.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-NoEncryption.json
+++ b/testdata/client-side-encryption/legacy/fle2-NoEncryption.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-NoEncryption.yml
+++ b/testdata/client-side-encryption/legacy/fle2-NoEncryption.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2-Update.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/testdata/client-side-encryption/legacy/fle2-validatorAndPartialFieldExpression.json
+++ b/testdata/client-side-encryption/legacy/fle2-validatorAndPartialFieldExpression.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/testdata/client-side-encryption/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/testdata/client-side-encryption/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -1,7 +1,9 @@
 # This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
-    - minServerVersion: "6.0.0"
+    - maxServerVersion: "6.2.99"
+      # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+      minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
       topology: [ "replicaset", "sharded", "load-balanced" ]
 


### PR DESCRIPTION
# Summary

- Sync `fle2-*` tests to https://github.com/mongodb/specifications/commit/baf3724155500acbb557e158b8a5d4334e7f3512
- Skip Queryable Encryption tests on server 6.2.99+

Verified changes with this patch build: https://spruce.mongodb.com/version/642c791d57e85a7b3b167af7/

# Background & Motivation

The feature flag for Queryable Encryption v2 is now enabled by default: [SERVER-69563](https://jira.mongodb.org/browse/SERVER-69563).
QEv2 introduces backwards breaking changes. Test failures are expected. E.g. using a driver with QEv1 on a server for QEv2 results in a server error. Here is an example: (Location7292602) Encountered a Queryable Encryption find payload type that is no longer supported: 5
This PR backports test updates to skip testing QE on server 6.2.99+. QEv2 support is not intended to be backported.