### PR TITLE
feat: add majority with journaled option on write concern option

### DIFF
--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -134,6 +134,18 @@ func Majority() *WriteConcern {
 	return &WriteConcern{W: majority}
 }
 
+// MajorityWithJournaled MajorityWithJournaled returns a WriteConcern that requests acknowledgment that
+// write operations have been durably committed to the calculated majority of
+// the data-bearing voting members and have been written to the on-disk journal
+// on MongoDB.
+//
+// For more information about write concern "w: majority" and "j: true", see
+// https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-
+func MajorityWithJournaled() *WriteConcern {
+	journal := true
+	return &WriteConcern{W: majority, Journal: &journal}
+}
+
 // Custom returns a WriteConcern that requests acknowledgment that write
 // operations have propagated to tagged members that satisfy the custom write
 // concern defined in "settings.getLastErrorModes".

--- a/mongo/writeconcern/writeconcern_test.go
+++ b/mongo/writeconcern/writeconcern_test.go
@@ -201,6 +201,12 @@ func TestWriteConcern(t *testing.T) {
 			wantIsValid:      false,
 		},
 		{
+			name:             "{w: majority, j: true}",
+			wc:               writeconcern.MajorityWithJournaled(),
+			wantAcknowledged: true,
+			wantIsValid:      true,
+		},
+		{
 			name:             "{w: custom}",
 			wc:               &writeconcern.WriteConcern{W: "custom"},
 			wantAcknowledged: true,


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Add WriteConcern Option MajorityWithJournaled to explicitly sets write majority with journaled write.


## Background & Motivation
<!--- Rationale for the pull request. -->

To explicitly use write majority with journaled option on mongo go driver package we have to use like this.

but using two option into one struct seems awkward to me. So I propose MajorityWithJounaled function to use both option at once. 

```go
writeConcern := &writeconcern.WriteConcern{
	W:       writeconcern.Majority().W,
	Journal: writeconcern.Journaled().Journal,
}
```