### PR TITLE
Skip frequently failing test cases with follow-up GODRIVER tickets.

### DIFF
--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -59,6 +59,10 @@ var skippedTestDescriptions = map[string]string{
 	// that request a new connection cannot be satisfied by a check-in.
 	// TODO(DRIVERS-2223): Re-enable this test once the spec test is updated to support the Go pool check-in behavior.
 	"threads blocked by maxConnecting check out returned connections": "test requires a checked-in connections cannot satisfy a check-out waiting on a new connection (DRIVERS-2223)",
+	// TODO(GODRIVER-2852): Fix and unskip this test case.
+	"must be able to start a pool with minPoolSize connections": "test fails frequently, skipping; see GODRIVER-2852",
+	// TODO(GODRIVER-2852): Fix and unskip this test case.
+	"pool clear halts background minPoolSize establishments": "test fails frequently, skipping; see GODRIVER-2852",
 }
 
 type cmapEvent struct {

--- a/x/mongo/driver/topology/cmap_prose_test.go
+++ b/x/mongo/driver/topology/cmap_prose_test.go
@@ -106,6 +106,9 @@ func TestCMAPProse(t *testing.T) {
 		})
 		t.Run("checkOut", func(t *testing.T) {
 			t.Run("connection error publishes events", func(t *testing.T) {
+				// TODO(GODRIVER-2851): Fix and unskip this test case.
+				t.Skip("Test fails frequently, skipping. See GODRIVER-2851")
+
 				// If checkOut() creates a connection that encounters an error while connecting,
 				// the pool should publish connection created and closed events and checkOut should
 				// return the error.


### PR DESCRIPTION
## Summary
Skip frequently failing test cases with follow-up GODRIVER tickets to resolve the failures:
* [GODRIVER-2851](https://jira.mongodb.org/browse/GODRIVER-2851)
* [GODRIVER-2852](https://jira.mongodb.org/browse/GODRIVER-2852)

## Background & Motivation
To prevent known intermittent test failures from hiding new real test failures, skip frequently failing test cases and create GODRIVER tickets to follow up with fixes.

See similar PR: https://github.com/mongodb/mongo-go-driver/pull/1265
