### PR TITLE
WIP - Spike out query interceptor

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -66,6 +66,10 @@ type CommandMonitor struct {
 	Failed    func(context.Context, *CommandFailedEvent)
 }
 
+type CommandInterceptor struct {
+	Process func(context.Context, *[]byte) error
+}
+
 // strings for pool command monitoring reasons
 const (
 	ReasonIdle              = "idle"

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	writeConcern   *writeconcern.WriteConcern
 	registry       *bsoncodec.Registry
 	monitor        *event.CommandMonitor
+	interceptor    *event.CommandInterceptor
 	serverAPI      *driver.ServerAPIOptions
 	serverMonitor  *event.ServerMonitor
 	sessionPool    *session.Pool
@@ -147,6 +148,10 @@ func NewClient(opts ...*options.ClientOptions) (*Client, error) {
 	// Monitor
 	if clientOpt.Monitor != nil {
 		client.monitor = clientOpt.Monitor
+	}
+	// Interceptor
+	if clientOpt.Interceptor != nil {
+		client.interceptor = clientOpt.Interceptor
 	}
 	// ServerMonitor
 	if clientOpt.ServerMonitor != nil {

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -106,6 +106,7 @@ type ClientOptions struct {
 	HeartbeatInterval        *time.Duration
 	Hosts                    []string
 	HTTPClient               *http.Client
+	Interceptor              *event.CommandInterceptor
 	LoadBalanced             *bool
 	LocalThreshold           *time.Duration
 	LoggerOptions            *LoggerOptions
@@ -632,6 +633,11 @@ func (c *ClientOptions) SetPoolMonitor(m *event.PoolMonitor) *ClientOptions {
 // information about the structure of the monitor and events that can be received.
 func (c *ClientOptions) SetMonitor(m *event.CommandMonitor) *ClientOptions {
 	c.Monitor = m
+	return c
+}
+
+func (c *ClientOptions) SetInterceptor(i *event.CommandInterceptor) *ClientOptions {
+	c.Interceptor = i
 	return c
 }
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->
In order to implement a feature like circuit breaking that relies on internal business logic, there needs to be a centralized space to stop queries from within the driver. This is a (very much incomplete) example of what that could look like.

## Background & Motivation
<!--- Rationale for the pull request. -->
When a cluster gets unhealthy, sometimes shutting off traffic to it temporarily is a good way to give it time to recover. This might be based on a business case of "we need to shut off feature XYZ and all the traffic it's sending to the cluster", or something more specific like "that reporting query knocking the cluster over shut it off now".
