### PR TITLE
Fix assert import.

### DIFF
--- a/mongo/options/changestreamoptions_test.go
+++ b/mongo/options/changestreamoptions_test.go
@@ -3,7 +3,7 @@ package options
 import (
 	"testing"
 
-	"go.mongodb.org/mongo-driver/internal/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeChangeStreamOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix the import failure of `assert` in changestreamoptions_test.go.

