### PR TITLE
GODRIVER-2851 Fix failing "TestCMAPProse" test.

### DIFF
--- a/x/mongo/driver/topology/cmap_prose_test.go
+++ b/x/mongo/driver/topology/cmap_prose_test.go
@@ -128,8 +128,7 @@ func TestCMAPProse(t *testing.T) {
 				_, err := pool.checkOut(context.Background())
 				assert.NotNil(t, err, "expected checkOut() error, got nil")
 
-				assert.Equal(t, 1, len(created), "expected 1 opened events, got %d", len(created))
-				assert.Equal(t, 1, len(closed), "expected 1 closed events, got %d", len(closed))
+				assertConnectionCounts(t, pool, 1, 1)
 			})
 			t.Run("pool is empty", func(t *testing.T) {
 				// If a checkOut() has to create a new connection and that connection encounters an

--- a/x/mongo/driver/topology/cmap_prose_test.go
+++ b/x/mongo/driver/topology/cmap_prose_test.go
@@ -106,9 +106,6 @@ func TestCMAPProse(t *testing.T) {
 		})
 		t.Run("checkOut", func(t *testing.T) {
 			t.Run("connection error publishes events", func(t *testing.T) {
-				// TODO(GODRIVER-2851): Fix and unskip this test case.
-				t.Skip("Test fails frequently, skipping. See GODRIVER-2851")
-
 				// If checkOut() creates a connection that encounters an error while connecting,
 				// the pool should publish connection created and closed events and checkOut should
 				// return the error.


### PR DESCRIPTION
GODRIVER-2851

## Summary
Fix failing "TestCMAPProse" test.

## Background & Motivation
Resume `TestCMAPProse` test cases.

