### PR TITLE
GODRIVER-2833 restrict aws lambda metadata detection logic

### DIFF
--- a/mongo/integration/handshake_test.go
+++ b/mongo/integration/handshake_test.go
@@ -78,7 +78,7 @@ func TestHandshakeProse(t *testing.T) {
 		want bson.D
 	}{
 		{
-			name: "valid AWS",
+			name: "1. valid AWS",
 			env: map[string]string{
 				envVarAWSExecutionEnv:             "AWS_Lambda_java8",
 				envVarAWSRegion:                   "us-east-2",
@@ -91,7 +91,7 @@ func TestHandshakeProse(t *testing.T) {
 			}),
 		},
 		{
-			name: "valid Azure",
+			name: "2. valid Azure",
 			env: map[string]string{
 				envVarFunctionsWorkerRuntime: "node",
 			},
@@ -100,7 +100,7 @@ func TestHandshakeProse(t *testing.T) {
 			}),
 		},
 		{
-			name: "valid GCP",
+			name: "3. valid GCP",
 			env: map[string]string{
 				envVarKService:           "servicename",
 				envVarFunctionMemoryMB:   "1024",
@@ -115,7 +115,7 @@ func TestHandshakeProse(t *testing.T) {
 			}),
 		},
 		{
-			name: "valid Vercel",
+			name: "4. valid Vercel",
 			env: map[string]string{
 				envVarVercel:       "1",
 				envVarVercelRegion: "cdg1",
@@ -126,7 +126,7 @@ func TestHandshakeProse(t *testing.T) {
 			}),
 		},
 		{
-			name: "invalid multiple providers",
+			name: "5. invalid multiple providers",
 			env: map[string]string{
 				envVarAWSExecutionEnv:        "AWS_Lambda_java8",
 				envVarFunctionsWorkerRuntime: "node",
@@ -134,7 +134,7 @@ func TestHandshakeProse(t *testing.T) {
 			want: clientMetadata(nil),
 		},
 		{
-			name: "invalid long string",
+			name: "6. invalid long string",
 			env: map[string]string{
 				envVarAWSExecutionEnv: "AWS_Lambda_java8",
 				envVarAWSRegion: func() string {
@@ -150,7 +150,7 @@ func TestHandshakeProse(t *testing.T) {
 			}),
 		},
 		{
-			name: "invalid wrong types",
+			name: "7. invalid wrong types",
 			env: map[string]string{
 				envVarAWSExecutionEnv:             "AWS_Lambda_java8",
 				envVarAWSLambdaFunctionMemorySize: "big",
@@ -158,6 +158,13 @@ func TestHandshakeProse(t *testing.T) {
 			want: clientMetadata(bson.D{
 				{Key: "name", Value: "aws.lambda"},
 			}),
+		},
+		{
+			name: "8. Invalid - AWS_EXECUTION_ENV does not start with \"AWS_Lambda_\"",
+			env: map[string]string{
+				envVarAWSExecutionEnv: "EC2",
+			},
+			want: clientMetadata(nil),
 		},
 	} {
 		test := test

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/internal"
@@ -29,6 +30,7 @@ import (
 // sharded clusters is 512.
 const maxClientMetadataSize = 512
 
+const awsLambdaPrefix = "AWS_Lambda_"
 const driverName = "mongo-go-driver"
 
 // Hello is used to run the handshake operation.
@@ -171,14 +173,21 @@ func getFaasEnvName() string {
 	names := make(map[string]struct{})
 
 	for _, envVar := range envVars {
-		if os.Getenv(envVar) == "" {
+		val := os.Getenv(envVar)
+		if val == "" {
 			continue
 		}
 
 		var name string
 
 		switch envVar {
-		case envVarAWSExecutionEnv, envVarAWSLambdaRuntimeAPI:
+		case envVarAWSExecutionEnv:
+			if !strings.HasPrefix(val, awsLambdaPrefix) {
+				continue
+			}
+
+			name = envNameAWSLambda
+		case envVarAWSLambdaRuntimeAPI:
 			name = envNameAWSLambda
 		case envVarFunctionsWorkerRuntime:
 			name = envNameAzureFunc

--- a/x/mongo/driver/operation/hello_test.go
+++ b/x/mongo/driver/operation/hello_test.go
@@ -153,14 +153,14 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws only",
 			env: map[string]string{
-				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv: "AWS_Lambda_foo",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda"}}`),
 		},
 		{
 			name: "aws mem only",
 			env: map[string]string{
-				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv:             "AWS_Lambda_foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda","memory_mb":1024}}`),
@@ -168,7 +168,7 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws region only",
 			env: map[string]string{
-				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv: "AWS_Lambda_foo",
 				envVarAWSRegion:       "us-east-2",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda","region":"us-east-2"}}`),
@@ -176,7 +176,7 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws mem and region",
 			env: map[string]string{
-				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv:             "AWS_Lambda_foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 				envVarAWSRegion:                   "us-east-2",
 			},
@@ -186,7 +186,7 @@ func TestAppendClientEnv(t *testing.T) {
 			name:          "aws mem and region with omit fields",
 			omitEnvFields: true,
 			env: map[string]string{
-				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv:             "AWS_Lambda_foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 				envVarAWSRegion:                   "us-east-2",
 			},
@@ -546,14 +546,14 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "one aws",
 			env: map[string]string{
-				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv: "AWS_Lambda_foo",
 			},
 			want: envNameAWSLambda,
 		},
 		{
 			name: "both aws options",
 			env: map[string]string{
-				envVarAWSExecutionEnv:     awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv:     "AWS_Lambda_foo",
 				envVarAWSLambdaRuntimeAPI: "hello",
 			},
 			want: envNameAWSLambda,
@@ -561,7 +561,7 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "multiple variables",
 			env: map[string]string{
-				envVarAWSExecutionEnv:        awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv:        "AWS_Lambda_foo",
 				envVarFunctionsWorkerRuntime: "hello",
 			},
 			want: "",
@@ -569,7 +569,7 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "vercel and aws lambda",
 			env: map[string]string{
-				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
+				envVarAWSExecutionEnv: "AWS_Lambda_foo",
 				envVarVercel:          "hello",
 			},
 			want: envNameVercel,

--- a/x/mongo/driver/operation/hello_test.go
+++ b/x/mongo/driver/operation/hello_test.go
@@ -153,14 +153,14 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws only",
 			env: map[string]string{
-				envVarAWSExecutionEnv: "AWS_Lambda_java8",
+				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda"}}`),
 		},
 		{
 			name: "aws mem only",
 			env: map[string]string{
-				envVarAWSExecutionEnv:             "AWS_Lambda_java8",
+				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda","memory_mb":1024}}`),
@@ -168,7 +168,7 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws region only",
 			env: map[string]string{
-				envVarAWSExecutionEnv: "AWS_Lambda_java8",
+				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
 				envVarAWSRegion:       "us-east-2",
 			},
 			want: []byte(`{"env":{"name":"aws.lambda","region":"us-east-2"}}`),
@@ -176,7 +176,7 @@ func TestAppendClientEnv(t *testing.T) {
 		{
 			name: "aws mem and region",
 			env: map[string]string{
-				envVarAWSExecutionEnv:             "AWS_Lambda_java8",
+				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 				envVarAWSRegion:                   "us-east-2",
 			},
@@ -186,7 +186,7 @@ func TestAppendClientEnv(t *testing.T) {
 			name:          "aws mem and region with omit fields",
 			omitEnvFields: true,
 			env: map[string]string{
-				envVarAWSExecutionEnv:             "AWS_Lambda_java8",
+				envVarAWSExecutionEnv:             awsLambdaPrefix + "foo",
 				envVarAWSLambdaFunctionMemorySize: "1024",
 				envVarAWSRegion:                   "us-east-2",
 			},
@@ -546,14 +546,14 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "one aws",
 			env: map[string]string{
-				envVarAWSExecutionEnv: "hello",
+				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
 			},
 			want: envNameAWSLambda,
 		},
 		{
 			name: "both aws options",
 			env: map[string]string{
-				envVarAWSExecutionEnv:     "hello",
+				envVarAWSExecutionEnv:     awsLambdaPrefix + "foo",
 				envVarAWSLambdaRuntimeAPI: "hello",
 			},
 			want: envNameAWSLambda,
@@ -561,7 +561,7 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "multiple variables",
 			env: map[string]string{
-				envVarAWSExecutionEnv:        "hello",
+				envVarAWSExecutionEnv:        awsLambdaPrefix + "foo",
 				envVarFunctionsWorkerRuntime: "hello",
 			},
 			want: "",
@@ -569,10 +569,17 @@ func TestParseFaasEnvName(t *testing.T) {
 		{
 			name: "vercel and aws lambda",
 			env: map[string]string{
-				envVarAWSExecutionEnv: "hello",
+				envVarAWSExecutionEnv: awsLambdaPrefix + "foo",
 				envVarVercel:          "hello",
 			},
 			want: envNameVercel,
+		},
+		{
+			name: "ivalid aws prefix",
+			env: map[string]string{
+				envVarAWSExecutionEnv: "foo",
+			},
+			want: "",
 		},
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2833

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Update handshake FaaS logic to skip AWS_EXECUTION_ENV data that is not prefixed with "AWS_Lambda_".

## Background & Motivation
<!--- Rationale for the pull request. -->

[DRIVERS-2209](https://jira.mongodb.org/browse/DRIVERS-2209) outlined that if the AWS_EXECUTION_ENV env var is present, the app is running on AWS Lambda. This turns out to be too permissive because AWS_EXECUTION_ENV is used in other non-Lambda envs. For example the Windows evergreen machines have AWS_EXECUTION_ENV=EC2.
