### PR TITLE
GODRIVER-2881 Enable logging for ComponentAll

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -76,8 +76,8 @@ func (logger *Logger) Close() error {
 
 // LevelComponentEnabled will return true if the given LogLevel is enabled for
 // the given LogComponent. If the ComponentLevels on the logger are enabled for
-// "ComponentAll", then this function will return true for any component upto
-// the logging level defined for "ComponentAll".
+// "ComponentAll", then this function will return true for any level bound by
+// the level assigned to "ComponentAll".
 //
 // If the level is not enabled (i.e. LevelOff), then false is returned. This is
 // to avoid false positives, such as returning "true" for a component that is

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -75,9 +75,25 @@ func (logger *Logger) Close() error {
 }
 
 // LevelComponentEnabled will return true if the given LogLevel is enabled for
-// the given LogComponent.
+// the given LogComponent. If the ComponentLevels on the logger are enabled for
+// "ComponentAll", then this function will return true for any component upto
+// the logging level defined for "ComponentAll".
+//
+// If the level is not enabled (i.e. LevelOff), then false is returned. This is
+// to avoid false positives, such as returning "true" for a component that is
+// not enabled. For example, without this condition, an empty LevelComponent
+// would be considered "enabled" for "LevelOff".
 func (logger *Logger) LevelComponentEnabled(level Level, component Component) bool {
-	return logger.ComponentLevels[component] >= level
+	if level == LevelOff {
+		return false
+	}
+
+	if logger.ComponentLevels == nil {
+		return false
+	}
+
+	return logger.ComponentLevels[component] >= level ||
+		logger.ComponentLevels[ComponentAll] >= level
 }
 
 // Print will synchronously print the given message to the configured LogSink.

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -348,15 +348,20 @@ func TestLogger_LevelComponentEnabled(t *testing.T) {
 		want      bool
 	}{
 		{
-			name: "nil",
-			want: false,
+			name:      "zero",
+			logger:    Logger{},
+			level:     LevelOff,
+			component: ComponentCommand,
+			want:      false,
 		},
 		{
 			name: "empty",
 			logger: Logger{
 				ComponentLevels: map[Component]Level{},
 			},
-			want: false, // LevelOff should never be considered enabled.
+			level:     LevelOff,
+			component: ComponentCommand,
+			want:      false, // LevelOff should never be considered enabled.
 		},
 		{
 			name: "one level below",
@@ -400,6 +405,7 @@ func TestLogger_LevelComponentEnabled(t *testing.T) {
 			},
 			level:     LevelDebug,
 			component: ComponentTopology,
+			want:      false,
 		},
 		{
 			name: "component all enables with topology",

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -500,7 +500,7 @@ func TestLogger_LevelComponentEnabled(t *testing.T) {
 			t.Parallel()
 
 			got := tcase.logger.LevelComponentEnabled(tcase.level, tcase.component)
-			assert.Equal(t, tcase.want, got)
+			assert.Equal(t, tcase.want, got, "unexpected result for LevelComponentEnabled")
 		})
 	}
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2881

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Update the considerations for enabling a log to 

1. Disable with any case where the level if "off"
2. Disable when ComponentLevels are undefined
3. Enable if the component "ComponentAll" is defined and it bounds the level passed to the function


## Background & Motivation

<!--- Rationale for the pull request. -->
There is a logging design oversight in which enabling logging with "options.LogComponentAll" does not result in the publication of logs. This issue arises because the "LevelComponentEnabled" method on the internal logger object fails to account for this specific use case. 

