### PR TITLE
GODRIVER-2713 Deprecate bsonrw.Copier and related functions and types.

### DIFF
--- a/bson/bsonrw/copier.go
+++ b/bson/bsonrw/copier.go
@@ -17,20 +17,32 @@ import (
 
 // Copier is a type that allows copying between ValueReaders, ValueWriters, and
 // []byte values.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 type Copier struct{}
 
 // NewCopier creates a new copier with the given registry. If a nil registry is provided
 // a default registry is used.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func NewCopier() Copier {
 	return Copier{}
 }
 
 // CopyDocument handles copying a document from src to dst.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func CopyDocument(dst ValueWriter, src ValueReader) error {
 	return Copier{}.CopyDocument(dst, src)
 }
 
 // CopyDocument handles copying one document from the src to the dst.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyDocument(dst ValueWriter, src ValueReader) error {
 	dr, err := src.ReadDocument()
 	if err != nil {
@@ -47,6 +59,9 @@ func (c Copier) CopyDocument(dst ValueWriter, src ValueReader) error {
 
 // CopyArrayFromBytes copies the values from a BSON array represented as a
 // []byte to a ValueWriter.
+//
+// Deprecated: Copying BSON arrays using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyArrayFromBytes(dst ValueWriter, src []byte) error {
 	aw, err := dst.WriteArray()
 	if err != nil {
@@ -63,6 +78,9 @@ func (c Copier) CopyArrayFromBytes(dst ValueWriter, src []byte) error {
 
 // CopyDocumentFromBytes copies the values from a BSON document represented as a
 // []byte to a ValueWriter.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyDocumentFromBytes(dst ValueWriter, src []byte) error {
 	dw, err := dst.WriteDocument()
 	if err != nil {
@@ -81,6 +99,9 @@ type writeElementFn func(key string) (ValueWriter, error)
 
 // CopyBytesToArrayWriter copies the values from a BSON Array represented as a []byte to an
 // ArrayWriter.
+//
+// Deprecated: Copying BSON arrays using the ArrayWriter interface will not be supported in Go
+// Driver 2.0.
 func (c Copier) CopyBytesToArrayWriter(dst ArrayWriter, src []byte) error {
 	wef := func(_ string) (ValueWriter, error) {
 		return dst.WriteArrayElement()
@@ -91,6 +112,9 @@ func (c Copier) CopyBytesToArrayWriter(dst ArrayWriter, src []byte) error {
 
 // CopyBytesToDocumentWriter copies the values from a BSON document represented as a []byte to a
 // DocumentWriter.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyBytesToDocumentWriter(dst DocumentWriter, src []byte) error {
 	wef := func(key string) (ValueWriter, error) {
 		return dst.WriteDocumentElement(key)
@@ -150,12 +174,18 @@ func (c Copier) copyBytesToValueWriter(src []byte, wef writeElementFn) error {
 
 // CopyDocumentToBytes copies an entire document from the ValueReader and
 // returns it as bytes.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyDocumentToBytes(src ValueReader) ([]byte, error) {
 	return c.AppendDocumentBytes(nil, src)
 }
 
 // AppendDocumentBytes functions the same as CopyDocumentToBytes, but will
 // append the result to dst.
+//
+// Deprecated: Copying BSON documents using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) AppendDocumentBytes(dst []byte, src ValueReader) ([]byte, error) {
 	if br, ok := src.(BytesReader); ok {
 		_, dst, err := br.ReadValueBytes(dst)
@@ -173,6 +203,9 @@ func (c Copier) AppendDocumentBytes(dst []byte, src ValueReader) ([]byte, error)
 }
 
 // AppendArrayBytes copies an array from the ValueReader to dst.
+//
+// Deprecated: Copying BSON arrays using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) AppendArrayBytes(dst []byte, src ValueReader) ([]byte, error) {
 	if br, ok := src.(BytesReader); ok {
 		_, dst, err := br.ReadValueBytes(dst)
@@ -190,6 +223,8 @@ func (c Copier) AppendArrayBytes(dst []byte, src ValueReader) ([]byte, error) {
 }
 
 // CopyValueFromBytes will write the value represtend by t and src to dst.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.UnmarshalValue] instead.
 func (c Copier) CopyValueFromBytes(dst ValueWriter, t bsontype.Type, src []byte) error {
 	if wvb, ok := dst.(BytesWriter); ok {
 		return wvb.WriteValueBytes(t, src)
@@ -206,12 +241,17 @@ func (c Copier) CopyValueFromBytes(dst ValueWriter, t bsontype.Type, src []byte)
 
 // CopyValueToBytes copies a value from src and returns it as a bsontype.Type and a
 // []byte.
+//
+// Deprecated: Use [go.mongodb.org/mongo-driver/bson.MarshalValue] instead.
 func (c Copier) CopyValueToBytes(src ValueReader) (bsontype.Type, []byte, error) {
 	return c.AppendValueBytes(nil, src)
 }
 
 // AppendValueBytes functions the same as CopyValueToBytes, but will append the
 // result to dst.
+//
+// Deprecated: Appending individual BSON elements to an existing slice will not be supported in Go
+// Driver 2.0.
 func (c Copier) AppendValueBytes(dst []byte, src ValueReader) (bsontype.Type, []byte, error) {
 	if br, ok := src.(BytesReader); ok {
 		return br.ReadValueBytes(dst)
@@ -234,6 +274,9 @@ func (c Copier) AppendValueBytes(dst []byte, src ValueReader) (bsontype.Type, []
 }
 
 // CopyValue will copy a single value from src to dst.
+//
+// Deprecated: Copying BSON values using the ValueWriter and ValueReader interfaces will not be
+// supported in Go Driver 2.0.
 func (c Copier) CopyValue(dst ValueWriter, src ValueReader) error {
 	var err error
 	switch src.Type() {

--- a/bson/bsonrw/reader.go
+++ b/bson/bsonrw/reader.go
@@ -58,6 +58,8 @@ type ValueReader interface {
 // types that implement ValueReader may also implement this interface.
 //
 // The bytes of the value will be appended to dst.
+//
+// Deprecated: BytesReader will not be supported in Go Driver 2.0.
 type BytesReader interface {
 	ReadValueBytes(dst []byte) (bsontype.Type, []byte, error)
 }

--- a/bson/bsonrw/writer.go
+++ b/bson/bsonrw/writer.go
@@ -56,6 +56,8 @@ type ValueWriter interface {
 }
 
 // ValueWriterFlusher is a superset of ValueWriter that exposes functionality to flush to the underlying buffer.
+//
+// Deprecated: ValueWriterFlusher will not be supported in Go Driver 2.0.
 type ValueWriterFlusher interface {
 	ValueWriter
 	Flush() error
@@ -64,6 +66,8 @@ type ValueWriterFlusher interface {
 // BytesWriter is the interface used to write BSON bytes to a ValueWriter.
 // This interface is meant to be a superset of ValueWriter, so that types that
 // implement ValueWriter may also implement this interface.
+//
+// Deprecated: BytesWriter will not be supported in Go Driver 2.0.
 type BytesWriter interface {
 	WriteValueBytes(t bsontype.Type, b []byte) error
 }


### PR DESCRIPTION
[GODRIVER-2713](https://jira.mongodb.org/browse/GODRIVER-2713)

## Summary
- Deprecate `bsonrw.Copier` and all associated methods.
- Deprecate the `bsonrw.BytesReader` and `bsonrw.BytesWriter` interfaces, which are only used by `bsonrw.Copier`.

## Background & Motivation
The `bsonrw.Copier` type exposes a collection of methods related to copying BSON or Extended JSON documents using the `ValueReader` and `ValueWriter` interfaces. There is no known use case for `bsonrw.Copier` outside of the BSON library, so deprecate it because it will not be supported in Go Driver 2.0.