### PR TITLE
GODRIVER-2896 Add IsZero to BSON RawValue

### DIFF
--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -102,3 +102,8 @@ func (bt Type) String() string {
 		return "invalid"
 	}
 }
+
+// IsValid will return true if the Type is valid.
+func (bt Type) IsValid() bool {
+	return bt.String() != "invalid"
+}

--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -103,8 +103,7 @@ func (bt Type) String() string {
 	}
 }
 
-// IsValidType checks if the BSON type is valid or invalid using a switch
-// statement.
+// IsValid will return true if the Type is valid.
 func (bt Type) IsValid() bool {
 	switch bt {
 	case Double, String, EmbeddedDocument, Array, Binary, Undefined, ObjectID, Boolean, DateTime, Null, Regex,

--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -103,7 +103,14 @@ func (bt Type) String() string {
 	}
 }
 
-// IsValid will return true if the Type is valid.
+// IsValidType checks if the BSON type is valid or invalid using a switch
+// statement.
 func (bt Type) IsValid() bool {
-	return bt.String() != "invalid"
+	switch bt {
+	case Double, String, EmbeddedDocument, Array, Binary, Undefined, ObjectID, Boolean, DateTime, Null, Regex,
+		DBPointer, JavaScript, Symbol, CodeWithScope, Int32, Timestamp, Int64, Decimal128, MinKey, MaxKey:
+		return true
+	default:
+		return false
+	}
 }

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -8,6 +8,7 @@ package bson
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
@@ -62,10 +63,7 @@ func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.
 	rawvalue := val.Interface().(RawValue)
 
 	if !rawvalue.Type.IsValid() {
-		return bsoncodec.ValueEncoderError{
-			Name:  "RawValueEncodeValue",
-			Types: []reflect.Type{tRawValue},
-		}
+		return fmt.Errorf("the RawValue Type specifies an invalid BSON type: %#x", byte(rawvalue.Type))
 	}
 
 	return bsonrw.Copier{}.CopyValueFromBytes(vw, rawvalue.Type, rawvalue.Value)

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -45,14 +45,28 @@ func (pc PrimitiveCodecs) RegisterPrimitiveCodecs(rb *bsoncodec.RegistryBuilder)
 
 // RawValueEncodeValue is the ValueEncoderFunc for RawValue.
 //
-// Deprecated: Use bson.NewRegistry to get a registry with all primitive encoders and decoders
-// registered.
+// If the RawValue's Type is "invalid" and the RawValue's Value is not empty or
+// nil, then this method will return an error.
+//
+// Deprecated: Use bson.NewRegistry to get a registry with all primitive
+// encoders and decoders registered.
 func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.ValueWriter, val reflect.Value) error {
 	if !val.IsValid() || val.Type() != tRawValue {
-		return bsoncodec.ValueEncoderError{Name: "RawValueEncodeValue", Types: []reflect.Type{tRawValue}, Received: val}
+		return bsoncodec.ValueEncoderError{
+			Name:     "RawValueEncodeValue",
+			Types:    []reflect.Type{tRawValue},
+			Received: val,
+		}
 	}
 
 	rawvalue := val.Interface().(RawValue)
+
+	if rawvalue.Type.String() == "invalid" && len(rawvalue.Value) > 0 {
+		return bsoncodec.ValueEncoderError{
+			Name:  "RawValueEncodeValue",
+			Types: []reflect.Type{tRawValue},
+		}
+	}
 
 	return bsonrw.Copier{}.CopyValueFromBytes(vw, rawvalue.Type, rawvalue.Value)
 }

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -61,7 +61,7 @@ func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.
 
 	rawvalue := val.Interface().(RawValue)
 
