### PR TITLE
GODRIVER-2811 Use UTC when marshalling primitive.DateTime as JSON.

### DIFF
--- a/bson/primitive/primitive.go
+++ b/bson/primitive/primitive.go
@@ -45,7 +45,7 @@ var _ json.Unmarshaler = (*DateTime)(nil)
 
 // MarshalJSON marshal to time type.
 func (d DateTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Time())
+	return json.Marshal(d.Time().UTC())
 }
 
 // UnmarshalJSON creates a primitive.DateTime from a JSON string.

--- a/bson/primitive/primitive_test.go
+++ b/bson/primitive/primitive_test.go
@@ -177,6 +177,12 @@ func TestDateTime(t *testing.T) {
 			assert.Nil(t, err, "Unmarshal error: %v", err)
 			assert.Equal(t, DateTime(0), dt, "expected DateTime value to be 0, got %v", dt)
 		})
+		t.Run("UTC", func(t *testing.T) {
+			dt := DateTime(1681145535123)
+			jsonBytes, err := json.Marshal(dt)
+			assert.Nil(t, err, "Marshal error: %v", err)
+			assert.Equal(t, `"2023-04-10T16:52:15.123Z"`, string(jsonBytes))
+		})
 	})
 	t.Run("NewDateTimeFromTime", func(t *testing.T) {
 		t.Run("range is not limited", func(t *testing.T) {


### PR DESCRIPTION
[GODRIVER-2811](https://jira.mongodb.org/browse/GODRIVER-2811)

## Summary
Make the JSON format of `primitive.DateTime` use UTC, consistent with the relaxed extJSON format.

## Background & Motivation
Marshalling in relaxed extJSON already uses UTC, which makes sense since the type has no timezone information.
Using local time in JSON does not appear to have been intentional, as there is no comment or test for this behavior.
Using UTC allows the JSON to be deterministic with respect to the BSON, rather than depend on the environment.