### PR TITLE
GODRIVER-2855 Relax closed, cleared, checkout conditions on logger verification

### DIFF
--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -161,6 +161,15 @@ func isUnorderedLog(log *logMessage) bool {
 	// or close a connection first. Because of this, either log may be
 	// received in any order. To account for this behavior, we considered
 	// both logs to be "unordered".
+	//
+	// The connection pool must clear before the connection is closed.
+	// However, either of these conditions can be valid:
+	//
+	//   1. connectoin checkout failed > connection pool cleared
+	//   2. conneciton pool clared > connection checkout failed
+	//
+	// Therefore, the ConnectionPoolCleared literal is added to unordered
+	// list. The check for cleared > closed is made in the matching logic.
 	return msgStr == logger.ConnectionCheckoutFailed ||
 		msgStr == logger.ConnectionClosed ||
 		msgStr == logger.ConnectionPoolCleared

--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -166,10 +166,11 @@ func isUnorderedLog(log *logMessage) bool {
 	// However, either of these conditions are valid:
 	//
 	//   1. connection checkout failed > connection pool cleared
-	//   2. connection pool clared > connection checkout failed
+	//   2. connection pool cleared > connection checkout failed
 	//
-	// Therefore, the ConnectionPoolCleared literal is added to unordered
-	// list. The check for cleared > closed is made in the matching logic.
+	// Therefore, the ConnectionPoolCleared literal is added to the
+	// unordered list. The check for cleared > closed is made in the
+	// matching logic.
 	return msgStr == logger.ConnectionCheckoutFailed ||
 		msgStr == logger.ConnectionClosed ||
 		msgStr == logger.ConnectionPoolCleared

--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -166,7 +166,7 @@ func isUnorderedLog(log *logMessage) bool {
 	// However, either of these conditions are valid:
 	//
 	//   1. connection checkout failed > connection pool cleared
-	//   2. conneciton pool clared > connection checkout failed
+	//   2. connection pool clared > connection checkout failed
 	//
 	// Therefore, the ConnectionPoolCleared literal is added to unordered
 	// list. The check for cleared > closed is made in the matching logic.

--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -271,7 +271,6 @@ func matchUnorderedLogs(ctx context.Context, logs logQueues) <-chan error {
 				errs <- fmt.Errorf("could not lookup message from unordered log: %w", err)
 
 				break
-
 			}
 
 			msgStr := msg.StringValue()

--- a/mongo/integration/unified/logger_verification.go
+++ b/mongo/integration/unified/logger_verification.go
@@ -163,9 +163,9 @@ func isUnorderedLog(log *logMessage) bool {
 	// both logs to be "unordered".
 	//
 	// The connection pool must clear before the connection is closed.
-	// However, either of these conditions can be valid:
+	// However, either of these conditions are valid:
 	//
-	//   1. connectoin checkout failed > connection pool cleared
+	//   1. connection checkout failed > connection pool cleared
 	//   2. conneciton pool clared > connection checkout failed
 	//
 	// Therefore, the ConnectionPoolCleared literal is added to unordered


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
[GODRIVER-2855](https://jira.mongodb.org/browse/GODRIVER-2855)

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Add the pool clear log event to the unordered list with the condition that closing a connection does not occur before clearing the pool.

## Background & Motivation
<!--- Rationale for the pull request. -->
The existing unified [spec test](https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/tests/logging/connection-logging.yml#L199-L220) for connection logging has a specific order required for the following three events: ConnectionPoolCleared, ConnectionPoolClosed, ConnectionCheckOutFailed. There is an acceptable race condition in the connection pool's workflow where it is non-deterministic whether the connection pool will fail a checkout or close a connection first. Because of this, either ConnectionPoolClosed or ConnectionCheckOutFailed may be received in any order. Currently, to account for this behavior, we considered both logs to be "unordered".

It appears that it is possible that the logs would propagate in this order: ConnectionCheckOutFailed, ConnectionPoolCleared, ConnectionPoolClosed. This is still technically allowed, the only condition is that "the pool clear does need to come before the connectionclosed.
