### PR TITLE
GODRIVER-2802 remove ENABLE_featureFlagFLE2ProtocolVersion2=ON

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -258,7 +258,6 @@ functions:
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           LOAD_BALANCER=${LOAD_BALANCER} \
-          ENABLE_featureFlagFLE2ProtocolVersion2=ON \
           sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:


### PR DESCRIPTION
GODRIVER-2802
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

- Remove the no longer used `ENABLE_featureFlagFLE2ProtocolVersion2=ON`
<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation
The `ENABLE_featureFlagFLE2ProtocolVersion2=ON` was part of a temporary workaround to opt in to enabling the feature flag `featureFlagFLE2ProtocolVersion2` on the server. The workaround was removed in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/289. Setting `ENABLE_featureFlagFLE2ProtocolVersion2=ON` no longer has any effect.