### PR TITLE
GODRIVER-2822 Add error on empty for ReadConcern marshaler.

### DIFF
--- a/mongo/readconcern/readconcern.go
+++ b/mongo/readconcern/readconcern.go
@@ -17,11 +17,6 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
-// ErrEmptyReadConcern indicates that a read concern has no fields set.
-//
-// Deprecated: ErrEmptyReadConcern will be removed in Go Driver 2.0.
-var ErrEmptyReadConcern = errors.New("a read concern must have the level field set")
-
 // A ReadConcern defines a MongoDB read concern, which allows you to control the consistency and
 // isolation properties of the data read from replica sets and replica set shards.
 //
@@ -114,7 +109,7 @@ func New(options ...Option) *ReadConcern {
 // Deprecated: Marshaling a ReadConcern to BSON will not be supported in Go Driver 2.0.
 func (rc *ReadConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	if rc == nil {
-		return 0, nil, ErrEmptyReadConcern
+		return 0, nil, errors.New("cannot marshal nil ReadConcern")
 	}
 
 	var elems []byte

--- a/mongo/readconcern/readconcern.go
+++ b/mongo/readconcern/readconcern.go
@@ -11,9 +11,16 @@
 package readconcern // import "go.mongodb.org/mongo-driver/mongo/readconcern"
 
 import (
+	"errors"
+
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
+
+// ErrEmptyReadConcern indicates that a read concern has no fields set.
+//
+// Deprecated: ErrEmptyReadConcern will be removed in Go Driver 2.0.
+var ErrEmptyReadConcern = errors.New("a read concern must have the level field set")
 
 // A ReadConcern defines a MongoDB read concern, which allows you to control the consistency and
 // isolation properties of the data read from replica sets and replica set shards.
@@ -106,6 +113,10 @@ func New(options ...Option) *ReadConcern {
 //
 // Deprecated: Marshaling a ReadConcern to BSON will not be supported in Go Driver 2.0.
 func (rc *ReadConcern) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	if rc == nil {
+		return 0, nil, ErrEmptyReadConcern
+	}
+
 	var elems []byte
 
 	if len(rc.Level) > 0 {

--- a/mongo/readconcern/readconcern_test.go
+++ b/mongo/readconcern/readconcern_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) MongoDB, Inc. 2023-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package readconcern_test
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+func TestReadConcern_MarshalBSONValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		rc        *readconcern.ReadConcern
+		bytes     []byte
+		wantError error
+	}{
+		{
+			name:      "local",
+			rc:        &readconcern.ReadConcern{Level: "local"},
+			bytes:     bsoncore.BuildDocument(nil, bsoncore.AppendStringElement(nil, "level", "local")),
+			wantError: nil,
+		},
+		{
+			name:      "empty",
+			rc:        &readconcern.ReadConcern{},
+			bytes:     bsoncore.BuildDocument(nil, nil),
+			wantError: nil,
+		},
+		{
+			name:      "nil",
+			rc:        nil,
+			bytes:     nil,
+			wantError: readconcern.ErrEmptyReadConcern,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable.
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, b, err := tc.rc.MarshalBSONValue()
+			assert.Equal(t, tc.bytes, b, "expected and actual outputs do not match")
+			assert.Equal(t, tc.wantError, err, "expected and actual errors do not match")
+		})
+	}
+}


### PR DESCRIPTION
GODRIVER-2822

## Summary
Add an `ErrEmptyReadConcern` following the convention in the marshaler of `WriteConcern`.

## Background & Motivation
The marshaler of `WriteConcern` has been protected at [writeconcern.go#L285](https://github.com/mongodb/mongo-go-driver/blob/master/mongo/writeconcern/writeconcern.go#L284-L286), and test-covered at [writeconcern_test.go#L127-L131](https://github.com/mongodb/mongo-go-driver/blame/master/mongo/writeconcern/writeconcern_test.go#L127-L131).

