### PR TITLE
GODRIVER-2930 Allow setting batch size for subsequent getMore's on a ChangeStream.

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -531,6 +531,16 @@ func (cs *ChangeStream) ID() int64 {
 	return cs.cursor.ID()
 }
 
+// SetBatchSize sets the number of documents to fetch from the database with
+// each iteration of the ChangeStream's "Next" or "TryNext" method. This setting
+// only affects subsequent document batches fetched from the database.
+func (cs *ChangeStream) SetBatchSize(size int32) {
+	// Set batch size on the cursor options also so any "resumed" change stream
+	// cursors will pick up the latest batch size setting.
+	cs.cursorOptions.BatchSize = size
+	cs.cursor.SetBatchSize(size)
+}
+
 // Decode will unmarshal the current event document into val and return any errors from the unmarshalling process
 // without any modification. If val is nil or is a typed nil, an error will be returned.
 func (cs *ChangeStream) Decode(val interface{}) error {


### PR DESCRIPTION
[GODRIVER-2930](https://jira.mongodb.org/browse/GODRIVER-2930)

## Summary
Allow setting batch size for subsequent `getMore`s on a `ChangeStream`.

## Background & Motivation
Currently you can set batch size on a `ChangeStream` using `ChangeStreamOptions.SetBatchSize`. However, that applies to both the initial "aggregate" command as well as the subsequent "getMore" commands run while iterating the change stream. That can cause a problem when starting a change stream on low- or bursty-traffic collections because the initial aggregate won't return a cursor until the batch size is filled. The tailable cursor used by a change stream is intended to wait indefinitely for updates, but the initial "aggregate" command isn't, so will time out if there aren't enough changes to fill a batch, leading to an unexpected error.