### PR TITLE
GODRIVER-2869 Test touchup

### DIFF
--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -945,8 +945,12 @@ func TestNullBytes(t *testing.T) {
 }
 
 func TestInvalidBytes(t *testing.T) {
+	t.Parallel()
+
 	t.Run("read length less than 4 int bytes", func(t *testing.T) {
-		_, src, ok := readLengthBytes([]byte{0x00, 0x00, 0x00, 0x01})
+		t.Parallel()
+
+		_, src, ok := readLengthBytes([]byte{0x01, 0x00, 0x00, 0x00})
 		assert.False(t, ok, "expected not ok response for invalid length read")
 		assert.Equal(t, 4, len(src), "expected src to contain the size parameter still")
 	})

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -42,7 +42,11 @@ func TestCompression(t *testing.T) {
 }
 
 func TestDecompressFailures(t *testing.T) {
+	t.Parallel()
+
 	t.Run("snappy decompress huge size", func(t *testing.T) {
+		t.Parallel()
+
 		opts := CompressionOpts{
 			Compressor:       wiremessage.CompressorSnappy,
 			UncompressedSize: 100, // reasonable size

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -892,3 +892,22 @@ func TestConvertI64PtrToI32Ptr(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeOpReply(t *testing.T) {
+	t.Parallel()
+
+	// GODRIVER-2869: Prevent infinite loop caused by malformatted wiremessage with length of 0.
+	t.Run("malformatted wiremessage with length of 0", func(t *testing.T) {
+		t.Parallel()
+
+		var wm []byte
+		wm = wiremessage.AppendReplyFlags(wm, 0)
+		wm = wiremessage.AppendReplyCursorID(wm, int64(0))
+		wm = wiremessage.AppendReplyStartingFrom(wm, 0)
+		wm = wiremessage.AppendReplyNumberReturned(wm, 0)
+		idx, wm := bsoncore.ReserveLength(wm)
+		wm = bsoncore.UpdateLength(wm, idx, 0)
+		reply := Operation{}.decodeOpReply(wm)
+		assert.Equal(t, []bsoncore.Document(nil), reply.documents)
+	})
+}


### PR DESCRIPTION
GODRIVER-2869

## Summary
- Parallelize new tests
- Add a test to reproduce the infinite loop

## Background & Motivation
A test touchup following https://github.com/mongodb/mongo-go-driver/commit/a888dc6678b7a91301018a6e1bf04bdd3d22a63b
