### PR TITLE
GODRIVER-2792 Separate Serverless OS into new axis.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2357,11 +2357,6 @@ axes:
         run_on: ubuntu1804-build
         variables:
           GO_DIST: "/opt/golang/go1.20"
-      - id: "ubuntu2004-go-1-20"
-        display_name: "Ubuntu 20.04"
-        run_on: ubuntu2004-build
-        variables:
-          GO_DIST: "/opt/golang/go1.20"
       - id: "macos11-go-1-20"
         display_name: "MacOS 11.0"
         run_on: macos-1100
@@ -2411,6 +2406,15 @@ axes:
       - id: "rhel80-large-go-1-20"
         display_name: "RHEL 8.0"
         run_on: rhel80-large
+        variables:
+          GO_DIST: "/opt/golang/go1.20"
+
+  - id: os-serverless
+    display_name: OS
+    values:
+      - id: "ubuntu2004-go-1-20"
+        display_name: "Ubuntu 20.04"
+        run_on: ubuntu2004-build
         variables:
           GO_DIST: "/opt/golang/go1.20"
 
@@ -2721,8 +2725,8 @@ buildvariants:
       - name: ".load-balancer"
 
   - matrix_name: "serverless"
-    matrix_spec: { os-ssl-40: ["ubuntu2004-go-1-20"] }
-    display_name: "Serverless ${os-ssl-40}"
+    matrix_spec: { os-serverless: "*" }
+    display_name: "Serverless ${os-serverless}"
     tasks:
       - "serverless_task_group"
 


### PR DESCRIPTION
[GODRIVER-2792](https://jira.mongodb.org/browse/GODRIVER-2792)

## Summary
Only use Ubuntu 20.04 for Serverless tasks.

## Background & Motivation
https://github.com/mongodb/mongo-go-driver/pull/1301 unintentionally added Ubuntu 20.04 builds for all MongoDB >4.0 tasks. Fix that issue so only Serverless uses Ubuntu 20.04.
