### PR TITLE
Use testify/assert in decimal_test.go for v1.11.7

### DIFF
--- a/bson/primitive/decimal_test.go
+++ b/bson/primitive/decimal_test.go
@@ -12,8 +12,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/internal/testutil/assert"
 )
 
 type bigIntTestCase struct {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
Use `testify/assert` in decimal_test.go for v1.11.7

## Background & Motivation
The `release/1.11` branch still uses the `testify/assert` package and does not contain the new unified internal assertion library. Update decimal_test.go to use `testify/assert`.

