### PR TITLE
GODRIVER-2685 Simplify the writeconcern API.

### DIFF
--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -137,16 +137,18 @@ func Custom(tag string) *WriteConcern {
 
 // Option is an option to provide when creating a WriteConcern.
 //
-// Deprecated: Use the WriteConcern helpers instead, then set individual fields if necessary.
+// Deprecated: Use the WriteConcern convenience functions or define a struct literal instead.
 // For example:
 //
 //	writeconcern.Majority()
 //
 // or
 //
-//	wc := writeconcern.W1()
 //	journal := true
-//	wc.Journal = &journal
+//	&writeconcern.WriteConcern{
+//		W:       2,
+//		Journal: &journal,
+//	}
 type Option func(concern *WriteConcern)
 
 // New constructs a new WriteConcern.
@@ -197,7 +199,7 @@ func W(w int) Option {
 // WMajority requests acknowledgement that write operations propagate to the majority of mongod
 // instances.
 //
-// Deprecated: Use the Majority function instead.
+// Deprecated: Use [Majority] instead.
 func WMajority() Option {
 	return func(concern *WriteConcern) {
 		concern.W = majority
@@ -207,7 +209,7 @@ func WMajority() Option {
 // WTagSet requests acknowledgement that write operations propagate to the specified mongod
 // instance.
 //
-// Deprecated: Use the Custom function instead.
+// Deprecated: Use [Custom] instead.
 func WTagSet(tag string) Option {
 	return func(concern *WriteConcern) {
 		concern.W = tag
@@ -422,7 +424,7 @@ func (wc *WriteConcern) WithOptions(options ...Option) *WriteConcern {
 
 // AckWrite returns true if a write concern represents an acknowledged write
 //
-// Deprecated: Use WriteConcern.Acknowledged instead.
+// Deprecated: Use [WriteConcern.Acknowledged] instead.
 func AckWrite(wc *WriteConcern) bool {
 	return wc == nil || wc.Acknowledged()
 }

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -5,10 +5,14 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package writeconcern defines write concerns for MongoDB operations.
+//
+// For more information about MongoDB write concerns, see
+// https://www.mongodb.com/docs/manual/reference/write-concern/
 package writeconcern // import "go.mongodb.org/mongo-driver/mongo/writeconcern"
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -17,34 +21,126 @@ import (
 )
 
 // ErrInconsistent indicates that an inconsistent write concern was specified.
+//
+// Deprecated: ErrInconsistent will be removed in Go Driver 2.0.
 var ErrInconsistent = errors.New("a write concern cannot have both w=0 and j=true")
 
 // ErrEmptyWriteConcern indicates that a write concern has no fields set.
+//
+// Deprecated: ErrEmptyWriteConcern will be removed in Go Driver 2.0.
 var ErrEmptyWriteConcern = errors.New("a write concern must have at least one field set")
 
 // ErrNegativeW indicates that a negative integer `w` field was specified.
+//
+// Deprecated: ErrNegativeW will be removed in Go Driver 2.0.
 var ErrNegativeW = errors.New("write concern `w` field cannot be a negative number")
 
 // ErrNegativeWTimeout indicates that a negative WTimeout was specified.
+//
+// Deprecated: ErrNegativeWTimeout will be removed in Go Driver 2.0.
 var ErrNegativeWTimeout = errors.New("write concern `wtimeout` field cannot be negative")
 
-// WriteConcern describes the level of acknowledgement requested from MongoDB for write operations
-// to a standalone mongod or to replica sets or to sharded clusters.
+// A WriteConcern defines a MongoDB read concern, which describes the level of acknowledgment
+// requested from MongoDB for write operations to a standalone mongod, to replica sets, or to
+// sharded clusters.
+//
+// For more information about MongoDB write concerns, see
+// https://www.mongodb.com/docs/manual/reference/write-concern/
 type WriteConcern struct {
-	w interface{}
-	j bool
+	// W requests acknowledgment that the write operation has propagated to a specified number of
+	// mongod instances or to mongod instances with specified tags. It sets the the "w" option
+	// in a MongoDB write concern.
+	//
+	// W must be a type string or int value.
+	//
+	// For more information about the "w" option, see
+	// https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
+	W interface{}
 
-	// NOTE(benjirewis): wTimeout will be deprecated in a future release. The more general Timeout
-	// option may be used in its place to control the amount of time that a single operation can run
-	// before returning an error. Using wTimeout and setting Timeout on the client will result in
-	// undefined behavior.
-	wTimeout time.Duration
+	// Journal requests acknowledgment from MongoDB that the write operation has been written to the
+	// on-disk journal. It sets the "j" option in a MongoDB write concern.
+	//
+	// For more information about the "j" option, see
+	// https://www.mongodb.com/docs/manual/reference/write-concern/#j-option
+	Journal *bool
+
+	// WTimeout specifies a time limit for the write concern. It sets the "wtimeout" option in a
+	// MongoDB write concern.
+	//
+	// It is only applicable for "w" values greater than 1. Using a WTimeout and setting Timeout on
+	// the Client at the same time will result in undefined behavior.
+	//
+	// For more information about the "wtimeout" option, see
+	// https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout
+	WTimeout time.Duration
+}
+
+// Majority returns a WriteConcern that requests acknowledgment that write operations have been
+// durably committed to the calculated majority of the data-bearing voting members. If journaling is
+// enabled on mongod, nodes only acknowledge when the write operation has been written to the
+// on-disk journal.
+//
+// For more information about write concern "w: majority", see
+// https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-
+func Majority() *WriteConcern {
+	return &WriteConcern{W: "majority"}
+}
+
+// Custom returns a WriteConcern that requests acknowledgment that the write operation has
+// propagated to tagged members that satisfy the custom write concern defined in
+// "settings.getLastErrorModes". If journaling is enabled on mongod, nodes only acknowledge when the
+// write operation has been written to the on-disk journal.
+//
+// For more information about custom write concern names, see
+// https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-custom-write-concern-name-
+func Custom(tag string) *WriteConcern {
+	return &WriteConcern{W: tag}
+}
+
+// W0 returns a WriteConcern that requests no acknowledgment of the write operation.
+//
+// For more information about write concern "w: 0", see
+// https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-number-
+func W0() *WriteConcern {
+	return &WriteConcern{W: 0}
+}
+
+// W1 returns a WriteConcern that requests acknowledgment that the write operation has propagated to
+// the standalone mongod or the primary in a replica set. If journal is true, mongod nodes only
+// acknowledge when the write operation has been written to the on-disk journal.
+//
+// For more information about write concern "w: 1", see
+// https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-number-
+func W1() *WriteConcern {
+	return &WriteConcern{W: 1}
 }
 
 // Option is an option to provide when creating a WriteConcern.
+//
+// Deprecated: Use the WriteConcern helpers instead, then set individual fields if necessary.
+// For example:
+//
+//	writeconcern.Majority()
+//
+// or
+//
+//	wc := writeconcern.W1()
+//	journal := true
+//	wc.Journal = &journal
 type Option func(concern *WriteConcern)
 
 // New constructs a new WriteConcern.
+//
+// Deprecated: Use the WriteConcern helpers instead, then set individual fields if necessary.
+// For example:
+//
+//	writeconcern.Majority()
+//
+// or
+//
+//	wc := writeconcern.W1()
+//	journal := true
+//	wc.Journal = &journal
 func New(options ...Option) *WriteConcern {
 	concern := &WriteConcern{}
 
@@ -57,49 +153,85 @@ func New(options ...Option) *WriteConcern {
 
 // W requests acknowledgement that write operations propagate to the specified number of mongod
 // instances.
+//
+// Deprecated: Use the W0 or W1 functions, then set individual fields if necessary.
+// For example:
+//
+//	writeconcern.W0()
+//
+// or
+//
+//	wc := writeconcern.W1()
+//	journal := true
+//	wc.Journal = &journal
 func W(w int) Option {
 	return func(concern *WriteConcern) {
-		concern.w = w
+		concern.W = w
 	}
 }
 
 // WMajority requests acknowledgement that write operations propagate to the majority of mongod
 // instances.
+//
+// Deprecated: Use the Majority function instead.
 func WMajority() Option {
 	return func(concern *WriteConcern) {
-		concern.w = "majority"
+		concern.W = "majority"
 	}
 }
 
 // WTagSet requests acknowledgement that write operations propagate to the specified mongod
 // instance.
+//
+// Deprecated: Use the Custom function instead.
 func WTagSet(tag string) Option {
 	return func(concern *WriteConcern) {
-		concern.w = tag
+		concern.W = tag
 	}
 }
 
 // J requests acknowledgement from MongoDB that write operations are written to
 // the journal.
+//
+// Deprecated: Use the WriteConcern helpers instead, then set individual fields if necessary.
+// For example:
+//
+//	writeconcern.Majority()
+//
+// or
+//
+//	wc := writeconcern.W1()
+//	journal := true
+//	wc.Journal = &journal
 func J(j bool) Option {
 	return func(concern *WriteConcern) {
-		concern.j = j
+		// To maintain backward compatible behavior (now that the J field is a *bool), only set a
+		// value for J if the input is true. If the input is false, do not set a value, which omits
+		// "j" from the marshaled write concern.
+		if j {
+			concern.Journal = &j
+		}
 	}
 }
 
-// WTimeout specifies specifies a time limit for the write concern.
+// WTimeout specifies a time limit for the write concern.
 //
-// NOTE(benjirewis): wTimeout will be deprecated in a future release. The more general Timeout
-// option may be used in its place to control the amount of time that a single operation can run
-// before returning an error. Using wTimeout and setting Timeout on the client will result in
-// undefined behavior.
+// It is only applicable for "w" values greater than 1. Using a WTimeout and setting Timeout on the
+// Client at the same time will result in undefined behavior.
+//
+// Deprecated: Use the WriteConcern helpers and then set WTimeout instead. For example:
+//
+//	wc := writeconcern.W1()
+//	wc.WTimeout = 30 * time.Second
 func WTimeout(d time.Duration) Option {
 	return func(concern *WriteConcern) {
-		concern.wTimeout = d
+		concern.WTimeout = d
 	}
 }
 
 // MarshalBSONValue implements the bson.ValueMarshaler interface.
+//
+// Deprecated: Marshaling a WriteConcern to BSON will not be supported in Go Driver 2.0.
 func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	if !wc.IsValid() {
 		return bsontype.Type(0), nil, ErrInconsistent
@@ -107,8 +239,10 @@ func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 
 	var elems []byte
 
-	if wc.w != nil {
-		switch t := wc.w.(type) {
+	if wc.W != nil {
+		// Only support string or int values for W. That aligns with the documentation and the
+		// behavior of other functions, like Acknowledged.
+		switch t := wc.W.(type) {
 		case int:
 			if t < 0 {
 				return bsontype.Type(0), nil, ErrNegativeW
@@ -117,19 +251,23 @@ func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 			elems = bsoncore.AppendInt32Element(elems, "w", int32(t))
 		case string:
 			elems = bsoncore.AppendStringElement(elems, "w", t)
+		default:
+			return bsontype.Type(0),
+				nil,
+				fmt.Errorf("WriteConcern.W must be a string or int, but is a %T", wc.W)
 		}
 	}
 
-	if wc.j {
-		elems = bsoncore.AppendBooleanElement(elems, "j", wc.j)
+	if wc.Journal != nil {
+		elems = bsoncore.AppendBooleanElement(elems, "j", *wc.Journal)
 	}
 
-	if wc.wTimeout < 0 {
+	if wc.WTimeout < 0 {
 		return bsontype.Type(0), nil, ErrNegativeWTimeout
 	}
 
-	if wc.wTimeout != 0 {
-		elems = bsoncore.AppendInt64Element(elems, "wtimeout", int64(wc.wTimeout/time.Millisecond))
+	if wc.WTimeout != 0 {
+		elems = bsoncore.AppendInt64Element(elems, "wtimeout", int64(wc.WTimeout/time.Millisecond))
 	}
 
 	if len(elems) == 0 {
@@ -163,27 +301,37 @@ func AcknowledgedValue(rawv bson.RawValue) bool {
 
 // Acknowledged indicates whether or not a write with the given write concern will be acknowledged.
 func (wc *WriteConcern) Acknowledged() bool {
-	if wc == nil || wc.j {
+	if wc == nil || (wc.Journal != nil && *wc.Journal) {
 		return true
 	}
 
-	switch v := wc.w.(type) {
-	case int:
-		if v == 0 {
-			return false
-		}
+	// Only int value 0 with no "j" or "j: false" is an unacknowledged write concern. All other
+	// values are either acknowledged or unsupported, which will cause a BSON marshaling error.
+	if i, ok := wc.W.(int); ok && i == 0 {
+		return false
 	}
 
 	return true
 }
 
 // IsValid checks whether the write concern is invalid.
+//
+// Deprecated: IsValid will not be supported in Go Driver 2.0.
 func (wc *WriteConcern) IsValid() bool {
-	if !wc.j {
+	if wc.Journal == nil || !*wc.Journal {
 		return true
 	}
 
-	switch v := wc.w.(type) {
+	switch v := wc.W.(type) {
+	// Now that users can set W to any type, IsValid doesn't handle cases where W is an unsupported
+	// type. However, the only use case of this function appears to be in MarshalBSONValue, which
+	// now does its own unsupported type handling and returns an usable error for unsupported types
+	// (MarshalBSONValue returns ErrInconsistent when IsValid is false, which doesn't cover
+	// unsupported types). To maintain backward compatibility and return good errors in
+	// MarshalBSONValue, keep the logic here the same and don't handle unsupported types.
+	//
+	// IsValid is deprecated and will be removed in Go Driver 2.0, so the inconsistency will only
+	// exist during the transition from Go Driver 1.x to Go Driver 2.0.
 	case int:
 		if v == 0 {
 			return false
@@ -194,21 +342,40 @@ func (wc *WriteConcern) IsValid() bool {
 }
 
 // GetW returns the write concern w level.
+//
+// Deprecated: Use the WriteConcern.W field instead.
 func (wc *WriteConcern) GetW() interface{} {
-	return wc.w
+	return wc.W
 }
 
 // GetJ returns the write concern journaling level.
+//
+// Deprecated: Use the WriteConcern.J field instead.
 func (wc *WriteConcern) GetJ() bool {
-	return wc.j
+	// Treat a nil J as false. That maintains backward compatibility with the existing behavior of
+	// GetJ where unset is false. If users want the real value of J, they can access the J field.
+	return wc.Journal != nil && *wc.Journal
 }
 
 // GetWTimeout returns the write concern timeout.
+//
+// Deprecated: Use the WriteConcern.WTimeout field instead.
 func (wc *WriteConcern) GetWTimeout() time.Duration {
-	return wc.wTimeout
+	return wc.WTimeout
 }
 
 // WithOptions returns a copy of this WriteConcern with the options set.
+//
+// Deprecated: Use the WriteConcern helpers instead, then set individual fields if necessary.
+// For example:
+//
+//	writeconcern.Majority()
+//
+// or
+//
+//	wc := writeconcern.W1()
+//	journal := true
+//	wc.Journal = &journal
 func (wc *WriteConcern) WithOptions(options ...Option) *WriteConcern {
 	if wc == nil {
 		return New(options...)
@@ -224,6 +391,8 @@ func (wc *WriteConcern) WithOptions(options ...Option) *WriteConcern {
 }
 
 // AckWrite returns true if a write concern represents an acknowledged write
+//
+// Deprecated: AckWrite will not be supported in Go Driver 2.0.
 func AckWrite(wc *WriteConcern) bool {
 	return wc == nil || wc.Acknowledged()
 }

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -49,41 +49,46 @@ var ErrNegativeWTimeout = errors.New("write concern `wtimeout` field cannot be n
 // For more information about MongoDB write concerns, see
 // https://www.mongodb.com/docs/manual/reference/write-concern/
 type WriteConcern struct {
-	// W requests acknowledgment that the write operation has propagated to a specified number of
-	// mongod instances or to mongod instances with specified tags. It sets the the "w" option
-	// in a MongoDB write concern.
+	// W requests acknowledgment that the write operation has propagated to a
+	// specified number of mongod instances or to mongod instances with
+	// specified tags. It sets the the "w" option in a MongoDB write concern.
 	//
 	// W values must be a string or an int.
 	//
 	// Common values are:
-	// - "majority": requests acknowledgment that write operations have been durably committed to
-	//   the calculated majority of the data-bearing voting members.
-	// - 1: requests acknowledgment that write operations have been written to 1 node.
-	// - 0: requests no acknowledgment of write operations
+	//   - "majority": requests acknowledgment that write operations have been
+	//     durably committed to the calculated majority of the data-bearing
+	//     voting members.
+	//   - 1: requests acknowledgment that write operations have been written
+	//     to 1 node.
+	//   - 0: requests no acknowledgment of write operations
 	//
 	// For more information about the "w" option, see
 	// https://www.mongodb.com/docs/manual/reference/write-concern/#w-option
 	W interface{}
 
-	// Journal requests acknowledgment from MongoDB that the write operation has been written to the
-	// on-disk journal. It sets the "j" option in a MongoDB write concern.
+	// Journal requests acknowledgment from MongoDB that the write operation has
+	// been written to the on-disk journal. It sets the "j" option in a MongoDB
+	// write concern.
 	//
 	// For more information about the "j" option, see
 	// https://www.mongodb.com/docs/manual/reference/write-concern/#j-option
 	Journal *bool
 
-	// WTimeout specifies a time limit for the write concern. It sets the "wtimeout" option in a
-	// MongoDB write concern.
+	// WTimeout specifies a time limit for the write concern. It sets the
+	// "wtimeout" option in a MongoDB write concern.
 	//
-	// It is only applicable for "w" values greater than 1. Using a WTimeout and setting Timeout on
-	// the Client at the same time will result in undefined behavior.
+	// It is only applicable for "w" values greater than 1. Using a WTimeout and
+	// setting Timeout on the Client at the same time will result in undefined
+	// behavior.
 	//
 	// For more information about the "wtimeout" option, see
 	// https://www.mongodb.com/docs/manual/reference/write-concern/#wtimeout
 	WTimeout time.Duration
 }
 
-// Unacknowledged returns a WriteConcern that requests no acknowledgment of write operations.
+// Unacknowledged returns a WriteConcern that requests no acknowledgment of
+// write operations.
 //
 // For more information about write concern "w: 0", see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-number-
@@ -91,8 +96,9 @@ func Unacknowledged() *WriteConcern {
 	return &WriteConcern{W: 0}
 }
 
-// W1 returns a WriteConcern that requests acknowledgment that write operations have been written to
-// memory on one node (e.g. the standalone mongod or the primary in a replica set).
+// W1 returns a WriteConcern that requests acknowledgment that write operations
+// have been written to memory on one node (e.g. the standalone mongod or the
+// primary in a replica set).
 //
 // For more information about write concern "w: 1", see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-number-
@@ -100,11 +106,11 @@ func W1() *WriteConcern {
 	return &WriteConcern{W: 1}
 }
 
-// Journaled returns a WriteConcern that requests acknowledgment that write operations have been
-// written to the on-disk journal on MongoDB.
+// Journaled returns a WriteConcern that requests acknowledgment that write
+// operations have been written to the on-disk journal on MongoDB.
 //
-// The database's default value for "w" determines how many nodes must write to their on-disk
-// journal before the write operation is acknowledged.
+// The database's default value for "w" determines how many nodes must write to
+// their on-disk journal before the write operation is acknowledged.
 //
 // For more information about write concern "j: true", see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-ournal
@@ -113,12 +119,14 @@ func Journaled() *WriteConcern {
 	return &WriteConcern{Journal: &journal}
 }
 
-// Majority returns a WriteConcern that requests acknowledgment that write operations have been
-// durably committed to the calculated majority of the data-bearing voting members.
+// Majority returns a WriteConcern that requests acknowledgment that write
+// operations have been durably committed to the calculated majority of the
+// data-bearing voting members.
 //
-// Write concern "w: majority" typically requires write operations to be written to the on-disk
-// journal before they are acknowledged, unless journaling is disabled on MongoDB or the
-// "writeConcernMajorityJournalDefault" replica set configuration is set to false.
+// Write concern "w: majority" typically requires write operations to be written
+// to the on-disk journal before they are acknowledged, unless journaling is
+// disabled on MongoDB or the "writeConcernMajorityJournalDefault" replica set
+// configuration is set to false.
 //
 // For more information about write concern "w: majority", see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-
@@ -126,8 +134,9 @@ func Majority() *WriteConcern {
 	return &WriteConcern{W: majority}
 }
 
-// Custom returns a WriteConcern that requests acknowledgment that write operations have propagated
-// to tagged members that satisfy the custom write concern defined in "settings.getLastErrorModes".
+// Custom returns a WriteConcern that requests acknowledgment that write
+// operations have propagated to tagged members that satisfy the custom write
+// concern defined in "settings.getLastErrorModes".
 //
 // For more information about custom write concern names, see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-custom-write-concern-name-
@@ -233,9 +242,10 @@ func WTagSet(tag string) Option {
 //	}
 func J(j bool) Option {
 	return func(concern *WriteConcern) {
-		// To maintain backward compatible behavior (now that the J field is a *bool), only set a
-		// value for J if the input is true. If the input is false, do not set a value, which omits
-		// "j" from the marshaled write concern.
+		// To maintain backward compatible behavior (now that the J field is a
+		// bool pointer), only set a value for J if the input is true. If the
+		// input is false, do not set a value, which omits "j" from the
+		// marshaled write concern.
 		if j {
 			concern.Journal = &j
 		}
@@ -268,28 +278,34 @@ func WTimeout(d time.Duration) Option {
 
 // MarshalBSONValue implements the bson.ValueMarshaler interface.
 //
-// Deprecated: Marshaling a WriteConcern to BSON will not be supported in Go Driver 2.0.
+// Deprecated: Marshaling a WriteConcern to BSON will not be supported in Go
+// Driver 2.0.
 func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
-	if !wc.IsValid() {
-		return bsontype.Type(0), nil, ErrInconsistent
+	if wc == nil {
+		return 0, nil, ErrEmptyWriteConcern
 	}
 
 	var elems []byte
-
 	if wc.W != nil {
-		// Only support string or int values for W. That aligns with the documentation and the
-		// behavior of other functions, like Acknowledged.
-		switch t := wc.W.(type) {
+		// Only support string or int values for W. That aligns with the
+		// documentation and the behavior of other functions, like Acknowledged.
+		switch w := wc.W.(type) {
 		case int:
-			if t < 0 {
-				return bsontype.Type(0), nil, ErrNegativeW
+			if w < 0 {
+				return 0, nil, ErrNegativeW
 			}
 
-			elems = bsoncore.AppendInt32Element(elems, "w", int32(t))
+			// If Journal=true and W=0, return an error because that write
+			// concern is ambiguous.
+			if wc.Journal != nil && *wc.Journal && w == 0 {
+				return 0, nil, ErrInconsistent
+			}
+
+			elems = bsoncore.AppendInt32Element(elems, "w", int32(w))
 		case string:
-			elems = bsoncore.AppendStringElement(elems, "w", t)
+			elems = bsoncore.AppendStringElement(elems, "w", w)
 		default:
-			return bsontype.Type(0),
+			return 0,
 				nil,
 				fmt.Errorf("WriteConcern.W must be a string or int, but is a %T", wc.W)
 		}
@@ -300,7 +316,7 @@ func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	}
 
 	if wc.WTimeout < 0 {
-		return bsontype.Type(0), nil, ErrNegativeWTimeout
+		return 0, nil, ErrNegativeWTimeout
 	}
 
 	if wc.WTimeout != 0 {
@@ -308,9 +324,9 @@ func (wc *WriteConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	}
 
 	if len(elems) == 0 {
-		return bsontype.Type(0), nil, ErrEmptyWriteConcern
+		return 0, nil, ErrEmptyWriteConcern
 	}
-	return bsontype.EmbeddedDocument, bsoncore.BuildDocument(nil, elems), nil
+	return bson.TypeEmbeddedDocument, bsoncore.BuildDocument(nil, elems), nil
 }
 
 // AcknowledgedValue returns true if a BSON RawValue for a write concern represents an acknowledged write concern.
@@ -343,31 +359,24 @@ func (wc *WriteConcern) Acknowledged() bool {
 	return wc == nil || wc.W != 0 || (wc.Journal != nil && *wc.Journal)
 }
 
-// IsValid checks whether the write concern is invalid.
-//
-// Deprecated: IsValid will not be supported in Go Driver 2.0.
+// IsValid returns true if the WriteConcern is valid.
 func (wc *WriteConcern) IsValid() bool {
-	if wc.Journal == nil || !*wc.Journal {
+	if wc == nil {
 		return true
 	}
 
-	switch v := wc.W.(type) {
-	// Now that users can set W to any type, IsValid doesn't handle cases where W is an unsupported
-	// type. However, the only use case of this function appears to be in MarshalBSONValue, which
-	// now does its own unsupported type handling and returns an usable error for unsupported types
-	// (MarshalBSONValue returns ErrInconsistent when IsValid is false, which doesn't cover
-	// unsupported types). To maintain backward compatibility and return good errors in
-	// MarshalBSONValue, keep the logic here the same and don't handle unsupported types.
-	//
-	// IsValid is deprecated and will be removed in Go Driver 2.0, so the inconsistency will only
-	// exist during the transition from Go Driver 1.x to Go Driver 2.0.
+	switch w := wc.W.(type) {
 	case int:
-		if v == 0 {
-			return false
-		}
+		// A write concern with {w: int} must have a non-negative value and
+		// cannot have the combination {w: 0, j: true}.
+		return w >= 0 && (w > 0 || wc.Journal == nil || !*wc.Journal)
+	case string, nil:
+		// A write concern with {w: string} or no w specified is always valid.
+		return true
+	default:
+		// A write concern with an unsupported w type is not valid.
+		return false
 	}
-
-	return true
 }
 
 // GetW returns the write concern w level.

--- a/mongo/writeconcern/writeconcern_example_test.go
+++ b/mongo/writeconcern/writeconcern_example_test.go
@@ -1,0 +1,54 @@
+package writeconcern_test
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+)
+
+// Configure a Client with write concern "majority" that requests
+// acknowledgement that a majority of the nodes have committed write operations.
+func Example_majority() {
+	wc := writeconcern.Majority()
+
+	opts := options.Client().
+		ApplyURI("mongodb://localhost:27017").
+		SetWriteConcern(wc)
+
+	_, err := mongo.Connect(context.Background(), opts)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Configure a Client with a write concern that requests acknowledgement that
+// exactly 2 nodes have committed and journaled write operations.
+func Example_w2Journaled() {
+	wc := &writeconcern.WriteConcern{
+		W:       2,
+		Journal: boolPtr(true),
+	}
+
+	opts := options.Client().
+		ApplyURI("mongodb://localhost:27017").
+		SetWriteConcern(wc)
+
+	_, err := mongo.Connect(context.Background(), opts)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// boolPtr is a helper function to convert a bool constant into a bool pointer.
+//
+// If you're using a version of Go that supports generics, you can define a
+// generic version of this function that works with any type. For example:
+//
+//	func ptr[T any](v T) *T {
+//		return &v
+//	}
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/mongo/writeconcern/writeconcern_example_test.go
+++ b/mongo/writeconcern/writeconcern_example_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2023-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package writeconcern_test
 
 import (

--- a/mongo/writeconcern/writeconcern_test.go
+++ b/mongo/writeconcern/writeconcern_test.go
@@ -7,21 +7,31 @@
 package writeconcern_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/assert"
 	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 )
 
 func TestWriteConcernWithOptions(t *testing.T) {
+	t.Parallel()
+
 	t.Run("on nil WriteConcern", func(t *testing.T) {
+		t.Parallel()
+
 		var wc *writeconcern.WriteConcern
 
 		wc = wc.WithOptions(writeconcern.WMajority())
 		require.Equal(t, wc.GetW().(string), "majority")
 	})
 	t.Run("on existing WriteConcern", func(t *testing.T) {
+		t.Parallel()
+
 		wc := writeconcern.New(writeconcern.W(1), writeconcern.J(true))
 		require.Equal(t, wc.GetW().(int), 1)
 		require.Equal(t, wc.GetJ(), true)
@@ -31,6 +41,8 @@ func TestWriteConcernWithOptions(t *testing.T) {
 		require.Equal(t, wc.GetJ(), true)
 	})
 	t.Run("with multiple options", func(t *testing.T) {
+		t.Parallel()
+
 		wc := writeconcern.New(writeconcern.W(1), writeconcern.J(true))
 		require.Equal(t, wc.GetW().(int), 1)
 		require.Equal(t, wc.GetJ(), true)
@@ -41,4 +53,102 @@ func TestWriteConcernWithOptions(t *testing.T) {
 		require.Equal(t, wc.GetJ(), true)
 		require.Equal(t, wc.GetWTimeout(), time.Second)
 	})
+}
+
+func TestWriteConcern_MarshalBSONValue(t *testing.T) {
+	t.Parallel()
+
+	tru := true
+	fals := false
+
+	testCases := []struct {
+		description string
+		input       *writeconcern.WriteConcern
+		wantType    bsontype.Type
+		wantValue   bson.D
+		wantError   error
+	}{
+		{
+			description: "all fields",
+			input: &writeconcern.WriteConcern{
+				W:        "majority",
+				Journal:  &fals,
+				WTimeout: 1 * time.Minute,
+			},
+			wantType: bson.TypeEmbeddedDocument,
+			wantValue: bson.D{
+				{Key: "w", Value: "majority"},
+				{Key: "j", Value: false},
+				{Key: "wtimeout", Value: int64(60_000)},
+			},
+		},
+		{
+			description: "string W",
+			input:       &writeconcern.WriteConcern{W: "majority"},
+			wantType:    bson.TypeEmbeddedDocument,
+			wantValue:   bson.D{{Key: "w", Value: "majority"}},
+		},
+		{
+			description: "int W",
+			input:       &writeconcern.WriteConcern{W: 1},
+			wantType:    bson.TypeEmbeddedDocument,
+			wantValue:   bson.D{{Key: "w", Value: int32(1)}},
+		},
+		{
+			description: "int32 W",
+			input:       &writeconcern.WriteConcern{W: int32(1)},
+			wantError:   errors.New("WriteConcern.W must be a string or int, but is a int32"),
+		},
+		{
+			description: "bool W",
+			input:       &writeconcern.WriteConcern{W: false},
+			wantError:   errors.New("WriteConcern.W must be a string or int, but is a bool"),
+		},
+		{
+			description: "W=0 and J=true",
+			input:       &writeconcern.WriteConcern{W: 0, Journal: &tru},
+			wantError:   writeconcern.ErrInconsistent,
+		},
+		{
+			description: "negative W",
+			input:       &writeconcern.WriteConcern{W: -1},
+			wantError:   writeconcern.ErrNegativeW,
+		},
+		{
+			description: "negative WTimeout",
+			input:       &writeconcern.WriteConcern{W: 1, WTimeout: -1},
+			wantError:   writeconcern.ErrNegativeWTimeout,
+		},
+		{
+			description: "empty",
+			input:       &writeconcern.WriteConcern{},
+			wantError:   writeconcern.ErrEmptyWriteConcern,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			typ, b, err := tc.input.MarshalBSONValue()
+			if tc.wantError != nil {
+				assert.Equal(t, tc.wantError, err, "expected and actual errors do not match")
+				return
+			}
+			require.NoError(t, err, "bson.MarshalValue error")
+
+			assert.Equal(t, tc.wantType, typ, "expected and actual BSON types do not match")
+
+			rv := bson.RawValue{
+				Type:  typ,
+				Value: b,
+			}
+			var gotValue bson.D
+			err = rv.Unmarshal(&gotValue)
+			require.NoError(t, err, "error unmarshaling RawValue")
+			assert.Equal(t, tc.wantValue, gotValue, "expected and actual BSON values do not match")
+		})
+	}
 }


### PR DESCRIPTION
[GODRIVER-2685](https://jira.mongodb.org/browse/GODRIVER-2685)

## Summary
Remove the functional options pattern, export all fields in the `WriteConcern` struct so users can set them directly, and add package functions for quickly specifying common write concerns `w: "majority"`, `w: 0`, and `w: 1`. Since users can now set any value to the exported `W` field, add type validation logic in the `MarshalBSONValue` function that returns an error if `W` is not a supported type, and add tests for the new error logic.

## Background & Motivation
The `writeconcern` package and types use a lot of unnecessary APIs that can confuse users. Additionally, there are no helper functions for specifying common write concerns like there are for the `readconcern` and `readpref` packages. Remove the functional options pattern, export all fields in the `WriteConcern` struct so users can set them directly, and add package functions for quickly building common write concerns `w: "majority"`, `w: 0`, and `w: 1`.
