### PR TITLE
Skip frequently failing TestClientSideEncryptionProse test case.

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -379,6 +379,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 	mt.Run("4. bson size limits", func(mt *mtest.T) {
+		// TODO(GODRIVER-2872): Fix and unskip this test case.
+		mt.Skip("Test fails frequently, skipping. See GODRIVER-2872")
+
 		kmsProviders := map[string]map[string]interface{}{
 			"local": {
 				"key": localMasterKey,


### PR DESCRIPTION
## Summary
Skip a frequently failing `TestClientSideEncryptionProse` test case with a follow-up ticket to resolve the failure:
* [GODRIVER-2872](https://jira.mongodb.org/browse/GODRIVER-2872)
