### PR TITLE
GODRIVER-2883 Handle boolean 'ok' responses

### DIFF
--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -145,3 +145,49 @@ func TestPlainAuthenticator_Succeeds(t *testing.T) {
 	)
 	compareResponses(t, <-c.Written, expectedCmd, "$external")
 }
+
+
+func TestPlainAuthenticator_SucceedsBoolean(t *testing.T) {
+	t.Parallel()
+
+	authenticator := PlainAuthenticator{
+		Username: "user",
+		Password: "pencil",
+	}
+
+	resps := make(chan []byte, 1)
+	writeReplies(resps, bsoncore.BuildDocumentFromElements(nil,
+		bsoncore.AppendBooleanElement(nil, "ok", true),
+		bsoncore.AppendInt32Element(nil, "conversationId", 1),
+		bsoncore.AppendBinaryElement(nil, "payload", 0x00, []byte{}),
+		bsoncore.AppendBooleanElement(nil, "done", true),
+	))
+
+	desc := description.Server{
+		WireVersion: &description.VersionRange{
+			Max: 6,
+		},
+	}
+	c := &drivertest.ChannelConn{
+		Written:  make(chan []byte, 1),
+		ReadResp: resps,
+		Desc:     desc,
+	}
+
+	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
+	if err != nil {
+		t.Fatalf("expected no error but got \"%s\"", err)
+	}
+
+	if len(c.Written) != 1 {
+		t.Fatalf("expected 1 messages to be sent but had %d", len(c.Written))
+	}
+
+	payload, _ := base64.StdEncoding.DecodeString("AHVzZXIAcGVuY2ls")
+	expectedCmd := bsoncore.BuildDocumentFromElements(nil,
+		bsoncore.AppendInt32Element(nil, "saslStart", 1),
+		bsoncore.AppendStringElement(nil, "mechanism", "PLAIN"),
+		bsoncore.AppendBinaryElement(nil, "payload", 0x00, payload),
+	)
+	compareResponses(t, <-c.Written, expectedCmd, "$external")
+}

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	. "go.mongodb.org/mongo-driver/x/mongo/driver/auth"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"
@@ -174,15 +175,12 @@ func TestPlainAuthenticator_SucceedsBoolean(t *testing.T) {
 	}
 
 	err := authenticator.Auth(context.Background(), &Config{Description: desc, Connection: c})
-	if err != nil {
-		t.Fatalf("expected no error but got \"%s\"", err)
-	}
+	require.NoError(t, err, "Auth error")
+	require.Len(t, c.Written, 1, "expected 1 messages to be sent")
 
-	if len(c.Written) != 1 {
-		t.Fatalf("expected 1 messages to be sent but had %d", len(c.Written))
-	}
+	payload, err := base64.StdEncoding.DecodeString("AHVzZXIAcGVuY2ls")
+	require.NoError(t, err, "DecodeString error")
 
-	payload, _ := base64.StdEncoding.DecodeString("AHVzZXIAcGVuY2ls")
 	expectedCmd := bsoncore.BuildDocumentFromElements(nil,
 		bsoncore.AppendInt32Element(nil, "saslStart", 1),
 		bsoncore.AppendStringElement(nil, "mechanism", "PLAIN"),

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -146,7 +146,6 @@ func TestPlainAuthenticator_Succeeds(t *testing.T) {
 	compareResponses(t, <-c.Written, expectedCmd, "$external")
 }
 
-
 func TestPlainAuthenticator_SucceedsBoolean(t *testing.T) {
 	t.Parallel()
 

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -13,8 +13,8 @@ import (
 
 	"encoding/base64"
 
-	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/internal/require"
+	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	. "go.mongodb.org/mongo-driver/x/mongo/driver/auth"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/drivertest"

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -392,6 +392,10 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 				if elem.Value().Double() == 1 {
 					ok = true
 				}
+			case bson.TypeBoolean:
+				if elem.Value().Boolean() == true {
+					ok = true
+				}
 			}
 		case "errmsg":
 			if str, okay := elem.Value().StringValueOK(); okay {

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -393,7 +393,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 					ok = true
 				}
 			case bson.TypeBoolean:
-				if elem.Value().Boolean() == true {
+				if elem.Value().Boolean() {
 					ok = true
 				}
 			}


### PR DESCRIPTION
GODRIVER-2883

## Summary
Handle boolean "ok" messages in command responses, and add text.

## Background & Motivation
While the specification says that [Command Responses](https://www.mongodb.com/docs/manual/reference/method/db.runCommand/#std-label-command-response) have an "ok" field that "A number that indicates whether the command has succeeded (1) or failed (0).", there are some cases where the returned command can have a boolean value.   Update the Go driver to handle boolean "ok" responses and treat "ok": true as a success. 

We do not handle the case of a "hello" command returning a boolean value, since it has not been observed and we do not have a direct way to test the handling of hello responses without creating a new unified spec test.

