### PR TITLE
GODRIVER-2872 Fix failing "TestClientSideEncryptionProse" test.

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -378,9 +378,6 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 	mt.Run("4. bson size limits", func(mt *mtest.T) {
-		// TODO(GODRIVER-2872): Fix and unskip this test case.
-		mt.Skip("Test fails frequently, skipping. See GODRIVER-2872")
-
 		kmsProviders := map[string]map[string]interface{}{
 			"local": {
 				"key": localMasterKey,

--- a/x/mongo/driver/mongocrypt/binary.go
+++ b/x/mongo/driver/mongocrypt/binary.go
@@ -9,7 +9,10 @@
 
 package mongocrypt
 
-// #include <mongocrypt.h>
+/*
+#include <stdlib.h>
+#include <mongocrypt.h>
+*/
 import "C"
 import (
 	"unsafe"
@@ -17,6 +20,7 @@ import (
 
 // binary is a wrapper type around a mongocrypt_binary_t*
 type binary struct {
+	p       *C.uint8_t
 	wrapped *C.mongocrypt_binary_t
 }
 
@@ -33,11 +37,11 @@ func newBinaryFromBytes(data []byte) *binary {
 		return newBinary()
 	}
 
-	// We don't need C.CBytes here because data cannot go out of scope. Any mongocrypt function that takes a
-	// mongocrypt_binary_t will make a copy of the data so the data can be garbage collected after calling.
-	addr := (*C.uint8_t)(unsafe.Pointer(&data[0])) // uint8_t*
-	dataLen := C.uint32_t(len(data))               // uint32_t
+	// TODO: Consider using runtime.Pinner to replace the C.CBytes after using go1.21.0.
+	addr := (*C.uint8_t)(C.CBytes(data)) // uint8_t*
+	dataLen := C.uint32_t(len(data))     // uint32_t
 	return &binary{
+		p:       addr,
 		wrapped: C.mongocrypt_binary_new_from_data(addr, dataLen),
 	}
 }
@@ -52,5 +56,8 @@ func (b *binary) toBytes() []byte {
 
 // close cleans up any resources associated with the given binary instance.
 func (b *binary) close() {
+	if b.p != nil {
+		C.free(unsafe.Pointer(b.p))
+	}
 	C.mongocrypt_binary_destroy(b.wrapped)
 }


### PR DESCRIPTION
GODRIVER-2872

## Summary
Fix the failing "TestClientSideEncryptionProse" test by duplicating the memory passed to the C side.

## Background & Motivation
The original comment was not accurate. The C side [mongocrypt_binary_new_from_data()](https://github.com/kevinAlbs/libmongocrypt/blob/master/src/mongocrypt-binary.c#L30-L41) does a shallow copy of the passed array only, while the Golang slice which holds the memory may be freed or moved by GC.

Once a GC happens, for example, between [C.mongocrypt_binary_new_from_data()](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/mongocrypt/mongocrypt.go#L122) and [C.mongocrypt_ctx_encrypt_init()](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/mongocrypt/mongocrypt.go#L127), the memory block pointed by `C.mongocrypt_binary_t` gets corrupted and resulted in sporadic "invalid BSON".

This PR proposes `C.CBytes()` to sync the lifecycle of the memory with the C code. Eventually, we can utilize [runtime.Pinner](https://pkg.go.dev/runtime#Pinner) (introduced in Go1.21.0) to avoid additional memory usage.

