### PR TITLE
GODRIVER-2858 Run a subset of tests on MacOS

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -90,7 +90,7 @@ fi
 if [ -z ${MAKEFILE_TARGET+x} ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
       # Run a subset of the tests on Darwin
-      MAKEFILE_TARGET="evg-test-serverless"
+      MAKEFILE_TARGET="evg-test-load-balancers"
   else
     MAKEFILE_TARGET="evg-test"
   fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -88,7 +88,12 @@ if [ "Windows_NT" = "$OS" ]; then
 fi
 
 if [ -z ${MAKEFILE_TARGET+x} ]; then
-  MAKEFILE_TARGET="evg-test"
+  if [ "$(uname -s)" = "Darwin" ]; then
+      # Run a subset of the tests on Darwin
+      MAKEFILE_TARGET="evg-test-serverless"
+  else
+    MAKEFILE_TARGET="evg-test"
+  fi
 fi
 
 AUTH=${AUTH} \


### PR DESCRIPTION
GODRIVER-2858

## Summary
Limit the amount of tests we run on MacOS to a subset, prioritizing the unified spec tests.
With this change, the longest task that had previously timed out finishes in 46m 31s.

## Background & Motivation
We often see timeouts when testing on MacOS on Evergreen, due to resource contention on the hosts.

