### PR TITLE
GODRIVER-2752 Add databaseName field to Command Events

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -43,6 +43,7 @@ type CommandFinishedEvent struct {
 	DurationNanos int64
 	Duration      time.Duration
 	CommandName   string
+	DatabaseName  string
 	RequestID     int64
 	ConnectionID  string
 	// ServerConnectionID contains the connection ID from the server of the operation. If the server does not return

--- a/internal/logger/component.go
+++ b/internal/logger/component.go
@@ -125,6 +125,7 @@ type Command struct {
 	// TODO(GODRIVER-2824): change the DriverConnectionID type to int64.
 	DriverConnectionID uint64              // Driver's ID for the connection
 	Name               string              // Command name
+	DatabaseName       string              // Database name
 	Message            string              // Message associated with the command
 	OperationID        int32               // Driver-generated operation ID
 	RequestID          int64               // Driver-generated request ID
@@ -141,6 +142,7 @@ func SerializeCommand(cmd Command, extraKeysAndValues ...interface{}) []interfac
 	// Initialize the boilerplate keys and values.
 	keysAndValues := KeyValues{
 		KeyCommandName, cmd.Name,
+		KeyDatabaseName, cmd.DatabaseName,
 		KeyDriverConnectionID, cmd.DriverConnectionID,
 		KeyMessage, cmd.Message,
 		KeyOperationID, cmd.OperationID,

--- a/internal/logger/component_test.go
+++ b/internal/logger/component_test.go
@@ -38,6 +38,7 @@ func TestSerializeCommand(t *testing.T) {
 			name: "empty",
 			want: KeyValues{
 				KeyCommandName, "",
+				KeyDatabaseName, "",
 				KeyDriverConnectionID, uint64(0),
 				KeyMessage, "",
 				KeyOperationID, int32(0),
@@ -50,6 +51,7 @@ func TestSerializeCommand(t *testing.T) {
 			cmd: Command{
 				DriverConnectionID: 1,
 				Name:               "foo",
+				DatabaseName:       "db",
 				Message:            "bar",
 				OperationID:        2,
 				RequestID:          3,
@@ -60,6 +62,7 @@ func TestSerializeCommand(t *testing.T) {
 			},
 			want: KeyValues{
 				KeyCommandName, "foo",
+				KeyDatabaseName, "db",
 				KeyDriverConnectionID, uint64(1),
 				KeyMessage, "bar",
 				KeyOperationID, int32(2),

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -28,6 +28,7 @@ type commandMonitoringEvent struct {
 
 	CommandSucceededEvent *struct {
 		CommandName           *string  `bson:"commandName"`
+		DatabaseName          *string  `bson:"databaseName"`
 		Reply                 bson.Raw `bson:"reply"`
 		HasServerConnectionID *bool    `bson:"hasServerConnectionId"`
 		HasServiceID          *bool    `bson:"hasServiceId"`
@@ -35,6 +36,7 @@ type commandMonitoringEvent struct {
 
 	CommandFailedEvent *struct {
 		CommandName           *string `bson:"commandName"`
+		DatabaseName          *string `bson:"databaseName"`
 		HasServerConnectionID *bool   `bson:"hasServerConnectionId"`
 		HasServiceID          *bool   `bson:"hasServiceId"`
 	} `bson:"commandFailedEvent"`
@@ -198,6 +200,10 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 				return newEventVerificationError(idx, client, "expected command name %q, got %q", *expected.CommandName,
 					actual.CommandName)
 			}
+			if expected.DatabaseName != nil && *expected.DatabaseName != actual.DatabaseName {
+				return newEventVerificationError(idx, client, "expected database name %q, got %q", *expected.DatabaseName,
+					actual.DatabaseName)
+			}
 			if expected.Reply != nil {
 				expectedDoc := documentToRawValue(expected.Reply)
 				actualDoc := documentToRawValue(actual.Reply)
@@ -237,6 +243,10 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 			if expected.CommandName != nil && *expected.CommandName != actual.CommandName {
 				return newEventVerificationError(idx, client, "expected command name %q, got %q", *expected.CommandName,
 					actual.CommandName)
+			}
+			if expected.DatabaseName != nil && *expected.DatabaseName != actual.DatabaseName {
+				return newEventVerificationError(idx, client, "expected database name %q, got %q", *expected.DatabaseName,
+					actual.DatabaseName)
 			}
 			if expected.HasServiceID != nil {
 				if err := verifyServiceID(*expected.HasServiceID, actual.ServiceID); err != nil {

--- a/mongo/integration/unified/schema_version.go
+++ b/mongo/integration/unified/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	supportedSchemaVersions = map[int]string{
-		1: "1.13",
+		1: "1.15",
 	}
 )
 

--- a/testdata/command-monitoring/find.json
+++ b/testdata/command-monitoring/find.json
@@ -1,6 +1,6 @@
 {
   "description": "find",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.15",
   "createEntities": [
     {
       "client": {
@@ -103,7 +103,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -198,7 +199,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -262,7 +264,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -338,7 +341,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -376,7 +380,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -464,7 +469,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -498,7 +504,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -539,7 +546,8 @@
             },
             {
               "commandFailedEvent": {
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]

--- a/testdata/command-monitoring/find.yml
+++ b/testdata/command-monitoring/find.yml
@@ -1,6 +1,6 @@
 description: "find"
 
-schemaVersion: "1.1"
+schemaVersion: "1.15"
 
 createEntities:
   - client:
@@ -56,6 +56,7 @@ tests:
                   firstBatch:
                     -  { _id: 1, x: 11 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with options"
     operations:
@@ -98,6 +99,7 @@ tests:
                     - { x: 33 }
                     - { x: 22 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with showRecordId and returnKey"
     operations:
@@ -131,6 +133,7 @@ tests:
                     - { _id: 4 }
                     - { _id: 5 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with a getMore"
     operations:
@@ -162,6 +165,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -179,6 +183,7 @@ tests:
                     - { _id: 4, x: 44 }
                     - { _id: 5, x: 55 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A successful find event with a getmore and the server kills the cursor (<= 4.4)"
     runOnRequirements:
@@ -216,6 +221,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -232,6 +238,7 @@ tests:
                   nextBatch:
                     - { _id: 4, x: 44 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A failed find event"
     operations:
@@ -252,3 +259,4 @@ tests:
               databaseName: *databaseName
           - commandFailedEvent:
               commandName: find
+              databaseName: *databaseName

--- a/testdata/command-monitoring/logging/command.json
+++ b/testdata/command-monitoring/logging/command.json
@@ -93,6 +93,7 @@
               "component": "command",
               "data": {
                 "message": "Command succeeded",
+                "databaseName": "logging-tests",
                 "commandName": "ping",
                 "reply": {
                   "$$type": "string"
@@ -177,6 +178,7 @@
               "component": "command",
               "data": {
                 "message": "Command failed",
+                "databaseName": "logging-tests",
                 "commandName": "find",
                 "failure": {
                   "$$exists": true

--- a/testdata/command-monitoring/logging/command.yml
+++ b/testdata/command-monitoring/logging/command.yml
@@ -52,6 +52,7 @@ tests:
             component: command
             data:
               message: "Command succeeded"
+              databaseName: *databaseName
               commandName: *commandName
               reply: { $$type: string }
               requestId: { $$type: [int, long] }
@@ -85,6 +86,7 @@ tests:
             component: command
             data:
               message: "Command failed"
+              databaseName: *databaseName
               commandName: *commandName
               failure: { $$exists: true }
               requestId:  { $$type: [int, long] }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1785,14 +1785,14 @@ func (op Operation) publishStartedEvent(ctx context.Context, info startedInforma
 				DriverConnectionID: info.driverConnectionID,
 				Message:            logger.CommandStarted,
 				Name:               info.cmdName,
+				DatabaseName:       op.Database,
 				RequestID:          int64(info.requestID),
 				ServerConnectionID: info.serverConnID,
 				ServerHost:         host,
 				ServerPort:         port,
 				ServiceID:          info.serviceID,
 			},
-				logger.KeyCommand, formattedCmd,
-				logger.KeyDatabaseName, op.Database)...)
+				logger.KeyCommand, formattedCmd)...)
 
 	}
 
@@ -1838,6 +1838,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 				DriverConnectionID: info.driverConnectionID,
 				Message:            logger.CommandSucceeded,
 				Name:               info.cmdName,
+				DatabaseName:       op.Database,
 				RequestID:          int64(info.requestID),
 				ServerConnectionID: info.serverConnID,
 				ServerHost:         host,
@@ -1860,6 +1861,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 				DriverConnectionID: info.driverConnectionID,
 				Message:            logger.CommandFailed,
 				Name:               info.cmdName,
+				DatabaseName:       op.Database,
 				RequestID:          int64(info.requestID),
 				ServerConnectionID: info.serverConnID,
 				ServerHost:         host,

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1877,6 +1877,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 
 	finished := event.CommandFinishedEvent{
 		CommandName:          info.cmdName,
+		DatabaseName:         op.Database,
 		RequestID:            int64(info.requestID),
 		ConnectionID:         info.connID,
 		Duration:             info.duration,


### PR DESCRIPTION
GODRIVER-2752

## Summary
Add databaseName field to Command Events.

## Background & Motivation
- Sync changes from commit https://github.com/mongodb/specifications/blob/6b267ddc7cca303a722d2893106fad4810709f06/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
    - add the `databaseName` field to `expectedCommandEvent.CommandFailedEvent` and `expectedCommandEvent.CommandSucceededEvent`
    - add "database name" to the "command failed" and "command succeeded" log messages
- Sync changes from commit https://github.com/mongodb/specifications/blob/e7ee829329400786e01279b4f37d4e440d1e9cfa/source/unified-test-format/unified-test-format.rst#expectedcommandevent
    - update mongo/integration/unified/event_verification.go
- update unified tests
