### PR TITLE
GODRIVER-2876 Automatically clean up mtest resources.

### DIFF
--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -88,7 +88,6 @@ func TestDocumentationExamples(t *testing.T) {
 	})
 
 	mt := mtest.New(t)
-	defer mt.Close()
 
 	// Stable API is supported in 5.0+
 	mtOpts := mtest.NewOptions().MinServerVersion("5.0")

--- a/mongo/integration/causal_consistency_test.go
+++ b/mongo/integration/causal_consistency_test.go
@@ -29,7 +29,6 @@ var readConcernOperations = map[string]struct{}{
 
 func TestCausalConsistency_Supported(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("3.6").Topologies(mtest.ReplicaSet, mtest.Sharded).CreateClient(false))
-	defer mt.Close()
 
 	mt.Run("operation time nil", func(mt *mtest.T) {
 		// when a ClientSession is first created, the operation time is nil
@@ -211,7 +210,6 @@ func TestCausalConsistency_NotSupported(t *testing.T) {
 		{Topology: []mtest.TopologyKind{mtest.Single}},
 	}
 	mt := mtest.New(t, mtest.NewOptions().RunOn(rob...).CreateClient(false))
-	defer mt.Close()
 
 	mt.Run("afterClusterTime not included", func(mt *mtest.T) {
 		// a read in a causally consistent session does not include afterClusterTime in a deployment that does not

--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -49,7 +49,6 @@ const (
 func TestChangeStream_Standalone(t *testing.T) {
 	mtOpts := mtest.NewOptions().MinServerVersion(minChangeStreamVersion).CreateClient(false).Topologies(mtest.Single)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.Run("no custom standalone error", func(mt *mtest.T) {
 		_, err := mt.Coll.Watch(context.Background(), mongo.Pipeline{})
@@ -61,7 +60,6 @@ func TestChangeStream_Standalone(t *testing.T) {
 func TestChangeStream_ReplicaSet(t *testing.T) {
 	mtOpts := mtest.NewOptions().MinServerVersion(minChangeStreamVersion).CreateClient(false).Topologies(mtest.ReplicaSet)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.Run("first stage is $changeStream", func(mt *mtest.T) {
 		// first stage in the aggregate pipeline must be $changeStream

--- a/mongo/integration/clam_prose_test.go
+++ b/mongo/integration/clam_prose_test.go
@@ -220,7 +220,6 @@ func TestCommandLoggingAndMonitoringProse(t *testing.T) {
 	t.Parallel()
 
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	for _, tcase := range []struct {
 		// name is the name of the test case

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -60,7 +60,6 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 	verifyClientSideEncryptionVarsSet(t)
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").Enterprise(true).CreateClient(false))
-	defer mt.Close()
 
 	defaultKvClientOptions := options.Client().ApplyURI(mtest.ClusterURI())
 	integtest.AddTestServerAPIVersion(defaultKvClientOptions)

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -96,7 +96,6 @@ func makeMonitor(mt *mtest.T, captured *[]event.CommandStartedEvent) *event.Comm
 func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 	verifyClientSideEncryptionVarsSet(t)
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").Enterprise(true).CreateClient(false))
-	defer mt.Close()
 
 	kmsProvidersMap := map[string]map[string]interface{}{
 		"local": {"key": localMasterKey},
@@ -345,7 +344,6 @@ func (c *customCrypt) RewrapDataKey(_ context.Context, _ []byte,
 
 func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").Enterprise(true).CreateClient(false))
-	defer mt.Close()
 
 	kmsProvidersMap := map[string]map[string]interface{}{
 		"local": {"key": localMasterKey},
@@ -414,7 +412,6 @@ func TestFLE2CreateCollection(t *testing.T) {
 			mtest.LoadBalanced,
 			mtest.ShardedReplicaSet)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	efJSON := `
 	{
@@ -488,7 +485,6 @@ func TestFLE2DocsExample(t *testing.T) {
 			mtest.LoadBalanced,
 			mtest.ShardedReplicaSet)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.Run("Auto Encryption", func(mt *mtest.T) {
 		// Drop data from prior test runs.

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -102,7 +102,6 @@ func (sc *slowConn) Read(b []byte) (n int, err error) {
 
 func TestClient(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	registryOpts := options.Client().
 		SetRegistry(bson.NewRegistryBuilder().RegisterCodec(reflect.TypeOf(int64(0)), &negateCodec{}).Build())
@@ -798,7 +797,6 @@ func TestClient_BSONOptions(t *testing.T) {
 	t.Parallel()
 
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	type jsonTagsTest struct {
 		A string
@@ -917,7 +915,6 @@ func TestClient_BSONOptions(t *testing.T) {
 func TestClientStress(t *testing.T) {
 	mtOpts := mtest.NewOptions().CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	// Test that a Client can recover from a massive traffic spike after the traffic spike is over.
 	mt.Run("Client recovers from traffic spike", func(mt *mtest.T) {

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -40,7 +40,6 @@ var (
 
 func TestCollection(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	mt.RunOpts("insert one", noClientOpts, func(mt *mtest.T) {
 		mt.Run("success", func(mt *mtest.T) {

--- a/mongo/integration/crud_prose_test.go
+++ b/mongo/integration/crud_prose_test.go
@@ -26,7 +26,6 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("4.0").Topologies(mtest.ReplicaSet).
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	label := "ExampleError"
 	mt.Run("InsertMany errors with label", func(mt *mtest.T) {
@@ -124,7 +123,6 @@ func TestWriteErrorsDetails(t *testing.T) {
 		CreateClient(false)
 
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.Run("JSON Schema validation", func(mt *mtest.T) {
 		// Create a JSON Schema validator document that requires properties "a" and "b". Use it in
@@ -293,7 +291,6 @@ func TestWriteErrorsDetails(t *testing.T) {
 func TestHintErrors(t *testing.T) {
 	mtOpts := mtest.NewOptions().MaxServerVersion("3.2").CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	expected := errors.New("the 'hint' command parameter requires a minimum server wire version of 5")
 	mt.Run("UpdateMany", func(mt *mtest.T) {
@@ -325,7 +322,6 @@ func TestHintErrors(t *testing.T) {
 
 func TestWriteConcernError(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	errInfoOpts := mtest.NewOptions().MinServerVersion("4.0").Topologies(mtest.ReplicaSet)
 	mt.RunOpts("errInfo is propagated", errInfoOpts, func(mt *mtest.T) {
@@ -372,7 +368,6 @@ func TestErrorsCodeNamePropagated(t *testing.T) {
 		Topologies(mtest.ReplicaSet).
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.RunOpts("command error", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 		// codeName is propagated in an ok:0 error.

--- a/mongo/integration/crud_spec_test.go
+++ b/mongo/integration/crud_spec_test.go
@@ -96,7 +96,6 @@ func runCrudFile(t *testing.T, file string) {
 	assert.Nil(t, err, "UnmarshalExtJSONWithRegistry error: %v", err)
 
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion(testFile.MinServerVersion).MaxServerVersion(testFile.MaxServerVersion))
-	defer mt.Close()
 
 	// Skip test if serverless requirements are not met.
 	if err = verifyServerlessConstraint(mt, testFile.Serverless); err != nil {

--- a/mongo/integration/csot_cse_prose_test.go
+++ b/mongo/integration/csot_cse_prose_test.go
@@ -26,7 +26,6 @@ import (
 func TestCSOTClientSideEncryptionProse(t *testing.T) {
 	verifyClientSideEncryptionVarsSet(t)
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").CreateClient(false))
-	defer mt.Close()
 
 	mt.RunOpts("2. maxTimeMS is not set for commands sent to mongocryptd",
 		noClientOpts, func(mt *mtest.T) {

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestCSOTProse(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	mt.RunOpts("1. multi-batch writes", mtest.NewOptions().MinServerVersion("4.4").
 		Topologies(mtest.Single), func(mt *mtest.T) {

--- a/mongo/integration/cursor_test.go
+++ b/mongo/integration/cursor_test.go
@@ -26,7 +26,6 @@ const (
 
 func TestCursor(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 	cappedCollectionOpts := options.CreateCollection().SetCapped(true).SetSizeInBytes(64 * 1024)
 
 	// Server versions 2.6 and 3.0 use OP_GET_MORE so this works on >= 3.2 and when RequireAPIVersion is false;

--- a/mongo/integration/data_lake_test.go
+++ b/mongo/integration/data_lake_test.go
@@ -21,7 +21,6 @@ func TestAtlasDataLake(t *testing.T) {
 	// Prose tests against Atlas Data Lake.
 
 	mt := mtest.New(t, mtest.NewOptions().AtlasDataLake(true).CreateClient(false))
-	defer mt.Close()
 	getMtOpts := func() *mtest.Options {
 		return mtest.NewOptions().CollectionName("driverdata")
 	}

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -38,7 +38,6 @@ var (
 
 func TestDatabase(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	mt.RunOpts("run command", noClientOpts, func(mt *mtest.T) {
 		mt.Run("decode raw", func(mt *mtest.T) {

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -59,7 +59,6 @@ func (we wrappedError) Unwrap() error {
 
 func TestErrors(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	mt.RunOpts("errors are wrapped", noClientOpts, func(mt *mtest.T) {
 		mt.Run("network error during application operation", func(mt *mtest.T) {

--- a/mongo/integration/gridfs_test.go
+++ b/mongo/integration/gridfs_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestGridFS(x *testing.T) {
 	mt := mtest.New(x, noClientOpts)
-	defer mt.Close()
 
 	mt.Run("skipping download", func(mt *mtest.T) {
 		data := []byte("abc.def.ghi")

--- a/mongo/integration/handshake_test.go
+++ b/mongo/integration/handshake_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestHandshakeProse(t *testing.T) {
 	mt := mtest.New(t)
-	defer mt.Close()
 
 	opts := mtest.NewOptions().
 		CreateCollection(false).

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -28,7 +28,6 @@ type index struct {
 
 func TestIndexView(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	var pbool = func(b bool) *bool { return &b }
 	var pint32 = func(i int32) *int32 { return &i }

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -45,7 +45,6 @@ type seedlistTest struct {
 
 func TestInitialDNSSeedlistDiscoverySpec(t *testing.T) {
 	mt := mtest.New(t, noClientOpts)
-	defer mt.Close()
 
 	mt.RunOpts("replica set", mtest.NewOptions().Topologies(mtest.ReplicaSet).CreateClient(false), func(mt *mtest.T) {
 		mt.Parallel()

--- a/mongo/integration/load_balancer_prose_test.go
+++ b/mongo/integration/load_balancer_prose_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestLoadBalancerSupport(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().Topologies(mtest.LoadBalanced).CreateClient(false))
-	defer mt.Close()
 
 	mt.Run("RunCommandCursor pins to a connection", func(mt *mtest.T) {
 		// The LB spec tests cover the behavior for cursors created by CRUD operations, but RunCommandCursor is

--- a/mongo/integration/mock_find_test.go
+++ b/mongo/integration/mock_find_test.go
@@ -69,7 +69,6 @@ func getItems(f finder) ([]ShopItem, error) {
 
 func TestMockFind(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	insertItems := []interface{}{
 		ShopItem{ID: 0, Price: 1.5},

--- a/mongo/integration/mongos_pinning_test.go
+++ b/mongo/integration/mongos_pinning_test.go
@@ -24,7 +24,6 @@ func TestMongosPinning(t *testing.T) {
 	mtOpts := mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.1").CreateClient(false).
 		ClientOptions(clientOpts)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	if len(options.Client().ApplyURI(mtest.ClusterURI()).Hosts) < 2 {
 		mt.Skip("skipping because at least 2 mongoses are required")

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -180,17 +180,14 @@ func New(wrapped *testing.T, opts ...*Options) *T {
 		t.createTestClient()
 	}
 
-	wrapped.Cleanup(t.Close)
+	wrapped.Cleanup(t.cleanup)
 
 	return t
 }
 
-// Close cleans up any resources associated with a T.
-//
-// Deprecated: Close is now called automatically by [testing.T.Cleanup] at the
-// end of a test, so it does not need to be called explicitly. It is safe to
-// call multiple times.
-func (t *T) Close() {
+// cleanup cleans up any resources associated with a T. It is intended to be
+// called by [testing.T.Cleanup].
+func (t *T) cleanup() {
 	if t.Client == nil {
 		return
 	}
@@ -204,9 +201,6 @@ func (t *T) Close() {
 	// always disconnect the client regardless of clientType because Client.Disconnect will work against
 	// all deployments
 	_ = t.Client.Disconnect(context.Background())
-
-	// Set the Client to nil so that subsequent calls to Close have no effect.
-	t.Client = nil
 }
 
 // Run creates a new T instance for a sub-test and runs the given callback. It also creates a new collection using the

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -180,10 +180,16 @@ func New(wrapped *testing.T, opts ...*Options) *T {
 		t.createTestClient()
 	}
 
+	wrapped.Cleanup(t.Close)
+
 	return t
 }
 
-// Close cleans up any resources associated with a T. There should be one Close corresponding to every New.
+// Close cleans up any resources associated with a T.
+//
+// Deprecated: Close is now called automatically by [testing.T.Cleanup] at the
+// end of a test, so it does not need to be called explicitly. It is safe to
+// call multiple times.
 func (t *T) Close() {
 	if t.Client == nil {
 		return
@@ -198,6 +204,9 @@ func (t *T) Close() {
 	// always disconnect the client regardless of clientType because Client.Disconnect will work against
 	// all deployments
 	_ = t.Client.Disconnect(context.Background())
+
+	// Set the Client to nil so that subsequent calls to Close have no effect.
+	t.Client = nil
 }
 
 // Run creates a new T instance for a sub-test and runs the given callback. It also creates a new collection using the

--- a/mongo/integration/primary_stepdown_test.go
+++ b/mongo/integration/primary_stepdown_test.go
@@ -26,7 +26,6 @@ const (
 
 func TestConnectionsSurvivePrimaryStepDown(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().Topologies(mtest.ReplicaSet).CreateClient(false))
-	defer mt.Close()
 
 	getMoreOpts := mtest.NewOptions().MinServerVersion("4.2")
 	mt.RunOpts("getMore iteration", getMoreOpts, func(mt *mtest.T) {

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -33,7 +33,6 @@ func TestRetryableReadsProse(t *testing.T) {
 
 	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("4.3")
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	mt.Run("PoolClearedError retryability", func(mt *mtest.T) {
 		if mtest.ClusterTopologyKind() == mtest.LoadBalanced {

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -31,7 +31,6 @@ func TestRetryableWritesProse(t *testing.T) {
 		SetReadConcern(mtest.MajorityRc)
 	mtOpts := mtest.NewOptions().ClientOptions(clientOpts).MinServerVersion("3.6").CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	includeOpts := mtest.NewOptions().Topologies(mtest.ReplicaSet, mtest.Sharded).CreateClient(false)
 	mt.RunOpts("txn number included", includeOpts, func(mt *mtest.T) {

--- a/mongo/integration/retryable_writes_spec_test.go
+++ b/mongo/integration/retryable_writes_spec_test.go
@@ -50,7 +50,6 @@ func runRetryableWritesFile(t *testing.T, filePath string) {
 	assert.Nil(t, err, "UnmarshalExtJSONWithRegistry error: %v", err)
 
 	mt := mtest.New(t, mtest.NewOptions().RunOn(testFile.RunOn...).CreateClient(false))
-	defer mt.Close()
 
 	for _, test := range testFile.Tests {
 		runRetryableWritesTest(mt, test, testFile)

--- a/mongo/integration/sdam_prose_test.go
+++ b/mongo/integration/sdam_prose_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestSDAMProse(t *testing.T) {
 	mt := mtest.New(t)
-	defer mt.Close()
 
 	// Server limits non-streaming heartbeats and explicit server transition checks to at most one
 	// per 500ms. Set the test interval to 500ms to minimize the difference between the behavior of

--- a/mongo/integration/server_selection_prose_test.go
+++ b/mongo/integration/server_selection_prose_test.go
@@ -107,7 +107,6 @@ func TestServerSelectionProse(t *testing.T) {
 	const localThreshold = 30 * time.Second
 
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
-	defer mt.Close()
 
 	mtOpts := mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.9")
 	mt.RunOpts("operationCount-based selection within latency window, with failpoint", mtOpts, func(mt *mtest.T) {

--- a/mongo/integration/sessions_mongocryptd_prose_test.go
+++ b/mongo/integration/sessions_mongocryptd_prose_test.go
@@ -119,7 +119,6 @@ func TestSessionsMongocryptdProse(t *testing.T) {
 	// Create a new instance of mtest (MongoDB testing framework) for this
 	// test and configure it to control server versions.
 	mt := mtest.New(t, mtOpts)
-	mt.Cleanup(mt.Close)
 
 	proseTest18 := "18. implicit session is ignored if connection does not support sessions"
 	mt.RunOpts(proseTest18, mtOpts, func(mt *mtest.T) {

--- a/mongo/integration/sessions_test.go
+++ b/mongo/integration/sessions_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestSessionPool(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("3.6").CreateClient(false))
-	defer mt.Close()
 
 	mt.Run("last use time updated", func(mt *mtest.T) {
 		sess, err := mt.Client.StartSession()
@@ -162,7 +161,6 @@ func TestSessionsProse(t *testing.T) {
 		CreateClient(false)
 
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	hosts := options.Client().ApplyURI(mtest.ClusterURI()).Hosts
 

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -107,7 +107,6 @@ func runTestFile(t *testing.T, filepath string, expectValidFail bool, opts ...*O
 		RunOn(fileReqs...).
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	for _, testCase := range testCases {
 		mtOpts := mtest.NewOptions().

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -224,7 +224,6 @@ func runSpecTestFile(t *testing.T, specDir, fileName string) {
 		mtOpts.AtlasDataLake(true)
 	}
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	for _, test := range testFile.Tests {
 		runSpecTestCase(mt, test, testFile)


### PR DESCRIPTION
[GODRIVER-2876](https://jira.mongodb.org/browse/GODRIVER-2876)

## Summary
Automatically clean up `mtest` resources by using [T.Cleanup](https://pkg.go.dev/testing#T.Cleanup).

## Background & Motivation
Currently all tests must run `defer mt.Close` after calling `mtest.New` to make sure `mtest` cleans up all of the server-side resources it created to run the test. That pattern is error-prone, possibly leading to tests that don't clean up server-side resources.

Instead, we should make the cleanup process automatic by using [T.Cleanup](https://pkg.go.dev/testing#T.Cleanup) and deprecate `mt.Close`.

