### PR TITLE
GODRIVER-2584 Error if RewrapManyDataKey is called with MasterKey and without Provider

### DIFF
--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -396,6 +396,11 @@ func (m *MongoCrypt) RewrapDataKeyContext(filter []byte, opts *options.RewrapMan
 		return nil, m.createErrorFromStatus()
 	}
 
+	if opts.MasterKey != nil && opts.Provider == nil {
+		// Provider is nil, but MasterKey is set. This is an error.
+		return nil, fmt.Errorf("expected 'Provider' to be set to identify type of 'MasterKey'")
+	}
+
 	if opts.Provider != nil {
 		// If a provider has been specified, create an encryption key document for creating a data key or for rewrapping
 		// datakeys. If a new provider is not specified, then the filter portion of this logic returns the data as it


### PR DESCRIPTION
GODRIVER-2584
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
- return error if `masterKey` is set, but `provider` is not set for `rewrapManyDataKey`
- add prose test specified in DRIVERS-2441

## Background & Motivation

The specified API for `rewrapManyDataKey` does not permit calling with a set `masterKey` without a `provider`.

```typescript
    class ClientEncryption {
        rewrapManyDataKey(filter: Document, opts: RewrapManyDataKeyOpts | null): RewrapManyDataKeyResult;
    }
    class RewrapManyDataKeyOpts {
        provider: String
        masterKey: Optional<Document>
    }
```

Some driver implementations do not represent `RewrapManyDataKeyOpts` as a separate type. Instead, the `provider` and `masterKey` are both optional arguments to `RewrapManyDataKey`.

The current behavior of `ClientEncryption#RewrapManyDataKey` silently ignores the `MasterKey` option if `Provider` is nil.

This may result in unexpected behavior. A user may be attempting to rewrap keys with a new `MasterKey` and mistakenly passed a nil `Provider`. A nil `Provider` results in rewrapping with the same `MasterKey`.

The Java driver had similar behavior, which was fixed in [JAVA-4717](https://jira.mongodb.org/browse/JAVA-4717).
