### PR TITLE
GODRIVER-2887 bson: remove use of reflect.Value.MethodByName

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1540,12 +1540,12 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 		return err
 	}
 
-	fn := val.Convert(tValueUnmarshaler).MethodByName("UnmarshalBSONValue")
-	errVal := fn.Call([]reflect.Value{reflect.ValueOf(t), reflect.ValueOf(src)})[0]
-	if !errVal.IsNil() {
-		return errVal.Interface().(error)
+	m, ok := val.Interface().(ValueUnmarshaler)
+	if !ok {
+		// NB: this error should be unreachable due to the above checks
+		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
-	return nil
+	return m.UnmarshalBSONValue(t, src)
 }
 
 // UnmarshalerDecodeValue is the ValueDecoderFunc for Unmarshaler implementations.
@@ -1588,12 +1588,12 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonr
 		val = val.Addr() // If the type doesn't implement the interface, a pointer to it must.
 	}
 
-	fn := val.Convert(tUnmarshaler).MethodByName("UnmarshalBSON")
-	errVal := fn.Call([]reflect.Value{reflect.ValueOf(src)})[0]
-	if !errVal.IsNil() {
-		return errVal.Interface().(error)
+	m, ok := val.Interface().(Unmarshaler)
+	if !ok {
+		// NB: this error should be unreachable due to the above checks
+		return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
 	}
-	return nil
+	return m.UnmarshalBSON(src)
 }
 
 // EmptyInterfaceDecodeValue is the ValueDecoderFunc for interface{}.

--- a/bson/bsoncodec/default_value_decoders_test.go
+++ b/bson/bsoncodec/default_value_decoders_test.go
@@ -1530,8 +1530,17 @@ func TestDefaultValueDecoders(t *testing.T) {
 					errors.New("copy error"),
 				},
 				{
-					"Unmarshaler",
+					// Only the pointer form of testUnmarshaler implements Unmarshaler
+					"value does not implement Unmarshaler",
 					testUnmarshaler{Val: bsoncore.AppendDouble(nil, 3.14159)},
+					nil,
+					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Double, Return: float64(3.14159)},
+					bsonrwtest.ReadDouble,
+					nil,
+				},
+				{
+					"Unmarshaler",
+					&testUnmarshaler{Val: bsoncore.AppendDouble(nil, 3.14159)},
 					nil,
 					&bsonrwtest.ValueReaderWriter{BSONType: bsontype.Double, Return: float64(3.14159)},
 					bsonrwtest.ReadDouble,

--- a/bson/bsoncodec/default_value_encoders.go
+++ b/bson/bsoncodec/default_value_encoders.go
@@ -564,12 +564,14 @@ func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw bs
 		return ValueEncoderError{Name: "ValueMarshalerEncodeValue", Types: []reflect.Type{tValueMarshaler}, Received: val}
 	}
 
-	fn := val.Convert(tValueMarshaler).MethodByName("MarshalBSONValue")
-	returns := fn.Call(nil)
-	if !returns[2].IsNil() {
-		return returns[2].Interface().(error)
+	m, ok := val.Interface().(ValueMarshaler)
+	if !ok {
+		return vw.WriteNull()
 	}
-	t, data := returns[0].Interface().(bsontype.Type), returns[1].Interface().([]byte)
+	t, data, err := m.MarshalBSONValue()
+	if err != nil {
+		return err
+	}
 	return bsonrw.Copier{}.CopyValueFromBytes(vw, t, data)
 }
 
@@ -593,12 +595,14 @@ func (dve DefaultValueEncoders) MarshalerEncodeValue(_ EncodeContext, vw bsonrw.
 		return ValueEncoderError{Name: "MarshalerEncodeValue", Types: []reflect.Type{tMarshaler}, Received: val}
 	}
 
-	fn := val.Convert(tMarshaler).MethodByName("MarshalBSON")
-	returns := fn.Call(nil)
-	if !returns[1].IsNil() {
-		return returns[1].Interface().(error)
+	m, ok := val.Interface().(Marshaler)
+	if !ok {
+		return vw.WriteNull()
 	}
-	data := returns[0].Interface().([]byte)
+	data, err := m.MarshalBSON()
+	if err != nil {
+		return err
+	}
 	return bsonrw.Copier{}.CopyValueFromBytes(vw, bsontype.EmbeddedDocument, data)
 }
 
@@ -622,23 +626,31 @@ func (dve DefaultValueEncoders) ProxyEncodeValue(ec EncodeContext, vw bsonrw.Val
 		return ValueEncoderError{Name: "ProxyEncodeValue", Types: []reflect.Type{tProxy}, Received: val}
 	}
 
-	fn := val.Convert(tProxy).MethodByName("ProxyBSON")
-	returns := fn.Call(nil)
-	if !returns[1].IsNil() {
-		return returns[1].Interface().(error)
+	m, ok := val.Interface().(Proxy)
+	if !ok {
+		return vw.WriteNull()
 	}
-	data := returns[0]
-	var encoder ValueEncoder
-	var err error
-	if data.Elem().IsValid() {
-		encoder, err = ec.LookupEncoder(data.Elem().Type())
-	} else {
-		encoder, err = ec.LookupEncoder(nil)
-	}
+	v, err := m.ProxyBSON()
 	if err != nil {
 		return err
 	}
-	return encoder.EncodeValue(ec, vw, data.Elem())
+	if v == nil {
+		encoder, err := ec.LookupEncoder(nil)
+		if err != nil {
+			return err
+		}
+		return encoder.EncodeValue(ec, vw, reflect.ValueOf(nil))
+	}
+	vv := reflect.ValueOf(v)
+	switch vv.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		vv = vv.Elem()
+	}
+	encoder, err := ec.LookupEncoder(vv.Type())
+	if err != nil {
+		return err
+	}
+	return encoder.EncodeValue(ec, vw, vv)
 }
 
 // JavaScriptEncodeValue is the ValueEncoderFunc for the primitive.JavaScript type.


### PR DESCRIPTION
[GODRIVER-2887](https://jira.mongodb.org/browse/GODRIVER-2887)

## Summary

Remove all uses of reflect.Value.MethodByName since it prevents dead code elimination. This causes binaries built with the mongodb/mongo-go-driver library to be larger than they need to be. 

All occurrences of reflect.Value.MethodByName are replaced with type assertions.

Source: https://go.dev/src/cmd/link/internal/ld/deadcode.go#L293

## Background & Motivation

Reduce the size of binaries built with mongodb/mongo-go-driver.