### PR TITLE
GODRIVER-2916 Clean up Lambda Test Script

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2249,7 +2249,7 @@ tasks:
       - command: shell.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
-          binary: bash
+          shell: bash
           add_expansions_to_env: true
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/internal/test/faas/awslambda

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2763,7 +2763,7 @@ buildvariants:
     matrix_spec: { version: ["latest"], os-faas-80: ["rhel80-large-go-1-20"] }
     display_name: "FaaS ${version} ${os-faas-80}"
     tasks:
-      - test_aws_lambda_task_group
+      - test-aws-lambda-task-group
 
   - name: testgcpkms-variant
     display_name: "GCP KMS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2246,17 +2246,18 @@ tasks:
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
           duration_seconds: 3600
-      - command: subprocess.exec
+      - command: shell.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
           add_expansions_to_env: true
-          args:
-            - .evergreen/run-deployed-lambda-aws-tests.sh
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/internal/test/faas/awslambda
             LAMBDA_STACK_NAME: dbx-go-lambda
             AWS_REGION: us-east-1
+          script: |
+            ${PREPARE_SHELL}
+            ./.evergreen/run-deployed-lambda-aws-tests.sh
 
 axes:
   - id: version

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2248,7 +2248,7 @@ tasks:
           duration_seconds: 3600
       - command: subprocess.exec
         params:
-          working_dir: src
+          working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
           add_expansions_to_env: true
           args:
@@ -2588,7 +2588,7 @@ task_groups:
       - func: prepare-resources
       - command: subprocess.exec
         params:
-          working_dir: src
+          working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
           add_expansions_to_env: true
           env:
@@ -2602,7 +2602,7 @@ task_groups:
     teardown_group:
       - command: subprocess.exec
         params:
-          working_dir: src
+          working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
           add_expansions_to_env: true
           env:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1173,33 +1173,6 @@ functions:
           ${PREPARE_SHELL}
           ${PROJECT_DIRECTORY}/.evergreen/run-fuzz.sh
 
-  run-deployed-aws-lambda-tests:
-    - command: ec2.assume_role
-      params:
-        role_arn: ${LAMBDA_AWS_ROLE_ARN}
-        duration_seconds: 3600
-    - command: shell.exec
-      params:
-        working_dir: src/go.mongodb.org/mongo-driver
-        shell: bash
-        env:
-          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
-          DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-          DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-          DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-          DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-          DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-          DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-          AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-          AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-          AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
-          TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/internal/test/faas/awslambda
-          LAMBDA_STACK_NAME: dbx-go-lambda
-          AWS_REGION: us-east-1
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/run-deployed-lambda-aws-tests.sh
-
 pre:
   - func: fetch-source
   - func: prepare-resources
@@ -2267,13 +2240,23 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-fuzz-tests
 
-  - name: "test-aws-lambda"
-    tags:
-      - latest
-      - lambda
+  - name: "test-aws-lambda-deployed"
     commands:
-      - func: bootstrap-mongo-orchestration
-      - func: run-deployed-aws-lambda-tests
+      - command: ec2.assume_role
+        params:
+          role_arn: ${LAMBDA_AWS_ROLE_ARN}
+          duration_seconds: 3600
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          add_expansions_to_env: true
+          args:
+            - .evergreen/run-deployed-lambda-aws-tests.sh
+          env:
+            TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/internal/test/faas/awslambda
+            LAMBDA_STACK_NAME: dbx-go-lambda
+            AWS_REGION: us-east-1
 
 axes:
   - id: version
@@ -2599,6 +2582,38 @@ task_groups:
     tasks:
       - testazurekms-task
 
+  - name: test_aws_lambda_task_group
+    setup_group:
+      - func: fetch source
+      - func: prepare resources
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          add_expansions_to_env: true
+          env:
+            LAMBDA_STACK_NAME: dbx-go-lambda
+            AWS_REGION: us-east-1
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+      - command: expansions.update
+        params:
+          file: src/atlas-expansion.yml
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          add_expansions_to_env: true
+          env:
+            LAMBDA_STACK_NAME: dbx-go-lambda
+            AWS_REGION: us-east-1
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - test-aws-lambda-deployed
 
 buildvariants:
   - name: static-analysis
@@ -2747,7 +2762,7 @@ buildvariants:
     matrix_spec: { version: ["latest"], os-faas-80: ["rhel80-large-go-1-20"] }
     display_name: "FaaS ${version} ${os-faas-80}"
     tasks:
-      - test-aws-lambda
+      - test_aws_lambda_task_group
 
   - name: testgcpkms-variant
     display_name: "GCP KMS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2584,8 +2584,8 @@ task_groups:
 
   - name: test_aws_lambda_task_group
     setup_group:
-      - func: fetch source
-      - func: prepare resources
+      - func: fetch-source
+      - func: prepare-resources
       - command: subprocess.exec
         params:
           working_dir: src

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2598,7 +2598,7 @@ task_groups:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
-          file: src/atlas-expansion.yml
+          file: src/go.mongodb.org/mongo-driver/atlas-expansion.yml
     teardown_group:
       - command: subprocess.exec
         params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2583,7 +2583,7 @@ task_groups:
     tasks:
       - testazurekms-task
 
-  - name: test_aws_lambda_task_group
+  - name: test-aws-lambda-task-group
     setup_group:
       - func: fetch-source
       - func: prepare-resources


### PR DESCRIPTION
GODRIVER-2916

## Summary
Ensure that the Atlas cluster created for FaaS test is properly cleaned up.

## Background & Motivation
A new set  of scripts was added to drivers-evergreen-tools to ensure the Atlas cluster is shut down cleanly.

