### PR TITLE
GODRIVER-2827 Add prose test for change stream splitting

### DIFF
--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -739,7 +740,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 		doc := idValue{
 			ID:    1,
-			Value: "q" + generateLongString(10*1024*1024),
+			Value: "q" + strings.Repeat("q", 10*1024*1024),
 		}
 
 		// Insert the document
@@ -765,7 +766,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			defer wg.Done()
 
 			filter := bson.D{{"_id", int32(1)}}
-			update := bson.D{{"$set", bson.D{{"value", "z" + generateLongString(10*1024*1024)}}}}
+			update := bson.D{{"$set", bson.D{{"value", "z" + strings.Repeat("q", 10*1024*1024)}}}}
 
 			_, err := mt.Coll.UpdateOne(context.Background(), filter, update)
 			require.NoError(mt, err, "failed to update idValue")
@@ -852,14 +853,4 @@ func getAggregateResponseInfo(mt *mtest.T) (bson.Raw, primitive.Timestamp) {
 func compareResumeTokens(mt *mtest.T, cs *mongo.ChangeStream, expected bson.Raw) {
 	mt.Helper()
 	assert.Equal(mt, expected, cs.ResumeToken(), "expected resume token %v, got %v", expected, cs.ResumeToken())
-}
-
-// generateLongString is a helper function to generate a long string of a
-// specific length
-func generateLongString(length int) string {
-	data := make([]byte, length)
-	for i := 0; i < length; i++ {
-		data[i] = 'q'
-	}
-	return string(data)
 }

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -736,7 +736,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 
 		// Insert the document
 		_, err := mt.Coll.InsertOne(context.Background(), doc)
-		require.NoError(t, err, "failed to insert idValue: %v", err)
+		require.NoError(t, err, "failed to insert idValue")
 
 		// Watch for change events
 		pipeline := mongo.Pipeline{
@@ -746,7 +746,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
 
 		cs, err := mt.Coll.Watch(context.Background(), pipeline, opts)
-		require.NoError(t, err, "failed to watch collection: %v", err)
+		require.NoError(t, err, "failed to watch collection")
 
 		defer closeStream(cs)
 
@@ -760,7 +760,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			update := bson.D{{"$set", bson.D{{"value", generateLongString(10 * 1024 * 1024)}}}}
 
 			_, err := mt.Coll.UpdateOne(context.Background(), filter, update)
-			require.NoError(mt, err, "UpdateOne failed: %v", err)
+			require.NoError(mt, err, "failed to update idValue")
 		}()
 
 		nextCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -778,7 +778,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		cs.Next(nextCtx)
 
 		err = cs.Decode(&got)
-		require.NoError(mt, err, "failed to decode first iteration: %v", err)
+		require.NoError(mt, err, "failed to decode first iteration")
 
 		want := splitEvent{
 			Fragment: 1,
@@ -790,7 +790,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		cs.Next(nextCtx)
 
 		err = cs.Decode(&got)
-		require.NoError(mt, err, "failed to decoded second iteration: %v", err)
+		require.NoError(mt, err, "failed to decoded second iteration")
 
 		want = splitEvent{
 			Fragment: 2,


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2827

## Summary
<!--- A summary of the changes proposed by this pull request. -->

The Go Driver does not have strongly typed change stream events, this PR adds the specification-defined prose test to ensure this behavior.

## Background & Motivation
<!--- Rationale for the pull request. -->

MongoDB 7.0 is adding a new aggregation stage $changeStreamSplitLargeEvent, which will split large events (>16MB) into smaller fragments. 
