### PR TITLE
GODRIVER-2711 Deprecate BSON *Append and *With functions.

### DIFF
--- a/bson/bsonrw/extjson_writer.go
+++ b/bson/bsonrw/extjson_writer.go
@@ -572,6 +572,10 @@ func (ejvw *extJSONValueWriter) WriteDocumentEnd() error {
 	case mDocument:
 		ejvw.buf = append(ejvw.buf, ',')
 	case mTopLevel:
+		// Always end top-level documents with a newline so that multiple documents can be encoded
+		// to the same writer. That matches the Go json.Encoder behavior and also works with
+		// bsonrw.NewExtJSONValueReader.
+		ejvw.buf = append(ejvw.buf, '\n')
 		if ejvw.w != nil {
 			if _, err := ejvw.w.Write(ejvw.buf); err != nil {
 				return err

--- a/bson/bsonrw/extjson_writer.go
+++ b/bson/bsonrw/extjson_writer.go
@@ -88,6 +88,7 @@ type extJSONValueWriter struct {
 	frame      int64
 	canonical  bool
 	escapeHTML bool
+	newlines   bool
 }
 
 // NewExtJSONValueWriter creates a ValueWriter that writes Extended JSON to w.
@@ -96,10 +97,13 @@ func NewExtJSONValueWriter(w io.Writer, canonical, escapeHTML bool) (ValueWriter
 		return nil, errNilWriter
 	}
 
-	return newExtJSONWriter(w, canonical, escapeHTML), nil
+	// Enable newlines for all Extended JSON value writers created by NewExtJSONValueWriter. We
+	// expect these value writers to be used with an Encoder, which should add newlines after
+	// encoded Extended JSON documents.
+	return newExtJSONWriter(w, canonical, escapeHTML, true), nil
 }
 
-func newExtJSONWriter(w io.Writer, canonical, escapeHTML bool) *extJSONValueWriter {
+func newExtJSONWriter(w io.Writer, canonical, escapeHTML, newlines bool) *extJSONValueWriter {
 	stack := make([]ejvwState, 1, 5)
 	stack[0] = ejvwState{mode: mTopLevel}
 
@@ -109,6 +113,7 @@ func newExtJSONWriter(w io.Writer, canonical, escapeHTML bool) *extJSONValueWrit
 		stack:      stack,
 		canonical:  canonical,
 		escapeHTML: escapeHTML,
+		newlines:   newlines,
 	}
 }
 
@@ -572,10 +577,12 @@ func (ejvw *extJSONValueWriter) WriteDocumentEnd() error {
 	case mDocument:
 		ejvw.buf = append(ejvw.buf, ',')
 	case mTopLevel:
-		// Always end top-level documents with a newline so that multiple documents can be encoded
-		// to the same writer. That matches the Go json.Encoder behavior and also works with
-		// bsonrw.NewExtJSONValueReader.
-		ejvw.buf = append(ejvw.buf, '\n')
+		// If the value writer has newlines enabled, end top-level documents with a newline so that
+		// multiple documents encoded to the same writer are separated by newlines. That matches the
+		// Go json.Encoder behavior and also works with bsonrw.NewExtJSONValueReader.
+		if ejvw.newlines {
+			ejvw.buf = append(ejvw.buf, '\n')
+		}
 		if ejvw.w != nil {
 			if _, err := ejvw.w.Write(ejvw.buf); err != nil {
 				return err

--- a/bson/bsonrw/extjson_writer_test.go
+++ b/bson/bsonrw/extjson_writer_test.go
@@ -139,7 +139,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 				t.Fatalf("fn must have one return value and it must be an error.")
 			}
 			params := make([]reflect.Value, 1, len(tc.params)+1)
-			ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+			ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 			params[0] = reflect.ValueOf(ejvw)
 			for _, param := range tc.params {
 				params = append(params, reflect.ValueOf(param))
@@ -162,7 +162,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 	}
 
 	t.Run("WriteArray", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mArray)
 		want := TransitionError{current: mArray, destination: mArray, parent: mTopLevel,
 			name: "WriteArray", modes: []mode{mElement, mValue}, action: "write"}
@@ -172,7 +172,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteCodeWithScope", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mArray)
 		want := TransitionError{current: mArray, destination: mCodeWithScope, parent: mTopLevel,
 			name: "WriteCodeWithScope", modes: []mode{mElement, mValue}, action: "write"}
@@ -182,7 +182,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteDocument", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mArray)
 		want := TransitionError{current: mArray, destination: mDocument, parent: mTopLevel,
 			name: "WriteDocument", modes: []mode{mElement, mValue, mTopLevel}, action: "write"}
@@ -192,7 +192,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteDocumentElement", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mElement)
 		want := TransitionError{current: mElement,
 			destination: mElement,
@@ -206,7 +206,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteDocumentEnd", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mElement)
 		want := fmt.Errorf("incorrect mode to end document: %s", mElement)
 		got := ejvw.WriteDocumentEnd()
@@ -215,7 +215,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteArrayElement", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mElement)
 		want := TransitionError{current: mElement,
 			destination: mValue,
@@ -229,7 +229,7 @@ func TestExtJSONValueWriter(t *testing.T) {
 		}
 	})
 	t.Run("WriteArrayEnd", func(t *testing.T) {
-		ejvw := newExtJSONWriter(ioutil.Discard, true, true)
+		ejvw := newExtJSONWriter(ioutil.Discard, true, true, false)
 		ejvw.push(mElement)
 		want := fmt.Errorf("incorrect mode to end array: %s", mElement)
 		got := ejvw.WriteArrayEnd()

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -59,8 +59,8 @@ func NewDecoder(vr bsonrw.ValueReader) (*Decoder, error) {
 
 // NewDecoderWithContext returns a new decoder that uses DecodeContext dc to read from vr.
 //
-// Deprecated: Use bson.NewDecoder and use the Decoder configuration methods set the desired
-// behavior of the decoder instead.
+// Deprecated: Use [NewDecoder] and use the Decoder configuration methods set the desired unmarshal
+// behavior instead.
 func NewDecoderWithContext(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader) (*Decoder, error) {
 	if dc.Registry == nil {
 		dc.Registry = DefaultRegistry
@@ -78,8 +78,7 @@ func NewDecoderWithContext(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader) (*
 // Decode reads the next BSON document from the stream and decodes it into the
 // value pointed to by val.
 //
-// The documentation for Unmarshal contains details about of BSON into a Go
-// value.
+// See [Unmarshal] for details about BSON unmarshaling behavior.
 func (d *Decoder) Decode(val interface{}) error {
 	if unmarshaler, ok := val.(Unmarshaler); ok {
 		// TODO(skriptble): Reuse a []byte here and use the AppendDocumentBytes method.
@@ -146,8 +145,7 @@ func (d *Decoder) SetRegistry(r *bsoncodec.Registry) error {
 
 // SetContext replaces the current registry of the decoder with dc.
 //
-// Deprecated: Use the Decoder configuration methods set the desired behavior of the decoder
-// instead.
+// Deprecated: Use the Decoder configuration methods set the desired unmarshal behavior instead.
 func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 	d.dc = dc
 	return nil

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -145,7 +145,7 @@ func (d *Decoder) SetRegistry(r *bsoncodec.Registry) error {
 
 // SetContext replaces the current registry of the decoder with dc.
 //
-// Deprecated: Use the Decoder configuration methods set the desired unmarshal behavior instead.
+// Deprecated: Use the Decoder configuration methods to set the desired unmarshal behavior instead.
 func (d *Decoder) SetContext(dc bsoncodec.DecodeContext) error {
 	d.dc = dc
 	return nil

--- a/bson/decoder_example_test.go
+++ b/bson/decoder_example_test.go
@@ -171,12 +171,12 @@ func ExampleDecoder_multipleExtendedJSONDocuments() {
 	// Define a newline-separated sequence of Extended JSON documents that
 	// contain X,Y coordinates.
 	data := []byte(`
-	{"x":{"$numberInt":"0"},"y":{"$numberInt":"0"}}
-	{"x":{"$numberInt":"1"},"y":{"$numberInt":"1"}}
-	{"x":{"$numberInt":"2"},"y":{"$numberInt":"2"}}
-	{"x":{"$numberInt":"3"},"y":{"$numberInt":"3"}}
-	{"x":{"$numberInt":"4"},"y":{"$numberInt":"4"}}
-	`)
+{"x":{"$numberInt":"0"},"y":{"$numberInt":"0"}}
+{"x":{"$numberInt":"1"},"y":{"$numberInt":"1"}}
+{"x":{"$numberInt":"2"},"y":{"$numberInt":"2"}}
+{"x":{"$numberInt":"3"},"y":{"$numberInt":"3"}}
+{"x":{"$numberInt":"4"},"y":{"$numberInt":"4"}}
+`)
 
 	// Create a Decoder that reads the Extended JSON documents and use it to
 	// unmarshal the documents Coordinate structs.

--- a/bson/decoder_example_test.go
+++ b/bson/decoder_example_test.go
@@ -7,7 +7,9 @@
 package bson_test
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
@@ -19,16 +21,16 @@ func ExampleDecoder() {
 	doc := bson.D{
 		{Key: "name", Value: "Cereal Rounds"},
 		{Key: "sku", Value: "AB12345"},
-		{Key: "price", Value: 399},
+		{Key: "price_cents", Value: 399},
 	}
-	b, err := bson.Marshal(doc)
+	data, err := bson.Marshal(doc)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create a Decoder that reads the marshaled BSON document and use it to
 	// unmarshal the document into a Product struct.
-	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +38,7 @@ func ExampleDecoder() {
 	type Product struct {
 		Name  string `bson:"name"`
 		SKU   string `bson:"sku"`
-		Price int64  `bson:"price"`
+		Price int64  `bson:"price_cents"`
 	}
 
 	var res Product
@@ -60,14 +62,14 @@ func ExampleDecoder_DefaultDocumentM() {
 			{Key: "elevation", Value: 10},
 		}},
 	}
-	b, err := bson.Marshal(doc)
+	data, err := bson.Marshal(doc)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create a Decoder that reads the marshaled BSON document and use it to unmarshal the document
 	// into a City struct.
-	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
 	if err != nil {
 		panic(err)
 	}
@@ -101,14 +103,14 @@ func ExampleDecoder_UseJSONStructTags() {
 		{Key: "sku", Value: "AB12345"},
 		{Key: "price_cents", Value: 399},
 	}
-	b, err := bson.Marshal(doc)
+	data, err := bson.Marshal(doc)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create a Decoder that reads the marshaled BSON document and use it to
 	// unmarshal the document into a Product struct.
-	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(b))
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
 	if err != nil {
 		panic(err)
 	}
@@ -131,4 +133,86 @@ func ExampleDecoder_UseJSONStructTags() {
 
 	fmt.Printf("%+v\n", res)
 	// Output: {Name:Cereal Rounds SKU:AB12345 Price:399}
+}
+
+func ExampleDecoder_extendedJSON() {
+	// Define an Extended JSON document that contains the name, SKU, and price
+	// (in cents) of a product.
+	data := []byte(`{"name":"Cereal Rounds","sku":"AB12345","price_cents":{"$numberLong":"399"}}`)
+
+	// Create a Decoder that reads the Extended JSON document and use it to
+	// unmarshal the document into a Product struct.
+	vr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), true)
+	if err != nil {
+		panic(err)
+	}
+	decoder, err := bson.NewDecoder(vr)
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `bson:"name"`
+		SKU   string `bson:"sku"`
+		Price int64  `bson:"price_cents"`
+	}
+
+	var res Product
+	err = decoder.Decode(&res)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+	// Output: {Name:Cereal Rounds SKU:AB12345 Price:399}
+}
+
+func ExampleDecoder_multipleExtendedJSONDocuments() {
+	// Define a newline-separated sequence of Extended JSON documents that
+	// contain X,Y coordinates.
+	data := []byte(`
+	{"x":{"$numberInt":"0"},"y":{"$numberInt":"0"}}
+	{"x":{"$numberInt":"1"},"y":{"$numberInt":"1"}}
+	{"x":{"$numberInt":"2"},"y":{"$numberInt":"2"}}
+	{"x":{"$numberInt":"3"},"y":{"$numberInt":"3"}}
+	{"x":{"$numberInt":"4"},"y":{"$numberInt":"4"}}
+	`)
+
+	// Create a Decoder that reads the Extended JSON documents and use it to
+	// unmarshal the documents Coordinate structs.
+	vr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), true)
+	if err != nil {
+		panic(err)
+	}
+	decoder, err := bson.NewDecoder(vr)
+	if err != nil {
+		panic(err)
+	}
+
+	type Coordinate struct {
+		X int
+		Y int
+	}
+
+	// Read and unmarshal each Extended JSON document from the sequence. If
+	// Decode returns error io.EOF, that means the Decoder has reached the end
+	// of the input, so break the loop.
+	for {
+		var res Coordinate
+		err = decoder.Decode(&res)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("%+v\n", res)
+	}
+	// Output:
+	// {X:0 Y:0}
+	// {X:1 Y:1}
+	// {X:2 Y:2}
+	// {X:3 Y:3}
+	// {X:4 Y:4}
 }

--- a/bson/encoder.go
+++ b/bson/encoder.go
@@ -54,7 +54,7 @@ func NewEncoder(vw bsonrw.ValueWriter) (*Encoder, error) {
 
 // NewEncoderWithContext returns a new encoder that uses EncodeContext ec to write to vw.
 //
-// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods to set the desired marshal
 // behavior instead.
 func NewEncoderWithContext(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter) (*Encoder, error) {
 	if ec.Registry == nil {

--- a/bson/encoder.go
+++ b/bson/encoder.go
@@ -54,8 +54,8 @@ func NewEncoder(vw bsonrw.ValueWriter) (*Encoder, error) {
 
 // NewEncoderWithContext returns a new encoder that uses EncodeContext ec to write to vw.
 //
-// Deprecated: Use bson.NewEncoder and use the Encoder configuration methods set the desired
-// behavior of the encoder instead.
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// behavior instead.
 func NewEncoderWithContext(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter) (*Encoder, error) {
 	if ec.Registry == nil {
 		ec = bsoncodec.EncodeContext{Registry: DefaultRegistry}
@@ -72,8 +72,7 @@ func NewEncoderWithContext(ec bsoncodec.EncodeContext, vw bsonrw.ValueWriter) (*
 
 // Encode writes the BSON encoding of val to the stream.
 //
-// The documentation for Marshal contains details about the conversion of Go
-// values to BSON.
+// See [Marshal] for details about BSON marshaling behavior.
 func (e *Encoder) Encode(val interface{}) error {
 	if marshaler, ok := val.(Marshaler); ok {
 		// TODO(skriptble): Should we have a MarshalAppender interface so that we can have []byte reuse?
@@ -134,8 +133,7 @@ func (e *Encoder) SetRegistry(r *bsoncodec.Registry) error {
 
 // SetContext replaces the current EncodeContext of the encoder with ec.
 //
-// Deprecated: Use the Encoder configuration methods set the desired behavior of the encoder
-// instead.
+// Deprecated: Use the Encoder configuration methods set the desired marshal behavior instead.
 func (e *Encoder) SetContext(ec bsoncodec.EncodeContext) error {
 	e.ec = ec
 	return nil

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -151,7 +151,7 @@ func ExampleEncoder_multipleBSONDocuments() {
 	for i := 0; i < 5; i++ {
 		err := encoder.Encode(Coordinate{
 			X: i,
-			Y: i+1,
+			Y: i + 1,
 		})
 		if err != nil {
 			panic(err)
@@ -168,7 +168,7 @@ func ExampleEncoder_multipleBSONDocuments() {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(bson.Raw(doc).String())
+		fmt.Println(doc.String())
 	}
 	// Output:
 	// {"x": {"$numberInt":"0"},"y": {"$numberInt":"1"}}
@@ -236,7 +236,7 @@ func ExampleEncoder_multipleExtendedJSONDocuments() {
 	for i := 0; i < 5; i++ {
 		err := encoder.Encode(Coordinate{
 			X: i,
-			Y: i+1,
+			Y: i + 1,
 		})
 		if err != nil {
 			panic(err)

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -151,7 +151,7 @@ func ExampleEncoder_multipleBSONDocuments() {
 	for i := 0; i < 5; i++ {
 		err := encoder.Encode(Coordinate{
 			X: i,
-			Y: i,
+			Y: i+1,
 		})
 		if err != nil {
 			panic(err)
@@ -171,11 +171,11 @@ func ExampleEncoder_multipleBSONDocuments() {
 		fmt.Println(bson.Raw(doc).String())
 	}
 	// Output:
-	// {"x": {"$numberInt":"0"},"y": {"$numberInt":"0"}}
-	// {"x": {"$numberInt":"1"},"y": {"$numberInt":"1"}}
-	// {"x": {"$numberInt":"2"},"y": {"$numberInt":"2"}}
-	// {"x": {"$numberInt":"3"},"y": {"$numberInt":"3"}}
-	// {"x": {"$numberInt":"4"},"y": {"$numberInt":"4"}}
+	// {"x": {"$numberInt":"0"},"y": {"$numberInt":"1"}}
+	// {"x": {"$numberInt":"1"},"y": {"$numberInt":"2"}}
+	// {"x": {"$numberInt":"2"},"y": {"$numberInt":"3"}}
+	// {"x": {"$numberInt":"3"},"y": {"$numberInt":"4"}}
+	// {"x": {"$numberInt":"4"},"y": {"$numberInt":"5"}}
 }
 
 func ExampleEncoder_extendedJSON() {
@@ -236,7 +236,7 @@ func ExampleEncoder_multipleExtendedJSONDocuments() {
 	for i := 0; i < 5; i++ {
 		err := encoder.Encode(Coordinate{
 			X: i,
-			Y: i,
+			Y: i+1,
 		})
 		if err != nil {
 			panic(err)
@@ -245,9 +245,9 @@ func ExampleEncoder_multipleExtendedJSONDocuments() {
 
 	fmt.Println(buf.String())
 	// Output:
-	// {"x":{"$numberInt":"0"},"y":{"$numberInt":"0"}}
-	// {"x":{"$numberInt":"1"},"y":{"$numberInt":"1"}}
-	// {"x":{"$numberInt":"2"},"y":{"$numberInt":"2"}}
-	// {"x":{"$numberInt":"3"},"y":{"$numberInt":"3"}}
-	// {"x":{"$numberInt":"4"},"y":{"$numberInt":"4"}}
+	// {"x":{"$numberInt":"0"},"y":{"$numberInt":"1"}}
+	// {"x":{"$numberInt":"1"},"y":{"$numberInt":"2"}}
+	// {"x":{"$numberInt":"2"},"y":{"$numberInt":"3"}}
+	// {"x":{"$numberInt":"3"},"y":{"$numberInt":"4"}}
+	// {"x":{"$numberInt":"4"},"y":{"$numberInt":"5"}}
 }

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -9,6 +9,7 @@ package bson_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
@@ -126,4 +127,127 @@ func ExampleEncoder_UseJSONStructTags() {
 	// Print the BSON document as Extended JSON by converting it to bson.Raw.
 	fmt.Println(bson.Raw(buf.Bytes()).String())
 	// Output: {"name": "Cereal Rounds","sku": "AB12345","price_cents": {"$numberLong":"399"}}
+}
+
+func ExampleEncoder_multipleBSONDocuments() {
+	// Create an Encoder that writes BSON values to a bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewBSONValueWriter(buf)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	type Coordinate struct {
+		X int
+		Y int
+	}
+
+	// Use the encoder to marshal 5 Coordinate values as a sequence of BSON
+	// documents.
+	for i := 0; i < 5; i++ {
+		err := encoder.Encode(Coordinate{
+			X: i,
+			Y: i,
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Read each marshaled BSON document from the buffer and print them as
+	// Extended JSON by converting them to bson.Raw.
+	for {
+		doc, err := bson.ReadDocument(buf)
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(bson.Raw(doc).String())
+	}
+	// Output:
+	// {"x": {"$numberInt":"0"},"y": {"$numberInt":"0"}}
+	// {"x": {"$numberInt":"1"},"y": {"$numberInt":"1"}}
+	// {"x": {"$numberInt":"2"},"y": {"$numberInt":"2"}}
+	// {"x": {"$numberInt":"3"},"y": {"$numberInt":"3"}}
+	// {"x": {"$numberInt":"4"},"y": {"$numberInt":"4"}}
+}
+
+func ExampleEncoder_extendedJSON() {
+	// Create an Encoder that writes canonical Extended JSON values to a
+	// bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewExtJSONValueWriter(buf, true, false)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	type Product struct {
+		Name  string `bson:"name"`
+		SKU   string `bson:"sku"`
+		Price int64  `bson:"price_cents"`
+	}
+
+	// Use the Encoder to marshal a BSON document that contains the name, SKU,
+	// and price (in cents) of a product.
+	product := Product{
+		Name:  "Cereal Rounds",
+		SKU:   "AB12345",
+		Price: 399,
+	}
+	err = encoder.Encode(product)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(buf.String())
+	// Output: {"name":"Cereal Rounds","sku":"AB12345","price_cents":{"$numberLong":"399"}}
+}
+
+func ExampleEncoder_multipleExtendedJSONDocuments() {
+	// Create an Encoder that writes canonical Extended JSON values to a
+	// bytes.Buffer.
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewExtJSONValueWriter(buf, true, false)
+	if err != nil {
+		panic(err)
+	}
+	encoder, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	type Coordinate struct {
+		X int
+		Y int
+	}
+
+	// Use the encoder to marshal 5 Coordinate values as a sequence of Extended
+	// JSON documents.
+	for i := 0; i < 5; i++ {
+		err := encoder.Encode(Coordinate{
+			X: i,
+			Y: i,
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	fmt.Println(buf.String())
+	// Output:
+	// {"x":{"$numberInt":"0"},"y":{"$numberInt":"0"}}
+	// {"x":{"$numberInt":"1"},"y":{"$numberInt":"1"}}
+	// {"x":{"$numberInt":"2"},"y":{"$numberInt":"2"}}
+	// {"x":{"$numberInt":"3"},"y":{"$numberInt":"3"}}
+	// {"x":{"$numberInt":"4"},"y":{"$numberInt":"4"}}
 }

--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -98,7 +98,7 @@ func MarshalWithRegistry(r *bsoncodec.Registry, val interface{}) ([]byte, error)
 // MarshalWithContext returns the BSON encoding of val as a BSON document using EncodeContext ec. If val is not a type
 // that can be transformed into a document, MarshalValueWithContext should be used instead.
 //
-// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods to set the desired marshal
 // behavior instead:
 //
 //	buf := bytes.NewBuffer(dst)
@@ -146,7 +146,7 @@ func MarshalAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val interface{
 // transformed into a document, MarshalValueAppendWithContext should be used instead.
 //
 // Deprecated: Use [NewEncoder], pass the dst byte slice (wrapped by a bytes.Buffer) into
-// [bsonrw.NewBSONValueWriter], and use the Encoder configuration methods set the desired marshal
+// [bsonrw.NewBSONValueWriter], and use the Encoder configuration methods to set the desired marshal
 // behavior instead:
 //
 //	buf := bytes.NewBuffer(dst)
@@ -315,7 +315,7 @@ func MarshalExtJSONWithRegistry(r *bsoncodec.Registry, val interface{}, canonica
 
 // MarshalExtJSONWithContext returns the extended JSON encoding of val using Registry r.
 //
-// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods to set the desired marshal
 // behavior instead:
 //
 //	buf := new(bytes.Buffer)
@@ -363,7 +363,7 @@ func MarshalExtJSONAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val int
 // encoding of val, dst will be grown.
 //
 // Deprecated: Use [NewEncoder], pass the dst byte slice (wrapped by a bytes.Buffer) into
-// [bsonrw.NewExtJSONValueWriter], and use the Encoder configuration methods set the desired marshal
+// [bsonrw.NewExtJSONValueWriter], and use the Encoder configuration methods to set the desired marshal
 // behavior instead:
 //
 //	buf := bytes.NewBuffer(dst)

--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -54,12 +54,42 @@ func Marshal(val interface{}) ([]byte, error) {
 // MarshalAppend will encode val as a BSON document and append the bytes to dst. If dst is not large enough to hold the
 // bytes, it will be grown. If val is not a type that can be transformed into a document, MarshalValueAppend should be
 // used instead.
+//
+// Deprecated: Use [NewEncoder] and pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewBSONValueWriter]:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+// See [Encoder] for more examples.
 func MarshalAppend(dst []byte, val interface{}) ([]byte, error) {
 	return MarshalAppendWithRegistry(DefaultRegistry, dst, val)
 }
 
 // MarshalWithRegistry returns the BSON encoding of val as a BSON document. If val is not a type that can be transformed
 // into a document, MarshalValueWithRegistry should be used instead.
+//
+// Deprecated: Use [NewEncoder] and specify the Registry by calling [Encoder.SetRegistry] instead:
+//
+//	buf := new(bytes.Buffer)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.SetRegistry(reg)
+//
+// See [Encoder] for more examples.
 func MarshalWithRegistry(r *bsoncodec.Registry, val interface{}) ([]byte, error) {
 	dst := make([]byte, 0)
 	return MarshalAppendWithRegistry(r, dst, val)
@@ -67,6 +97,22 @@ func MarshalWithRegistry(r *bsoncodec.Registry, val interface{}) ([]byte, error)
 
 // MarshalWithContext returns the BSON encoding of val as a BSON document using EncodeContext ec. If val is not a type
 // that can be transformed into a document, MarshalValueWithContext should be used instead.
+//
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// behavior instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.IntMinSize()
+//
+// See [Encoder] for more examples.
 func MarshalWithContext(ec bsoncodec.EncodeContext, val interface{}) ([]byte, error) {
 	dst := make([]byte, 0)
 	return MarshalAppendWithContext(ec, dst, val)
@@ -75,6 +121,22 @@ func MarshalWithContext(ec bsoncodec.EncodeContext, val interface{}) ([]byte, er
 // MarshalAppendWithRegistry will encode val as a BSON document using Registry r and append the bytes to dst. If dst is
 // not large enough to hold the bytes, it will be grown. If val is not a type that can be transformed into a document,
 // MarshalValueAppendWithRegistry should be used instead.
+//
+// Deprecated: Use [NewEncoder], and pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewBSONValueWriter], and specify the Registry by calling [Encoder.SetRegistry] instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.SetRegistry(reg)
+//
+// See [Encoder] for more examples.
 func MarshalAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val interface{}) ([]byte, error) {
 	return MarshalAppendWithContext(bsoncodec.EncodeContext{Registry: r}, dst, val)
 }
@@ -82,6 +144,23 @@ func MarshalAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val interface{
 // MarshalAppendWithContext will encode val as a BSON document using Registry r and EncodeContext ec and append the
 // bytes to dst. If dst is not large enough to hold the bytes, it will be grown. If val is not a type that can be
 // transformed into a document, MarshalValueAppendWithContext should be used instead.
+//
+// Deprecated: Use [NewEncoder], pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewBSONValueWriter], and use the Encoder configuration methods set the desired marshal
+// behavior instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.IntMinSize()
+//
+// See [Encoder] for more examples.
 func MarshalAppendWithContext(ec bsoncodec.EncodeContext, dst []byte, val interface{}) ([]byte, error) {
 	sw := new(bsonrw.SliceWriter)
 	*sw = dst
@@ -118,17 +197,26 @@ func MarshalValue(val interface{}) (bsontype.Type, []byte, error) {
 
 // MarshalValueAppend will append the BSON encoding of val to dst. If dst is not large enough to hold the BSON encoding
 // of val, dst will be grown.
+//
+// Deprecated: Appending individual BSON elements to an existing slice will not be supported in Go
+// Driver 2.0.
 func MarshalValueAppend(dst []byte, val interface{}) (bsontype.Type, []byte, error) {
 	return MarshalValueAppendWithRegistry(DefaultRegistry, dst, val)
 }
 
 // MarshalValueWithRegistry returns the BSON encoding of val using Registry r.
+//
+// Deprecated: Using a custom registry to marshal individual BSON values will not be supported in Go
+// Driver 2.0.
 func MarshalValueWithRegistry(r *bsoncodec.Registry, val interface{}) (bsontype.Type, []byte, error) {
 	dst := make([]byte, 0)
 	return MarshalValueAppendWithRegistry(r, dst, val)
 }
 
 // MarshalValueWithContext returns the BSON encoding of val using EncodeContext ec.
+//
+// Deprecated: Using a custom EncodeContext to marshal individual BSON elements will not be
+// supported in Go Driver 2.0.
 func MarshalValueWithContext(ec bsoncodec.EncodeContext, val interface{}) (bsontype.Type, []byte, error) {
 	dst := make([]byte, 0)
 	return MarshalValueAppendWithContext(ec, dst, val)
@@ -136,12 +224,18 @@ func MarshalValueWithContext(ec bsoncodec.EncodeContext, val interface{}) (bsont
 
 // MarshalValueAppendWithRegistry will append the BSON encoding of val to dst using Registry r. If dst is not large
 // enough to hold the BSON encoding of val, dst will be grown.
+//
+// Deprecated: Appending individual BSON elements to an existing slice will not be supported in Go
+// Driver 2.0.
 func MarshalValueAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val interface{}) (bsontype.Type, []byte, error) {
 	return MarshalValueAppendWithContext(bsoncodec.EncodeContext{Registry: r}, dst, val)
 }
 
 // MarshalValueAppendWithContext will append the BSON encoding of val to dst using EncodeContext ec. If dst is not large
 // enough to hold the BSON encoding of val, dst will be grown.
+//
+// Deprecated: Appending individual BSON elements to an existing slice will not be supported in Go
+// Driver 2.0.
 func MarshalValueAppendWithContext(ec bsoncodec.EncodeContext, dst []byte, val interface{}) (bsontype.Type, []byte, error) {
 	// get a ValueWriter configured to write to dst
 	sw := new(bsonrw.SliceWriter)
@@ -179,17 +273,63 @@ func MarshalExtJSON(val interface{}, canonical, escapeHTML bool) ([]byte, error)
 // MarshalExtJSONAppend will append the extended JSON encoding of val to dst.
 // If dst is not large enough to hold the extended JSON encoding of val, dst
 // will be grown.
+//
+// Deprecated: Use [NewEncoder] and pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewExtJSONValueWriter] instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewExtJSONValueWriter(buf, true, false)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+// See [Encoder] for more examples.
 func MarshalExtJSONAppend(dst []byte, val interface{}, canonical, escapeHTML bool) ([]byte, error) {
 	return MarshalExtJSONAppendWithRegistry(DefaultRegistry, dst, val, canonical, escapeHTML)
 }
 
 // MarshalExtJSONWithRegistry returns the extended JSON encoding of val using Registry r.
+//
+// Deprecated: Use [NewEncoder] and specify the Registry by calling [Encoder.SetRegistry] instead:
+//
+//	buf := new(bytes.Buffer)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.SetRegistry(reg)
+//
+// See [Encoder] for more examples.
 func MarshalExtJSONWithRegistry(r *bsoncodec.Registry, val interface{}, canonical, escapeHTML bool) ([]byte, error) {
 	dst := make([]byte, 0, defaultDstCap)
 	return MarshalExtJSONAppendWithContext(bsoncodec.EncodeContext{Registry: r}, dst, val, canonical, escapeHTML)
 }
 
 // MarshalExtJSONWithContext returns the extended JSON encoding of val using Registry r.
+//
+// Deprecated: Use [NewEncoder] and use the Encoder configuration methods set the desired marshal
+// behavior instead:
+//
+//	buf := new(bytes.Buffer)
+//	vw, err := bsonrw.NewBSONValueWriter(buf)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.IntMinSize()
+//
+// See [Encoder] for more examples.
 func MarshalExtJSONWithContext(ec bsoncodec.EncodeContext, val interface{}, canonical, escapeHTML bool) ([]byte, error) {
 	dst := make([]byte, 0, defaultDstCap)
 	return MarshalExtJSONAppendWithContext(ec, dst, val, canonical, escapeHTML)
@@ -198,6 +338,22 @@ func MarshalExtJSONWithContext(ec bsoncodec.EncodeContext, val interface{}, cano
 // MarshalExtJSONAppendWithRegistry will append the extended JSON encoding of
 // val to dst using Registry r. If dst is not large enough to hold the BSON
 // encoding of val, dst will be grown.
+//
+// Deprecated: Use [NewEncoder], pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewExtJSONValueWriter], and specify the Registry by calling [Encoder.SetRegistry]
+// instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewExtJSONValueWriter(buf, true, false)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+// See [Encoder] for more examples.
 func MarshalExtJSONAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val interface{}, canonical, escapeHTML bool) ([]byte, error) {
 	return MarshalExtJSONAppendWithContext(bsoncodec.EncodeContext{Registry: r}, dst, val, canonical, escapeHTML)
 }
@@ -205,6 +361,23 @@ func MarshalExtJSONAppendWithRegistry(r *bsoncodec.Registry, dst []byte, val int
 // MarshalExtJSONAppendWithContext will append the extended JSON encoding of
 // val to dst using Registry r. If dst is not large enough to hold the BSON
 // encoding of val, dst will be grown.
+//
+// Deprecated: Use [NewEncoder], pass the dst byte slice (wrapped by a bytes.Buffer) into
+// [bsonrw.NewExtJSONValueWriter], and use the Encoder configuration methods set the desired marshal
+// behavior instead:
+//
+//	buf := bytes.NewBuffer(dst)
+//	vw, err := bsonrw.NewExtJSONValueWriter(buf, true, false)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc, err := bson.NewEncoder(vw)
+//	if err != nil {
+//		panic(err)
+//	}
+//	enc.IntMinSize()
+//
+// See [Encoder] for more examples.
 func MarshalExtJSONAppendWithContext(ec bsoncodec.EncodeContext, dst []byte, val interface{}, canonical, escapeHTML bool) ([]byte, error) {
 	sw := new(bsonrw.SliceWriter)
 	*sw = dst

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -48,6 +48,16 @@ func Unmarshal(data []byte, val interface{}) error {
 // UnmarshalWithRegistry parses the BSON-encoded data using Registry r and
 // stores the result in the value pointed to by val. If val is nil or not
 // a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
+//
+// Deprecated: Use [NewDecoder] and specify the Registry by calling [Decoder.SetRegistry] instead:
+//
+//	dec, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec.SetRegistry(reg)
+//
+// See [Decoder] for more examples.
 func UnmarshalWithRegistry(r *bsoncodec.Registry, data []byte, val interface{}) error {
 	vr := bsonrw.NewBSONDocumentReader(data)
 	return unmarshalFromReader(bsoncodec.DecodeContext{Registry: r}, vr, val)
@@ -56,6 +66,17 @@ func UnmarshalWithRegistry(r *bsoncodec.Registry, data []byte, val interface{}) 
 // UnmarshalWithContext parses the BSON-encoded data using DecodeContext dc and
 // stores the result in the value pointed to by val. If val is nil or not
 // a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
+//
+// Deprecated: Use [NewDecoder] and use the Decoder configuration methods set the desired unmarshal
+// behavior instead:
+//
+//	dec, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec.DefaultDocumentM()
+//
+// See [Decoder] for more examples.
 func UnmarshalWithContext(dc bsoncodec.DecodeContext, data []byte, val interface{}) error {
 	vr := bsonrw.NewBSONDocumentReader(data)
 	return unmarshalFromReader(dc, vr, val)
@@ -68,11 +89,12 @@ func UnmarshalValue(t bsontype.Type, data []byte, val interface{}) error {
 	return UnmarshalValueWithRegistry(DefaultRegistry, t, data, val)
 }
 
-// TODO(GODRIVER-2711): Deprecate UnmarshalValueWithRegistry with other *WithRegistry functions.
-
 // UnmarshalValueWithRegistry parses the BSON value of type t with registry r and
 // stores the result in the value pointed to by val. If val is nil or not a pointer,
 // UnmarshalValue returns an error.
+//
+// Deprecated: Using a custom registry to unmarshal individual BSON values will not be supported in
+// Go Driver 2.0.
 func UnmarshalValueWithRegistry(r *bsoncodec.Registry, t bsontype.Type, data []byte, val interface{}) error {
 	vr := bsonrw.NewBSONValueReader(t, data)
 	return unmarshalFromReader(bsoncodec.DecodeContext{Registry: r}, vr, val)
@@ -88,6 +110,20 @@ func UnmarshalExtJSON(data []byte, canonical bool, val interface{}) error {
 // UnmarshalExtJSONWithRegistry parses the extended JSON-encoded data using
 // Registry r and stores the result in the value pointed to by val. If val is
 // nil or not a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
+//
+// Deprecated: Use [NewDecoder] and specify the Registry by calling [Decoder.SetRegistry] instead:
+//
+//	vr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), true)
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec, err := bson.NewDecoder(vr)
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec.SetRegistry(reg)
+//
+// See [Decoder] for more examples.
 func UnmarshalExtJSONWithRegistry(r *bsoncodec.Registry, data []byte, canonical bool, val interface{}) error {
 	ejvr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), canonical)
 	if err != nil {
@@ -100,6 +136,21 @@ func UnmarshalExtJSONWithRegistry(r *bsoncodec.Registry, data []byte, canonical 
 // UnmarshalExtJSONWithContext parses the extended JSON-encoded data using
 // DecodeContext dc and stores the result in the value pointed to by val. If val is
 // nil or not a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
+//
+// Deprecated: Use [NewDecoder] and use the Decoder configuration methods set the desired unmarshal
+// behavior instead:
+//
+//	vr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), true)
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec, err := bson.NewDecoder(vr)
+//	if err != nil {
+//		panic(err)
+//	}
+//	dec.DefaultDocumentM()
+//
+// See [Decoder] for more examples.
 func UnmarshalExtJSONWithContext(dc bsoncodec.DecodeContext, data []byte, canonical bool, val interface{}) error {
 	ejvr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), canonical)
 	if err != nil {

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -67,7 +67,7 @@ func UnmarshalWithRegistry(r *bsoncodec.Registry, data []byte, val interface{}) 
 // stores the result in the value pointed to by val. If val is nil or not
 // a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
 //
-// Deprecated: Use [NewDecoder] and use the Decoder configuration methods set the desired unmarshal
+// Deprecated: Use [NewDecoder] and use the Decoder configuration methods to set the desired unmarshal
 // behavior instead:
 //
 //	dec, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
@@ -137,7 +137,7 @@ func UnmarshalExtJSONWithRegistry(r *bsoncodec.Registry, data []byte, canonical 
 // DecodeContext dc and stores the result in the value pointed to by val. If val is
 // nil or not a pointer, UnmarshalWithRegistry returns InvalidUnmarshalError.
 //
-// Deprecated: Use [NewDecoder] and use the Decoder configuration methods set the desired unmarshal
+// Deprecated: Use [NewDecoder] and use the Decoder configuration methods to set the desired unmarshal
 // behavior instead:
 //
 //	vr, err := bsonrw.NewExtJSONValueReader(bytes.NewReader(data), true)


### PR DESCRIPTION
[GODRIVER-2711](https://jira.mongodb.org/browse/GODRIVER-2711)

## Summary
* Deprecate all `bson` package `Marshal`/`Unmarshal` functions that append data to an existing byte slice. Recommend people use the `Encoder` or `Decoder` types instead.
* Deprecate all `bson` package `Marshal`/`Unmarshal` functions that accept a `Registry`. Recommend people use the `Encoder` or `Decoder` types instead.
* Deprecate all functions that use an `EncodeContext` or `DecodeContext` during marshaling or unmarshaling. Recommend people use the `Encoder` or `Decoder` configuration functions instead.
* Add testable examples of how to use `Encoder` and `Decoder` to achieve most deprecated behaviors.

## Background & Motivation
The `bson` package is cluttered with permutations of `*WithRegistry`, `*WithContext` and `*Append` functions for `Marshal` and `Unmarshal`. The same behavior can be now be achieved with an `Encoder` or `Decoder`, making the `*WithRegistry`, `*WithContext`, and `*Append` functions redundant. Provide examples to show users how to migrate their use cases to `Encoder` or `Decoder` and deprecate the redundant functions in preparation to remove them in Go Driver 2.0.