### PR TITLE
GODRIVER-2712 Deprecate BSON Encoder and Decoder 'Context' methods.

### DIFF
--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -53,6 +53,9 @@ func NewDecoder(vr bsonrw.ValueReader) (*Decoder, error) {
 }
 
 // NewDecoderWithContext returns a new decoder that uses DecodeContext dc to read from vr.
+//
+// Deprecated: Use bson.NewDecoder and use the Decoder configuration methods set the desired
+// behavior of the decoder instead.
 func NewDecoderWithContext(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader) (*Decoder, error) {
 	if dc.Registry == nil {
 		dc.Registry = DefaultRegistry
@@ -123,6 +126,9 @@ func (d *Decoder) SetRegistry(r *bsoncodec.Registry) error {
 }
 
 // SetContext replaces the current registry of the decoder with dc.
+//
+// Deprecated: Use the Decoder configuration methods set the desired behavior of the decoder
+// instead.
 func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 	d.dc = dc
 	return nil

--- a/bson/encoder.go
+++ b/bson/encoder.go
@@ -44,6 +44,9 @@ func NewEncoder(vw bsonrw.ValueWriter) (*Encoder, error) {
 }
 
 // NewEncoderWithContext returns a new encoder that uses EncodeContext ec to write to vw.
+//
+// Deprecated: Use bson.NewEncoder and use the Encoder configuration methods set the desired
+// behavior of the encoder instead.
 func NewEncoderWithContext(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter) (*Encoder, error) {
 	if ec.Registry == nil {
 		ec = bsoncodec.EncodeContext{Registry: DefaultRegistry}
@@ -93,6 +96,9 @@ func (e *Encoder) SetRegistry(r *bsoncodec.Registry) error {
 }
 
 // SetContext replaces the current EncodeContext of the encoder with er.
+//
+// Deprecated: Use the Encoder configuration methods set the desired behavior of the encoder
+// instead.
 func (e *Encoder) SetContext(ec bsoncodec.EncodeContext) error {
 	e.ec = ec
 	return nil


### PR DESCRIPTION
[GODRIVER-2712](https://jira.mongodb.org/browse/GODRIVER-2712)

## Summary
* Deprecate the bson.NewEncoderWithContext and Encoder.SetContext functions. Recommend using the Encoder configuration methods set the desired behavior of the encoder instead.
* Deprecate the bson.NewDecoderWithContext and Decoder.SetContext functions. Recommend using the Decoder configuration methods set the desired behavior of the decoder instead.


## Background & Motivation
There are too many ways to configure a `bson.Encoder` and `bson.Decoder` to get the exact same behavior. We're planning to remove all usages of the `EncodeContext` and `DecodeContext` from the standard user configuration of the `bson.Encoder` and `bson.Decoder` types. All configuration will be done via the configuration methods on the `bson.Encoder` and `bson.Decoder` types.

