### PR TITLE
GODRIVER-2804 Fix bug that can squash FullDocument when merging ChangeStreamOptions.

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -428,10 +428,8 @@ func (cs *ChangeStream) createPipelineOptionsDoc() (bsoncore.Document, error) {
 		plDoc = bsoncore.AppendBooleanElement(plDoc, "allChangesForCluster", true)
 	}
 
-	if cs.options.FullDocument != nil {
-		if *cs.options.FullDocument != options.Default {
-			plDoc = bsoncore.AppendStringElement(plDoc, "fullDocument", string(*cs.options.FullDocument))
-		}
+	if cs.options.FullDocument != nil && *cs.options.FullDocument != options.Default {
+		plDoc = bsoncore.AppendStringElement(plDoc, "fullDocument", string(*cs.options.FullDocument))
 	}
 
 	if cs.options.FullDocumentBeforeChange != nil {

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -74,7 +74,6 @@ type ChangeStreamOptions struct {
 // ChangeStream creates a new ChangeStreamOptions instance.
 func ChangeStream() *ChangeStreamOptions {
 	cso := &ChangeStreamOptions{}
-	cso.SetFullDocument(Default)
 	return cso
 }
 

--- a/mongo/options/changestreamoptions_test.go
+++ b/mongo/options/changestreamoptions_test.go
@@ -1,0 +1,62 @@
+package options
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/internal/assert"
+)
+
+func TestMergeChangeStreamOptions(t *testing.T) {
+	fullDocumentP := func(x FullDocument) *FullDocument { return &x }
+	int32P := func(x int32) *int32 { return &x }
+
+	testCases := []struct {
+		description string
+		input       []*ChangeStreamOptions
+		want        *ChangeStreamOptions
+	}{
+		{
+			description: "empty",
+			input:       []*ChangeStreamOptions{},
+			want:        &ChangeStreamOptions{},
+		},
+		{
+			description: "many ChangeStreamOptions with one configuration each",
+			input: []*ChangeStreamOptions{
+				ChangeStream().SetFullDocumentBeforeChange(Required),
+				ChangeStream().SetFullDocument(Required),
+				ChangeStream().SetBatchSize(10),
+			},
+			want: &ChangeStreamOptions{
+				FullDocument:             fullDocumentP(Required),
+				FullDocumentBeforeChange: fullDocumentP(Required),
+				BatchSize:                int32P(10),
+			},
+		},
+		{
+			description: "single ChangeStreamOptions with many configurations",
+			input: []*ChangeStreamOptions{
+				ChangeStream().
+					SetFullDocumentBeforeChange(Required).
+					SetFullDocument(Required).
+					SetBatchSize(10),
+			},
+			want: &ChangeStreamOptions{
+				FullDocument:             fullDocumentP(Required),
+				FullDocumentBeforeChange: fullDocumentP(Required),
+				BatchSize:                int32P(10),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			got := MergeChangeStreamOptions(tc.input...)
+			assert.Equal(t, tc.want, got, "expected and actual ChangeStreamOptions are different")
+		})
+	}
+}

--- a/mongo/options/changestreamoptions_test.go
+++ b/mongo/options/changestreamoptions_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestMergeChangeStreamOptions(t *testing.T) {
+	t.Parallel()
+
+	fullDocumentP := func(x FullDocument) *FullDocument { return &x }
 	fullDocumentP := func(x FullDocument) *FullDocument { return &x }
 	int32P := func(x int32) *int32 { return &x }
 

--- a/mongo/options/changestreamoptions_test.go
+++ b/mongo/options/changestreamoptions_test.go
@@ -10,7 +10,6 @@ func TestMergeChangeStreamOptions(t *testing.T) {
 	t.Parallel()
 
 	fullDocumentP := func(x FullDocument) *FullDocument { return &x }
-	fullDocumentP := func(x FullDocument) *FullDocument { return &x }
 	int32P := func(x int32) *int32 { return &x }
 
 	testCases := []struct {


### PR DESCRIPTION
[GODRIVER-2804](https://jira.mongodb.org/browse/GODRIVER-2804)

## Summary
Fix bug that can squash the `FullDocument` configuration value when merging multiple `ChangeStreamOptions` structs.

## Background & Motivation
The `options.ChangeStream` options constructor currently sets a default `FullDocument` configuration of `Default`. That can lead to the `FullDocument` configuration value in some `ChangeStreamOptions` structs being squashed because `Default` appears to be a user-configured option in the default struct constructed via `options.ChangeStream`.

