### PR TITLE
GODRIVER-2253 Remove srvMaxHosts tests expecting an error for invalid values.

### DIFF
--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.json
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.yml
+++ b/testdata/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.json
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.yml
+++ b/testdata/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer


### PR DESCRIPTION
GODRIVER-2253

## Summary
Remove the incorrect (and redundant) tests.

## Background & Motivation
We don't have warnings in Go, so we return warnings as errors though the spec states that a warning should be logged and the parsed value ignored. The behavior is commented at [connstring_spec_test.go#L123-L128](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/connstring/connstring_spec_test.go#L123-L128).