### PR TITLE
Always add relevant errors to pool events.

### DIFF
--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -500,6 +500,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 				Type:    event.GetFailed,
 				Address: p.address.String(),
 				Reason:  event.ReasonConnectionErrored,
+				Error:   err,
 			})
 		}
 		return nil, err
@@ -542,6 +543,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 					Type:    event.GetFailed,
 					Address: p.address.String(),
 					Reason:  event.ReasonConnectionErrored,
+					Error:   w.err,
 				})
 			}
 			return nil, w.err
@@ -589,6 +591,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 					Type:    event.GetFailed,
 					Address: p.address.String(),
 					Reason:  event.ReasonConnectionErrored,
+					Error:   w.err,
 				})
 			}
 
@@ -625,6 +628,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 				Type:    event.GetFailed,
 				Address: p.address.String(),
 				Reason:  event.ReasonTimedOut,
+				Error:   ctx.Err(),
 			})
 		}
 
@@ -878,6 +882,7 @@ func (p *pool) clear(err error, serviceID *primitive.ObjectID) {
 			Type:      event.PoolCleared,
 			Address:   p.address.String(),
 			ServiceID: serviceID,
+			Error:     err,
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Always add relevant errors to pool events.

## Background & Motivation
The `Error` field was added to [PoolEvent](https://pkg.go.dev/go.mongodb.org/mongo-driver/event#PoolEvent) in v1.12.0, but is currently only used for errors that cause a connection to be closed. There are other events, like `ConnectionPoolCleared` and `ConnectionCheckOutFailed` that frequently have an error associated with them. Add the associated error to those events as well to make the events more useful for understanding what's going on.