### PR TITLE
GODRIVER-2847 Improve error message if RunCommandCursor command doesn't return a cursor.

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -253,6 +253,10 @@ func (db *Database) RunCommandCursor(ctx context.Context, runCommand interface{}
 	}
 
 	if err = op.Execute(ctx); err != nil {
+		if errors.Is(err, driver.ErrNoCursor) {
+			return nil, errors.New(
+				"database response does not contain a cursor; try using RunCommand instead")
+		}
 		closeImplicitSession(sess)
 		return nil, replaceErrors(err)
 	}

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -253,11 +253,11 @@ func (db *Database) RunCommandCursor(ctx context.Context, runCommand interface{}
 	}
 
 	if err = op.Execute(ctx); err != nil {
+		closeImplicitSession(sess)
 		if errors.Is(err, driver.ErrNoCursor) {
 			return nil, errors.New(
 				"database response does not contain a cursor; try using RunCommand instead")
 		}
-		closeImplicitSession(sess)
 		return nil, replaceErrors(err)
 	}
 

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -357,7 +357,7 @@ func TestDatabase(t *testing.T) {
 			{"cursor", bson.D{}},
 		}
 		pingCmd := bson.D{{"ping", 1}}
-		pingErr := errors.New("cursor should be an embedded document but is of BSON type invalid")
+		pingErr := errors.New("database response does not contain a cursor; try using RunCommand instead")
 
 		testCases := []struct {
 			name        string


### PR DESCRIPTION
[GODRIVER-2847](https://jira.mongodb.org/browse/GODRIVER-2847)

## Summary
Currently when you run a command that does not return a cursor (e.g. an "explain" command) with `RunCommandCursor`, you get a cryptic error message:
```go
"cursor should be an embedded document but is of BSON type invalid"
```
Improve the error message that is returned so that it more clearly expresses what went wrong and guides users to use `RunCommand` instead of `RunCommandCursor`:
```go
"database response does not contain a cursor; try using RunCommand instead"
```

## Background & Motivation
The existing error message is confusing for users (see [GODRIVER-2847](https://jira.mongodb.org/browse/GODRIVER-2847)). When a user runs a command that does not return a cursor with `RunCommandCursor`, the error should give them enough information to switch to use `RunCommand` instead.