-	if rawvalue.Type.String() == "invalid" {
+	if !rawvalue.Type.IsValid() {
 		return bsoncodec.ValueEncoderError{
 			Name:  "RawValueEncodeValue",
 			Types: []reflect.Type{tRawValue},

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -61,7 +61,7 @@ func (PrimitiveCodecs) RawValueEncodeValue(_ bsoncodec.EncodeContext, vw bsonrw.
 
 	rawvalue := val.Interface().(RawValue)
 
-	if rawvalue.Type.String() == "invalid" && len(rawvalue.Value) > 0 {
+	if rawvalue.Type.String() == "invalid" {
 		return bsoncodec.ValueEncoderError{
 			Name:  "RawValueEncodeValue",
 			Types: []reflect.Type{tRawValue},

--- a/bson/primitive_codecs_test.go
+++ b/bson/primitive_codecs_test.go
@@ -118,10 +118,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 					nil,
 					nil,
 					bsonrwtest.Nothing,
-					bsoncodec.ValueEncoderError{
-						Name:  "RawValueEncodeValue",
-						Types: []reflect.Type{tRawValue},
-					},
+					fmt.Errorf("the RawValue Type specifies an invalid BSON type: 0x0"),
 				},
 				{
 					"RawValue Type is invalid",
@@ -132,10 +129,7 @@ func TestDefaultValueEncoders(t *testing.T) {
 					nil,
 					nil,
 					bsonrwtest.Nothing,
-					bsoncodec.ValueEncoderError{
-						Name:  "RawValueEncodeValue",
-						Types: []reflect.Type{tRawValue},
-					},
+					fmt.Errorf("the RawValue Type specifies an invalid BSON type: 0x8f"),
 				},
 			},
 		},

--- a/bson/primitive_codecs_test.go
+++ b/bson/primitive_codecs_test.go
@@ -65,6 +65,8 @@ func compareErrors(err1, err2 error) bool {
 }
 
 func TestDefaultValueEncoders(t *testing.T) {
+	t.Parallel()
+
 	var pc PrimitiveCodecs
 
 	var wrong = func(string, string) string { return "wrong" }
@@ -106,6 +108,34 @@ func TestDefaultValueEncoders(t *testing.T) {
 					nil,
 					bsonrwtest.WriteDouble,
 					nil,
+				},
+				{
+					"RawValue Type is zero with non-zero value",
+					RawValue{
+						Type:  0x00,
+						Value: bsoncore.AppendDouble(nil, 3.14159),
+					},
+					nil,
+					nil,
+					bsonrwtest.Nothing,
+					bsoncodec.ValueEncoderError{
+						Name:  "RawValueEncodeValue",
+						Types: []reflect.Type{tRawValue},
+					},
+				},
+				{
+					"RawValue Type is invalid",
+					RawValue{
+						Type:  0x8F,
+						Value: bsoncore.AppendDouble(nil, 3.14159),
+					},
+					nil,
+					nil,
+					bsonrwtest.Nothing,
+					bsoncodec.ValueEncoderError{
+						Name:  "RawValueEncodeValue",
+						Types: []reflect.Type{tRawValue},
+					},
 				},
 			},
 		},
@@ -166,9 +196,17 @@ func TestDefaultValueEncoders(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc // Capture the range variable
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			for _, subtest := range tc.subtests {
+				subtest := subtest // Capture the range variable
+
 				t.Run(subtest.name, func(t *testing.T) {
+					t.Parallel()
+
 					var ec bsoncodec.EncodeContext
 					if subtest.ectx != nil {
 						ec = *subtest.ectx
@@ -192,6 +230,8 @@ func TestDefaultValueEncoders(t *testing.T) {
 	}
 
 	t.Run("success path", func(t *testing.T) {
+		t.Parallel()
+
 		oid := primitive.NewObjectID()
 		oids := []primitive.ObjectID{primitive.NewObjectID(), primitive.NewObjectID(), primitive.NewObjectID()}
 		var str = new(string)
@@ -426,7 +466,11 @@ func TestDefaultValueEncoders(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
+			tc := tc // Capture the range variable
+
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				b := make(bsonrw.SliceWriter, 0, 512)
 				vw, err := bsonrw.NewBSONValueWriter(&b)
 				noerr(t, err)

--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -38,8 +38,7 @@ type RawValue struct {
 }
 
 // IsZero reports whether the RawValue is zero, i.e. no data is present on
-// the RawValue. Since a RawValue is defined by the Type and Value, the
-// bsoncodec.Registry will not be considered when this method is called.
+// the RawValue. It returns true if Type is 0 and Value is empty or nil.
 func (rv RawValue) IsZero() bool {
 	return rv.Type == 0x00 && len(rv.Value) == 0
 }

--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -38,8 +38,8 @@ type RawValue struct {
 }
 
 // IsZero reports whether the RawValue is zero, i.e. no data is present on
-// the RawValue. Since a raw value is defined by the Type and Value, the
-// bsoncodec.Registry will not be considered when IsZero is called.
+// the RawValue. Since a RawValue is defined by the Type and Value, the
+// bsoncodec.Registry will not be considered when this method is called.
 func (rv RawValue) IsZero() bool {
 	return rv.Type == 0x00 && len(rv.Value) == 0
 }

--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -37,6 +37,13 @@ type RawValue struct {
 	r *bsoncodec.Registry
 }
 
+// IsZero reports whether the RawValue is zero, i.e. no data is present on
+// the RawValue. Since a raw value is defined by the Type and Value, the
+// bsoncodec.Registry will not be considered when IsZero is called.
+func (rv RawValue) IsZero() bool {
+	return rv.Type == 0x00 && len(rv.Value) == 0
+}
+
 // Unmarshal deserializes BSON into the provided val. If RawValue cannot be unmarshaled into val, an
 // error is returned. This method will use the registry used to create the RawValue, if the RawValue
 // was created from partial BSON processing, or it will use the default registry. Users wishing to

--- a/bson/raw_value_test.go
+++ b/bson/raw_value_test.go
@@ -13,12 +13,19 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/assert"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestRawValue(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Unmarshal", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Uses registry attached to value", func(t *testing.T) {
+			t.Parallel()
+
 			reg := bsoncodec.NewRegistryBuilder().Build()
 			val := RawValue{Type: bsontype.String, Value: bsoncore.AppendString(nil, "foobar"), r: reg}
 			var s string
@@ -29,6 +36,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Uses default registry if no registry attached", func(t *testing.T) {
+			t.Parallel()
+
 			want := "foobar"
 			val := RawValue{Type: bsontype.String, Value: bsoncore.AppendString(nil, want)}
 			var got string
@@ -40,7 +49,11 @@ func TestRawValue(t *testing.T) {
 		})
 	})
 	t.Run("UnmarshalWithRegistry", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Returns error when registry is nil", func(t *testing.T) {
+			t.Parallel()
+
 			want := ErrNilRegistry
 			var val RawValue
 			got := val.UnmarshalWithRegistry(nil, &D{})
@@ -49,6 +62,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Returns lookup error", func(t *testing.T) {
+			t.Parallel()
+
 			reg := bsoncodec.NewRegistryBuilder().Build()
 			var val RawValue
 			var s string
@@ -59,6 +74,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Returns DecodeValue error", func(t *testing.T) {
+			t.Parallel()
+
 			reg := NewRegistryBuilder().Build()
 			val := RawValue{Type: bsontype.Double, Value: bsoncore.AppendDouble(nil, 3.14159)}
 			var s string
@@ -69,6 +86,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Success", func(t *testing.T) {
+			t.Parallel()
+
 			reg := NewRegistryBuilder().Build()
 			want := float64(3.14159)
 			val := RawValue{Type: bsontype.Double, Value: bsoncore.AppendDouble(nil, want)}
@@ -81,7 +100,11 @@ func TestRawValue(t *testing.T) {
 		})
 	})
 	t.Run("UnmarshalWithContext", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Returns error when DecodeContext is nil", func(t *testing.T) {
+			t.Parallel()
+
 			want := ErrNilContext
 			var val RawValue
 			got := val.UnmarshalWithContext(nil, &D{})
@@ -90,6 +113,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Returns lookup error", func(t *testing.T) {
+			t.Parallel()
+
 			dc := bsoncodec.DecodeContext{Registry: bsoncodec.NewRegistryBuilder().Build()}
 			var val RawValue
 			var s string
@@ -100,6 +125,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Returns DecodeValue error", func(t *testing.T) {
+			t.Parallel()
+
 			dc := bsoncodec.DecodeContext{Registry: NewRegistryBuilder().Build()}
 			val := RawValue{Type: bsontype.Double, Value: bsoncore.AppendDouble(nil, 3.14159)}
 			var s string
@@ -110,6 +137,8 @@ func TestRawValue(t *testing.T) {
 			}
 		})
 		t.Run("Success", func(t *testing.T) {
+			t.Parallel()
+
 			dc := bsoncodec.DecodeContext{Registry: NewRegistryBuilder().Build()}
 			want := float64(3.14159)
 			val := RawValue{Type: bsontype.Double, Value: bsoncore.AppendDouble(nil, want)}
@@ -120,5 +149,60 @@ func TestRawValue(t *testing.T) {
 				t.Errorf("Expected results to match. got %g; want %g", got, want)
 			}
 		})
+	})
+
+	t.Run("IsZero", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			val  RawValue
+			want bool
+		}{
+			{
+				name: "empty",
+				val:  RawValue{},
+				want: true,
+			},
+			{
+				name: "zero type but non-zero value",
+				val: RawValue{
+					Type:  0x00,
+					Value: bsoncore.AppendInt32(nil, 0),
+				},
+				want: false,
+			},
+			{
+				name: "zero type and zero value",
+				val: RawValue{
+					Type:  0x00,
+					Value: bsoncore.AppendInt32(nil, 0),
+				},
+			},
+			{
+				name: "non-zero type and non-zero value",
+				val: RawValue{
+					Type:  bsontype.String,
+					Value: bsoncore.AppendString(nil, "foobar"),
+				},
+				want: false,
+			},
+			{
+				name: "non-zero type and zero value",
+				val: RawValue{
+					Type:  bsontype.String,
+					Value: bsoncore.AppendString(nil, "foobar"),
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt // Capture the range variable
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, tt.val.IsZero())
+			})
+		}
 	})
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2896

## Summary
<!--- A summary of the changes proposed by this pull request. -->

This PR proposes an "IsZero" method for the BSON "RawValue" type, which will be used by the EncodeValue-implementing types to "skip" encoding when the "omitempty" tag is present. Otherwise, this PR proposes that the PrimitiveCodecs' "RawValueEncodeValue" method should return an error when the RawValue's type is "invalid".

For clarity, after these changes the use case in the "Background & Motivation" section WILL NOT result in  a runtime error. However, if the user removes the "omitempty" tag from the "Likes" field, like this:

```go
type P struct {
	Name  string        `bson:"name,omitempty"`
	Likes bson.RawValue `bson:"likes"`
}
```

then the following error will be thrown:

```
the RawValue Type specifies an invalid BSON type: 0x0
```

## Background & Motivation
<!--- Rationale for the pull request. -->
A user has reported an issue where the following code will result in a runtime error:

```go
type P struct {
	Name  string        `bson:"name,omitempty"`
	Likes bson.RawValue `bson:"likes,omitempty"`
}

func main() {
	bytes, err := bson.Marshal(&P{Name: "lilei"})
	
	if err != nil {
		panic(fmt.Sprintf("failed to meep: %v", err))
	}

	p := new(P)
	
	if err = bson.Unmarshal(bytes, p); err != nil {
		panic(err)
	}
}
```

The error looks like this:

```
unmarshal error document is invalid, end byte is at 28, but null byte found at 21
```

This occurs because an empty bson.RawValue has an invalid type, specifically the 0x00 (null) type. When the  PrimitiveCodecs' "RawValueEncodeValue" method tries to encode this invalid type, it incidentally puts this "null" byte in the buffer by the "bsoncore.AppendHeader"  function, [here](https://github.com/mongodb/mongo-go-driver/blob/master/x/bsonx/bsoncore/bsoncore.go#L43).
