### PR TITLE
GODRIVER-2900 Fix handling of EC2 Instance Profile in EG Tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -715,6 +715,17 @@ functions:
           # balancer is not running.
           DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop || echo "Ignoring load balancer stop error"
 
+  teardown-aws:
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
+          if [ -f "./aws_e2e_setup.json" ]; then
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
+          fi
+
   add-aws-auth-variables-to-file:
     - command: shell.exec
       type: test
@@ -1215,6 +1226,7 @@ post:
         - "src/go.mongodb.org/mongo-driver/*.suite"
   - func: upload-mo-artifacts
   - func: stop-load-balancer
+  - func: teardown-aws
   - func: cleanup
 
 tasks:


### PR DESCRIPTION
GODRIVER-2900

## Summary
Ensures that the AWS EC2 Instance Profile is restored after the test runs: "Assigned authtest_instance_profile_role".

## Background & Motivation
AWS Instance Profiles are now assigned for each of the EG hosts.  The "run-aws-auth-test-with-aws-web-identity-credentials" removes that instance profile to ensure that `AssumeRoleWithWebIdentity` is used.    We add a `post:` task to ensure that it is restored.

