### PR TITLE
GODRIVER-2716 Introduce a new BSON Encoder and Decoder configuration API to replace the bsoncodec configurations.

### DIFF
--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -14,11 +14,15 @@ import (
 )
 
 // ArrayCodec is the Codec used for bsoncore.Array values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the ArrayCodec registered.
 type ArrayCodec struct{}
 
 var defaultArrayCodec = NewArrayCodec()
 
 // NewArrayCodec returns an ArrayCodec.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the ArrayCodec registered.
 func NewArrayCodec() *ArrayCodec {
 	return &ArrayCodec{}
 }

--- a/bson/bsoncodec/array_codec.go
+++ b/bson/bsoncodec/array_codec.go
@@ -15,14 +15,16 @@ import (
 
 // ArrayCodec is the Codec used for bsoncore.Array values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the ArrayCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// ArrayCodec registered.
 type ArrayCodec struct{}
 
 var defaultArrayCodec = NewArrayCodec()
 
 // NewArrayCodec returns an ArrayCodec.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the ArrayCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// ArrayCodec registered.
 func NewArrayCodec() *ArrayCodec {
 	return &ArrayCodec{}
 }

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -120,15 +120,15 @@ func (vde ValueDecoderError) Error() string {
 type EncodeContext struct {
 	*Registry
 
-	// MinSize, if true, instructs encoders to marshal Go integer values (int, int8, int16, int32,
-	// or int64) as the minimum BSON int size (either 32-bit or 64-bit) that can represent the
-	// integer value.
+	// MinSize causes the Encoder to marshal Go integer values (int, int8, int16, int32, int64,
+	// uint, uint8, uint16, uint32, or uint64) as the minimum BSON int size (either 32 or 64 bits)
+	// that can represent the integer value.
 	//
 	// Deprecated: Use bson.Encoder.IntMinSize instead.
 	MinSize bool
 
 	errorOnInlineDuplicates bool
-	mapKeysWithStringer     bool
+	stringifyMapKeysWithFmt bool
 	nilMapAsEmpty           bool
 	nilSliceAsEmpty         bool
 	nilByteSliceAsEmpty     bool
@@ -144,12 +144,12 @@ func (ec *EncodeContext) ErrorOnInlineDuplicates() {
 	ec.errorOnInlineDuplicates = true
 }
 
-// MapKeysWithStringer causes the Encoder to convert Go map keys to BSON document field name strings
+// StringifyMapKeysWithFmt causes the Encoder to convert Go map keys to BSON document field name strings
 // using fmt.Sprintf() instead of the default string conversion logic.
 //
-// Deprecated: Use bson.Encoder.MapKeysWithStringer instead.
-func (ec *EncodeContext) MapKeysWithStringer() {
-	ec.mapKeysWithStringer = true
+// Deprecated: Use bson.Encoder.StringifyMapKeysWithFmt instead.
+func (ec *EncodeContext) StringifyMapKeysWithFmt() {
+	ec.stringifyMapKeysWithFmt = true
 }
 
 // NilMapAsEmpty causes the Encoder to marshal nil Go maps as empty BSON documents instead of BSON
@@ -201,8 +201,9 @@ type DecodeContext struct {
 	*Registry
 
 	// Truncate, if true, instructs decoders to to truncate the fractional part of BSON "double"
-	// values when attempting to unmarshal them into a Go integer (int, int8, int16, int32, or
-	// int64) struct field. The truncation logic does not apply to BSON "decimal128" values.
+	// values when attempting to unmarshal them into a Go integer (int, int8, int16, int32, int64,
+	// uint, uint8, uint16, uint32, or uint64) struct field. The truncation logic does not apply to
+	// BSON "decimal128" values.
 	//
 	// Deprecated: Use bson.Decoder.AllowTruncatingDoubles instead.
 	Truncate bool

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -24,7 +24,7 @@ var (
 // into a BSON document represented as bytes. The bytes returned must be a valid
 // BSON document if the error is nil.
 //
-// Deprecated: Use bson.Marshaler instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Marshaler] instead.
 type Marshaler interface {
 	MarshalBSON() ([]byte, error)
 }
@@ -34,7 +34,7 @@ type Marshaler interface {
 // the bytes returned. The bytes and byte type together must be valid if the
 // error is nil.
 //
-// Deprecated: Use bson.ValueMarshaler instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.ValueMarshaler] instead.
 type ValueMarshaler interface {
 	MarshalBSONValue() (bsontype.Type, []byte, error)
 }
@@ -44,7 +44,7 @@ type ValueMarshaler interface {
 // valid. UnmarshalBSON must copy the BSON bytes if it wishes to retain the data
 // after returning.
 //
-// Deprecated: Use bson.Unmarshaler instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Unmarshaler] instead.
 type Unmarshaler interface {
 	UnmarshalBSON([]byte) error
 }
@@ -54,7 +54,7 @@ type Unmarshaler interface {
 // assumed to be valid. UnmarshalBSONValue must copy the BSON value bytes if it
 // wishes to retain the data after returning.
 //
-// Deprecated: Use bson.ValueUnmarshaler instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.ValueUnmarshaler] instead.
 type ValueUnmarshaler interface {
 	UnmarshalBSONValue(bsontype.Type, []byte) error
 }
@@ -139,15 +139,15 @@ type EncodeContext struct {
 // ErrorOnInlineDuplicates causes the Encoder to return an error if there is a duplicate field in
 // the marshaled BSON when the "inline" struct tag option is set.
 //
-// Deprecated: Use bson.Encoder.ErrorOnInlineDuplicates instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.ErrorOnInlineDuplicates] instead.
 func (ec *EncodeContext) ErrorOnInlineDuplicates() {
 	ec.errorOnInlineDuplicates = true
 }
 
-// StringifyMapKeysWithFmt causes the Encoder to convert Go map keys to BSON document field name strings
-// using fmt.Sprintf() instead of the default string conversion logic.
+// StringifyMapKeysWithFmt causes the Encoder to convert Go map keys to BSON document field name
+// strings using fmt.Sprintf() instead of the default string conversion logic.
 //
-// Deprecated: Use bson.Encoder.StringifyMapKeysWithFmt instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.StringifyMapKeysWithFmt] instead.
 func (ec *EncodeContext) StringifyMapKeysWithFmt() {
 	ec.stringifyMapKeysWithFmt = true
 }
@@ -155,7 +155,7 @@ func (ec *EncodeContext) StringifyMapKeysWithFmt() {
 // NilMapAsEmpty causes the Encoder to marshal nil Go maps as empty BSON documents instead of BSON
 // null.
 //
-// Deprecated: Use bson.Encoder.NilMapAsEmpty instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilMapAsEmpty] instead.
 func (ec *EncodeContext) NilMapAsEmpty() {
 	ec.nilMapAsEmpty = true
 }
@@ -163,7 +163,7 @@ func (ec *EncodeContext) NilMapAsEmpty() {
 // NilSliceAsEmpty causes the Encoder to marshal nil Go slices as empty BSON arrays instead of BSON
 // null.
 //
-// Deprecated: Use bson.Encoder.NilSliceAsEmpty instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilSliceAsEmpty] instead.
 func (ec *EncodeContext) NilSliceAsEmpty() {
 	ec.nilSliceAsEmpty = true
 }
@@ -171,7 +171,7 @@ func (ec *EncodeContext) NilSliceAsEmpty() {
 // NilByteSliceAsEmpty causes the Encoder to marshal nil Go byte slices as empty BSON binary values
 // instead of BSON null.
 //
-// Deprecated: Use bson.Encoder.NilByteSliceAsEmpty instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilByteSliceAsEmpty] instead.
 func (ec *EncodeContext) NilByteSliceAsEmpty() {
 	ec.nilByteSliceAsEmpty = true
 }
@@ -182,7 +182,7 @@ func (ec *EncodeContext) NilByteSliceAsEmpty() {
 // Note that the Encoder only examines exported struct fields when determining if a struct is the
 // zero value. It considers pointers to a zero struct value (e.g. &MyStruct{}) not empty.
 //
-// Deprecated: Use bson.Encoder.OmitZeroStruct instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.OmitZeroStruct] instead.
 func (ec *EncodeContext) OmitZeroStruct() {
 	ec.omitZeroStruct = true
 }
@@ -190,7 +190,7 @@ func (ec *EncodeContext) OmitZeroStruct() {
 // UseJSONStructTags causes the Encoder to fall back to using the "json" struct tag if a "bson"
 // struct tag is not specified.
 //
-// Deprecated: Use bson.Encoder.UseJSONStructTags instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.UseJSONStructTags] instead.
 func (ec *EncodeContext) UseJSONStructTags() {
 	ec.useJSONStructTags = true
 }
@@ -231,7 +231,7 @@ type DecodeContext struct {
 // BinaryAsSlice causes the Decoder to unmarshal BSON binary field values that are the "Generic" or
 // "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
 //
-// Deprecated: Use bson.Decoder.BinaryAsSlice instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.BinaryAsSlice] instead.
 func (dc *DecodeContext) BinaryAsSlice() {
 	dc.binaryAsSlice = true
 }
@@ -239,7 +239,7 @@ func (dc *DecodeContext) BinaryAsSlice() {
 // UseJSONStructTags causes the Decoder to fall back to using the "json" struct tag if a "bson"
 // struct tag is not specified.
 //
-// Deprecated: Use bson.Decoder.UseJSONStructTags instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.UseJSONStructTags] instead.
 func (dc *DecodeContext) UseJSONStructTags() {
 	dc.useJSONStructTags = true
 }
@@ -247,7 +247,7 @@ func (dc *DecodeContext) UseJSONStructTags() {
 // ZeroMaps causes the Decoder to delete any existing values from Go maps in the destination value
 // passed to Decode before unmarshaling BSON documents into them.
 //
-// Deprecated: Use bson.Decoder.ZeroMaps instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.ZeroMaps] instead.
 func (dc *DecodeContext) ZeroMaps() {
 	dc.zeroMaps = true
 }
@@ -255,7 +255,7 @@ func (dc *DecodeContext) ZeroMaps() {
 // ZeroStructs causes the Decoder to delete any existing values from Go structs in the destination
 // value passed to Decode before unmarshaling BSON documents into them.
 //
-// Deprecated: Use bson.Decoder.ZeroStructs instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.ZeroStructs] instead.
 func (dc *DecodeContext) ZeroStructs() {
 	dc.zeroStructs = true
 }
@@ -263,7 +263,7 @@ func (dc *DecodeContext) ZeroStructs() {
 // DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
 //
-// Deprecated: Use bson.Decoder.DefaultDocumentM instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.DefaultDocumentM] instead.
 func (dc *DecodeContext) DefaultDocumentM() {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.M{})
 }
@@ -271,7 +271,7 @@ func (dc *DecodeContext) DefaultDocumentM() {
 // DefaultDocumentD will decode empty documents using the primitive.D type. This behavior is restricted to data typed as
 // "interface{}" or "map[string]interface{}".
 //
-// Deprecated: Use bson.Decoder.DefaultDocumentD instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.DefaultDocumentD] instead.
 func (dc *DecodeContext) DefaultDocumentD() {
 	dc.defaultDocumentType = reflect.TypeOf(primitive.D{})
 }
@@ -279,7 +279,7 @@ func (dc *DecodeContext) DefaultDocumentD() {
 // ValueCodec is an interface for encoding and decoding a reflect.Value.
 // values.
 //
-// Deprecated: Use ValueEncoder and ValueDecoder instead.
+// Deprecated: Use [ValueEncoder] and [ValueDecoder] instead.
 type ValueCodec interface {
 	ValueEncoder
 	ValueDecoder

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -120,7 +120,7 @@ func (vde ValueDecoderError) Error() string {
 type EncodeContext struct {
 	*Registry
 
-	// IntMinSize, if true, instructs encoders to marshal Go integer values (int, int8, int16,
+	// MinSize, if true, instructs encoders to marshal Go integer values (int, int8, int16,
 	// int32, or int64) as the minimum BSON int size (either 32-bit or 64-bit) that can represent
 	// the integer value.
 	//

--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -119,13 +119,63 @@ func (vde ValueDecoderError) Error() string {
 // value.
 type EncodeContext struct {
 	*Registry
+
+	// IntMinSize, if true, instructs encoders to marshal Go integer values (int, int8, int16,
+	// int32, or int64) as the minimum BSON int size (either 32-bit or 64-bit) that can represent
+	// the integer value.
+	//
+	// Deprecated: Use IntMinSize instead.
 	MinSize bool
+
+	// AllowUnexportedFields, if true, instructs encoders to marshal values from unexported struct
+	// fields.
+	AllowUnexportedFields bool
+
+	// ErrorOnInlineDuplicates, if true, instructs encoders to return an error if there is a
+	// duplicate field in the marshaled BSON when the "inline" struct tag option is set.
+	ErrorOnInlineDuplicates bool
+
+	// IntMinSize, if true, instructs encoders to marshal Go integer values (int, int8, int16,
+	// int32, or int64) as the minimum BSON int size (either 32-bit or 64-bit) that can represent
+	// the integer value.
+	IntMinSize bool
+
+	// MapKeysWithStringer, if true, instructs encoders to convert Go map keys to BSON document
+	// field name strings using fmt.Sprintf() instead of the default string conversion logic.
+	MapKeysWithStringer bool
+
+	// NilMapAsEmpty, if true, instructs encoders to marshal nil Go maps as empty BSON documents
+	// instead of BSON null.
+	NilMapAsEmpty bool
+
+	// NilSliceAsEmpty, if true, instructs encoders to marshal nil Go slices as empty BSON arrays
+	// instead of BSON null.
+	NilSliceAsEmpty bool
+
+	// NilByteSliceAsEmpty, if true, instructs encoders to marshal nil Go byte slices as empty BSON
+	// binary values instead of BSON null.
+	NilByteSliceAsEmpty bool
+
+	// OmitDefaultStruct, if true, instructs encoders to consider the zero value for a struct (e.g.
+	// MyStruct{}) as empty and omit it from the marshaled BSON when the "omitempty" struct tag
+	// option is set.
+	OmitDefaultStruct bool
+
+	// UseJSONStructTags, if true, instructs encoders to fall back to using the "json" struct tag if
+	// a "bson" struct tag is not specified.
+	UseJSONStructTags bool
 }
 
 // DecodeContext is the contextual information required for a Codec to decode a
 // value.
 type DecodeContext struct {
 	*Registry
+
+	// Truncate allows truncating the fractional part of BSON floating point values when decoding
+	// them into a Go integer value. The default is false, which returns an error when attempting to
+	// decode BSON floating point values with a fractional part into a Go integer.
+	//
+	// Deprecated: Use AllowTruncatingFloats instead.
 	Truncate bool
 
 	// Ancestor is the type of a containing document. This is mainly used to determine what type
@@ -141,6 +191,30 @@ type DecodeContext struct {
 	// set to a type that a BSON document cannot be unmarshaled into (e.g. "string"), unmarshalling will result in an
 	// error. DocumentType overrides the Ancestor field.
 	defaultDocumentType reflect.Type
+
+	// AllowTruncatingDoubles, if true, instructs decoders to truncate the fractional part of BSON
+	// "double" values when attempting to unmarshal them into a Go integer struct field. The
+	// truncation logic does not apply to BSON "decimal128" values.
+	AllowTruncatingDoubles bool
+
+	// AllowUnexportedFields, if true, instructs decoders to unmarshal values into unexported struct fields.
+	AllowUnexportedFields bool
+
+	// BinaryAsSlice, if true, instructs decoders to unmarshal BSON binary field values that are the
+	// "Generic" or "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
+	BinaryAsSlice bool
+
+	// UseJSONStructTags, if true, instructs decoders to fall back to using the "json" struct tag if
+	// a "bson" struct tag is not specified.
+	UseJSONStructTags bool
+
+	// ZeroMaps, if true, instructs decoders to delete any existing values from Go maps in the
+	// destination value passed to Decode before unmarshaling BSON documents into them.
+	ZeroMaps bool
+
+	// ZeroStructs, if true, instructs decoders to delete any existing values from Go structs in the
+	// destination value passed to Decode before unmarshaling BSON documents into them.
+	ZeroStructs bool
 }
 
 // DefaultDocumentM will decode empty documents using the primitive.M type. This behavior is restricted to data typed as

--- a/bson/bsoncodec/bsoncodec_test.go
+++ b/bson/bsoncodec/bsoncodec_test.go
@@ -108,10 +108,6 @@ func (z zeroTest) IsZero() bool { return z.reportZero }
 
 func compareZeroTest(_, _ zeroTest) bool { return true }
 
-type nonZeroer struct {
-	value bool
-}
-
 type llCodec struct {
 	t         *testing.T
 	decodeval interface{}

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -48,7 +48,7 @@ func (bsc *ByteSliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, 
 	if !val.IsValid() || val.Type() != tByteSlice {
 		return ValueEncoderError{Name: "ByteSliceEncodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
 	}
-	if val.IsNil() && !bsc.EncodeNilAsEmpty && !ec.NilByteSliceAsEmpty {
+	if val.IsNil() && !bsc.EncodeNilAsEmpty && !ec.nilByteSliceAsEmpty {
 		return vw.WriteNull()
 	}
 	return vw.WriteBinary(val.Interface().([]byte))

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -19,6 +19,10 @@ import (
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the ByteSliceCodec registered.
 type ByteSliceCodec struct {
+	// EncodeNilAsEmpty causes EncodeValue to marshal nil Go byte slices as empty BSON binary values
+	// instead of BSON null.
+	//
+	// Deprecated: Use bson.Encoder.NilByteSliceAsEmpty instead.
 	EncodeNilAsEmpty bool
 }
 

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -17,7 +17,8 @@ import (
 
 // ByteSliceCodec is the Codec used for []byte values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the ByteSliceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// ByteSliceCodec registered.
 type ByteSliceCodec struct {
 	// EncodeNilAsEmpty causes EncodeValue to marshal nil Go byte slices as empty BSON binary values
 	// instead of BSON null.
@@ -37,7 +38,8 @@ var (
 
 // NewByteSliceCodec returns a ByteSliceCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the ByteSliceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// ByteSliceCodec registered.
 func NewByteSliceCodec(opts ...*bsonoptions.ByteSliceCodecOptions) *ByteSliceCodec {
 	byteSliceOpt := bsonoptions.MergeByteSliceCodecOptions(opts...)
 	codec := ByteSliceCodec{}

--- a/bson/bsoncodec/byte_slice_codec.go
+++ b/bson/bsoncodec/byte_slice_codec.go
@@ -16,6 +16,8 @@ import (
 )
 
 // ByteSliceCodec is the Codec used for []byte values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the ByteSliceCodec registered.
 type ByteSliceCodec struct {
 	EncodeNilAsEmpty bool
 }
@@ -29,7 +31,9 @@ var (
 	_ typeDecoder = defaultByteSliceCodec
 )
 
-// NewByteSliceCodec returns a StringCodec with options opts.
+// NewByteSliceCodec returns a ByteSliceCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the ByteSliceCodec registered.
 func NewByteSliceCodec(opts ...*bsonoptions.ByteSliceCodecOptions) *ByteSliceCodec {
 	byteSliceOpt := bsonoptions.MergeByteSliceCodecOptions(opts...)
 	codec := ByteSliceCodec{}
@@ -40,11 +44,11 @@ func NewByteSliceCodec(opts ...*bsonoptions.ByteSliceCodecOptions) *ByteSliceCod
 }
 
 // EncodeValue is the ValueEncoder for []byte.
-func (bsc *ByteSliceCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
+func (bsc *ByteSliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tByteSlice {
 		return ValueEncoderError{Name: "ByteSliceEncodeValue", Types: []reflect.Type{tByteSlice}, Received: val}
 	}
-	if val.IsNil() && !bsc.EncodeNilAsEmpty {
+	if val.IsNil() && !bsc.EncodeNilAsEmpty && !ec.NilByteSliceAsEmpty {
 		return vw.WriteNull()
 	}
 	return vw.WriteBinary(val.Interface().([]byte))

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -49,7 +49,8 @@ func newDefaultStructCodec() *StructCodec {
 // DefaultValueDecoders is a namespace type for the default ValueDecoders used
 // when creating a registry.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 type DefaultValueDecoders struct{}
 
 // RegisterDefaultDecoders will register the decoder methods attached to DefaultValueDecoders with
@@ -59,7 +60,8 @@ type DefaultValueDecoders struct{}
 // interface{}, so users must either register this decoder themselves or use the
 // EmptyInterfaceDecoder available in the bson package.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 	if rb == nil {
 		panic(errors.New("argument to RegisterDefaultDecoders must not be nil"))
@@ -137,7 +139,8 @@ func (dvd DefaultValueDecoders) RegisterDefaultDecoders(rb *RegistryBuilder) {
 
 // DDecodeValue is the ValueDecoderFunc for primitive.D instances.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) DDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || !val.CanSet() || val.Type() != tD {
 		return ValueDecoderError{Name: "DDecodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
@@ -242,7 +245,8 @@ func (dvd DefaultValueDecoders) booleanDecodeType(_ DecodeContext, vr bsonrw.Val
 
 // BooleanDecodeValue is the ValueDecoderFunc for bool types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) BooleanDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || !val.CanSet() || val.Kind() != reflect.Bool {
 		return ValueDecoderError{Name: "BooleanDecodeValue", Kinds: []reflect.Kind{reflect.Bool}, Received: val}
@@ -342,7 +346,8 @@ func (DefaultValueDecoders) intDecodeType(dc DecodeContext, vr bsonrw.ValueReade
 
 // IntDecodeValue is the ValueDecoderFunc for int types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) IntDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() {
 		return ValueDecoderError{
@@ -505,7 +510,8 @@ func (dvd DefaultValueDecoders) floatDecodeType(dc DecodeContext, vr bsonrw.Valu
 
 // FloatDecodeValue is the ValueDecoderFunc for float types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) FloatDecodeValue(ec DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() {
 		return ValueDecoderError{
@@ -578,7 +584,8 @@ func (DefaultValueDecoders) javaScriptDecodeType(_ DecodeContext, vr bsonrw.Valu
 
 // JavaScriptDecodeValue is the ValueDecoderFunc for the primitive.JavaScript type.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) JavaScriptDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tJavaScript {
 		return ValueDecoderError{Name: "JavaScriptDecodeValue", Types: []reflect.Type{tJavaScript}, Received: val}
@@ -635,7 +642,8 @@ func (DefaultValueDecoders) symbolDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 
 // SymbolDecodeValue is the ValueDecoderFunc for the primitive.Symbol type.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) SymbolDecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tSymbol {
 		return ValueDecoderError{Name: "SymbolDecodeValue", Types: []reflect.Type{tSymbol}, Received: val}
@@ -681,7 +689,8 @@ func (DefaultValueDecoders) binaryDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 
 // BinaryDecodeValue is the ValueDecoderFunc for Binary.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) BinaryDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tBinary {
 		return ValueDecoderError{Name: "BinaryDecodeValue", Types: []reflect.Type{tBinary}, Received: val}
@@ -723,7 +732,8 @@ func (DefaultValueDecoders) undefinedDecodeType(_ DecodeContext, vr bsonrw.Value
 
 // UndefinedDecodeValue is the ValueDecoderFunc for Undefined.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) UndefinedDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tUndefined {
 		return ValueDecoderError{Name: "UndefinedDecodeValue", Types: []reflect.Type{tUndefined}, Received: val}
@@ -786,7 +796,8 @@ func (dvd DefaultValueDecoders) objectIDDecodeType(_ DecodeContext, vr bsonrw.Va
 
 // ObjectIDDecodeValue is the ValueDecoderFunc for primitive.ObjectID.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) ObjectIDDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tOID {
 		return ValueDecoderError{Name: "ObjectIDDecodeValue", Types: []reflect.Type{tOID}, Received: val}
@@ -831,7 +842,8 @@ func (DefaultValueDecoders) dateTimeDecodeType(_ DecodeContext, vr bsonrw.ValueR
 
 // DateTimeDecodeValue is the ValueDecoderFunc for DateTime.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) DateTimeDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDateTime {
 		return ValueDecoderError{Name: "DateTimeDecodeValue", Types: []reflect.Type{tDateTime}, Received: val}
@@ -873,7 +885,8 @@ func (DefaultValueDecoders) nullDecodeType(_ DecodeContext, vr bsonrw.ValueReade
 
 // NullDecodeValue is the ValueDecoderFunc for Null.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) NullDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tNull {
 		return ValueDecoderError{Name: "NullDecodeValue", Types: []reflect.Type{tNull}, Received: val}
@@ -918,7 +931,8 @@ func (DefaultValueDecoders) regexDecodeType(_ DecodeContext, vr bsonrw.ValueRead
 
 // RegexDecodeValue is the ValueDecoderFunc for Regex.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) RegexDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRegex {
 		return ValueDecoderError{Name: "RegexDecodeValue", Types: []reflect.Type{tRegex}, Received: val}
@@ -964,7 +978,8 @@ func (DefaultValueDecoders) dBPointerDecodeType(_ DecodeContext, vr bsonrw.Value
 
 // DBPointerDecodeValue is the ValueDecoderFunc for DBPointer.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) DBPointerDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDBPointer {
 		return ValueDecoderError{Name: "DBPointerDecodeValue", Types: []reflect.Type{tDBPointer}, Received: val}
@@ -1009,7 +1024,8 @@ func (DefaultValueDecoders) timestampDecodeType(_ DecodeContext, vr bsonrw.Value
 
 // TimestampDecodeValue is the ValueDecoderFunc for Timestamp.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) TimestampDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tTimestamp {
 		return ValueDecoderError{Name: "TimestampDecodeValue", Types: []reflect.Type{tTimestamp}, Received: val}
@@ -1053,7 +1069,8 @@ func (DefaultValueDecoders) minKeyDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 
 // MinKeyDecodeValue is the ValueDecoderFunc for MinKey.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) MinKeyDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tMinKey {
 		return ValueDecoderError{Name: "MinKeyDecodeValue", Types: []reflect.Type{tMinKey}, Received: val}
@@ -1097,7 +1114,8 @@ func (DefaultValueDecoders) maxKeyDecodeType(_ DecodeContext, vr bsonrw.ValueRea
 
 // MaxKeyDecodeValue is the ValueDecoderFunc for MaxKey.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) MaxKeyDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tMaxKey {
 		return ValueDecoderError{Name: "MaxKeyDecodeValue", Types: []reflect.Type{tMaxKey}, Received: val}
@@ -1142,7 +1160,8 @@ func (dvd DefaultValueDecoders) decimal128DecodeType(_ DecodeContext, vr bsonrw.
 
 // Decimal128DecodeValue is the ValueDecoderFunc for primitive.Decimal128.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) Decimal128DecodeValue(dctx DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tDecimal {
 		return ValueDecoderError{Name: "Decimal128DecodeValue", Types: []reflect.Type{tDecimal}, Received: val}
@@ -1203,7 +1222,8 @@ func (dvd DefaultValueDecoders) jsonNumberDecodeType(_ DecodeContext, vr bsonrw.
 
 // JSONNumberDecodeValue is the ValueDecoderFunc for json.Number.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) JSONNumberDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tJSONNumber {
 		return ValueDecoderError{Name: "JSONNumberDecodeValue", Types: []reflect.Type{tJSONNumber}, Received: val}
@@ -1254,7 +1274,8 @@ func (dvd DefaultValueDecoders) urlDecodeType(_ DecodeContext, vr bsonrw.ValueRe
 
 // URLDecodeValue is the ValueDecoderFunc for url.URL.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) URLDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tURL {
 		return ValueDecoderError{Name: "URLDecodeValue", Types: []reflect.Type{tURL}, Received: val}
@@ -1379,7 +1400,8 @@ func (dvd DefaultValueDecoders) MapDecodeValue(dc DecodeContext, vr bsonrw.Value
 
 // ArrayDecodeValue is the ValueDecoderFunc for array types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) ArrayDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Array {
 		return ValueDecoderError{Name: "ArrayDecodeValue", Kinds: []reflect.Kind{reflect.Array}, Received: val}
@@ -1492,7 +1514,8 @@ func (dvd DefaultValueDecoders) SliceDecodeValue(dc DecodeContext, vr bsonrw.Val
 
 // ValueUnmarshalerDecodeValue is the ValueDecoderFunc for ValueUnmarshaler implementations.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tValueUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tValueUnmarshaler)) {
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
@@ -1527,7 +1550,8 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 
 // UnmarshalerDecodeValue is the ValueDecoderFunc for Unmarshaler implementations.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.IsValid() || (!val.Type().Implements(tUnmarshaler) && !reflect.PtrTo(val.Type()).Implements(tUnmarshaler)) {
 		return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
@@ -1614,7 +1638,8 @@ func (dvd DefaultValueDecoders) EmptyInterfaceDecodeValue(dc DecodeContext, vr b
 
 // CoreDocumentDecodeValue is the ValueDecoderFunc for bsoncore.Document.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (DefaultValueDecoders) CoreDocumentDecodeValue(_ DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCoreDocument {
 		return ValueDecoderError{Name: "CoreDocumentDecodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
@@ -1722,7 +1747,8 @@ func (dvd DefaultValueDecoders) codeWithScopeDecodeType(dc DecodeContext, vr bso
 
 // CodeWithScopeDecodeValue is the ValueDecoderFunc for CodeWithScope.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value decoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value decoders registered.
 func (dvd DefaultValueDecoders) CodeWithScopeDecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCodeWithScope {
 		return ValueDecoderError{Name: "CodeWithScopeDecodeValue", Types: []reflect.Type{tCodeWithScope}, Received: val}

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -277,7 +277,7 @@ func (DefaultValueDecoders) intDecodeType(dc DecodeContext, vr bsonrw.ValueReade
 		if err != nil {
 			return emptyValue, err
 		}
-		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
+		if !dc.Truncate && math.Floor(f64) != f64 {
 			return emptyValue, errCannotTruncate
 		}
 		if f64 > float64(math.MaxInt64) {
@@ -384,7 +384,7 @@ func (dvd DefaultValueDecoders) UintDecodeValue(dc DecodeContext, vr bsonrw.Valu
 		if err != nil {
 			return err
 		}
-		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
+		if !dc.Truncate && math.Floor(f64) != f64 {
 			return errors.New("UintDecodeValue can only truncate float64 to an integer type when truncation is enabled")
 		}
 		if f64 > float64(math.MaxInt64) {
@@ -487,7 +487,7 @@ func (dvd DefaultValueDecoders) floatDecodeType(dc DecodeContext, vr bsonrw.Valu
 
 	switch t.Kind() {
 	case reflect.Float32:
-		if !(dc.AllowTruncatingDoubles || dc.Truncate) && float64(float32(f)) != f {
+		if !dc.Truncate && float64(float32(f)) != f {
 			return emptyValue, errCannotTruncate
 		}
 

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -277,7 +277,7 @@ func (DefaultValueDecoders) intDecodeType(dc DecodeContext, vr bsonrw.ValueReade
 		if err != nil {
 			return emptyValue, err
 		}
-		if !dc.Truncate && math.Floor(f64) != f64 {
+		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
 			return emptyValue, errCannotTruncate
 		}
 		if f64 > float64(math.MaxInt64) {
@@ -384,7 +384,7 @@ func (dvd DefaultValueDecoders) UintDecodeValue(dc DecodeContext, vr bsonrw.Valu
 		if err != nil {
 			return err
 		}
-		if !dc.Truncate && math.Floor(f64) != f64 {
+		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
 			return errors.New("UintDecodeValue can only truncate float64 to an integer type when truncation is enabled")
 		}
 		if f64 > float64(math.MaxInt64) {
@@ -444,7 +444,7 @@ func (dvd DefaultValueDecoders) UintDecodeValue(dc DecodeContext, vr bsonrw.Valu
 	return nil
 }
 
-func (dvd DefaultValueDecoders) floatDecodeType(ec DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (dvd DefaultValueDecoders) floatDecodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	var f float64
 	var err error
 	switch vrType := vr.Type(); vrType {
@@ -487,7 +487,7 @@ func (dvd DefaultValueDecoders) floatDecodeType(ec DecodeContext, vr bsonrw.Valu
 
 	switch t.Kind() {
 	case reflect.Float32:
-		if !ec.Truncate && float64(float32(f)) != f {
+		if !(dc.AllowTruncatingDoubles || dc.Truncate) && float64(float32(f)) != f {
 			return emptyValue, errCannotTruncate
 		}
 

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -145,7 +145,7 @@ func (dve DefaultValueEncoders) IntEncodeValue(ec EncodeContext, vw bsonrw.Value
 		return vw.WriteInt64(i64)
 	case reflect.Int64:
 		i64 := val.Int()
-		if (ec.IntMinSize || ec.MinSize) && fitsIn32Bits(i64) {
+		if ec.MinSize && fitsIn32Bits(i64) {
 			return vw.WriteInt32(int32(i64))
 		}
 		return vw.WriteInt64(i64)
@@ -167,7 +167,7 @@ func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.Valu
 		return vw.WriteInt32(int32(val.Uint()))
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		u64 := val.Uint()
-		if (ec.IntMinSize || ec.MinSize) && u64 <= math.MaxInt32 {
+		if ec.MinSize && u64 <= math.MaxInt32 {
 			return vw.WriteInt32(int32(u64))
 		}
 		if u64 > math.MaxInt64 {

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -145,7 +145,7 @@ func (dve DefaultValueEncoders) IntEncodeValue(ec EncodeContext, vw bsonrw.Value
 		return vw.WriteInt64(i64)
 	case reflect.Int64:
 		i64 := val.Int()
-		if ec.MinSize && fitsIn32Bits(i64) {
+		if (ec.IntMinSize || ec.MinSize) && fitsIn32Bits(i64) {
 			return vw.WriteInt32(int32(i64))
 		}
 		return vw.WriteInt64(i64)
@@ -167,7 +167,7 @@ func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.Valu
 		return vw.WriteInt32(int32(val.Uint()))
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		u64 := val.Uint()
-		if ec.MinSize && u64 <= math.MaxInt32 {
+		if (ec.IntMinSize || ec.MinSize) && u64 <= math.MaxInt32 {
 			return vw.WriteInt32(int32(u64))
 		}
 		if u64 > math.MaxInt64 {

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -59,13 +59,15 @@ func encodeElement(ec EncodeContext, dw bsonrw.DocumentWriter, e primitive.E) er
 // DefaultValueEncoders is a namespace type for the default ValueEncoders used
 // when creating a registry.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 type DefaultValueEncoders struct{}
 
 // RegisterDefaultEncoders will register the encoder methods attached to DefaultValueEncoders with
 // the provided RegistryBuilder.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 	if rb == nil {
 		panic(errors.New("argument to RegisterDefaultEncoders must not be nil"))
@@ -118,7 +120,8 @@ func (dve DefaultValueEncoders) RegisterDefaultEncoders(rb *RegistryBuilder) {
 
 // BooleanEncodeValue is the ValueEncoderFunc for bool types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) BooleanEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Bool {
 		return ValueEncoderError{Name: "BooleanEncodeValue", Kinds: []reflect.Kind{reflect.Bool}, Received: val}
@@ -132,7 +135,8 @@ func fitsIn32Bits(i int64) bool {
 
 // IntEncodeValue is the ValueEncoderFunc for int types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) IntEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	switch val.Kind() {
 	case reflect.Int8, reflect.Int16, reflect.Int32:
@@ -185,7 +189,8 @@ func (dve DefaultValueEncoders) UintEncodeValue(ec EncodeContext, vw bsonrw.Valu
 
 // FloatEncodeValue is the ValueEncoderFunc for float types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) FloatEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	switch val.Kind() {
 	case reflect.Float32, reflect.Float64:
@@ -212,7 +217,8 @@ func (dve DefaultValueEncoders) StringEncodeValue(_ EncodeContext, vw bsonrw.Val
 
 // ObjectIDEncodeValue is the ValueEncoderFunc for primitive.ObjectID.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) ObjectIDEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tOID {
 		return ValueEncoderError{Name: "ObjectIDEncodeValue", Types: []reflect.Type{tOID}, Received: val}
@@ -222,7 +228,8 @@ func (dve DefaultValueEncoders) ObjectIDEncodeValue(_ EncodeContext, vw bsonrw.V
 
 // Decimal128EncodeValue is the ValueEncoderFunc for primitive.Decimal128.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) Decimal128EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDecimal {
 		return ValueEncoderError{Name: "Decimal128EncodeValue", Types: []reflect.Type{tDecimal}, Received: val}
@@ -232,7 +239,8 @@ func (dve DefaultValueEncoders) Decimal128EncodeValue(_ EncodeContext, vw bsonrw
 
 // JSONNumberEncodeValue is the ValueEncoderFunc for json.Number.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) JSONNumberEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tJSONNumber {
 		return ValueEncoderError{Name: "JSONNumberEncodeValue", Types: []reflect.Type{tJSONNumber}, Received: val}
@@ -254,7 +262,8 @@ func (dve DefaultValueEncoders) JSONNumberEncodeValue(ec EncodeContext, vw bsonr
 
 // URLEncodeValue is the ValueEncoderFunc for url.URL.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) URLEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tURL {
 		return ValueEncoderError{Name: "URLEncodeValue", Types: []reflect.Type{tURL}, Received: val}
@@ -362,7 +371,8 @@ func (dve DefaultValueEncoders) mapEncodeValue(ec EncodeContext, dw bsonrw.Docum
 
 // ArrayEncodeValue is the ValueEncoderFunc for array types.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) ArrayEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Kind() != reflect.Array {
 		return ValueEncoderError{Name: "ArrayEncodeValue", Kinds: []reflect.Kind{reflect.Array}, Received: val}
@@ -536,7 +546,8 @@ func (dve DefaultValueEncoders) EmptyInterfaceEncodeValue(ec EncodeContext, vw b
 
 // ValueMarshalerEncodeValue is the ValueEncoderFunc for ValueMarshaler implementations.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement ValueMarshaler
 	switch {
@@ -564,7 +575,8 @@ func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bs
 
 // MarshalerEncodeValue is the ValueEncoderFunc for Marshaler implementations.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement Marshaler
 	switch {
@@ -592,7 +604,8 @@ func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.
 
 // ProxyEncodeValue is the ValueEncoderFunc for Proxy implementations.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	// Either val or a pointer to val must implement Proxy
 	switch {
@@ -630,7 +643,8 @@ func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.Val
 
 // JavaScriptEncodeValue is the ValueEncoderFunc for the primitive.JavaScript type.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) JavaScriptEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tJavaScript {
 		return ValueEncoderError{Name: "JavaScriptEncodeValue", Types: []reflect.Type{tJavaScript}, Received: val}
@@ -641,7 +655,8 @@ func (DefaultValueEncoders) JavaScriptEncodeValue(_ EncodeContext, vw bsonrw.Val
 
 // SymbolEncodeValue is the ValueEncoderFunc for the primitive.Symbol type.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) SymbolEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tSymbol {
 		return ValueEncoderError{Name: "SymbolEncodeValue", Types: []reflect.Type{tSymbol}, Received: val}
@@ -652,7 +667,8 @@ func (DefaultValueEncoders) SymbolEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 
 // BinaryEncodeValue is the ValueEncoderFunc for Binary.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) BinaryEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tBinary {
 		return ValueEncoderError{Name: "BinaryEncodeValue", Types: []reflect.Type{tBinary}, Received: val}
@@ -664,7 +680,8 @@ func (DefaultValueEncoders) BinaryEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 
 // UndefinedEncodeValue is the ValueEncoderFunc for Undefined.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) UndefinedEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tUndefined {
 		return ValueEncoderError{Name: "UndefinedEncodeValue", Types: []reflect.Type{tUndefined}, Received: val}
@@ -675,7 +692,8 @@ func (DefaultValueEncoders) UndefinedEncodeValue(_ EncodeContext, vw bsonrw.Valu
 
 // DateTimeEncodeValue is the ValueEncoderFunc for DateTime.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) DateTimeEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDateTime {
 		return ValueEncoderError{Name: "DateTimeEncodeValue", Types: []reflect.Type{tDateTime}, Received: val}
@@ -686,7 +704,8 @@ func (DefaultValueEncoders) DateTimeEncodeValue(_ EncodeContext, vw bsonrw.Value
 
 // NullEncodeValue is the ValueEncoderFunc for Null.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) NullEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tNull {
 		return ValueEncoderError{Name: "NullEncodeValue", Types: []reflect.Type{tNull}, Received: val}
@@ -697,7 +716,8 @@ func (DefaultValueEncoders) NullEncodeValue(_ EncodeContext, vw bsonrw.ValueWrit
 
 // RegexEncodeValue is the ValueEncoderFunc for Regex.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) RegexEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRegex {
 		return ValueEncoderError{Name: "RegexEncodeValue", Types: []reflect.Type{tRegex}, Received: val}
@@ -710,7 +730,8 @@ func (DefaultValueEncoders) RegexEncodeValue(_ EncodeContext, vw bsonrw.ValueWri
 
 // DBPointerEncodeValue is the ValueEncoderFunc for DBPointer.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) DBPointerEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tDBPointer {
 		return ValueEncoderError{Name: "DBPointerEncodeValue", Types: []reflect.Type{tDBPointer}, Received: val}
@@ -723,7 +744,8 @@ func (DefaultValueEncoders) DBPointerEncodeValue(_ EncodeContext, vw bsonrw.Valu
 
 // TimestampEncodeValue is the ValueEncoderFunc for Timestamp.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) TimestampEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tTimestamp {
 		return ValueEncoderError{Name: "TimestampEncodeValue", Types: []reflect.Type{tTimestamp}, Received: val}
@@ -736,7 +758,8 @@ func (DefaultValueEncoders) TimestampEncodeValue(_ EncodeContext, vw bsonrw.Valu
 
 // MinKeyEncodeValue is the ValueEncoderFunc for MinKey.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) MinKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMinKey {
 		return ValueEncoderError{Name: "MinKeyEncodeValue", Types: []reflect.Type{tMinKey}, Received: val}
@@ -747,7 +770,8 @@ func (DefaultValueEncoders) MinKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 
 // MaxKeyEncodeValue is the ValueEncoderFunc for MaxKey.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) MaxKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tMaxKey {
 		return ValueEncoderError{Name: "MaxKeyEncodeValue", Types: []reflect.Type{tMaxKey}, Received: val}
@@ -758,7 +782,8 @@ func (DefaultValueEncoders) MaxKeyEncodeValue(_ EncodeContext, vw bsonrw.ValueWr
 
 // CoreDocumentEncodeValue is the ValueEncoderFunc for bsoncore.Document.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (DefaultValueEncoders) CoreDocumentEncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCoreDocument {
 		return ValueEncoderError{Name: "CoreDocumentEncodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
@@ -771,7 +796,8 @@ func (DefaultValueEncoders) CoreDocumentEncodeValue(_ EncodeContext, vw bsonrw.V
 
 // CodeWithScopeEncodeValue is the ValueEncoderFunc for CodeWithScope.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all default value encoders registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with all default
+// value encoders registered.
 func (dve DefaultValueEncoders) CodeWithScopeEncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tCodeWithScope {
 		return ValueEncoderError{Name: "CodeWithScopeEncodeValue", Types: []reflect.Type{tCodeWithScope}, Received: val}

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -19,6 +19,10 @@ import (
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the EmptyInterfaceCodec registered.
 type EmptyInterfaceCodec struct {
+	// DecodeBinaryAsSlice causes DecodeValue to unmarshal BSON binary field values that are the
+	// "Generic" or "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
+	//
+	// Deprecated: Use bson.Decoder.BinaryAsSlice instead.
 	DecodeBinaryAsSlice bool
 }
 

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -17,7 +17,8 @@ import (
 
 // EmptyInterfaceCodec is the Codec used for interface{} values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the EmptyInterfaceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// EmptyInterfaceCodec registered.
 type EmptyInterfaceCodec struct {
 	// DecodeBinaryAsSlice causes DecodeValue to unmarshal BSON binary field values that are the
 	// "Generic" or "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
@@ -37,7 +38,8 @@ var (
 
 // NewEmptyInterfaceCodec returns a EmptyInterfaceCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the EmptyInterfaceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// EmptyInterfaceCodec registered.
 func NewEmptyInterfaceCodec(opts ...*bsonoptions.EmptyInterfaceCodecOptions) *EmptyInterfaceCodec {
 	interfaceOpt := bsonoptions.MergeEmptyInterfaceCodecOptions(opts...)
 

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -127,7 +127,7 @@ func (eic EmptyInterfaceCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReade
 		return emptyValue, err
 	}
 
-	if (eic.DecodeBinaryAsSlice || dc.BinaryAsSlice) && rtype == tBinary {
+	if (eic.DecodeBinaryAsSlice || dc.binaryAsSlice) && rtype == tBinary {
 		binElem := elem.Interface().(primitive.Binary)
 		if binElem.Subtype == bsontype.BinaryGeneric || binElem.Subtype == bsontype.BinaryBinaryOld {
 			elem = reflect.ValueOf(binElem.Data)

--- a/bson/bsoncodec/empty_interface_codec.go
+++ b/bson/bsoncodec/empty_interface_codec.go
@@ -16,6 +16,8 @@ import (
 )
 
 // EmptyInterfaceCodec is the Codec used for interface{} values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the EmptyInterfaceCodec registered.
 type EmptyInterfaceCodec struct {
 	DecodeBinaryAsSlice bool
 }
@@ -30,6 +32,8 @@ var (
 )
 
 // NewEmptyInterfaceCodec returns a EmptyInterfaceCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the EmptyInterfaceCodec registered.
 func NewEmptyInterfaceCodec(opts ...*bsonoptions.EmptyInterfaceCodecOptions) *EmptyInterfaceCodec {
 	interfaceOpt := bsonoptions.MergeEmptyInterfaceCodecOptions(opts...)
 
@@ -123,7 +127,7 @@ func (eic EmptyInterfaceCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReade
 		return emptyValue, err
 	}
 
-	if eic.DecodeBinaryAsSlice && rtype == tBinary {
+	if (eic.DecodeBinaryAsSlice || dc.BinaryAsSlice) && rtype == tBinary {
 		binElem := elem.Interface().(primitive.Binary)
 		if binElem.Subtype == bsontype.BinaryGeneric || binElem.Subtype == bsontype.BinaryBinaryOld {
 			elem = reflect.ValueOf(binElem.Data)

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -69,7 +69,7 @@ func (mc *MapCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val ref
 		return ValueEncoderError{Name: "MapEncodeValue", Kinds: []reflect.Kind{reflect.Map}, Received: val}
 	}
 
-	if val.IsNil() && !mc.EncodeNilAsEmpty && !ec.NilMapAsEmpty {
+	if val.IsNil() && !mc.EncodeNilAsEmpty && !ec.nilMapAsEmpty {
 		// If we have a nil map but we can't WriteNull, that means we're probably trying to encode
 		// to a TopLevel document. We can't currently tell if this is what actually happened, but if
 		// there's a deeper underlying problem, the error will also be returned from WriteDocument,
@@ -102,7 +102,7 @@ func (mc *MapCodec) mapEncodeValue(ec EncodeContext, dw bsonrw.DocumentWriter, v
 
 	keys := val.MapKeys()
 	for _, key := range keys {
-		keyStr, err := mc.encodeKey(key, ec.MapKeysWithStringer)
+		keyStr, err := mc.encodeKey(key, ec.mapKeysWithStringer)
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func (mc *MapCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val ref
 		val.Set(reflect.MakeMap(val.Type()))
 	}
 
-	if val.Len() > 0 && mc.DecodeZerosMap {
+	if val.Len() > 0 && (mc.DecodeZerosMap || dc.zeroMaps) {
 		clearMap(val)
 	}
 

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -21,7 +21,8 @@ var defaultMapCodec = NewMapCodec()
 
 // MapCodec is the Codec used for map values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the MapCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// MapCodec registered.
 type MapCodec struct {
 	// DecodeZerosMap causes DecodeValue to delete any existing values from Go maps in the destination
 	// value passed to Decode before unmarshaling BSON documents into them.
@@ -60,7 +61,8 @@ type KeyUnmarshaler interface {
 
 // NewMapCodec returns a MapCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the MapCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// MapCodec registered.
 func NewMapCodec(opts ...*bsonoptions.MapCodecOptions) *MapCodec {
 	mapOpt := bsonoptions.MergeMapCodecOptions(opts...)
 

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -23,7 +23,7 @@ var defaultMapCodec = NewMapCodec()
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the MapCodec registered.
 type MapCodec struct {
-	// ZeroMaps causes DecodeValue to delete any existing values from Go maps in the destination
+	// DecodeZerosMap causes DecodeValue to delete any existing values from Go maps in the destination
 	// value passed to Decode before unmarshaling BSON documents into them.
 	//
 	// Deprecated: Use bson.Decoder.ZeroMaps instead.

--- a/bson/bsoncodec/map_codec.go
+++ b/bson/bsoncodec/map_codec.go
@@ -23,8 +23,22 @@ var defaultMapCodec = NewMapCodec()
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the MapCodec registered.
 type MapCodec struct {
-	DecodeZerosMap         bool
-	EncodeNilAsEmpty       bool
+	// ZeroMaps causes DecodeValue to delete any existing values from Go maps in the destination
+	// value passed to Decode before unmarshaling BSON documents into them.
+	//
+	// Deprecated: Use bson.Decoder.ZeroMaps instead.
+	DecodeZerosMap bool
+
+	// EncodeNilAsEmpty causes EncodeValue to marshal nil Go maps as empty BSON documents instead of
+	// BSON null.
+	//
+	// Deprecated: Use bson.Encoder.NilMapAsEmpty instead.
+	EncodeNilAsEmpty bool
+
+	// EncodeKeysWithStringer causes the Encoder to convert Go map keys to BSON document field name
+	// strings using fmt.Sprintf() instead of the default string conversion logic.
+	//
+	// Deprecated: Use bson.Encoder.StringifyMapKeysWithFmt instead.
 	EncodeKeysWithStringer bool
 }
 
@@ -102,7 +116,7 @@ func (mc *MapCodec) mapEncodeValue(ec EncodeContext, dw bsonrw.DocumentWriter, v
 
 	keys := val.MapKeys()
 	for _, key := range keys {
-		keyStr, err := mc.encodeKey(key, ec.mapKeysWithStringer)
+		keyStr, err := mc.encodeKey(key, ec.stringifyMapKeysWithFmt)
 		if err != nil {
 			return err
 		}

--- a/bson/bsoncodec/pointer_codec.go
+++ b/bson/bsoncodec/pointer_codec.go
@@ -18,6 +18,8 @@ var _ ValueEncoder = &PointerCodec{}
 var _ ValueDecoder = &PointerCodec{}
 
 // PointerCodec is the Codec used for pointers.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the PointerCodec registered.
 type PointerCodec struct {
 	ecache map[reflect.Type]ValueEncoder
 	dcache map[reflect.Type]ValueDecoder
@@ -25,6 +27,8 @@ type PointerCodec struct {
 }
 
 // NewPointerCodec returns a PointerCodec that has been initialized.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the PointerCodec registered.
 func NewPointerCodec() *PointerCodec {
 	return &PointerCodec{
 		ecache: make(map[reflect.Type]ValueEncoder),

--- a/bson/bsoncodec/pointer_codec.go
+++ b/bson/bsoncodec/pointer_codec.go
@@ -19,7 +19,8 @@ var _ ValueDecoder = &PointerCodec{}
 
 // PointerCodec is the Codec used for pointers.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the PointerCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// PointerCodec registered.
 type PointerCodec struct {
 	ecache map[reflect.Type]ValueEncoder
 	dcache map[reflect.Type]ValueDecoder
@@ -28,7 +29,8 @@ type PointerCodec struct {
 
 // NewPointerCodec returns a PointerCodec that has been initialized.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the PointerCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// PointerCodec registered.
 func NewPointerCodec() *PointerCodec {
 	return &PointerCodec{
 		ecache: make(map[reflect.Type]ValueEncoder),

--- a/bson/bsoncodec/slice_codec.go
+++ b/bson/bsoncodec/slice_codec.go
@@ -22,6 +22,10 @@ var defaultSliceCodec = NewSliceCodec()
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the SliceCodec registered.
 type SliceCodec struct {
+	// EncodeNilAsEmpty causes EncodeValue to marshal nil Go slices as empty BSON arrays instead of
+	// BSON null.
+	//
+	// Deprecated: Use bson.Encoder.NilSliceAsEmpty instead.
 	EncodeNilAsEmpty bool
 }
 

--- a/bson/bsoncodec/slice_codec.go
+++ b/bson/bsoncodec/slice_codec.go
@@ -19,11 +19,15 @@ import (
 var defaultSliceCodec = NewSliceCodec()
 
 // SliceCodec is the Codec used for slice values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the SliceCodec registered.
 type SliceCodec struct {
 	EncodeNilAsEmpty bool
 }
 
 // NewSliceCodec returns a MapCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the SliceCodec registered.
 func NewSliceCodec(opts ...*bsonoptions.SliceCodecOptions) *SliceCodec {
 	sliceOpt := bsonoptions.MergeSliceCodecOptions(opts...)
 
@@ -40,7 +44,7 @@ func (sc SliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val re
 		return ValueEncoderError{Name: "SliceEncodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
 	}
 
-	if val.IsNil() && !sc.EncodeNilAsEmpty {
+	if val.IsNil() && !sc.EncodeNilAsEmpty && !ec.NilSliceAsEmpty {
 		return vw.WriteNull()
 	}
 

--- a/bson/bsoncodec/slice_codec.go
+++ b/bson/bsoncodec/slice_codec.go
@@ -44,7 +44,7 @@ func (sc SliceCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val re
 		return ValueEncoderError{Name: "SliceEncodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
 	}
 
-	if val.IsNil() && !sc.EncodeNilAsEmpty && !ec.NilSliceAsEmpty {
+	if val.IsNil() && !sc.EncodeNilAsEmpty && !ec.nilSliceAsEmpty {
 		return vw.WriteNull()
 	}
 

--- a/bson/bsoncodec/slice_codec.go
+++ b/bson/bsoncodec/slice_codec.go
@@ -20,7 +20,8 @@ var defaultSliceCodec = NewSliceCodec()
 
 // SliceCodec is the Codec used for slice values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the SliceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// SliceCodec registered.
 type SliceCodec struct {
 	// EncodeNilAsEmpty causes EncodeValue to marshal nil Go slices as empty BSON arrays instead of
 	// BSON null.
@@ -31,7 +32,8 @@ type SliceCodec struct {
 
 // NewSliceCodec returns a MapCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the SliceCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// SliceCodec registered.
 func NewSliceCodec(opts ...*bsonoptions.SliceCodecOptions) *SliceCodec {
 	sliceOpt := bsonoptions.MergeSliceCodecOptions(opts...)
 

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -16,6 +16,8 @@ import (
 )
 
 // StringCodec is the Codec used for string values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the StringCodec registered.
 type StringCodec struct {
 	DecodeObjectIDAsHex bool
 }
@@ -30,6 +32,8 @@ var (
 )
 
 // NewStringCodec returns a StringCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the StringCodec registered.
 func NewStringCodec(opts ...*bsonoptions.StringCodecOptions) *StringCodec {
 	stringOpt := bsonoptions.MergeStringCodecOptions(opts...)
 	return &StringCodec{*stringOpt.DecodeObjectIDAsHex}
@@ -48,7 +52,7 @@ func (sc *StringCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val r
 	return vw.WriteString(val.String())
 }
 
-func (sc *StringCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (sc *StringCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t.Kind() != reflect.String {
 		return emptyValue, ValueDecoderError{
 			Name:     "StringDecodeValue",
@@ -70,9 +74,10 @@ func (sc *StringCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t refl
 		if err != nil {
 			return emptyValue, err
 		}
-		if sc.DecodeObjectIDAsHex {
+		if sc.DecodeObjectIDAsHex || dc.ObjectIDAsHexString {
 			str = oid.Hex()
 		} else {
+			// TODO(GODRIVER-2796): Return an error here instead of decoding to a garbled string.
 			byteArray := [12]byte(oid)
 			str = string(byteArray[:])
 		}

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -17,7 +17,8 @@ import (
 
 // StringCodec is the Codec used for string values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the StringCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// StringCodec registered.
 type StringCodec struct {
 	DecodeObjectIDAsHex bool
 }
@@ -33,7 +34,8 @@ var (
 
 // NewStringCodec returns a StringCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the StringCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// StringCodec registered.
 func NewStringCodec(opts ...*bsonoptions.StringCodecOptions) *StringCodec {
 	stringOpt := bsonoptions.MergeStringCodecOptions(opts...)
 	return &StringCodec{*stringOpt.DecodeObjectIDAsHex}

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -52,7 +52,7 @@ func (sc *StringCodec) EncodeValue(_ EncodeContext, vw bsonrw.ValueWriter, val r
 	return vw.WriteString(val.String())
 }
 
-func (sc *StringCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (sc *StringCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t.Kind() != reflect.String {
 		return emptyValue, ValueDecoderError{
 			Name:     "StringDecodeValue",
@@ -74,7 +74,7 @@ func (sc *StringCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t ref
 		if err != nil {
 			return emptyValue, err
 		}
-		if sc.DecodeObjectIDAsHex || dc.ObjectIDAsHexString {
+		if sc.DecodeObjectIDAsHex {
 			str = oid.Hex()
 		} else {
 			// TODO(GODRIVER-2796): Return an error here instead of decoding to a garbled string.

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -62,13 +62,40 @@ type Zeroer interface {
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the StructCodec registered.
 type StructCodec struct {
-	cache                            map[reflect.Type]*structDescription
-	l                                sync.RWMutex
-	parser                           StructTagParser
-	DecodeZeroStruct                 bool
-	DecodeDeepZeroInline             bool
-	EncodeOmitDefaultStruct          bool
-	AllowUnexportedFields            bool
+	cache  map[reflect.Type]*structDescription
+	l      sync.RWMutex
+	parser StructTagParser
+
+	// DecodeZeroStruct causes DecodeValue to delete any existing values from Go structs in the
+	// destination value passed to Decode before unmarshaling BSON documents into them.
+	//
+	// Deprecated: Use bson.Decoder.ZeroStructs instead.
+	DecodeZeroStruct bool
+
+	// DecodeZeroStruct causes DecodeValue to delete any existing values from Go structs in the
+	// destination value passed to Decode before unmarshaling BSON documents into them.
+	//
+	// Deprecated: DecodeDeepZeroInline will not be supported in Go Driver 2.0.
+	DecodeDeepZeroInline bool
+
+	// EncodeOmitDefaultStruct causes the Encoder to consider the zero value for a struct (e.g.
+	// MyStruct{}) as empty and omit it from the marshaled BSON when the "omitempty" struct tag
+	// option is set.
+	//
+	// Deprecated: Use bson.Encoder.OmitZeroStruct instead.
+	EncodeOmitDefaultStruct bool
+
+	// AllowUnexportedFields allows encoding and decoding values from un-exported struct fields.
+	//
+	// Deprecated: AllowUnexportedFields does not work on recent versions of Go and will not be
+	// supported in Go Driver 2.0.
+	AllowUnexportedFields bool
+
+	// OverwriteDuplicatedInlinedFields, if false, causes EncodeValue to return an error if there is
+	// a duplicate field in the marshaled BSON when the "inline" struct tag option is set. The
+	// default value is true.
+	//
+	// Deprecated: Use bson.Encoder.ErrorOnInlineDuplicates instead.
 	OverwriteDuplicatedInlinedFields bool
 }
 
@@ -186,7 +213,7 @@ func (sc *StructCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val 
 			Registry:                ec.Registry,
 			MinSize:                 desc.minSize || ec.MinSize,
 			errorOnInlineDuplicates: ec.errorOnInlineDuplicates,
-			mapKeysWithStringer:     ec.mapKeysWithStringer,
+			stringifyMapKeysWithFmt: ec.stringifyMapKeysWithFmt,
 			nilMapAsEmpty:           ec.nilMapAsEmpty,
 			nilSliceAsEmpty:         ec.nilSliceAsEmpty,
 			nilByteSliceAsEmpty:     ec.nilByteSliceAsEmpty,

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -72,7 +72,7 @@ type StructCodec struct {
 	// Deprecated: Use bson.Decoder.ZeroStructs instead.
 	DecodeZeroStruct bool
 
-	// DecodeZeroStruct causes DecodeValue to delete any existing values from Go structs in the
+	// DecodeDeepZeroInline causes DecodeValue to delete any existing values from Go structs in the
 	// destination value passed to Decode before unmarshaling BSON documents into them.
 	//
 	// Deprecated: DecodeDeepZeroInline will not be supported in Go Driver 2.0.

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -60,7 +60,8 @@ type Zeroer interface {
 
 // StructCodec is the Codec used for struct values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the StructCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// StructCodec registered.
 type StructCodec struct {
 	cache  map[reflect.Type]*structDescription
 	l      sync.RWMutex
@@ -104,7 +105,8 @@ var _ ValueDecoder = &StructCodec{}
 
 // NewStructCodec returns a StructCodec that uses p for struct tag parsing.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the StructCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// StructCodec registered.
 func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) (*StructCodec, error) {
 	if p == nil {
 		return nil, errors.New("a StructTagParser must be provided to NewStructCodec")

--- a/bson/bsoncodec/struct_codec_test.go
+++ b/bson/bsoncodec/struct_codec_test.go
@@ -120,7 +120,7 @@ func TestIsZero(t *testing.T) {
 			want:           true,
 		},
 		// TODO(GODRIVER-2820): Change the expected value to "false" once the logic is updated to
-		// TODO also inspct private struct fields.
+		// TODO also inspect private struct fields.
 		{
 			description:    "non-zero struct with only private fields with omitZeroStruct",
 			value:          struct{ val bool }{val: true},

--- a/bson/bsoncodec/struct_codec_test.go
+++ b/bson/bsoncodec/struct_codec_test.go
@@ -24,6 +24,7 @@ func (z zeroer) IsZero() bool {
 }
 
 func TestIsZero(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		description    string
 		value          interface{}

--- a/bson/bsoncodec/struct_codec_test.go
+++ b/bson/bsoncodec/struct_codec_test.go
@@ -13,35 +13,141 @@ import (
 	"go.mongodb.org/mongo-driver/internal/assert"
 )
 
-func TestZeoerInterfaceUsedByDecoder(t *testing.T) {
-	enc := &StructCodec{}
+var _ Zeroer = zeroer{}
 
-	// cases that are zero, because they are known types or pointers
-	var st *nonZeroer
-	assert.True(t, enc.isZero(st))
-	assert.True(t, enc.isZero(0))
-	assert.True(t, enc.isZero(false))
+type zeroer struct {
+	val int
+}
 
-	// cases that shouldn't be zero
-	st = &nonZeroer{value: false}
-	assert.False(t, enc.isZero(struct{ val bool }{val: true}))
-	assert.False(t, enc.isZero(struct{ val bool }{val: false}))
-	assert.False(t, enc.isZero(st))
-	st.value = true
-	assert.False(t, enc.isZero(st))
+func (z zeroer) IsZero() bool {
+	return z.val != 0
+}
 
-	// a test to see if the interface impacts the outcome
-	z := zeroTest{}
-	assert.False(t, enc.isZero(z))
+func TestIsZero(t *testing.T) {
+	testCases := []struct {
+		description    string
+		value          interface{}
+		omitZeroStruct bool
+		want           bool
+	}{
+		{
+			description: "false",
+			value:       false,
+			want:        true,
+		},
+		{
+			description: "0",
+			value:       0,
+			want:        true,
+		},
+		{
+			description: "nil pointer to int",
+			value:       (*int)(nil),
+			want:        true,
+		},
+		{
+			description: "time.Time",
+			value:       time.Unix(1682123781, 0),
+			want:        false,
+		},
+		{
+			description: "empty time.Time",
+			value:       time.Time{},
+			want:        true,
+		},
+		{
+			description: "nil pointer to time.Time",
+			value:       (*time.Time)(nil),
+			want:        true,
+		},
+		{
+			description: "zero struct",
+			value:       struct{ Val bool }{},
+			want:        false,
+		},
+		{
+			description: "non-zero struct",
+			value:       struct{ Val bool }{Val: true},
+			want:        false,
+		},
+		{
+			description: "nil pointer to struct",
+			value:       (*struct{ Val bool })(nil),
+			want:        true,
+		},
+		{
+			description: "pointer to struct",
+			value:       &struct{ Val bool }{},
+			want:        false,
+		},
+		{
+			description: "zero struct that implements Zeroer",
+			value:       zeroer{},
+			want:        false,
+		},
+		{
+			description: "non-zero struct that implements Zeroer",
+			value:       &zeroer{val: 1},
+			want:        true,
+		},
+		{
+			description: "pointer to zero struct that implements Zeroer",
+			value:       &zeroer{},
+			want:        false,
+		},
+		{
+			description: "pointer to non-zero struct that implements Zeroer",
+			value:       zeroer{val: 1},
+			want:        true,
+		},
+		{
+			description:    "zero struct with omitZeroStruct",
+			value:          struct{ Val bool }{},
+			omitZeroStruct: true,
+			want:           true,
+		},
+		{
+			description:    "non-zero struct with omitZeroStruct",
+			value:          struct{ Val bool }{Val: true},
+			omitZeroStruct: true,
+			want:           false,
+		},
+		{
+			description:    "zero struct with only private fields omitZeroStruct",
+			value:          struct{ val bool }{},
+			omitZeroStruct: true,
+			want:           true,
+		},
+		// TODO(GODRIVER-2820): Change the expected value to "false" once the logic is updated to
+		// TODO also inspct private struct fields.
+		{
+			description:    "non-zero struct with only private fields with omitZeroStruct",
+			value:          struct{ val bool }{val: true},
+			omitZeroStruct: true,
+			want:           true,
+		},
+		{
+			description:    "pointer to zero struct with omitZeroStruct",
+			value:          &struct{ Val bool }{},
+			omitZeroStruct: true,
+			want:           false,
+		},
+		{
+			description:    "pointer to non-zero struct with omitZeroStruct",
+			value:          &struct{ Val bool }{Val: true},
+			omitZeroStruct: true,
+			want:           false,
+		},
+	}
 
-	z.reportZero = true
-	assert.True(t, enc.isZero(z))
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
 
-	// *time.Time with nil should be zero
-	var tp *time.Time
-	assert.True(t, enc.isZero(tp))
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 
-	// actually all zeroer if nil should also be zero
-	var zp *zeroTest
-	assert.True(t, enc.isZero(zp))
+			got := isZero(tc.value, tc.omitZeroStruct)
+			assert.Equal(t, tc.want, got, "expected and actual isZero return are different")
+		})
+	}
 }

--- a/bson/bsoncodec/struct_tag_parser.go
+++ b/bson/bsoncodec/struct_tag_parser.go
@@ -12,12 +12,16 @@ import (
 )
 
 // StructTagParser returns the struct tags for a given struct field.
+//
+// Deprecated: Defining custom BSON struct tag parsers will not be supported in Go Driver 2.0.
 type StructTagParser interface {
 	ParseStructTags(reflect.StructField) (StructTags, error)
 }
 
 // StructTagParserFunc is an adapter that allows a generic function to be used
 // as a StructTagParser.
+//
+// Deprecated: Defining custom BSON struct tag parsers will not be supported in Go Driver 2.0.
 type StructTagParserFunc func(reflect.StructField) (StructTags, error)
 
 // ParseStructTags implements the StructTagParser interface.
@@ -49,6 +53,8 @@ func (stpf StructTagParserFunc) ParseStructTags(sf reflect.StructField) (StructT
 //
 //	Skip       This struct field should be skipped. This is usually denoted by parsing a "-"
 //	           for the name.
+//
+// Deprecated: Defining custom BSON struct tag parsers will not be supported in Go Driver 2.0.
 type StructTags struct {
 	Name      string
 	OmitEmpty bool
@@ -83,6 +89,8 @@ type StructTags struct {
 // A struct tag either consisting entirely of '-' or with a bson key with a
 // value consisting entirely of '-' will return a StructTags with Skip true and
 // the remaining fields will be their default values.
+//
+// Deprecated: DefaultStructTagParser will be removed in Go Driver 2.0.
 var DefaultStructTagParser StructTagParserFunc = func(sf reflect.StructField) (StructTags, error) {
 	key := strings.ToLower(sf.Name)
 	tag, ok := sf.Tag.Lookup("bson")
@@ -123,6 +131,8 @@ func parseTags(key string, tag string) (StructTags, error) {
 // JSONFallbackStructTagParser has the same behavior as DefaultStructTagParser
 // but will also fallback to parsing the json tag instead on a field where the
 // bson tag isn't available.
+//
+// Deprecated: Use bson.Encoder.UseJSONStructTags and bson.Decoder.UseJSONStructTags instead.
 var JSONFallbackStructTagParser StructTagParserFunc = func(sf reflect.StructField) (StructTags, error) {
 	key := strings.ToLower(sf.Name)
 	tag, ok := sf.Tag.Lookup("bson")

--- a/bson/bsoncodec/struct_tag_parser.go
+++ b/bson/bsoncodec/struct_tag_parser.go
@@ -132,7 +132,8 @@ func parseTags(key string, tag string) (StructTags, error) {
 // but will also fallback to parsing the json tag instead on a field where the
 // bson tag isn't available.
 //
-// Deprecated: Use bson.Encoder.UseJSONStructTags and bson.Decoder.UseJSONStructTags instead.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.UseJSONStructTags] and
+// [go.mongodb.org/mongo-driver/bson.Decoder.UseJSONStructTags] instead.
 var JSONFallbackStructTagParser StructTagParserFunc = func(sf reflect.StructField) (StructTags, error) {
 	key := strings.ToLower(sf.Name)
 	tag, ok := sf.Tag.Lookup("bson")

--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -22,6 +22,8 @@ const (
 )
 
 // TimeCodec is the Codec used for time.Time values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the TimeCodec registered.
 type TimeCodec struct {
 	UseLocalTimeZone bool
 }
@@ -35,6 +37,8 @@ var (
 )
 
 // NewTimeCodec returns a TimeCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the TimeCodec registered.
 func NewTimeCodec(opts ...*bsonoptions.TimeCodecOptions) *TimeCodec {
 	timeOpt := bsonoptions.MergeTimeCodecOptions(opts...)
 

--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -23,7 +23,8 @@ const (
 
 // TimeCodec is the Codec used for time.Time values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the TimeCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// TimeCodec registered.
 type TimeCodec struct {
 	UseLocalTimeZone bool
 }
@@ -38,7 +39,8 @@ var (
 
 // NewTimeCodec returns a TimeCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the TimeCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// TimeCodec registered.
 func NewTimeCodec(opts ...*bsonoptions.TimeCodecOptions) *TimeCodec {
 	timeOpt := bsonoptions.MergeTimeCodecOptions(opts...)
 

--- a/bson/bsoncodec/uint_codec.go
+++ b/bson/bsoncodec/uint_codec.go
@@ -17,6 +17,8 @@ import (
 )
 
 // UIntCodec is the Codec used for uint values.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the UIntCodec registered.
 type UIntCodec struct {
 	EncodeToMinSize bool
 }
@@ -30,6 +32,8 @@ var (
 )
 
 // NewUIntCodec returns a UIntCodec with options opts.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with the UIntCodec registered.
 func NewUIntCodec(opts ...*bsonoptions.UIntCodecOptions) *UIntCodec {
 	uintOpt := bsonoptions.MergeUIntCodecOptions(opts...)
 
@@ -49,7 +53,7 @@ func (uic *UIntCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val r
 		u64 := val.Uint()
 
 		// If ec.MinSize or if encodeToMinSize is true for a non-uint64 value we should write val as an int32
-		useMinSize := ec.MinSize || (uic.EncodeToMinSize && val.Kind() != reflect.Uint64)
+		useMinSize := (ec.IntMinSize || ec.MinSize) || (uic.EncodeToMinSize && val.Kind() != reflect.Uint64)
 
 		if u64 <= math.MaxInt32 && useMinSize {
 			return vw.WriteInt32(int32(u64))
@@ -87,7 +91,7 @@ func (uic *UIntCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t refl
 		if err != nil {
 			return emptyValue, err
 		}
-		if !dc.Truncate && math.Floor(f64) != f64 {
+		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
 			return emptyValue, errCannotTruncate
 		}
 		if f64 > float64(math.MaxInt64) {

--- a/bson/bsoncodec/uint_codec.go
+++ b/bson/bsoncodec/uint_codec.go
@@ -53,7 +53,7 @@ func (uic *UIntCodec) EncodeValue(ec EncodeContext, vw bsonrw.ValueWriter, val r
 		u64 := val.Uint()
 
 		// If ec.MinSize or if encodeToMinSize is true for a non-uint64 value we should write val as an int32
-		useMinSize := (ec.IntMinSize || ec.MinSize) || (uic.EncodeToMinSize && val.Kind() != reflect.Uint64)
+		useMinSize := ec.MinSize || (uic.EncodeToMinSize && val.Kind() != reflect.Uint64)
 
 		if u64 <= math.MaxInt32 && useMinSize {
 			return vw.WriteInt32(int32(u64))
@@ -91,7 +91,7 @@ func (uic *UIntCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t refl
 		if err != nil {
 			return emptyValue, err
 		}
-		if !(dc.AllowTruncatingDoubles || dc.Truncate) && math.Floor(f64) != f64 {
+		if !dc.Truncate && math.Floor(f64) != f64 {
 			return emptyValue, errCannotTruncate
 		}
 		if f64 > float64(math.MaxInt64) {

--- a/bson/bsoncodec/uint_codec.go
+++ b/bson/bsoncodec/uint_codec.go
@@ -18,7 +18,8 @@ import (
 
 // UIntCodec is the Codec used for uint values.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the UIntCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// UIntCodec registered.
 type UIntCodec struct {
 	// EncodeToMinSize causes EncodeValue to marshal Go uint values (excluding uint64) as the
 	// minimum BSON int size (either 32-bit or 64-bit) that can represent the integer value.
@@ -37,7 +38,8 @@ var (
 
 // NewUIntCodec returns a UIntCodec with options opts.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with the UIntCodec registered.
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
+// UIntCodec registered.
 func NewUIntCodec(opts ...*bsonoptions.UIntCodecOptions) *UIntCodec {
 	uintOpt := bsonoptions.MergeUIntCodecOptions(opts...)
 

--- a/bson/bsoncodec/uint_codec.go
+++ b/bson/bsoncodec/uint_codec.go
@@ -20,6 +20,10 @@ import (
 //
 // Deprecated: Use bson.NewRegistry to get a registry with the UIntCodec registered.
 type UIntCodec struct {
+	// EncodeToMinSize causes EncodeValue to marshal Go uint values (excluding uint64) as the
+	// minimum BSON int size (either 32-bit or 64-bit) that can represent the integer value.
+	//
+	// Deprecated: Use bson.Encoder.IntMinSize instead.
 	EncodeToMinSize bool
 }
 

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -145,3 +145,40 @@ func (d *Decoder) DefaultDocumentM() {
 func (d *Decoder) DefaultDocumentD() {
 	d.defaultDocumentD = true
 }
+
+// AllowTruncatingDoubles causes the Decoder to truncate the fractional part of BSON "double" values
+// when attempting to unmarshal them into a Go integer struct field. The truncation logic does not
+// apply to BSON "decimal128" values.
+func (d *Decoder) AllowTruncatingDoubles() {
+	d.dc.AllowTruncatingDoubles = true
+	d.dc.Truncate = true
+}
+
+// AllowUnexportedFields causes the Decoder to unmarshal values into unexported struct fields.
+func (d *Decoder) AllowUnexportedFields() {
+	d.dc.AllowUnexportedFields = true
+}
+
+// BinaryAsSlice causes the Decoder to unmarshal BSON binary field values that are the "Generic" or
+// "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
+func (d *Decoder) BinaryAsSlice() {
+	d.dc.BinaryAsSlice = true
+}
+
+// UseJSONStructTags causes the Decoder to fall back to using the "json" struct tag if a "bson"
+// struct tag is not specified.
+func (d *Decoder) UseJSONStructTags() {
+	d.dc.UseJSONStructTags = true
+}
+
+// ZeroMaps causes the Decoder to delete any existing values from Go maps in the destination value
+// passed to Decode before unmarshaling BSON documents into them.
+func (d *Decoder) ZeroMaps() {
+	d.dc.ZeroMaps = true
+}
+
+// ZeroStructs causes the Decoder to delete any existing values from Go structs in the destination
+// value passed to Decode before unmarshaling BSON documents into them.
+func (d *Decoder) ZeroStructs() {
+	d.dc.ZeroStructs = true
+}

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -38,6 +38,11 @@ type Decoder struct {
 	// (*Decoder).SetContext.
 	defaultDocumentM bool
 	defaultDocumentD bool
+
+	binaryAsSlice     bool
+	useJSONStructTags bool
+	zeroMaps          bool
+	zeroStructs       bool
 }
 
 // NewDecoder returns a new decoder that uses the DefaultRegistry to read from vr.
@@ -103,12 +108,26 @@ func (d *Decoder) Decode(val interface{}) error {
 	if err != nil {
 		return err
 	}
+
 	if d.defaultDocumentM {
 		d.dc.DefaultDocumentM()
 	}
 	if d.defaultDocumentD {
 		d.dc.DefaultDocumentD()
 	}
+	if d.binaryAsSlice {
+		d.dc.BinaryAsSlice()
+	}
+	if d.useJSONStructTags {
+		d.dc.UseJSONStructTags()
+	}
+	if d.zeroMaps {
+		d.dc.ZeroMaps()
+	}
+	if d.zeroStructs {
+		d.dc.ZeroStructs()
+	}
+
 	return decoder.DecodeValue(d.dc, d.vr, rval)
 }
 
@@ -147,38 +166,32 @@ func (d *Decoder) DefaultDocumentD() {
 }
 
 // AllowTruncatingDoubles causes the Decoder to truncate the fractional part of BSON "double" values
-// when attempting to unmarshal them into a Go integer struct field. The truncation logic does not
-// apply to BSON "decimal128" values.
+// when attempting to unmarshal them into a Go integer (int, int8, int16, int32, or int64) struct
+// field. The truncation logic does not apply to BSON "decimal128" values.
 func (d *Decoder) AllowTruncatingDoubles() {
-	d.dc.AllowTruncatingDoubles = true
 	d.dc.Truncate = true
-}
-
-// AllowUnexportedFields causes the Decoder to unmarshal values into unexported struct fields.
-func (d *Decoder) AllowUnexportedFields() {
-	d.dc.AllowUnexportedFields = true
 }
 
 // BinaryAsSlice causes the Decoder to unmarshal BSON binary field values that are the "Generic" or
 // "Old" BSON binary subtype as a Go byte slice instead of a primitive.Binary.
 func (d *Decoder) BinaryAsSlice() {
-	d.dc.BinaryAsSlice = true
+	d.binaryAsSlice = true
 }
 
 // UseJSONStructTags causes the Decoder to fall back to using the "json" struct tag if a "bson"
 // struct tag is not specified.
 func (d *Decoder) UseJSONStructTags() {
-	d.dc.UseJSONStructTags = true
+	d.useJSONStructTags = true
 }
 
 // ZeroMaps causes the Decoder to delete any existing values from Go maps in the destination value
 // passed to Decode before unmarshaling BSON documents into them.
 func (d *Decoder) ZeroMaps() {
-	d.dc.ZeroMaps = true
+	d.zeroMaps = true
 }
 
 // ZeroStructs causes the Decoder to delete any existing values from Go structs in the destination
 // value passed to Decode before unmarshaling BSON documents into them.
 func (d *Decoder) ZeroStructs() {
-	d.dc.ZeroStructs = true
+	d.zeroStructs = true
 }

--- a/bson/decoder_example_test.go
+++ b/bson/decoder_example_test.go
@@ -1,0 +1,128 @@
+package bson_test
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+)
+
+func ExampleDecoder() {
+	// Marshal a BSON document that contains the name, SKU, and price (in cents)
+	// of a product.
+	doc := bson.D{
+		{Key: "name", Value: "Cereal Rounds"},
+		{Key: "sku", Value: "AB12345"},
+		{Key: "price", Value: 399},
+	}
+	b, err := bson.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a Decoder that reads the marshaled BSON document and use it to
+	// unmarshal the document into a Product struct.
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `bson:"name"`
+		SKU   string `bson:"sku"`
+		Price int64  `bson:"price"`
+	}
+
+	var res Product
+	err = decoder.Decode(&res)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+	// Output: {Name:Cereal Rounds SKU:AB12345 Price:399}
+}
+
+func ExampleDecoder_DefaultDocumentM() {
+	// Marshal a BSON document that contains a city name and a nested document
+	// with various city properties.
+	doc := bson.D{
+		{Key: "name", Value: "New York"},
+		{Key: "properties", Value: bson.D{
+			{Key: "state", Value: "NY"},
+			{Key: "population", Value: 8_804_190},
+			{Key: "elevation", Value: 10},
+		}},
+	}
+	b, err := bson.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a Decoder that reads the marshaled BSON document and use it to unmarshal the document
+	// into a City struct.
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	if err != nil {
+		panic(err)
+	}
+
+	type City struct {
+		Name       string      `bson:"name"`
+		Properties interface{} `bson:"properties"`
+	}
+
+	// Configure the Decoder to default to decoding BSON documents as the bson.M
+	// type if the decode destination has no type information. The Properties
+	// field in the City struct will be decoded as a "bson.M" (i.e. map) instead
+	// of the default "bson.D".
+	decoder.DefaultDocumentM()
+
+	var res City
+	err = decoder.Decode(&res)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+	// Output: {Name:New York Properties:map[elevation:10 population:8804190 state:NY]}
+}
+
+func ExampleDecoder_UseJSONStructTags() {
+	// Marshal a BSON document that contains the name, SKU, and price (in cents)
+	// of a product.
+	doc := bson.D{
+		{Key: "name", Value: "Cereal Rounds"},
+		{Key: "sku", Value: "AB12345"},
+		{Key: "price_cents", Value: 399},
+	}
+	b, err := bson.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a Decoder that reads the marshaled BSON document and use it to
+	// unmarshal the document into a Product struct.
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `json:"name"`
+		SKU   string `json:"sku"`
+		Price int64  `json:"price_cents"`
+	}
+
+	// Configure the Decoder to use "json" struct tags when decoding if "bson"
+	// struct tags are not present.
+	decoder.UseJSONStructTags()
+
+	var res Product
+	err = decoder.Decode(&res)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+	// Output: {Name:Cereal Rounds SKU:AB12345 Price:399}
+}

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -298,11 +298,16 @@ func (tu *testUnmarshaler) UnmarshalBSON(d []byte) error {
 
 func TestDecoderConfiguration(t *testing.T) {
 	type truncateDoublesTest struct {
-		MyInt   int
-		MyInt8  int8
-		MyInt16 int16
-		MyInt32 int32
-		MyInt64 int64
+		MyInt    int
+		MyInt8   int8
+		MyInt16  int16
+		MyInt32  int32
+		MyInt64  int64
+		MyUint   uint
+		MyUint8  uint8
+		MyUint16 uint16
+		MyUint32 uint32
+		MyUint64 uint64
 	}
 
 	type jsonStructTest struct {
@@ -338,14 +343,24 @@ func TestDecoderConfiguration(t *testing.T) {
 				AppendDouble("myInt16", 1.999).
 				AppendDouble("myInt32", 1.999).
 				AppendDouble("myInt64", 1.999).
+				AppendDouble("myUint", 1.999).
+				AppendDouble("myUint8", 1.999).
+				AppendDouble("myUint16", 1.999).
+				AppendDouble("myUint32", 1.999).
+				AppendDouble("myUint64", 1.999).
 				Build(),
 			decodeInto: func() interface{} { return &truncateDoublesTest{} },
 			want: &truncateDoublesTest{
-				MyInt:   1,
-				MyInt8:  1,
-				MyInt16: 1,
-				MyInt32: 1,
-				MyInt64: 1,
+				MyInt:    1,
+				MyInt8:   1,
+				MyInt16:  1,
+				MyInt32:  1,
+				MyInt64:  1,
+				MyUint:   1,
+				MyUint8:  1,
+				MyUint16: 1,
+				MyUint32: 1,
+				MyUint64: 1,
 			},
 		},
 		// Test that BinaryAsSlice causes the Decoder to unmarshal BSON binary fields into Go byte

--- a/bson/decoder_test.go
+++ b/bson/decoder_test.go
@@ -17,8 +17,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -282,144 +282,6 @@ func TestDecoderv2(t *testing.T) {
 			t.Fatalf("Decode error mismatch; expected %v, got %v", ErrDecodeToNil, err)
 		}
 	})
-	t.Run("DefaultDocuemntD embedded map as empty interface", func(t *testing.T) {
-		t.Parallel()
-
-		type someMap map[string]interface{}
-
-		in := make(someMap)
-		in["foo"] = map[string]interface{}{"bar": "baz"}
-
-		bytes, err := Marshal(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var bsonOut someMap
-		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(bytes))
-		if err != nil {
-			t.Fatal(err)
-		}
-		dec.DefaultDocumentM()
-		if err := dec.Decode(&bsonOut); err != nil {
-			t.Fatal(err)
-		}
-
-		// Ensure that interface{}-typed top-level data is converted to the document type.
-		bsonOutType := reflect.TypeOf(bsonOut)
-		inType := reflect.TypeOf(in)
-		assert.Equal(t, inType, bsonOutType, "expected %v to equal %v", inType.String(), bsonOutType.String())
-
-		// Ensure that the embedded type is a primitive map.
-		mType := reflect.TypeOf(primitive.M{})
-		bsonFooOutType := reflect.TypeOf(bsonOut["foo"])
-		assert.Equal(t, mType, bsonFooOutType, "expected %v to equal %v", mType.String(), bsonFooOutType.String())
-	})
-	t.Run("DefaultDocuemntD for decoding into interface{} alias", func(t *testing.T) {
-		t.Parallel()
-
-		var in interface{} = map[string]interface{}{"bar": "baz"}
-
-		bytes, err := Marshal(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var bsonOut interface{}
-		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(bytes))
-		if err != nil {
-			t.Fatal(err)
-		}
-		dec.DefaultDocumentD()
-		if err := dec.Decode(&bsonOut); err != nil {
-			t.Fatal(err)
-		}
-
-		// Ensure that interface{}-typed top-level data is converted to the document type.
-		dType := reflect.TypeOf(primitive.D{})
-		bsonOutType := reflect.TypeOf(bsonOut)
-		assert.Equal(t, dType, bsonOutType,
-			"expected %v to equal %v", dType.String(), bsonOutType.String())
-	})
-	t.Run("DefaultDocuemntD for decoding into non-interface{} alias", func(t *testing.T) {
-		t.Parallel()
-
-		var in interface{} = map[string]interface{}{"bar": "baz"}
-
-		bytes, err := Marshal(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var bsonOut struct{}
-		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(bytes))
-		if err != nil {
-			t.Fatal(err)
-		}
-		dec.DefaultDocumentD()
-		if err := dec.Decode(&bsonOut); err != nil {
-			t.Fatal(err)
-		}
-
-		// Ensure that typed top-level data is not converted to the document type.
-		dType := reflect.TypeOf(primitive.D{})
-		bsonOutType := reflect.TypeOf(bsonOut)
-		assert.NotEqual(t, dType, bsonOutType,
-			"expected %v to not equal %v", dType.String(), bsonOutType.String())
-	})
-	t.Run("DefaultDocumentD for deep struct values", func(t *testing.T) {
-		t.Parallel()
-
-		type emb struct {
-			Foo map[int]interface{} `bson:"foo"`
-		}
-
-		objID := primitive.NewObjectID()
-
-		in := emb{
-			Foo: map[int]interface{}{
-				1: map[string]interface{}{"bar": "baz"},
-				2: map[int]interface{}{
-					3: map[string]interface{}{"bar": "baz"},
-				},
-				4: map[primitive.ObjectID]interface{}{
-					objID: map[string]interface{}{"bar": "baz"},
-				},
-			},
-		}
-
-		bytes, err := Marshal(in)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(bytes))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		dec.DefaultDocumentD()
-
-		var out emb
-		if err := dec.Decode(&out); err != nil {
-			t.Fatal(err)
-		}
-
-		mType := reflect.TypeOf(primitive.M{})
-		bsonOutType := reflect.TypeOf(out)
-		assert.NotEqual(t, mType, bsonOutType,
-			"expected %v to not equal %v", mType.String(), bsonOutType.String())
-
-		want := emb{
-			Foo: map[int]interface{}{
-				1: primitive.D{{Key: "bar", Value: "baz"}},
-				2: primitive.D{{Key: "3", Value: primitive.D{{Key: "bar", Value: "baz"}}}},
-				4: primitive.D{{Key: objID.Hex(), Value: primitive.D{{Key: "bar", Value: "baz"}}}},
-			},
-		}
-
-		assert.Equal(t, want, out, "expected %v, got %v", want, out)
-	})
 }
 
 type testUnmarshaler struct {
@@ -432,4 +294,221 @@ func (tu *testUnmarshaler) UnmarshalBSON(d []byte) error {
 	tu.invoked = true
 	tu.data = d
 	return tu.err
+}
+
+func TestDecoderConfiguration(t *testing.T) {
+	type truncateDoublesTest struct {
+		MyInt   int
+		MyInt8  int8
+		MyInt16 int16
+		MyInt32 int32
+		MyInt64 int64
+	}
+
+	type jsonStructTest struct {
+		StructFieldName string `json:"jsonFieldName"`
+	}
+
+	type zeroMapsTest struct {
+		MyMap map[string]string
+	}
+
+	type zeroStructsTest struct {
+		MyString string
+		MyInt    int
+	}
+
+	testCases := []struct {
+		description string
+		configure   func(*Decoder)
+		input       []byte
+		decodeInto  func() interface{}
+		want        interface{}
+	}{
+		// Test that AllowTruncatingDoubles causes the Decoder to unmarshal BSON doubles with
+		// fractional parts into Go integer types by truncating the fractional part.
+		{
+			description: "AllowTruncatingDoubles",
+			configure: func(dec *Decoder) {
+				dec.AllowTruncatingDoubles()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendDouble("myInt", 1.999).
+				AppendDouble("myInt8", 1.999).
+				AppendDouble("myInt16", 1.999).
+				AppendDouble("myInt32", 1.999).
+				AppendDouble("myInt64", 1.999).
+				Build(),
+			decodeInto: func() interface{} { return &truncateDoublesTest{} },
+			want: &truncateDoublesTest{
+				MyInt:   1,
+				MyInt8:  1,
+				MyInt16: 1,
+				MyInt32: 1,
+				MyInt64: 1,
+			},
+		},
+		// Test that BinaryAsSlice causes the Decoder to unmarshal BSON binary fields into Go byte
+		// slices when there is no type information (e.g when unmarshaling into a bson.D).
+		{
+			description: "BinaryAsSlice",
+			configure: func(dec *Decoder) {
+				dec.BinaryAsSlice()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendBinary("myBinary", bsontype.BinaryGeneric, []byte{}).
+				Build(),
+			decodeInto: func() interface{} { return &D{} },
+			want:       &D{{Key: "myBinary", Value: []byte{}}},
+		},
+		// Test that DefaultDocumentD overrides the default "ancestor" logic and always decodes BSON
+		// documents into bson.D values, independent of the top-level Go value type.
+		{
+			description: "DefaultDocumentD nested",
+			configure: func(dec *Decoder) {
+				dec.DefaultDocumentD()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendDocument("myDocument", bsoncore.NewDocumentBuilder().
+					AppendString("myString", "test value").
+					Build()).
+				Build(),
+			decodeInto: func() interface{} { return M{} },
+			want: M{
+				"myDocument": D{{Key: "myString", Value: "test value"}},
+			},
+		},
+		// Test that DefaultDocumentM overrides the default "ancestor" logic and always decodes BSON
+		// documents into bson.M values, independent of the top-level Go value type.
+		{
+			description: "DefaultDocumentM nested",
+			configure: func(dec *Decoder) {
+				dec.DefaultDocumentM()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendDocument("myDocument", bsoncore.NewDocumentBuilder().
+					AppendString("myString", "test value").
+					Build()).
+				Build(),
+			decodeInto: func() interface{} { return &D{} },
+			want: &D{
+				{Key: "myDocument", Value: M{"myString": "test value"}},
+			},
+		},
+		// Test that UseJSONStructTags causes the Decoder to fall back to "json" struct tags if
+		// "bson" struct tags are not available.
+		{
+			description: "UseJSONStructTags",
+			configure: func(dec *Decoder) {
+				dec.UseJSONStructTags()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendString("jsonFieldName", "test value").
+				Build(),
+			decodeInto: func() interface{} { return &jsonStructTest{} },
+			want:       &jsonStructTest{StructFieldName: "test value"},
+		},
+		// Test that ZeroMaps causes the Decoder to empty any Go map values before decoding BSON
+		// documents into them.
+		{
+			description: "ZeroMaps",
+			configure: func(dec *Decoder) {
+				dec.ZeroMaps()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendDocument("myMap", bsoncore.NewDocumentBuilder().
+					AppendString("myString", "test value").
+					Build()).
+				Build(),
+			decodeInto: func() interface{} {
+				return &zeroMapsTest{MyMap: map[string]string{"myExtraValue": "extra value"}}
+			},
+			want: &zeroMapsTest{MyMap: map[string]string{"myString": "test value"}},
+		},
+		// Test that ZeroStructs causes the Decoder to empty any Go struct values before decoding
+		// BSON documents into them.
+		{
+			description: "ZeroStructs",
+			configure: func(dec *Decoder) {
+				dec.ZeroStructs()
+			},
+			input: bsoncore.NewDocumentBuilder().
+				AppendString("myString", "test value").
+				Build(),
+			decodeInto: func() interface{} {
+				return &zeroStructsTest{MyInt: 1}
+			},
+			want: &zeroStructsTest{MyString: "test value"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(tc.input))
+			require.NoError(t, err, "NewDecoder error")
+
+			tc.configure(dec)
+
+			got := tc.decodeInto()
+			err = dec.Decode(got)
+			require.NoError(t, err, "Decode error")
+
+			assert.Equal(t, tc.want, got, "expected and actual decode results do not match")
+		})
+	}
+
+	t.Run("DefaultDocumentM top-level", func(t *testing.T) {
+		t.Parallel()
+
+		input := bsoncore.NewDocumentBuilder().
+			AppendDocument("myDocument", bsoncore.NewDocumentBuilder().
+				AppendString("myString", "test value").
+				Build()).
+			Build()
+
+		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(input))
+		require.NoError(t, err, "NewDecoder error")
+
+		dec.DefaultDocumentM()
+
+		var got interface{}
+		err = dec.Decode(&got)
+		require.NoError(t, err, "Decode error")
+
+		want := M{
+			"myDocument": M{
+				"myString": "test value",
+			},
+		}
+		assert.Equal(t, want, got, "expected and actual decode results do not match")
+	})
+	t.Run("DefaultDocumentD top-level", func(t *testing.T) {
+		t.Parallel()
+
+		input := bsoncore.NewDocumentBuilder().
+			AppendDocument("myDocument", bsoncore.NewDocumentBuilder().
+				AppendString("myString", "test value").
+				Build()).
+			Build()
+
+		dec, err := NewDecoder(bsonrw.NewBSONDocumentReader(input))
+		require.NoError(t, err, "NewDecoder error")
+
+		dec.DefaultDocumentD()
+
+		var got interface{}
+		err = dec.Decode(&got)
+		require.NoError(t, err, "Decode error")
+
+		want := D{
+			{Key: "myDocument", Value: D{
+				{Key: "myString", Value: "test value"},
+			}},
+		}
+		assert.Equal(t, want, got, "expected and actual decode results do not match")
+	})
 }

--- a/bson/encoder.go
+++ b/bson/encoder.go
@@ -32,7 +32,7 @@ type Encoder struct {
 
 	errorOnInlineDuplicates bool
 	intMinSize              bool
-	mapKeysWithStringer     bool
+	stringifyMapKeysWithFmt bool
 	nilMapAsEmpty           bool
 	nilSliceAsEmpty         bool
 	nilByteSliceAsEmpty     bool
@@ -97,8 +97,8 @@ func (e *Encoder) Encode(val interface{}) error {
 	if e.intMinSize {
 		e.ec.MinSize = true
 	}
-	if e.mapKeysWithStringer {
-		e.ec.MapKeysWithStringer()
+	if e.stringifyMapKeysWithFmt {
+		e.ec.StringifyMapKeysWithFmt()
 	}
 	if e.nilMapAsEmpty {
 		e.ec.NilMapAsEmpty()
@@ -147,16 +147,17 @@ func (e *Encoder) ErrorOnInlineDuplicates() {
 	e.errorOnInlineDuplicates = true
 }
 
-// IntMinSize causes the Encoder to marshal Go integer values (int, int8, int16, int32, or int64) as
-// the minimum BSON int size (either 32-bit or 64-bit) that can represent the integer value.
+// IntMinSize causes the Encoder to marshal Go integer values (int, int8, int16, int32, int64, uint,
+// uint8, uint16, uint32, or uint64) as the minimum BSON int size (either 32 or 64 bits) that can
+// represent the integer value.
 func (e *Encoder) IntMinSize() {
 	e.intMinSize = true
 }
 
-// MapKeysWithStringer causes the Encoder to convert Go map keys to BSON document field name strings
-// using fmt.Sprintf() instead of the default string conversion logic.
-func (e *Encoder) MapKeysWithStringer() {
-	e.mapKeysWithStringer = true
+// StringifyMapKeysWithFmt causes the Encoder to convert Go map keys to BSON document field name
+// strings using fmt.Sprint instead of the default string conversion logic.
+func (e *Encoder) StringifyMapKeysWithFmt() {
+	e.stringifyMapKeysWithFmt = true
 }
 
 // NilMapAsEmpty causes the Encoder to marshal nil Go maps as empty BSON documents instead of BSON

--- a/bson/encoder.go
+++ b/bson/encoder.go
@@ -82,24 +82,78 @@ func (e *Encoder) Encode(val interface{}) error {
 	return encoder.EncodeValue(e.ec, e.vw, reflect.ValueOf(val))
 }
 
-// Reset will reset the state of the encoder, using the same *EncodeContext used in
+// Reset will reset the state of the Encoder, using the same *EncodeContext used in
 // the original construction but using vw.
 func (e *Encoder) Reset(vw bsonrw.ValueWriter) error {
 	e.vw = vw
 	return nil
 }
 
-// SetRegistry replaces the current registry of the encoder with r.
+// SetRegistry replaces the current registry of the Encoder with r.
 func (e *Encoder) SetRegistry(r *bsoncodec.Registry) error {
 	e.ec.Registry = r
 	return nil
 }
 
-// SetContext replaces the current EncodeContext of the encoder with er.
+// SetContext replaces the current EncodeContext of the encoder with ec.
 //
 // Deprecated: Use the Encoder configuration methods set the desired behavior of the encoder
 // instead.
 func (e *Encoder) SetContext(ec bsoncodec.EncodeContext) error {
 	e.ec = ec
 	return nil
+}
+
+// AllowUnexportedFields causes the Encoder to marshal values from unexported struct fields.
+func (e *Encoder) AllowUnexportedFields() {
+	e.ec.AllowUnexportedFields = true
+}
+
+// ErrorOnInlineDuplicates causes the Encoder to return an error if there is a duplicate field in
+// the marshaled BSON when the "inline" struct tag option is set.
+func (e *Encoder) ErrorOnInlineDuplicates() {
+	e.ec.ErrorOnInlineDuplicates = true
+}
+
+// IntMinSize causes the Encoder to marshal Go integer values (int, int8, int16, int32, or int64) as
+// the minimum BSON int size (either 32-bit or 64-bit) that can represent the integer value.
+func (e *Encoder) IntMinSize() {
+	e.ec.IntMinSize = true
+	e.ec.MinSize = true
+}
+
+// MapKeysWithStringer causes the Encoder to convert Go map keys to BSON document field name strings
+// using fmt.Sprintf() instead of the default string conversion logic.
+func (e *Encoder) MapKeysWithStringer() {
+	e.ec.MapKeysWithStringer = true
+}
+
+// NilMapAsEmpty causes the Encoder to marshal nil Go maps as empty BSON documents instead of BSON
+// null.
+func (e *Encoder) NilMapAsEmpty() {
+	e.ec.NilMapAsEmpty = true
+}
+
+// NilSliceAsEmpty causes the Encoder to marshal nil Go slices as empty BSON arrays instead of BSON
+// null.
+func (e *Encoder) NilSliceAsEmpty() {
+	e.ec.NilSliceAsEmpty = true
+}
+
+// NilByteSliceAsEmpty causes the Encoder to marshal nil Go byte slices as empty BSON binary values
+// instead of BSON null.
+func (e *Encoder) NilByteSliceAsEmpty() {
+	e.ec.NilByteSliceAsEmpty = true
+}
+
+// OmitDefaultStruct causes the Encoder to consider the zero value for a struct (e.g. MyStruct{}) as
+// empty and omit it from the marshaled BSON when the "omitempty" struct tag option is set.
+func (e *Encoder) OmitDefaultStruct() {
+	e.ec.OmitDefaultStruct = true
+}
+
+// UseJSONStructTags causes the Encoder to fall back to using the "json" struct tag if a "bson"
+// struct tag is not specified.
+func (e *Encoder) UseJSONStructTags() {
+	e.ec.UseJSONStructTags = true
 }

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -52,7 +52,7 @@ func (k CityState) String() string {
 	return fmt.Sprintf("%s, %s", k.City, k.State)
 }
 
-func ExampleEncoder_MapKeysWithStringer() {
+func ExampleEncoder_StringifyMapKeysWithFmt() {
 	// Create an Encoder that writes BSON values to a bytes.Buffer.
 	buf := new(bytes.Buffer)
 	vw, err := bsonrw.NewBSONValueWriter(buf)
@@ -66,13 +66,12 @@ func ExampleEncoder_MapKeysWithStringer() {
 
 	// Configure the Encoder to convert Go map keys to BSON document field names
 	// using fmt.Sprintf instead of the default string conversion logic.
-	encoder.MapKeysWithStringer()
+	encoder.StringifyMapKeysWithFmt()
 
 	// Use the Encoder to marshal a BSON document that contains is a map of
 	// city and state to a list of zip codes in that city.
 	zipCodes := map[CityState][]int{
-		{City: "New York", State: "NY"}: {10001, 10005},
-		{City: "Seattle", State: "WA"}:  {98101, 98105},
+		{City: "New York", State: "NY"}: {10001, 10301, 10451},
 	}
 	err = encoder.Encode(zipCodes)
 	if err != nil {
@@ -81,7 +80,7 @@ func ExampleEncoder_MapKeysWithStringer() {
 
 	// Print the BSON document as Extended JSON by converting it to bson.Raw.
 	fmt.Println(bson.Raw(buf.Bytes()).String())
-	// Output: {"New York, NY": [{"$numberInt":"10001"},{"$numberInt":"10005"}],"Seattle, WA": [{"$numberInt":"98101"},{"$numberInt":"98105"}]}
+	// Output: {"New York, NY": [{"$numberInt":"10001"},{"$numberInt":"10301"},{"$numberInt":"10451"}]}
 }
 
 func ExampleEncoder_UseJSONStructTags() {

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -1,0 +1,124 @@
+package bson_test
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+)
+
+func ExampleEncoder() {
+	// Create an Encoder that writes BSON values to a bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewBSONValueWriter(buf)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `bson:"name"`
+		SKU   string `bson:"sku"`
+		Price int64  `bson:"price_cents"`
+	}
+
+	// Use the Encoder to marshal a BSON document that contains the name, SKU,
+	// and price (in cents) of a product.
+	product := Product{
+		Name:  "Cereal Rounds",
+		SKU:   "AB12345",
+		Price: 399,
+	}
+	err = encoder.Encode(product)
+	if err != nil {
+		panic(err)
+	}
+
+	// Print the BSON document as Extended JSON by converting it to bson.Raw.
+	fmt.Println(bson.Raw(buf.Bytes()).String())
+	// Output: {"name": "Cereal Rounds","sku": "AB12345","price_cents": {"$numberLong":"399"}}
+}
+
+type CityState struct {
+	City  string
+	State string
+}
+
+func (k CityState) String() string {
+	return fmt.Sprintf("%s, %s", k.City, k.State)
+}
+
+func ExampleEncoder_MapKeysWithStringer() {
+	// Create an Encoder that writes BSON values to a bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewBSONValueWriter(buf)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	// Configure the Encoder to convert Go map keys to BSON document field names
+	// using fmt.Sprintf instead of the default string conversion logic.
+	encoder.MapKeysWithStringer()
+
+	// Use the Encoder to marshal a BSON document that contains is a map of
+	// city and state to a list of zip codes in that city.
+	zipCodes := map[CityState][]int{
+		{City: "New York", State: "NY"}: {10001, 10005},
+		{City: "Seattle", State: "WA"}:  {98101, 98105},
+	}
+	err = encoder.Encode(zipCodes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Print the BSON document as Extended JSON by converting it to bson.Raw.
+	fmt.Println(bson.Raw(buf.Bytes()).String())
+	// Output: {"New York, NY": [{"$numberInt":"10001"},{"$numberInt":"10005"}],"Seattle, WA": [{"$numberInt":"98101"},{"$numberInt":"98105"}]}
+}
+
+func ExampleEncoder_UseJSONStructTags() {
+	// Create an Encoder that writes BSON values to a bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewBSONValueWriter(buf)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `json:"name"`
+		SKU   string `json:"sku"`
+		Price int64  `json:"price_cents"`
+	}
+
+	// Configure the Encoder to use "json" struct tags when decoding if "bson"
+	// struct tags are not present.
+	encoder.UseJSONStructTags()
+
+	// Use the Encoder to marshal a BSON document that contains the name, SKU,
+	// and price (in cents) of a product.
+	product := Product{
+		Name:  "Cereal Rounds",
+		SKU:   "AB12345",
+		Price: 399,
+	}
+	err = encoder.Encode(product)
+	if err != nil {
+		panic(err)
+	}
+
+	// Print the BSON document as Extended JSON by converting it to bson.Raw.
+	fmt.Println(bson.Raw(buf.Bytes()).String())
+	// Output: {"name": "Cereal Rounds","sku": "AB12345","price_cents": {"$numberLong":"399"}}
+}

--- a/bson/encoder_test.go
+++ b/bson/encoder_test.go
@@ -15,6 +15,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsonrw/bsonrwtest"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestBasicEncode(t *testing.T) {
@@ -132,4 +136,174 @@ func docToBytes(d interface{}) []byte {
 		panic(err)
 	}
 	return b
+}
+
+type stringerTest struct{}
+
+func (stringerTest) String() string {
+	return "test key"
+}
+
+func TestEncoderConfiguration(t *testing.T) {
+	type inlineDuplicateInner struct {
+		Duplicate string
+	}
+
+	type inlineDuplicateOuter struct {
+		Inline    inlineDuplicateInner `bson:",inline"`
+		Duplicate string
+	}
+
+	type zeroStruct struct {
+		MyString string
+	}
+
+	testCases := []struct {
+		description string
+		configure   func(*Encoder)
+		input       interface{}
+		want        []byte
+		wantErr     error
+	}{
+		// Test that ErrorOnInlineDuplicates causes the Encoder to return an error if there are any
+		// duplicate fields in the marshaled document caused by using the "inline" struct tag.
+		{
+			description: "ErrorOnInlineDuplicates",
+			configure: func(enc *Encoder) {
+				enc.ErrorOnInlineDuplicates()
+			},
+			input: inlineDuplicateOuter{
+				Inline:    inlineDuplicateInner{Duplicate: "inner"},
+				Duplicate: "outer",
+			},
+			wantErr: errors.New("struct bson.inlineDuplicateOuter has duplicated key duplicate"),
+		},
+		// Test that IntMinSize encodes Go int and int64 values as BSON int32 if the value is small
+		// enough.
+		{
+			description: "IntMinSize",
+			configure: func(enc *Encoder) {
+				enc.IntMinSize()
+			},
+			input: D{
+				{Key: "myInt", Value: int(1)},
+				{Key: "myInt64", Value: int64(1)},
+			},
+			want: bsoncore.NewDocumentBuilder().
+				AppendInt32("myInt", 1).
+				AppendInt32("myInt64", 1).
+				Build(),
+		},
+		// Test that MapKeysWithStringer uses fmt.Sprintf to convert map keys to BSON field names.
+		{
+			description: "MapKeysWithStringer",
+			configure: func(enc *Encoder) {
+				enc.MapKeysWithStringer()
+			},
+			input: map[stringerTest]string{
+				{}: "test value",
+			},
+			want: bsoncore.NewDocumentBuilder().
+				AppendString("test key", "test value").
+				Build(),
+		},
+		// Test that NilMapAsEmpty encodes nil Go maps as empty BSON documents.
+		{
+			description: "NilMapAsEmpty",
+			configure: func(enc *Encoder) {
+				enc.NilMapAsEmpty()
+			},
+			input: D{{Key: "myMap", Value: map[string]string(nil)}},
+			want: bsoncore.NewDocumentBuilder().
+				AppendDocument("myMap", bsoncore.NewDocumentBuilder().Build()).
+				Build(),
+		},
+		// Test that NilSliceAsEmpty encodes nil Go slices as empty BSON arrays.
+		{
+			description: "NilSliceAsEmpty",
+			configure: func(enc *Encoder) {
+				enc.NilSliceAsEmpty()
+			},
+			input: D{{Key: "mySlice", Value: []string(nil)}},
+			want: bsoncore.NewDocumentBuilder().
+				AppendArray("mySlice", bsoncore.NewArrayBuilder().Build()).
+				Build(),
+		},
+		// Test that NilByteSliceAsEmpty encodes nil Go byte slices as empty BSON binary elements.
+		{
+			description: "NilByteSliceAsEmpty",
+			configure: func(enc *Encoder) {
+				enc.NilByteSliceAsEmpty()
+			},
+			input: D{{Key: "myBytes", Value: []byte(nil)}},
+			want: bsoncore.NewDocumentBuilder().
+				AppendBinary("myBytes", bsontype.BinaryGeneric, []byte{}).
+				Build(),
+		},
+		// Test that OmitZeroStruct omits empty structs from the marshaled document if the
+		// "omitempty" struct tag is used.
+		{
+			description: "OmitZeroStruct",
+			configure: func(enc *Encoder) {
+				enc.OmitZeroStruct()
+			},
+			input: struct {
+				Zero zeroStruct `bson:",omitempty"`
+			}{},
+			want: bsoncore.NewDocumentBuilder().Build(),
+		},
+		// Test that UseJSONStructTags causes the Encoder to fall back to "json" struct tags if
+		// "bson" struct tags are not available.
+		{
+			description: "UseJSONStructTags",
+			configure: func(enc *Encoder) {
+				enc.UseJSONStructTags()
+			},
+			input: struct {
+				StructFieldName string `json:"jsonFieldName"`
+			}{
+				StructFieldName: "test value",
+			},
+			want: bsoncore.NewDocumentBuilder().
+				AppendString("jsonFieldName", "test value").
+				Build(),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			got := new(bytes.Buffer)
+			vw, err := bsonrw.NewBSONValueWriter(got)
+			require.NoError(t, err, "bsonrw.NewBSONValueWriter error")
+			enc, err := NewEncoder(vw)
+			require.NoError(t, err, "NewEncoder error")
+
+			tc.configure(enc)
+
+			err = enc.Encode(tc.input)
+			if tc.wantErr != nil {
+				assert.Equal(t, tc.wantErr, err, "expected and actual errors do not match")
+				return
+			}
+			require.NoError(t, err, "Encode error")
+
+			assert.Equal(t, tc.want, got.Bytes(), "expected and actual encoded BSON do not match")
+
+			// After we compare the raw bytes, also decode the expected and actual BSON as a bson.D
+			// and compare them. The goal is to make assertion failures easier to debug because
+			// binary diffs are very difficult to understand.
+			var wantDoc D
+			err = Unmarshal(tc.want, &wantDoc)
+			require.NoError(t, err, "Unmarshal error")
+			var gotDoc D
+			err = Unmarshal(got.Bytes(), &gotDoc)
+			require.NoError(t, err, "Unmarshal error")
+
+			assert.Equal(t, wantDoc, gotDoc, "expected and actual decoded documents do not match")
+		})
+	}
 }

--- a/bson/encoder_test.go
+++ b/bson/encoder_test.go
@@ -188,17 +188,23 @@ func TestEncoderConfiguration(t *testing.T) {
 			input: D{
 				{Key: "myInt", Value: int(1)},
 				{Key: "myInt64", Value: int64(1)},
+				{Key: "myUint", Value: uint(1)},
+				{Key: "myUint32", Value: uint32(1)},
+				{Key: "myUint64", Value: uint64(1)},
 			},
 			want: bsoncore.NewDocumentBuilder().
 				AppendInt32("myInt", 1).
 				AppendInt32("myInt64", 1).
+				AppendInt32("myUint", 1).
+				AppendInt32("myUint32", 1).
+				AppendInt32("myUint64", 1).
 				Build(),
 		},
-		// Test that MapKeysWithStringer uses fmt.Sprintf to convert map keys to BSON field names.
+		// Test that StringifyMapKeysWithFmt uses fmt.Sprint to convert map keys to BSON field names.
 		{
-			description: "MapKeysWithStringer",
+			description: "StringifyMapKeysWithFmt",
 			configure: func(enc *Encoder) {
-				enc.MapKeysWithStringer()
+				enc.StringifyMapKeysWithFmt()
 			},
 			input: map[stringerTest]string{
 				{}: "test value",


### PR DESCRIPTION
[GODRIVER-2716](https://jira.mongodb.org/browse/GODRIVER-2716)

## Summary
Introduce a new way to customize BSON marshaling and unmarshaling by configuring a BSON `Encoder` or `Decoder`. Deprecate all existing codec types and configurations in the `bsoncodec` package (to be removed in Go Driver 2.0).

Add tests for all of the new configuration functions and add testable examples for some of them.

## Background & Motivation

Currently, users have to go through the complex process of creating codecs to apply any custom marshal/unmarshal behavior and registering them in a registry. We want to provide a new, simpler API to configure BSON and Extended JSON marshaling/unmarshaling behavior via the `bson.Encoder` and `bson.Decoder` types.

The new API for configuring a `bson.Encoder` is:
```go
func (*Encoder).ErrorOnInlineDuplicates() // Replaces StructCodec.OverwriteDuplicatedInlinedFields
func (*Encoder).IntMinSize()              // Replaces EncodeContext.MinSize
func (*Encoder).MapKeysWithStringer()     // Replaces MapCodec.EncodeKeysWithStringer
func (*Encoder).NilByteSliceAsEmpty()     // Replaces ByteSliceCodec.EncodeNilAsEmpty
func (*Encoder).NilMapAsEmpty()           // Replaces MapCodec.EncodeNilAsEmpty
func (*Encoder).NilSliceAsEmpty()         // Replaces SliceCodec.EncodeNilAsEmpty
func (*Encoder).OmitZeroStruct()          // Replaces StructCodec.EncodeOmitDefaultStruct
func (*Encoder).UseJSONStructTags()       // Replaces StructCodec.StructTagParser
```

The new API for configuring a `bson.Decoder` is:
```go
func (*Decoder).AllowTruncatingDoubles() // Replaces DecodeContext.Truncate
func (*Decoder).BinaryAsSlice()          // Replaces EmptyInterfaceCodec.DecodeBinaryAsSlice
func (*Decoder).DefaultDocumentM()       // Replaces DecodeContext.DefaultDocumentM
func (*Decoder).UseJSONStructTags()      // Replaces StructCodec.StructTagParser 
func (*Decoder).ZeroMaps()               // Replaces MapCodec.DecodeZerosMap
func (*Decoder).ZeroStructs()            // Replaces StructCodec.DecodeZeroStruct
```

Some of the configuration options that are currently available via the `bsoncodec` types 
* `StructCodec.AllowUnexportedFields` - Newer versions of Go prevent changing the value of an unexported struct field using the `reflect` package, preventing unmarshaling BSON into unexported struct fields. We can still read unexported struct fields, but the lack of symmetry between unmarshaling and marshaling would be too confusing, so drop the configuration.
* `StructCodec.DecodeDeepZeroInline` - This configuration resets a struct decode target to the zero value for that struct and then recursively creates empty structs for any nested struct pointers in the struct decode target. The similar configuration value `Decoder.ZeroStruct` also resets the struct decode target to the zero value, but leaves nested struct pointers `nil`. It's not clear if there's a use case for `DecodeDeepZeroInline`, so exclude it.

Additionally, `DecodeContext.DefaultDocumentD`/`Decoder.DefaultDocumentD` are deprecated because decoding to a `bson.D` will be the default behavior in Go Driver 2.0 (there will be no "ancestor" behavior), so there will be no need for a configuration function that sets the default.

Those changes allow un-exporting all exported built-in codecs in Go Driver 2.0. Deprecate all `*Codec` types in the `bsoncodec` package to indicate they will be removed in Go Driver 2.0 and should not be used.