### PR TITLE
GODRIVER-2761 use libmongocrypt 1.8.0-alpha1

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -95,7 +95,7 @@ functions:
           go version
           go env
 
-          LIBMONGOCRYPT_TAG="1.8.0-alpha0"
+          LIBMONGOCRYPT_TAG="1.8.0-alpha1"
           # Install libmongocrypt based on OS.
           if [ "Windows_NT" = "$OS" ]; then
              mkdir -p c:/libmongocrypt/include

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -88,11 +88,6 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 		C.mongocrypt_setopt_bypass_query_analysis(wrapped)
 	}
 
-	// Enable Queryable Encryption V2 protocol.
-	if !C.mongocrypt_setopt_fle2v2(wrapped, true) {
-		return nil, crypt.createErrorFromStatus()
-	}
-
 	// If loading the crypt_shared library isn't disabled, set the default library search path "$SYSTEM"
 	// and set a library override path if one was provided.
 	if !opts.CryptSharedLibDisabled {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2761

## Summary

- use libmongocrypt 1.8.0-alpha1
- remove use of `mongocrypt_setopt_fle2v2`

## Background & Motivation

This PR is a follow-up to https://github.com/mongodb/mongo-go-driver/pull/1213

Queryable Encryption v2 is enabled by default in libmongocrypt 1.8.0-alpha1. libmongocrypt 1.8.0-alpha1 removes the symbol `mongocrypt_setopt_fle2v2` from the public API. `mongocrypt_setopt_fle2v2` was added in libmongocrypt 1.8.0-alpha0.

