### PR TITLE
GODRIVER-2837 Don't use for loops in the Makefile and always build test packages.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -189,18 +189,6 @@ functions:
       params:
         file: src/go.mongodb.org/mongo-driver/expansion.yml
 
-  install-linters:
-    - command: shell.exec
-      params:
-        working_dir: src/go.mongodb.org/mongo-driver
-        script: |
-          ${PREPARE_SHELL}
-
-          # Install linters. Use "go install" instead of "go get" to prevent modifying the go.mod
-          # file.
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
-          go install github.com/walle/lll/...@latest
-
   upload-mo-artifacts:
     - command: shell.exec
       params:
@@ -1163,7 +1151,6 @@ tasks:
   - name: sa-fmt
     tags: ["static-analysis"]
     commands:
-      - func: install-linters
       - func: run-make
         vars:
           targets: check-fmt
@@ -1178,7 +1165,6 @@ tasks:
   - name: sa-lint
     tags: ["static-analysis"]
     commands:
-      - func: install-linters
       - func: run-make
         vars:
           targets: "lint add-license"
@@ -1196,13 +1182,6 @@ tasks:
         vars:
           targets: driver-benchmark
       - func: send-perf-data
-
-  - name: sa-build-examples
-    tags: ["static-analysis"]
-    commands:
-      - func: run-make
-        vars:
-          targets: build-examples
 
   - name: test-standalone-noauth-nossl
     tags: ["test", "standalone"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -320,7 +320,7 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          ${BUILD_ENV|} make ${targets} BUILD_TAGS="-tags \"cse gssapi\""
+          ${BUILD_ENV|} make ${targets} BUILD_TAGS=${BUILD_TAGS|"-tags \"cse gssapi\""}
 
   run-tests:
     - command: shell.exec
@@ -1899,8 +1899,6 @@ tasks:
       - func: run-make
         vars:
           targets: "build-compile-check"
-          # Use GO111MODULE=off to disable modules, as go versions less than
-          # 1.16 will complain about the retract directives in go.mod.
           BUILD_ENV: "PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
 
   # Build with whatever the latest Go version is that we're using for tests
@@ -1909,31 +1907,40 @@ tasks:
     commands:
       - func: run-make
         vars:
-          targets: "build build-tests"
+          targets: "build"
 
   - name: linux-32-bit
     tags: ["compile-check"]
     commands:
       - func: run-make
         vars:
-          targets: "build-no-tags"
+          # The build target runs the build-tests dependency, which actually builds and runs the
+          # tests. That won't work for cross-compiled binaries, so omit that task.
+          targets: "build -o build-tests"
           BUILD_ENV: "GOARCH=386"
+          BUILD_TAGS: ""
 
   - name: linux-arm64
     tags: ["compile-check"]
     commands:
       - func: run-make
         vars:
-          targets: "build-no-tags"
+          # The build target runs the build-tests dependency, which actually builds and runs the
+          # tests. That won't work for cross-compiled binaries, so omit that task.
+          targets: "build -o build-tests"
           BUILD_ENV: "GOARCH=arm64"
+          BUILD_TAGS: ""
 
   - name: linux-s390x
     tags: ["compile-check"]
     commands:
       - func: run-make
         vars:
-          targets: "build-no-tags"
+          # The build target runs the build-tests dependency, which actually builds and runs the
+          # tests. That won't work for cross-compiled binaries, so omit that task.
+          targets: "build -o build-tests"
           BUILD_ENV: "GOARCH=ppc64le"
+          BUILD_TAGS: ""
 
   - name: "atlas-test"
     commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1898,6 +1898,8 @@ tasks:
     commands:
       - func: run-make
         vars:
+          # We only test building the compilecheck submodule with Go 1.13 because the root module's
+          # go.mod file contains retract directives, which are not supported until Go 1.16.
           targets: "build-compile-check"
           BUILD_ENV: "PATH=/opt/golang/go1.13/bin:$PATH GOROOT=/opt/golang/go1.13"
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_TIMEOUT = 1800
 
 ### Utility targets. ###
 .PHONY: default
-default: add-license build build-tests check-fmt check-modules lint test-short
+default: add-license build check-fmt check-modules lint test-short
 
 # Find all .go files not in the vendor directory and try to write a license notice. Then check for
 # any changes made with -G. to ignore permissions changes. Exit with a non-zero exit code if there
@@ -14,12 +14,8 @@ add-license:
 	git diff -G. --quiet
 
 .PHONY: build
-build:
+build: build-tests
 	go build $(BUILD_TAGS) ./...
-
-.PHONY: build-no-tags
-build-no-tags:
-	go build ./...
 
 # Use ^$ to match no tests so that no tests are actually run but all tests are
 # compiled. Run with -short to ensure none of the TestMain functions try to

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ add-license:
 	git diff -G. --quiet
 
 .PHONY: build
-build: build-tests
+build: build-tests build-compile-check
 	go build $(BUILD_TAGS) ./...
 
 # Use ^$ to match no tests so that no tests are actually run but all tests are

--- a/etc/add_license.sh
+++ b/etc/add_license.sh
@@ -17,11 +17,11 @@ add_copyright() {
     fi
 
     # Check if first 14 bytes matches the word "// Copied from"
-     local line=$(head -c 14 $1)
-     if [ "$line" == "// Copied from" ]; then
- 	echo "$1 has a third-party copyright notice" >&2
- 	return
-     fi
+    local line=$(head -c 14 $1)
+    if [ "$line" == "// Copied from" ]; then
+        echo "$1 has a third-party copyright notice" >&2
+        return
+    fi
 
     echo "$copyright" | cat - $1 > temp && mv temp $1
 }


### PR DESCRIPTION
[GODRIVER-2837](https://jira.mongodb.org/browse/GODRIVER-2837)

## Summary
* Don't use `for` loops in the Makefile.
* Remove redundant `make build-examples` Makefile target.
* Don't limit package parallelism on `make test-short` because it's not necessary.
* Install `lll` and `golangci-lint` as part of Makefile targets to make commands repeatable.

I attempted to combine the `build` and `build-tests` Makefile targets, but there are many build CI tasks that are unable to run test code (e.g. Go 1.13 build, S390X build, etc).

## Background & Motivation
A recent release that failed to build on customers' workstations highlighted cases where the Makefile targets can silently swallow errors (see [GODRIVER-2831](https://jira.mongodb.org/browse/GODRIVER-2831)). The main culprit is `for` loops in Makefiles, which only return the error code of the last evaluated statement in the loop. While we investigate better build systems, fix the issue in the short term by never using `for` loops in the Makefile.

