### PR TITLE
GODRIVER-2867 Unpin connections when ending a session.

### DIFF
--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -331,9 +331,10 @@ func (c *Client) ClearPinnedResources() error {
 	return nil
 }
 
-// UnpinConnection gracefully unpins the connection associated with the session if there is one. This is done via
-// the pinned connection's UnpinFromTransaction function.
-func (c *Client) UnpinConnection() error {
+// unpinConnection gracefully unpins the connection associated with the session
+// if there is one. This is done via the pinned connection's
+// UnpinFromTransaction function.
+func (c *Client) unpinConnection() error {
 	if c == nil || c.PinnedConnection == nil {
 		return nil
 	}
@@ -353,6 +354,12 @@ func (c *Client) EndSession() {
 		return
 	}
 	c.Terminated = true
+
+	// Ignore the error when unpinning the connection because we can't do
+	// anything about it if it doesn't work. Typically the only errors that can
+	// happen here indicate that something went wrong with the connection state,
+	// like it wasn't marked as pinned or attempted to return to the wrong pool.
+	_ = c.unpinConnection()
 	c.pool.ReturnSession(c.Server)
 }
 


### PR DESCRIPTION
[GODRIVER-2867](https://jira.mongodb.org/browse/GODRIVER-2867)

## Summary
* Unpin connections when ending a session.
* Add a test that asserts that running transactions when connected to a load balancer does not leak connections.

## Background & Motivation
Currently the Go driver leaks connections if a user runs a transaction while connected to a load balancer. When a user explicitly ends a session, we should unpin any pinned connection so it can be reused.

