### PR TITLE
GODRIVER-2860 Update Go driver module version in all submodules.

### DIFF
--- a/examples/_logger/logrus/go.mod
+++ b/examples/_logger/logrus/go.mod
@@ -7,7 +7,9 @@ replace go.mongodb.org/mongo-driver => ../../../
 require (
 	github.com/bombsimon/logrusr/v4 v4.0.0
 	github.com/sirupsen/logrus v1.9.0
-	go.mongodb.org/mongo-driver v1.11.1
+	// Note that the Go driver version is replaced with the local Go driver code
+	// by the replace directive above.
+	go.mongodb.org/mongo-driver v1.11.7
 )
 
 require (

--- a/examples/_logger/zap/go.mod
+++ b/examples/_logger/zap/go.mod
@@ -6,7 +6,9 @@ replace go.mongodb.org/mongo-driver => ../../../
 
 require (
 	github.com/go-logr/zapr v1.2.3
-	go.mongodb.org/mongo-driver v1.11.1
+	// Note that the Go driver version is replaced with the local Go driver code
+	// by the replace directive above.
+	go.mongodb.org/mongo-driver v1.11.7
 	go.uber.org/zap v1.24.0
 )
 

--- a/examples/_logger/zerolog/go.mod
+++ b/examples/_logger/zerolog/go.mod
@@ -7,7 +7,9 @@ replace go.mongodb.org/mongo-driver => ../../../
 require (
 	github.com/go-logr/zerologr v1.2.2
 	github.com/rs/zerolog v1.28.0
-	go.mongodb.org/mongo-driver v1.11.1
+	// Note that the Go driver version is replaced with the local Go driver code
+	// by the replace directive above.
+	go.mongodb.org/mongo-driver v1.11.7
 )
 
 require (

--- a/internal/test/compilecheck/go.mod
+++ b/internal/test/compilecheck/go.mod
@@ -4,4 +4,6 @@ go 1.13
 
 replace go.mongodb.org/mongo-driver => ../../../
 
-require go.mongodb.org/mongo-driver v0.0.0-00010101000000-000000000000
+// Note that the Go driver version is replaced with the local Go driver code by
+// the replace directive above.
+require go.mongodb.org/mongo-driver v1.11.7

--- a/internal/test/faas/awslambda/mongodb/go.mod
+++ b/internal/test/faas/awslambda/mongodb/go.mod
@@ -6,14 +6,15 @@ replace go.mongodb.org/mongo-driver => ../../../../../
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0
-	go.mongodb.org/mongo-driver v1.11.4
+	// Note that the Go driver version is replaced with the local Go driver code
+	// by the replace directive above.
+	go.mongodb.org/mongo-driver v1.11.7
 )
 
 require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect


### PR DESCRIPTION
[GODRIVER-2860](https://jira.mongodb.org/browse/GODRIVER-2860)

## Summary
Update Go driver module version to `latest` in all submodules and add a note about the version being mostly irrelevant because of the replace directive.

## Background & Motivation
This should resolve Github Dependabot alert https://github.com/mongodb/mongo-go-driver/security/dependabot/7