### PR TITLE
GODRIVER-2912 Backport: Avoiding Errors if Change Stream Events Exceed 16MB

### DIFF
--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -726,7 +726,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		SetChangeStreamPreAndPostImages(bson.M{"enabled": true})
 
 	splitLargeChangesOpts := mtOpts.
-		MinServerVersion("7.0.0").
+		MinServerVersion("6.0.9").
 		CreateClient(true).
 		CollectionCreateOptions(splitLargeChangesCollOpts)
 


### PR DESCRIPTION
GODRIVER-2912

## Summary
Run the split large changes change stream prose test on server versions 6.0.9 or higher.

## Background & Motivation
The feature was backported to 6.0.9.
