### PR TITLE
GODRIVER-2423 Include pinned connections in WaitQueueTimeoutError only for load balanced clusters.

### DIFF
--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -70,12 +70,12 @@ func (e ServerSelectionError) Unwrap() error {
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool
 type WaitQueueTimeoutError struct {
-	Wrapped                  error
-	pinnedConnections        *pinnedConnections
-	maxPoolSize              uint64
-	totalConnectionCount     int
-	availableConnectionCount int
-	waitDuration             time.Duration
+	Wrapped              error
+	pinnedConnections    *pinnedConnections
+	maxPoolSize          uint64
+	totalConnections     int
+	availableConnections int
+	waitDuration         time.Duration
 }
 
 type pinnedConnections struct {
@@ -102,18 +102,18 @@ func (w WaitQueueTimeoutError) Error() string {
 		)
 	}
 
-	msg := fmt.Sprintf("%s; maxPoolSize: %d, ", errorMsg, w.maxPoolSize)
+	msg := fmt.Sprintf("%s; total connections: %d, maxPoolSize: %d, ", errorMsg, w.totalConnections, w.maxPoolSize)
 	if pinnedConnections := w.pinnedConnections; pinnedConnections != nil {
-		openConnectionCount := uint64(w.totalConnectionCount) -
-			(*pinnedConnections).cursorConnections -
-			(*pinnedConnections).transactionConnections
+		openConnectionCount := uint64(w.totalConnections) -
+			pinnedConnections.cursorConnections -
+			pinnedConnections.transactionConnections
 		msg += fmt.Sprintf("connections in use by cursors: %d, connections in use by transactions: %d, connections in use by other operations: %d, ",
-			(*pinnedConnections).cursorConnections,
-			(*pinnedConnections).transactionConnections,
+			pinnedConnections.cursorConnections,
+			pinnedConnections.transactionConnections,
 			openConnectionCount,
 		)
 	}
-	msg += fmt.Sprintf("idle connections: %d, wait duration: %s", w.availableConnectionCount, w.waitDuration.String())
+	msg += fmt.Sprintf("idle connections: %d, wait duration: %s", w.availableConnections, w.waitDuration.String())
 	return msg
 }
 

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -9,6 +9,7 @@ package topology
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
 )
@@ -69,11 +70,17 @@ func (e ServerSelectionError) Unwrap() error {
 
 // WaitQueueTimeoutError represents a timeout when requesting a connection from the pool
 type WaitQueueTimeoutError struct {
-	Wrapped                      error
-	PinnedCursorConnections      uint64
-	PinnedTransactionConnections uint64
-	maxPoolSize                  uint64
-	totalConnectionCount         int
+	Wrapped                  error
+	pinnedConnections        *pinnedConnections
+	maxPoolSize              uint64
+	totalConnectionCount     int
+	availableConnectionCount int
+	waitDuration             time.Duration
+}
+
+type pinnedConnections struct {
+	cursorConnections      uint64
+	transactionConnections uint64
 }
 
 // Error implements the error interface.
@@ -95,14 +102,23 @@ func (w WaitQueueTimeoutError) Error() string {
 		)
 	}
 
+	var msg string
+	openConnectionCount := uint64(w.totalConnectionCount)
+	if pinnedConnections := w.pinnedConnections; pinnedConnections != nil {
+		openConnectionCount -= (*pinnedConnections).cursorConnections
+		msg += fmt.Sprintf("connections in use by cursors: %d, ", (*pinnedConnections).cursorConnections)
+		openConnectionCount -= (*pinnedConnections).transactionConnections
+		msg += fmt.Sprintf("connections in use by transactions: %d, ", (*pinnedConnections).transactionConnections)
+	}
 	return fmt.Sprintf(
-		"%s; maxPoolSize: %d, connections in use by cursors: %d"+
-			", connections in use by transactions: %d, connections in use by other operations: %d",
+		"%s; maxPoolSize: %d, %sconnections in use by other operations: %d, idle connections: %d, wait duration: %s",
 		errorMsg,
 		w.maxPoolSize,
-		w.PinnedCursorConnections,
-		w.PinnedTransactionConnections,
-		uint64(w.totalConnectionCount)-w.PinnedCursorConnections-w.PinnedTransactionConnections)
+		msg,
+		openConnectionCount,
+		w.availableConnectionCount,
+		w.waitDuration.String(),
+	)
 }
 
 // Unwrap returns the underlying error.

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -639,11 +639,11 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 		}
 
 		err := WaitQueueTimeoutError{
-			Wrapped:                  ctx.Err(),
-			maxPoolSize:              p.maxSize,
-			totalConnectionCount:     p.totalConnectionCount(),
-			availableConnectionCount: p.availableConnectionCount(),
-			waitDuration:             duration,
+			Wrapped:              ctx.Err(),
+			maxPoolSize:          p.maxSize,
+			totalConnections:     p.totalConnectionCount(),
+			availableConnections: p.availableConnectionCount(),
+			waitDuration:         duration,
 		}
 		if p.loadBalanced {
 			err.pinnedConnections = &pinnedConnections{

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -177,6 +177,7 @@ func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...Serv
 		MaxConnecting:    cfg.maxConnecting,
 		MaxIdleTime:      cfg.poolMaxIdleTime,
 		MaintainInterval: cfg.poolMaintainInterval,
+		LoadBalanced:     cfg.loadBalanced,
 		PoolMonitor:      cfg.poolMonitor,
 		Logger:           cfg.logger,
 		handshakeErrFn:   s.ProcessHandshakeError,


### PR DESCRIPTION
GODRIVER-2423

## Summary
Include "connections in use by cursors" and "connections in use by transactions" in `WaitQueueTimeoutError` only for load balanced clusters.

## Background & Motivation
When connected to Load Balancers, drivers are required to pin connections to cursors and transactions. However, The Go driver always reports pinned connections in WaitQueueTimeoutError, even if no connection pinning occurs.
This PR proposes the pinned connections in the `WaitQueueTimeoutError` to be optional. The pool includes the pinned connections in `WaitQueueTimeoutError` only when the topology is load-balanced.