### PR TITLE
GODRIVER-2791 Bump maxWireVersion for MongoDB 7.0

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -21,7 +21,7 @@ var (
 	MinSupportedMongoDBVersion = "3.6"
 
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(6, 17)
+	SupportedWireVersions = description.NewVersionRange(6, 21)
 )
 
 type fsm struct {


### PR DESCRIPTION
GODRIVER-2791

## Summary
Bumps the max supported wire version to 21, which correlates with MongoDB server version 7.0.
