### PR TITLE
GODRIVER-2818 Deprecate bsoncodec errors that will be removed in Go Driver 2.0

### DIFF
--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -16,12 +16,18 @@ import (
 )
 
 // ErrNilType is returned when nil is passed to either LookupEncoder or LookupDecoder.
+//
+// Deprecated: ErrNilType will not be supported in Go Driver 2.0.
 var ErrNilType = errors.New("cannot perform a decoder lookup on <nil>")
 
 // ErrNotPointer is returned when a non-pointer type is provided to LookupDecoder.
+//
+// Deprecated: ErrNotPointer will not be supported in Go Driver 2.0.
 var ErrNotPointer = errors.New("non-pointer provided to LookupDecoder")
 
 // ErrNoEncoder is returned when there wasn't an encoder available for a type.
+//
+// Deprecated: ErrNoEncoder will not be supported in Go Driver 2.0.
 type ErrNoEncoder struct {
 	Type reflect.Type
 }
@@ -34,6 +40,8 @@ func (ene ErrNoEncoder) Error() string {
 }
 
 // ErrNoDecoder is returned when there wasn't a decoder available for a type.
+//
+// Deprecated: ErrNoDecoder will not be supported in Go Driver 2.0.
 type ErrNoDecoder struct {
 	Type reflect.Type
 }
@@ -43,6 +51,8 @@ func (end ErrNoDecoder) Error() string {
 }
 
 // ErrNoTypeMapEntry is returned when there wasn't a type available for the provided BSON type.
+//
+// Deprecated: ErrNoTypeMapEntry will not be supported in Go Driver 2.0.
 type ErrNoTypeMapEntry struct {
 	Type bsontype.Type
 }
@@ -52,6 +62,8 @@ func (entme ErrNoTypeMapEntry) Error() string {
 }
 
 // ErrNotInterface is returned when the provided type is not an interface.
+//
+// Deprecated: ErrNotInterface will not be supported in Go Driver 2.0.
 var ErrNotInterface = errors.New("The provided type is not an interface")
 
 // A RegistryBuilder is used to build a Registry. This type is not goroutine


### PR DESCRIPTION
[GODRIVER-2818](https://jira.mongodb.org/browse/GODRIVER-2818)

## Summary
Deprecate bsoncodec errors that will be removed in Go Driver 2.0.

## Background & Motivation
There are a number of exported error values and types in the `bsoncodec` package that do not need to be exported.

Errors that indicate an implementation error typically do not need to support comparison at runtime because we expect users will fix the implementation error rather than write error handling logic. There are a number of exported error values and types in the `bsoncodec` package that are only used to signal an implementation error and don't need to be exported:
Error values:
* `ErrNilType`
* `ErrNotPointer`
* `ErrNotInterface`

Error types:
* `ErrNoEncoder`
* `ErrNoDecoder`
* `ErrNoTypeMapEntry`

We still need to return errors in most of those cases, but we don't expect users to write error handling logic when any of the above errors are returned.