### PR TITLE
Improve tag sets documentation and add testable examples.

### DIFF
--- a/mongo/readpref/options.go
+++ b/mongo/readpref/options.go
@@ -29,9 +29,14 @@ func WithMaxStaleness(ms time.Duration) Option {
 	}
 }
 
-// WithTags sets a single tag set used to match
-// a server. The last call to WithTags or WithTagSets
-// overrides all previous calls to either method.
+// WithTags specifies a single tag set used to match replica set members. If no members match the
+// tag set, read operations will return an error. To avoid errors if no members match the tag set, use
+// [WithTagSets] and include an empty tag set as the last tag set in the list.
+//
+// The last call to [WithTags] or [WithTagSets] overrides all previous calls to either method.
+//
+// For more information about read preference tags, see
+// https://www.mongodb.com/docs/manual/core/read-preference-tags/
 func WithTags(tags ...string) Option {
 	return func(rp *ReadPref) error {
 		length := len(tags)
@@ -49,9 +54,16 @@ func WithTags(tags ...string) Option {
 	}
 }
 
-// WithTagSets sets the tag sets used to match
-// a server. The last call to WithTags or WithTagSets
-// overrides all previous calls to either method.
+// WithTagSets specifies a list of tag sets used to match replica set members. If the list contains
+// multiple tag sets, members are matched against each tag set in succession until a match is found.
+// Once a match is found, the remaining tag sets are ignored. If no members match any of the tag
+// sets, the read operation returns with an error. To avoid an error if no members match any of the
+// tag sets, include an empty tag set as the last tag set in the list.
+//
+// The last call to [WithTags] or [WithTagSets] overrides all previous calls to either method.
+//
+// For more information about read preference tags, see
+// https://www.mongodb.com/docs/manual/core/read-preference-tags/
 func WithTagSets(tagSets ...tag.Set) Option {
 	return func(rp *ReadPref) error {
 		rp.tagSets = tagSets

--- a/mongo/readpref/options_example_test.go
+++ b/mongo/readpref/options_example_test.go
@@ -1,0 +1,56 @@
+package readpref_test
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/tag"
+)
+
+// Configure a Client with a read preference that selects the nearest replica
+// set member that includes tags "region: South" and "datacenter: A".
+func ExampleWithTags() {
+	rp := readpref.Nearest(
+		readpref.WithTags(
+			"region", "South",
+			"datacenter", "A"))
+
+	opts := options.Client().
+		ApplyURI("mongodb://localhost:27017").
+		SetReadPreference(rp)
+
+	_, err := mongo.Connect(context.Background(), opts)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Configure a Client with a read preference that selects the nearest replica
+// set member matching a set of tags. Try to match members in 3 stages:
+//
+//  1. Match replica set members that include tags "region: South" and
+//     "datacenter: A".
+//  2. Match replica set members that includes tag "region: South".
+//  3. Match any replica set member.
+//
+// Stage 3 is used to avoid errors when no members match the previous 2 stages.
+func ExampleWithTagSets() {
+	tagSetList := tag.NewTagSetsFromMaps([]map[string]string{
+		{"region": "South", "datacenter": "A"},
+		{"region": "South"},
+		{},
+	})
+
+	rp := readpref.Nearest(readpref.WithTagSets(tagSetList...))
+
+	opts := options.Client().
+		ApplyURI("mongodb://localhost").
+		SetReadPreference(rp)
+
+	_, err := mongo.Connect(context.Background(), opts)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -4,7 +4,10 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-// Package tag provides a way to define filters for tagged servers.
+// Package tag provides types for filtering replica set members using tags in a read preference.
+//
+// For more information about read preference tags, see
+// https://www.mongodb.com/docs/manual/core/read-preference-tags/
 package tag // import "go.mongodb.org/mongo-driver/tag"
 
 import (
@@ -12,7 +15,7 @@ import (
 	"fmt"
 )
 
-// Tag is a name/vlaue pair.
+// Tag is a name/value pair.
 type Tag struct {
 	Name  string
 	Value string
@@ -23,7 +26,10 @@ func (tag Tag) String() string {
 	return fmt.Sprintf("%s=%s", tag.Name, tag.Value)
 }
 
-// NewTagSetFromMap creates a new tag set from a map.
+// NewTagSetFromMap creates a tag set from a map.
+//
+// For more information about read preference tags, see
+// https://www.mongodb.com/docs/manual/core/read-preference-tags/
 func NewTagSetFromMap(m map[string]string) Set {
 	var set Set
 	for k, v := range m {
@@ -33,7 +39,10 @@ func NewTagSetFromMap(m map[string]string) Set {
 	return set
 }
 
-// NewTagSetsFromMaps creates new tag sets from maps.
+// NewTagSetsFromMaps creates a list of tag sets from a slice of maps.
+//
+// For more information about read preference tags, see
+// https://www.mongodb.com/docs/manual/core/read-preference-tags/
 func NewTagSetsFromMaps(maps []map[string]string) []Set {
 	sets := make([]Set, 0, len(maps))
 	for _, m := range maps {


### PR DESCRIPTION
## Summary
Improve tag sets documentation and add testable examples.

## Background & Motivation
While investigating [GODRIVER-2687](https://jira.mongodb.org/browse/GODRIVER-2687), I realized that the documentation in the `tag` and `readpref` package concerning read preference tag sets could be improved. There is not much information about tag set matching behavior, and there are also no links to relevant documentation.

