### PR TITLE
Skip TestServerHeartbeatTimeout when using -short test flag.

### DIFF
--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -128,6 +128,10 @@ func (d *timeoutDialer) DialContext(ctx context.Context, network, address string
 
 // TestServerHeartbeatTimeout tests timeout retry for GODRIVER-2577.
 func TestServerHeartbeatTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	networkTimeoutError := &net.DNSError{
 		IsTimeout: true,
 	}


### PR DESCRIPTION
## Summary
Skip the `TestServerHeartbeatTimeout` integration test when using the `-short` test flag.

## Background & Motivation
The `go test -short` / `make test-short` targets should work even if there is no running MongoDB database.