### PR TITLE
GODRIVER-2689 Always return a distinct Primary read preference.

### DIFF
--- a/mongo/readpref/readpref.go
+++ b/mongo/readpref/readpref.go
@@ -20,11 +20,9 @@ var (
 	errInvalidReadPreference = errors.New("can not specify tags, max staleness, or hedge with mode primary")
 )
 
-var primary = ReadPref{mode: PrimaryMode}
-
 // Primary constructs a read preference with a PrimaryMode.
 func Primary() *ReadPref {
-	return &primary
+	return &ReadPref{mode: PrimaryMode}
 }
 
 // PrimaryPreferred constructs a read preference with a PrimaryPreferredMode.


### PR DESCRIPTION
[GODRIVER-2689](https://jira.mongodb.org/browse/GODRIVER-2689)

## Summary
Always return a distinct `ReadPreference` value from the `Primary` read preference helper function.

## Background & Motivation
The `readpref.Primary` helper function currently returns a pointer to the same value for every call. It's technically possible to modify the `*ReadPreference` value returned, which would modify the value for all callers of `readpref.Primary`.