### PR TITLE
GODRIVER-2926 Add BSON Binary Data subtype Sensitive

### DIFF
--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -47,7 +47,7 @@ const (
 	BinaryMD5         byte = 0x05
 	BinaryEncrypted   byte = 0x06
 	BinaryColumn      byte = 0x07
-	BinarySenstive    byte = 0x08
+	BinarySensitive   byte = 0x08
 	BinaryUserDefined byte = 0x80
 )
 

--- a/bson/bsontype/bsontype.go
+++ b/bson/bsontype/bsontype.go
@@ -47,6 +47,7 @@ const (
 	BinaryMD5         byte = 0x05
 	BinaryEncrypted   byte = 0x06
 	BinaryColumn      byte = 0x07
+	BinarySenstive    byte = 0x08
 	BinaryUserDefined byte = 0x80
 )
 

--- a/bson/types.go
+++ b/bson/types.go
@@ -45,5 +45,6 @@ const (
 	TypeBinaryMD5         = bsontype.BinaryMD5
 	TypeBinaryEncrypted   = bsontype.BinaryEncrypted
 	TypeBinaryColumn      = bsontype.BinaryColumn
+	TypeBinarySensitive   = bsontype.BinarySensitive
 	TypeBinaryUserDefined = bsontype.BinaryUserDefined
 )

--- a/testdata/bson-corpus/binary.json
+++ b/testdata/bson-corpus/binary.json
@@ -56,6 +56,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
         },
         {
+            "description": "subtype 0x08",
+            "canonical_bson": "1D000000057800100000000873FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"08\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"


### PR DESCRIPTION
GODRIVER-2926

## Summary
Adds support for BSON Binary Data subtype 8: Sensitive

## Background & Motivation
Query stats users who wish to supply their own HMAC key will do so via this subtype.

