### PR TITLE
GODRIVER-2871 Unexport optional setter for internal-package logger

### DIFF
--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -196,7 +196,7 @@ func WithServerLoadBalanced(fn func(bool) bool) ServerOption {
 	}
 }
 
-// WithLogger configures the logger for the server to use.
+// withLogger configures the logger for the server to use.
 func withLogger(fn func() *logger.Logger) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.logger = fn()

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -197,7 +197,7 @@ func WithServerLoadBalanced(fn func(bool) bool) ServerOption {
 }
 
 // WithLogger configures the logger for the server to use.
-func WithLogger(fn func() *logger.Logger) ServerOption {
+func withLogger(fn func() *logger.Logger) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.logger = fn()
 	}

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -349,7 +349,7 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 
 		serverOpts = append(
 			serverOpts,
-			WithLogger(func() *logger.Logger { return log }),
+			withLogger(func() *logger.Logger { return log }),
 		)
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2871

## Summary
<!--- A summary of the changes proposed by this pull request. -->

This PR unexports the WithLogger server configuration setter. This function sets an internal-package object to the server configuration, which is useless to an external user. 

## Background & Motivation
<!--- Rationale for the pull request. -->

The configuration of the topology server includes a functional setter that allows for the export of the Logger struct from the internal/logger package. However, since this setter is not intended for use by external users who cannot import data from the internal package, it is recommended to unexport the WithLogger function to prevent confusion.

This setter was added as a part of the work for GODRIVER-2586 , adding log messages to CMAP. WithLogger is not currently exported as part of the experimental API in an existing release.
