### PR TITLE
GODRIVER-2209 Omit readPreference on BatchCursor commands

### DIFF
--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -1,4 +1,4 @@
-// Copyright (C) MongoDB, Inc. 2022-present.batch_cursor
+// Copyright (C) MongoDB, Inc. 2022-present.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License. You may obtain
@@ -331,7 +331,7 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 		// resulting in the default read preference: "primaryPreferred".
 		// Since this could be confusing, and there is no requirement
 		// to use a read preference here, we omit it.
-		OmitReadPreference: true,
+		omitReadPreference: true,
 	}.Execute(ctx)
 }
 
@@ -437,7 +437,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		// resulting in the default read preference: "primaryPreferred".
 		// Since this could be confusing, and there is no requirement
 		// to use a read preference here, we omit it.
-		OmitReadPreference: true,
+		omitReadPreference: true,
 	}.Execute(ctx)
 
 	// Once the cursor has been drained, we can unpin the connection if one is currently pinned.

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -1,4 +1,4 @@
-// Copyright (C) MongoDB, Inc. 2022-present.
+// Copyright (C) MongoDB, Inc. 2022-present.batch_cursor
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License. You may obtain
@@ -326,6 +326,12 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 		Legacy:         LegacyKillCursors,
 		CommandMonitor: bc.cmdMonitor,
 		ServerAPI:      bc.serverAPI,
+
+		// No read preference is passed to the killCursor command,
+		// resulting in the default read preference: "primaryPreferred".
+		// Since this could be confusing, and there is no requirement
+		// to use a read preference here, we omit it.
+		OmitReadPreference: true,
 	}.Execute(ctx)
 }
 
@@ -426,6 +432,12 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		CommandMonitor: bc.cmdMonitor,
 		Crypt:          bc.crypt,
 		ServerAPI:      bc.serverAPI,
+
+		// No read preference is passed to the getMore command,
+		// resulting in the default read preference: "primaryPreferred".
+		// Since this could be confusing, and there is no requirement
+		// to use a read preference here, we omit it.
+		OmitReadPreference: true,
 	}.Execute(ctx)
 
 	// Once the cursor has been drained, we can unpin the connection if one is currently pinned.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -228,12 +228,6 @@ type Operation struct {
 	// not specified a default read preference of primary will be used.
 	ReadPreference *readpref.ReadPref
 
-	// OmitReadPreference is a boolean that indicates whether to omit the
-	// read preference from the command. This omition includes the case
-	// where a default read preference is used when the operation
-	// ReadPreference is not specified.
-	OmitReadPreference bool
-
 	// ReadConcern is the read concern used when running read commands. This field should not be set
 	// for write operations. If this field is set, it will be encoded onto the commands sent to the
 	// server.
@@ -313,6 +307,12 @@ type Operation struct {
 
 	// cmdName is only set when serializing OP_MSG and is used internally in readWireMessage.
 	cmdName string
+
+	// omitReadPreference is a boolean that indicates whether to omit the
+	// read preference from the command. This omition includes the case
+	// where a default read preference is used when the operation
+	// ReadPreference is not specified.
+	omitReadPreference bool
 }
 
 // shouldEncrypt returns true if this operation should automatically be encrypted.
@@ -1443,7 +1443,7 @@ func (op Operation) getReadPrefBasedOnTransaction() (*readpref.ReadPref, error) 
 // object and various related fields such as "mode", "tags", and
 // "maxStalenessSeconds".
 func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bool) (bsoncore.Document, error) {
-	if op.OmitReadPreference {
+	if op.omitReadPreference {
 		return nil, nil
 	}
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -228,6 +228,12 @@ type Operation struct {
 	// not specified a default read preference of primary will be used.
 	ReadPreference *readpref.ReadPref
 
+	// OmitReadPreference is a boolean that indicates whether to omit the
+	// read preference from the command. This omition includes the case
+	// where a default read preference is used when the operation
+	// ReadPreference is not specified.
+	OmitReadPreference bool
+
 	// ReadConcern is the read concern used when running read commands. This field should not be set
 	// for write operations. If this field is set, it will be encoded onto the commands sent to the
 	// server.
@@ -1437,6 +1443,10 @@ func (op Operation) getReadPrefBasedOnTransaction() (*readpref.ReadPref, error) 
 // object and various related fields such as "mode", "tags", and
 // "maxStalenessSeconds".
 func (op Operation) createReadPref(desc description.SelectedServer, isOpQuery bool) (bsoncore.Document, error) {
+	if op.OmitReadPreference {
+		return nil, nil
+	}
+
 	// TODO(GODRIVER-2231): Instead of checking if isOutputAggregate and desc.Server.WireVersion.Max < 13, somehow check
 	// TODO if supplied readPreference was "overwritten" with primary in description.selectForReplicaSet.
 	if desc.Server.Kind == description.Standalone || (isOpQuery && desc.Server.Kind != description.Mongos) ||


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2209

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Add an "OmitReadPreference" field to the Operation struct with the goal of excluding the readPreference from the command, regardless of state (nil or not nil) on an instance of Operation.

## Background & Motivation
<!--- Rationale for the pull request. -->

Currently, the default read preference of primaryPreferred is included in the getMore and killCursors. This can be surprising to users logging CommandStarted events.
