### PR TITLE
Don't call t.Parallel in tests that use t.Setenv.

### DIFF
--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -115,8 +115,6 @@ func TestIOSinkInfo(t *testing.T) {
 }
 
 func TestSelectMaxDocumentLength(t *testing.T) {
-	t.Parallel()
-
 	for _, tcase := range []struct {
 		name     string
 		arg      uint
@@ -166,8 +164,6 @@ func TestSelectMaxDocumentLength(t *testing.T) {
 }
 
 func TestSelectLogSink(t *testing.T) {
-	t.Parallel()
-
 	for _, tcase := range []struct {
 		name     string
 		arg      LogSink
@@ -217,8 +213,6 @@ func TestSelectLogSink(t *testing.T) {
 }
 
 func TestSelectedComponentLevels(t *testing.T) {
-	t.Parallel()
-
 	for _, tcase := range []struct {
 		name     string
 		arg      map[Component]Level


### PR DESCRIPTION
## Summary
Don't call `t.Parallel` in tests that use `t.Setenv`.

## Background & Motivation
[t.Setenv](https://pkg.go.dev/testing#T.Setenv) documents:
> Because Setenv affects the whole process, it cannot be used in parallel tests or tests with parallel ancestors.

Some of the logger tests do call `t.Parallel` in tests that use `t.Setenv`, resulting in a panic:
```
❯ go test -run ^TestSelectLogSink$ go.mongodb.org/mongo-driver/internal/logger
--- FAIL: TestSelectLogSink (0.00s)
    --- FAIL: TestSelectLogSink/stdout (0.00s)
panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests [recovered]
        panic: testing: t.Setenv called after t.Parallel; cannot set environment variables in parallel tests
```
These tests confusingly don't panic in the Evergreen CI.

