### PR TITLE
remove toc from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@
 The MongoDB supported driver for Go.
 
 -------------------------
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Feedback](#feedback)
-- [Testing / Development](#testing--development)
-- [Continuous Integration](#continuous-integration)
-- [License](#license)
-
--------------------------
 ## Requirements
 
 - Go 1.13 or higher. We aim to support the latest versions of Go.


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Remove the team-maintained table of contents from the README.md file in favor of the GitHub-generated ToC: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/

The linting CI failures are fixed in PR https://github.com/mongodb/mongo-go-driver/pull/1246

## Background & Motivation
<!--- Rationale for the pull request. -->

