### PR TITLE
GODRIVER-2891 Add documentation for log levels

### DIFF
--- a/mongo/options/loggeroptions.go
+++ b/mongo/options/loggeroptions.go
@@ -63,8 +63,8 @@ type LogSink interface {
 	// This level mapping is taken from the go-logr/logr library
 	// specifications, specifically:
 	//
-	// > Level V(0) is the default, and logger.V(0).Info() has the same
-	// > meaning as logger.Info().
+	// "Level V(0) is the default, and logger.V(0).Info() has the same meaning
+	// as logger.Info()."
 	Info(level int, message string, keysAndValues ...interface{})
 
 	// Error logs an error message with the given key/value pairs

--- a/mongo/options/loggeroptions.go
+++ b/mongo/options/loggeroptions.go
@@ -52,7 +52,7 @@ type LogSink interface {
 	// method will only be called if the provided level has been defined
 	// for a component in the LoggerOptions.
 	//
-	// The level returned by this function is not guarunteed to be 1-1 with
+	// The level returned by this function is not guaranteed to be 1-1 with
 	// the optional levels used to construct logging for a client. These
 	// are the following level mappings for V = "Verbosity":
 	//

--- a/mongo/options/loggeroptions.go
+++ b/mongo/options/loggeroptions.go
@@ -51,6 +51,20 @@ type LogSink interface {
 	// Info logs a non-error message with the given key/value pairs. This
 	// method will only be called if the provided level has been defined
 	// for a component in the LoggerOptions.
+	//
+	// The level returned by this function is not guarunteed to be 1-1 with
+	// the optional levels used to construct logging for a client. These
+	// are the following level mappings for V = "Verbosity":
+	//
+	// V(0) - off
+	// V(1) - informational
+	// V(2) - debugging
+	//
+	// This level mapping is taken from the go-logr/logr library
+	// specifications, specifically:
+	//
+	// > Level V(0) is the default, and logger.V(0).Info() has the same
+	// > meaning as logger.Info().
 	Info(level int, message string, keysAndValues ...interface{})
 
 	// Error logs an error message with the given key/value pairs

--- a/mongo/options/loggeroptions.go
+++ b/mongo/options/loggeroptions.go
@@ -56,9 +56,9 @@ type LogSink interface {
 	// the optional levels used to construct logging for a client. These
 	// are the following level mappings for V = "Verbosity":
 	//
-	// V(0) - off
-	// V(1) - informational
-	// V(2) - debugging
+	//  - V(0): off
+	//  - V(1): informational
+	//  - V(2): debugging
 	//
 	// This level mapping is taken from the go-logr/logr library
 	// specifications, specifically:

--- a/mongo/options/loggeroptions.go
+++ b/mongo/options/loggeroptions.go
@@ -52,9 +52,7 @@ type LogSink interface {
 	// method will only be called if the provided level has been defined
 	// for a component in the LoggerOptions.
 	//
-	// The level returned by this function is not guaranteed to be 1-1 with
-	// the optional levels used to construct logging for a client. These
-	// are the following level mappings for V = "Verbosity":
+	// Here are the following level mappings for V = "Verbosity":
 	//
 	//  - V(0): off
 	//  - V(1): informational
@@ -63,8 +61,8 @@ type LogSink interface {
 	// This level mapping is taken from the go-logr/logr library
 	// specifications, specifically:
 	//
-	// "Level V(0) is the default, and logger.V(0).Info() has the same meaning
-	// as logger.Info()."
+	// "Level V(0) is the default, and logger.V(0).Info() has the same
+	// meaning as logger.Info()."
 	Info(level int, message string, keysAndValues ...interface{})
 
 	// Error logs an error message with the given key/value pairs


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

GODRIVER-2891

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Add documentation for the level mappings propagated by the internal library to the user-defined LogSink. Clarify that the level returned is not intended to be 1-1 with the optional level enumeration used to construct a logger on a client.

## Background & Motivation
<!--- Rationale for the pull request. -->

The documentation team ran into an issue when attempting to compare the optional log levels to those returned by the "Info" method in a custom log sink. See [here](https://gist.github.com/prestonvasquez/faa1626b117a1cde12cfe02fb21a3107) for a detailed example.

