### PR TITLE
GODRIVER-2568 Add link to BSON fundamentals page in bson package docs.

### DIFF
--- a/bson/doc.go
+++ b/bson/doc.go
@@ -7,7 +7,8 @@
 // Package bson is a library for reading, writing, and manipulating BSON. BSON is a binary serialization format used to
 // store documents and make remote procedure calls in MongoDB. The BSON specification is located at https://bsonspec.org.
 // The BSON library handles marshalling and unmarshalling of values through a configurable codec system. For a description
-// of the codec system and examples of registering custom codecs, see the bsoncodec package.
+// of the codec system and examples of registering custom codecs, see the bsoncodec package. For additional information and
+// usage examples, check out the [Work with BSON] page in the Go Driver docs site.
 //
 // # Raw BSON
 //
@@ -138,4 +139,6 @@
 // # Marshalling and Unmarshalling
 //
 // Manually marshalling and unmarshalling can be done with the Marshal and Unmarshal family of functions.
+//
+// [Work with BSON]: https://www.mongodb.com/docs/drivers/go/current/fundamentals/bson/
 package bson


### PR DESCRIPTION
[GODRIVER-2568](https://jira.mongodb.org/browse/GODRIVER-2568)

## Summary
Add a link to the [Work with BSON](https://www.mongodb.com/docs/drivers/go/current/fundamentals/bson/) page in the `bson` package docs.

## Background & Motivation
There is additional useful information in the Go Driver docs site. We should regularly link to it from the Go package docs.

