### PR TITLE
Add a list of possible errors to bson.Raw.LookupErr’s documentation.

### DIFF
--- a/bson/raw.go
+++ b/bson/raw.go
@@ -51,6 +51,11 @@ func (r Raw) Lookup(key ...string) RawValue {
 
 // LookupErr searches the document and potentially subdocuments or arrays for the
 // provided key. Each key provided to this method represents a layer of depth.
+//
+// The returned error is one of:
+//   - bsoncore.ErrElementNotFound
+//   - bsoncore.InsufficientBytesError
+//   - bsoncore.InvalidDepthTraversalError
 func (r Raw) LookupErr(key ...string) (RawValue, error) {
 	val, err := bsoncore.Document(r).LookupErr(key...)
 	return convertFromCoreValue(val), err


### PR DESCRIPTION
## Summary

This adds detail about the errors callers should expect from bson.Raw.LookupErr.

## Background & Motivation

I’ve seen LookupErr() used where the caller expects that any error indicates nonexistence of the key. This change adds useful clarity on this point.
