### PR TITLE
GODRIVER-2836 Preview from Queryable Encryption Equality API

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -75,7 +75,6 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 
 // CreateEncryptedCollection creates a new collection for Queryable Encryption with the help of automatic generation of new encryption data keys for null keyIds.
 // It returns the created collection and the encrypted fields document used to create it.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (ce *ClientEncryption) CreateEncryptedCollection(ctx context.Context,
 	db *Database, coll string, createOpts *options.CreateCollectionOptions,
 	kmsProvider string, masterKey interface{}) (*Collection, bson.M, error) {

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -151,7 +151,6 @@ func (a *AutoEncryptionOptions) SetTLSConfig(tlsOpts map[string]*tls.Config) *Au
 
 // SetEncryptedFieldsMap specifies a map from namespace to local EncryptedFieldsMap document.
 // EncryptedFieldsMap is used for Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{}) *AutoEncryptionOptions {
 	a.EncryptedFieldsMap = ef
 	return a
@@ -159,7 +158,6 @@ func (a *AutoEncryptionOptions) SetEncryptedFieldsMap(ef map[string]interface{})
 
 // SetBypassQueryAnalysis specifies whether or not query analysis should be used for automatic encryption.
 // Use this option when using explicit encryption with Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (a *AutoEncryptionOptions) SetBypassQueryAnalysis(bypass bool) *AutoEncryptionOptions {
 	a.BypassQueryAnalysis = &bypass
 	return a

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -13,7 +13,6 @@ import (
 
 // These constants specify valid values for QueryType
 // QueryType is used for Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 const (
 	QueryTypeEquality string = "equality"
 )
@@ -61,7 +60,6 @@ func (e *EncryptOptions) SetKeyAltName(keyAltName string) *EncryptOptions {
 // - Unindexed
 // This is required.
 // Indexed and Unindexed are used for Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 	e.Algorithm = algorithm
 	return e
@@ -71,7 +69,6 @@ func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
 // This should be one of the following:
 // - equality
 // QueryType is used for Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
 	e.QueryType = queryType
 	return e
@@ -79,7 +76,6 @@ func (e *EncryptOptions) SetQueryType(queryType string) *EncryptOptions {
 
 // SetContentionFactor specifies the contention factor. It is only valid to set if algorithm is "Indexed".
 // ContentionFactor is used for Queryable Encryption.
-// Beta: Queryable Encryption is in Public Technical Preview. Queryable Encryption should not be used in production and is subject to backwards breaking changes.
 func (e *EncryptOptions) SetContentionFactor(contentionFactor int64) *EncryptOptions {
 	e.ContentionFactor = &contentionFactor
 	return e


### PR DESCRIPTION
[GODRIVER-2836](https://jira.mongodb.org/browse/GODRIVER-2836)

## Summary
Remove the Beta notices for Queryable Encryption Equality APIs.

## Background & Motivation
The feature will be stable in MongoDB Server 7.0.

