### PR TITLE
GODRIVER-2139 Fix invalid field name in regex parse error test.

### DIFF
--- a/testdata/bson-corpus/top.json
+++ b/testdata/bson-corpus/top.json
@@ -96,11 +96,11 @@
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",


### PR DESCRIPTION
GODRIVER-2139

## Summary
Sync BSON corpus spec tests to [mongodb/specifications@5fad277](https://github.com/mongodb/specifications/commit/5fad2773960d63d46b7738dde8d7b1aca0ceaac9).

## Background & Motivation
Two decodeErrors tests in top.json incorrectly use $options as a field within $regularExpression.