### PR TITLE
GODRIVER-2884 Export withMonitoringDisabled

### DIFF
--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -235,7 +235,7 @@ func setUpTopology(t *testing.T, uri string) *Topology {
 
 	// Disable server monitoring because the hosts in the SDAM spec tests don't actually exist, so the server monitor
 	// can race with the test and mark the server Unknown when it fails to connect, which causes tests to fail.
-	cfg.ServerOpts = append(cfg.ServerOpts, withMonitoringDisabled(func(bool) bool { return true }))
+	cfg.ServerOpts = append(cfg.ServerOpts, WithMonitoringDisabled(func(bool) bool { return true }))
 
 	topo, err := New(cfg)
 	assert.Nil(t, err, "topology.New error: %v", err)

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -68,6 +68,7 @@ func ServerAPIFromServerOptions(opts []ServerOption) *driver.ServerAPIOptions {
 	return newServerConfig(opts...).serverAPI
 }
 
+// WithMonitoringDisabled enable/disable the server's monitoring.
 func WithMonitoringDisabled(fn func(bool) bool) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.monitoringDisabled = fn(cfg.monitoringDisabled)

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -68,7 +68,7 @@ func ServerAPIFromServerOptions(opts []ServerOption) *driver.ServerAPIOptions {
 	return newServerConfig(opts...).serverAPI
 }
 
-func withMonitoringDisabled(fn func(bool) bool) ServerOption {
+func WithMonitoringDisabled(fn func(bool) bool) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.monitoringDisabled = fn(cfg.monitoringDisabled)
 	}

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -312,7 +312,7 @@ func TestServerConnectionTimeout(t *testing.T) {
 				}),
 				// Disable monitoring to prevent unrelated failures from the RTT monitor and
 				// heartbeats from unexpectedly clearing the connection pool.
-				withMonitoringDisabled(func(bool) bool { return true }),
+				WithMonitoringDisabled(func(bool) bool { return true }),
 			)
 			require.NoError(t, server.Connect(nil))
 
@@ -543,7 +543,7 @@ func TestServer(t *testing.T) {
 					}),
 					// Disable the monitoring routine because we're only testing pooled connections and we don't want
 					// errors in monitoring to clear the pool and make this test flaky.
-					withMonitoringDisabled(func(bool) bool {
+					WithMonitoringDisabled(func(bool) bool {
 						return true
 					}),
 					// With the default maxConnecting (2), there are multiple goroutines creating
@@ -711,7 +711,7 @@ func TestServer(t *testing.T) {
 			WithConnectionOptions(func(connOpts ...ConnectionOption) []ConnectionOption {
 				return append(connOpts, dialerOpt)
 			}),
-			withMonitoringDisabled(func(bool) bool { return true }),
+			WithMonitoringDisabled(func(bool) bool { return true }),
 			WithServerMonitor(func(*event.ServerMonitor) *event.ServerMonitor { return sdam }),
 		}
 
@@ -805,7 +805,7 @@ func TestServer(t *testing.T) {
 			address.Address("invalid"),
 			nil,
 			primitive.NewObjectID(),
-			withMonitoringDisabled(func(bool) bool {
+			WithMonitoringDisabled(func(bool) bool {
 				return true
 			}),
 		)

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -695,7 +695,7 @@ func runInWindowTest(t *testing.T, directory string, filename string) {
 		server := NewServer(
 			address.Address(testDesc.Address),
 			primitive.NilObjectID,
-			withMonitoringDisabled(func(bool) bool { return true }))
+			WithMonitoringDisabled(func(bool) bool { return true }))
 		servers[testDesc.Address] = server
 
 		desc := description.Server{


### PR DESCRIPTION
GODRIVER-2884

## Summary

Expose this method so it can be called externally.

## Background & Motivation
If user have a need to disable monitoring(or set the monitoring to `ZeroRTTMonitor`), we should allow them to.

`make {fmt,lint}` all green. I'm afraid some of the tests in `make {test,test-race}` are not passing using latest mongodb image. But I do not see any connection with my change(mine is a name change after all).

