### PR TITLE
GODRIVER-2706 Deprecate all code in the bsonoptions package.

### DIFF
--- a/bson/bsoncodec/bsoncodec.go
+++ b/bson/bsoncodec/bsoncodec.go
@@ -224,6 +224,7 @@ type DecodeContext struct {
 
 	binaryAsSlice     bool
 	useJSONStructTags bool
+	useLocalTimeZone  bool
 	zeroMaps          bool
 	zeroStructs       bool
 }
@@ -242,6 +243,14 @@ func (dc *DecodeContext) BinaryAsSlice() {
 // Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.UseJSONStructTags] instead.
 func (dc *DecodeContext) UseJSONStructTags() {
 	dc.useJSONStructTags = true
+}
+
+// UseLocalTimeZone causes the Decoder to unmarshal time.Time values in the local timezone instead
+// of the UTC timezone.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.UseLocalTimeZone] instead.
+func (dc *DecodeContext) UseLocalTimeZone() {
+	dc.useLocalTimeZone = true
 }
 
 // ZeroMaps causes the Decoder to delete any existing values from Go maps in the destination value

--- a/bson/bsoncodec/string_codec.go
+++ b/bson/bsoncodec/string_codec.go
@@ -20,6 +20,10 @@ import (
 // Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
 // StringCodec registered.
 type StringCodec struct {
+	// DecodeObjectIDAsHex specifies if object IDs should be decoded as their hex representation.
+	// If false, a string made from the raw object ID bytes will be used. Defaults to true.
+	//
+	// Deprecated: Decoding object IDs as raw bytes will not be supported in Go Driver 2.0.
 	DecodeObjectIDAsHex bool
 }
 

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -376,6 +376,7 @@ func (sc *StructCodec) DecodeValue(dc DecodeContext, vr bsonrw.ValueReader, val 
 			defaultDocumentType: dc.defaultDocumentType,
 			binaryAsSlice:       dc.binaryAsSlice,
 			useJSONStructTags:   dc.useJSONStructTags,
+			useLocalTimeZone:    dc.useLocalTimeZone,
 			zeroMaps:            dc.zeroMaps,
 			zeroStructs:         dc.zeroStructs,
 		}

--- a/bson/bsoncodec/time_codec.go
+++ b/bson/bsoncodec/time_codec.go
@@ -26,6 +26,9 @@ const (
 // Deprecated: Use [go.mongodb.org/mongo-driver/bson.NewRegistry] to get a registry with the
 // TimeCodec registered.
 type TimeCodec struct {
+	// UseLocalTimeZone specifies if we should decode into the local time zone. Defaults to false.
+	//
+	// Deprecated: Use bson.Decoder.UseLocalTimeZone instead.
 	UseLocalTimeZone bool
 }
 
@@ -51,7 +54,7 @@ func NewTimeCodec(opts ...*bsonoptions.TimeCodecOptions) *TimeCodec {
 	return &codec
 }
 
-func (tc *TimeCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
+func (tc *TimeCodec) decodeType(dc DecodeContext, vr bsonrw.ValueReader, t reflect.Type) (reflect.Value, error) {
 	if t != tTime {
 		return emptyValue, ValueDecoderError{
 			Name:     "TimeDecodeValue",
@@ -102,7 +105,7 @@ func (tc *TimeCodec) decodeType(_ DecodeContext, vr bsonrw.ValueReader, t reflec
 		return emptyValue, fmt.Errorf("cannot decode %v into a time.Time", vrType)
 	}
 
-	if !tc.UseLocalTimeZone {
+	if !tc.UseLocalTimeZone && !dc.useLocalTimeZone {
 		timeVal = timeVal.UTC()
 	}
 	return reflect.ValueOf(timeVal), nil

--- a/bson/bsonoptions/byte_slice_codec_options.go
+++ b/bson/bsonoptions/byte_slice_codec_options.go
@@ -7,16 +7,24 @@
 package bsonoptions
 
 // ByteSliceCodecOptions represents all possible options for byte slice encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type ByteSliceCodecOptions struct {
 	EncodeNilAsEmpty *bool // Specifies if a nil byte slice should encode as an empty binary instead of null. Defaults to false.
 }
 
 // ByteSliceCodec creates a new *ByteSliceCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func ByteSliceCodec() *ByteSliceCodecOptions {
 	return &ByteSliceCodecOptions{}
 }
 
 // SetEncodeNilAsEmpty specifies  if a nil byte slice should encode as an empty binary instead of null. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilByteSliceAsEmpty] instead.
 func (bs *ByteSliceCodecOptions) SetEncodeNilAsEmpty(b bool) *ByteSliceCodecOptions {
 	bs.EncodeNilAsEmpty = &b
 	return bs

--- a/bson/bsonoptions/empty_interface_codec_options.go
+++ b/bson/bsonoptions/empty_interface_codec_options.go
@@ -7,16 +7,24 @@
 package bsonoptions
 
 // EmptyInterfaceCodecOptions represents all possible options for interface{} encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type EmptyInterfaceCodecOptions struct {
 	DecodeBinaryAsSlice *bool // Specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
 }
 
 // EmptyInterfaceCodec creates a new *EmptyInterfaceCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func EmptyInterfaceCodec() *EmptyInterfaceCodecOptions {
 	return &EmptyInterfaceCodecOptions{}
 }
 
 // SetDecodeBinaryAsSlice specifies if Old and Generic type binarys should default to []slice instead of primitive.Binary. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.BinaryAsSlice] instead.
 func (e *EmptyInterfaceCodecOptions) SetDecodeBinaryAsSlice(b bool) *EmptyInterfaceCodecOptions {
 	e.DecodeBinaryAsSlice = &b
 	return e

--- a/bson/bsonoptions/map_codec_options.go
+++ b/bson/bsonoptions/map_codec_options.go
@@ -7,6 +7,9 @@
 package bsonoptions
 
 // MapCodecOptions represents all possible options for map encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type MapCodecOptions struct {
 	DecodeZerosMap   *bool // Specifies if the map should be zeroed before decoding into it. Defaults to false.
 	EncodeNilAsEmpty *bool // Specifies if a nil map should encode as an empty document instead of null. Defaults to false.
@@ -19,17 +22,24 @@ type MapCodecOptions struct {
 }
 
 // MapCodec creates a new *MapCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func MapCodec() *MapCodecOptions {
 	return &MapCodecOptions{}
 }
 
 // SetDecodeZerosMap specifies if the map should be zeroed before decoding into it. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.ZeroMaps] instead.
 func (t *MapCodecOptions) SetDecodeZerosMap(b bool) *MapCodecOptions {
 	t.DecodeZerosMap = &b
 	return t
 }
 
 // SetEncodeNilAsEmpty specifies if a nil map should encode as an empty document instead of null. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilMapAsEmpty] instead.
 func (t *MapCodecOptions) SetEncodeNilAsEmpty(b bool) *MapCodecOptions {
 	t.EncodeNilAsEmpty = &b
 	return t
@@ -40,6 +50,8 @@ func (t *MapCodecOptions) SetEncodeNilAsEmpty(b bool) *MapCodecOptions {
 // type must either be a string, an integer type, or implement bsoncodec.KeyUnmarshaler. If true, keys are encoded with
 // fmt.Sprint() and the encoding key type must be a string, an integer type, or a float. If true, the use of Stringer
 // will override TextMarshaler/TextUnmarshaler. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.StringifyMapKeysWithFmt] instead.
 func (t *MapCodecOptions) SetEncodeKeysWithStringer(b bool) *MapCodecOptions {
 	t.EncodeKeysWithStringer = &b
 	return t

--- a/bson/bsonoptions/slice_codec_options.go
+++ b/bson/bsonoptions/slice_codec_options.go
@@ -7,16 +7,24 @@
 package bsonoptions
 
 // SliceCodecOptions represents all possible options for slice encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type SliceCodecOptions struct {
 	EncodeNilAsEmpty *bool // Specifies if a nil slice should encode as an empty array instead of null. Defaults to false.
 }
 
 // SliceCodec creates a new *SliceCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func SliceCodec() *SliceCodecOptions {
 	return &SliceCodecOptions{}
 }
 
 // SetEncodeNilAsEmpty specifies  if a nil slice should encode as an empty array instead of null. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.NilSliceAsEmpty] instead.
 func (s *SliceCodecOptions) SetEncodeNilAsEmpty(b bool) *SliceCodecOptions {
 	s.EncodeNilAsEmpty = &b
 	return s

--- a/bson/bsonoptions/string_codec_options.go
+++ b/bson/bsonoptions/string_codec_options.go
@@ -9,17 +9,25 @@ package bsonoptions
 var defaultDecodeOIDAsHex = true
 
 // StringCodecOptions represents all possible options for string encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type StringCodecOptions struct {
 	DecodeObjectIDAsHex *bool // Specifies if we should decode ObjectID as the hex value. Defaults to true.
 }
 
 // StringCodec creates a new *StringCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func StringCodec() *StringCodecOptions {
 	return &StringCodecOptions{}
 }
 
 // SetDecodeObjectIDAsHex specifies if object IDs should be decoded as their hex representation. If false, a string made
 // from the raw object ID bytes will be used. Defaults to true.
+//
+// Deprecated: Decoding object IDs as raw bytes will not be supported in Go Driver 2.0.
 func (t *StringCodecOptions) SetDecodeObjectIDAsHex(b bool) *StringCodecOptions {
 	t.DecodeObjectIDAsHex = &b
 	return t

--- a/bson/bsonoptions/struct_codec_options.go
+++ b/bson/bsonoptions/struct_codec_options.go
@@ -9,6 +9,9 @@ package bsonoptions
 var defaultOverwriteDuplicatedInlinedFields = true
 
 // StructCodecOptions represents all possible options for struct encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type StructCodecOptions struct {
 	DecodeZeroStruct                 *bool // Specifies if structs should be zeroed before decoding into them. Defaults to false.
 	DecodeDeepZeroInline             *bool // Specifies if structs should be recursively zeroed when a inline value is decoded. Defaults to false.
@@ -18,17 +21,24 @@ type StructCodecOptions struct {
 }
 
 // StructCodec creates a new *StructCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func StructCodec() *StructCodecOptions {
 	return &StructCodecOptions{}
 }
 
 // SetDecodeZeroStruct specifies if structs should be zeroed before decoding into them. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.ZeroStructs] instead.
 func (t *StructCodecOptions) SetDecodeZeroStruct(b bool) *StructCodecOptions {
 	t.DecodeZeroStruct = &b
 	return t
 }
 
 // SetDecodeDeepZeroInline specifies if structs should be zeroed before decoding into them. Defaults to false.
+//
+// Deprecated: DecodeDeepZeroInline will not be supported in Go Driver 2.0.
 func (t *StructCodecOptions) SetDecodeDeepZeroInline(b bool) *StructCodecOptions {
 	t.DecodeDeepZeroInline = &b
 	return t
@@ -36,6 +46,8 @@ func (t *StructCodecOptions) SetDecodeDeepZeroInline(b bool) *StructCodecOptions
 
 // SetEncodeOmitDefaultStruct specifies if default structs should be considered empty by omitempty. A default struct has all
 // its values set to their default value. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.OmitZeroStruct] instead.
 func (t *StructCodecOptions) SetEncodeOmitDefaultStruct(b bool) *StructCodecOptions {
 	t.EncodeOmitDefaultStruct = &b
 	return t
@@ -45,12 +57,17 @@ func (t *StructCodecOptions) SetEncodeOmitDefaultStruct(b bool) *StructCodecOpti
 // same bson key. When true and decoding, values will be written to the outermost struct with a matching key, and when
 // encoding, keys will have the value of the top-most matching field. When false, decoding and encoding will error if
 // there are duplicate keys after the struct is inlined. Defaults to true.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.ErrorOnInlineDuplicates] instead.
 func (t *StructCodecOptions) SetOverwriteDuplicatedInlinedFields(b bool) *StructCodecOptions {
 	t.OverwriteDuplicatedInlinedFields = &b
 	return t
 }
 
 // SetAllowUnexportedFields specifies if unexported fields should be marshaled/unmarshaled. Defaults to false.
+//
+// Deprecated: AllowUnexportedFields does not work on recent versions of Go and will not be
+// supported in Go Driver 2.0.
 func (t *StructCodecOptions) SetAllowUnexportedFields(b bool) *StructCodecOptions {
 	t.AllowUnexportedFields = &b
 	return t

--- a/bson/bsonoptions/time_codec_options.go
+++ b/bson/bsonoptions/time_codec_options.go
@@ -7,16 +7,24 @@
 package bsonoptions
 
 // TimeCodecOptions represents all possible options for time.Time encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type TimeCodecOptions struct {
 	UseLocalTimeZone *bool // Specifies if we should decode into the local time zone. Defaults to false.
 }
 
 // TimeCodec creates a new *TimeCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func TimeCodec() *TimeCodecOptions {
 	return &TimeCodecOptions{}
 }
 
 // SetUseLocalTimeZone specifies if we should decode into the local time zone. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Decoder.UseLocalTimeZone] instead.
 func (t *TimeCodecOptions) SetUseLocalTimeZone(b bool) *TimeCodecOptions {
 	t.UseLocalTimeZone = &b
 	return t

--- a/bson/bsonoptions/uint_codec_options.go
+++ b/bson/bsonoptions/uint_codec_options.go
@@ -7,16 +7,24 @@
 package bsonoptions
 
 // UIntCodecOptions represents all possible options for uint encoding and decoding.
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 type UIntCodecOptions struct {
 	EncodeToMinSize *bool // Specifies if all uints except uint64 should be decoded to minimum size bsontype. Defaults to false.
 }
 
 // UIntCodec creates a new *UIntCodecOptions
+//
+// Deprecated: Use the bson.Encoder and bson.Decoder configuration methods to set the desired BSON marshal
+// and unmarshal behavior instead.
 func UIntCodec() *UIntCodecOptions {
 	return &UIntCodecOptions{}
 }
 
 // SetEncodeToMinSize specifies if all uints except uint64 should be decoded to minimum size bsontype. Defaults to false.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.Encoder.IntMinSize] instead.
 func (u *UIntCodecOptions) SetEncodeToMinSize(b bool) *UIntCodecOptions {
 	u.EncodeToMinSize = &b
 	return u

--- a/bson/decoder.go
+++ b/bson/decoder.go
@@ -41,6 +41,7 @@ type Decoder struct {
 
 	binaryAsSlice     bool
 	useJSONStructTags bool
+	useLocalTimeZone  bool
 	zeroMaps          bool
 	zeroStructs       bool
 }
@@ -121,6 +122,9 @@ func (d *Decoder) Decode(val interface{}) error {
 	if d.useJSONStructTags {
 		d.dc.UseJSONStructTags()
 	}
+	if d.useLocalTimeZone {
+		d.dc.UseLocalTimeZone()
+	}
 	if d.zeroMaps {
 		d.dc.ZeroMaps()
 	}
@@ -182,6 +186,12 @@ func (d *Decoder) BinaryAsSlice() {
 // struct tag is not specified.
 func (d *Decoder) UseJSONStructTags() {
 	d.useJSONStructTags = true
+}
+
+// UseLocalTimeZone causes the Decoder to unmarshal time.Time values in the local timezone instead
+// of the UTC timezone.
+func (d *Decoder) UseLocalTimeZone() {
+	d.useLocalTimeZone = true
 }
 
 // ZeroMaps causes the Decoder to delete any existing values from Go maps in the destination value


### PR DESCRIPTION
[GODRIVER-2706](https://jira.mongodb.org/browse/GODRIVER-2706)

## Summary
* Deprecate all types and methods in the `bsonoptions` package with suggested alternatives.
* Add the `Decoder.UseLocalTimeZone` option and deprecate `TimeCodec.UseLocalTimeZone` and the corresponding `bsonoptions` options. Note this should have been done with [#1229](https://github.com/mongodb/mongo-go-driver/pull/1229), but I missed it.
* Deprecate `StringCodec.DecodeObjectIDAsHex`. Note this should have been done with [#1229](https://github.com/mongodb/mongo-go-driver/pull/1229), but I missed it.

## Background & Motivation
Currently the `bsonoptions` package is used exclusively to define configuration options for types and functions in the `bsoncodec` package. Those options structs are almost exact duplicates of most of the `*Codec` structs, which are all deprecated now as well.