### PR TITLE
GODRIVER-2686 Simplify the readconcern API.

### DIFF
--- a/mongo/readconcern/readconcern.go
+++ b/mongo/readconcern/readconcern.go
@@ -5,6 +5,9 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package readconcern defines read concerns for MongoDB operations.
+//
+// For more information about MongoDB read concerns, see
+// https://www.mongodb.com/docs/manual/reference/read-concern/
 package readconcern // import "go.mongodb.org/mongo-driver/mongo/readconcern"
 
 import (
@@ -12,50 +15,83 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
-// ReadConcern for replica sets and replica set shards determines which data to return from a query.
+// A ReadConcern defines a MongoDB read concern, which allows you to control the consistency and
+// isolation properties of the data read from replica sets and replica set shards.
+//
+// For more information about MongoDB read concerns, see
+// https://www.mongodb.com/docs/manual/reference/read-concern/
 type ReadConcern struct {
-	level string
+	Level string
 }
 
 // Option is an option to provide when creating a ReadConcern.
+//
+// Deprecated: Use the ReadConcern literal declaration instead. For example:
+//
+//	&readconcern.ReadConcern{Level: "local"}
 type Option func(concern *ReadConcern)
 
 // Level creates an option that sets the level of a ReadConcern.
+//
+// Deprecated: Use the ReadConcern literal declaration instead. For example:
+//
+//	&readconcern.ReadConcern{Level: "local"}
 func Level(level string) Option {
 	return func(concern *ReadConcern) {
-		concern.level = level
+		concern.Level = level
 	}
 }
 
-// Local specifies that the query should return the instance’s most recent data.
+// Local returns a ReadConcern that requests data from the instance with no guarantee that the data
+// has been written to a majority of the replica set members (i.e. may be rolled back).
+//
+// For more information about read concern "local", see
+// https://www.mongodb.com/docs/manual/reference/read-concern-local/
 func Local() *ReadConcern {
 	return New(Level("local"))
 }
 
-// Majority specifies that the query should return the instance’s most recent data acknowledged as
-// having been written to a majority of members in the replica set.
+// Majority returns a ReadConcern that requests data that has been acknowledged by a majority of the
+// replica set members (i.e. the documents read are durable and guaranteed not to roll back).
+//
+// For more information about read concern "majority", see
+// https://www.mongodb.com/docs/manual/reference/read-concern-majority/
 func Majority() *ReadConcern {
 	return New(Level("majority"))
 }
 
-// Linearizable specifies that the query should return data that reflects all successful writes
-// issued with a write concern of "majority" and acknowledged prior to the start of the read operation.
+// Linearizable returns a ReadConcern that requests data that reflects all successful
+// majority-acknowledged writes that completed prior to the start of the read operation.
+//
+// For more information about read concern "linearizable", see
+// https://www.mongodb.com/docs/manual/reference/read-concern-linearizable/
 func Linearizable() *ReadConcern {
 	return New(Level("linearizable"))
 }
 
-// Available specifies that the query should return data from the instance with no guarantee
-// that the data has been written to a majority of the replica set members (i.e. may be rolled back).
+// Available returns a ReadConcern that requests data from an instance with no guarantee that the
+// data has been written to a majority of the replica set members (i.e. may be rolled back).
+//
+// For more information about read concern "available", see
+// https://www.mongodb.com/docs/manual/reference/read-concern-available/
 func Available() *ReadConcern {
 	return New(Level("available"))
 }
 
-// Snapshot is only available for operations within multi-document transactions.
+// Snapshot returns a ReadConcern that requests majority-committed data as it appears across shards
+// from a specific single point in time in the recent past.
+//
+// For more information about read concern "snapshot", see
+// https://www.mongodb.com/docs/manual/reference/read-concern-snapshot/
 func Snapshot() *ReadConcern {
 	return New(Level("snapshot"))
 }
 
 // New constructs a new read concern from the given string.
+//
+// Deprecated: Use the ReadConcern literal declaration instead. For example:
+//
+//	&readconcern.ReadConcern{Level: "local"}
 func New(options ...Option) *ReadConcern {
 	concern := &ReadConcern{}
 
@@ -67,17 +103,21 @@ func New(options ...Option) *ReadConcern {
 }
 
 // MarshalBSONValue implements the bson.ValueMarshaler interface.
+//
+// Deprecated: Marshaling a ReadConcern to BSON will not be supported in Go Driver 2.0.
 func (rc *ReadConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	var elems []byte
 
-	if len(rc.level) > 0 {
-		elems = bsoncore.AppendStringElement(elems, "level", rc.level)
+	if len(rc.Level) > 0 {
+		elems = bsoncore.AppendStringElement(elems, "level", rc.Level)
 	}
 
 	return bsontype.EmbeddedDocument, bsoncore.BuildDocument(nil, elems), nil
 }
 
 // GetLevel returns the read concern level.
+//
+// Deprecated: Use the ReadConcern.Level field instead.
 func (rc *ReadConcern) GetLevel() string {
-	return rc.level
+	return rc.Level
 }


### PR DESCRIPTION
[GODRIVER-2686](https://jira.mongodb.org/browse/GODRIVER-2686)

## Summary
Simplify the `readconcern` package API by deprecating the "functional options" setters and exporting all fields in a `ReadConcern`. Also improve the documentation and add links to the corresponding MongoDB manual pages.

## Background & Motivation
The `readconcern` package unnecessarily uses the "functional options" pattern which is not used on any other public API. Remove the functional options pattern and just export all fields in the `ReadConcern` struct so users can set them directly.

Also, some exported values or functions do not need to be exported:
* `ReadConcern.MarshalBSONValue` - There is no known use case for this outside of the Go driver.

