### PR TITLE
Skip frequently failing test cases with follow-up GODRIVER tickets.

### DIFF
--- a/mongo/integration/server_selection_prose_test.go
+++ b/mongo/integration/server_selection_prose_test.go
@@ -184,6 +184,9 @@ func TestServerSelectionProse(t *testing.T) {
 
 	mtOpts = mtest.NewOptions().Topologies(mtest.Sharded)
 	mt.RunOpts("operationCount-based selection within latency window, no failpoint", mtOpts, func(mt *mtest.T) {
+		// TODO(GODRIVER-2842): Fix and unskip this test case.
+		mt.Skip("Test fails frequently, skipping. See GODRIVER-2842")
+
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
 		require.NoError(mt, err, "InsertOne() error")
 

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -365,6 +365,9 @@ func TestSessions(t *testing.T) {
 	sessallocopts := mtest.NewOptions().ClientOptions(options.Client().SetMaxPoolSize(1).SetRetryWrites(true).
 		SetHosts(hosts[:1]))
 	mt.RunOpts("14. implicit session allocation", sessallocopts, func(mt *mtest.T) {
+		// TODO(GODRIVER-2844): Fix and unskip this test case.
+		mt.Skip("Test fails frequently, skipping. See GODRIVER-2844")
+
 		ops := map[string]func(ctx context.Context) error{
 			"insert": func(ctx context.Context) error {
 				_, err := mt.Coll.InsertOne(ctx, bson.D{})

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -23,10 +23,13 @@ import (
 )
 
 var (
-	skippedTestDescriptions = map[string]struct{}{
+	skippedTestDescriptions = map[string]string{
 		// GODRIVER-1773: This test runs a "find" with limit=4 and batchSize=3. It expects batchSize values of three for
 		// the "find" and one for the "getMore", but we send three for both.
-		"A successful find event with a getmore and the server kills the cursor (<= 4.4)": {},
+		"A successful find event with a getmore and the server kills the cursor (<= 4.4)": "See GODRIVER-1773",
+		// TODO(GODRIVER-2843): Fix and unskip these test cases.
+		"Find operation with snapshot":                                      "Test fails frequently. See GODRIVER-2843",
+		"Write commands with snapshot session do not affect snapshot reads": "Test fails frequently. See GODRIVER-2843",
 	}
 
 	logMessageValidatorTimeout = 10 * time.Millisecond
@@ -210,9 +213,10 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 	if tc.SkipReason != nil {
 		ls.Skipf("skipping for reason: %q", *tc.SkipReason)
 	}
-	if _, ok := skippedTestDescriptions[tc.Description]; ok {
-		ls.Skip("skipping due to known failure")
+	if skipReason, ok := skippedTestDescriptions[tc.Description]; ok {
+		ls.Skipf("skipping due to known failure: %v", skipReason)
 	}
+
 	// Validate that we support the schema declared by the test file before attempting to use its contents.
 	if err := checkSchemaVersion(tc.schemaVersion); err != nil {
 		return fmt.Errorf("schema version %q not supported: %v", tc.schemaVersion, err)


### PR DESCRIPTION
## Summary
Skip frequently failing test cases with follow-up GODRIVER tickets to resolve the failures:
* [GODRIVER-2842](https://jira.mongodb.org/browse/GODRIVER-2842)
* [GODRIVER-2843](https://jira.mongodb.org/browse/GODRIVER-2843)
* [GODRIVER-2844](https://jira.mongodb.org/browse/GODRIVER-2844)


## Background & Motivation
To prevent known intermittent test failures from hiding new real test failures, skip frequently failing test cases and create GODRIVER tickets to follow up with fixes.