### PR TITLE
GODRIVER-2951 Improper handling of env vars in Load Balancer Test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1696,6 +1696,9 @@ tasks:
           LOAD_BALANCER: "true"
       - func: run-load-balancer
       - func: run-load-balancer-tests
+        vars:
+          AUTH: "noauth"
+          SSL: "nossl"
 
   - name: test-load-balancer-auth-ssl
     tags: ["load-balancer"]
@@ -1708,6 +1711,9 @@ tasks:
           LOAD_BALANCER: "true"
       - func: run-load-balancer
       - func: run-load-balancer-tests
+        vars:
+          AUTH: "auth"
+          SSL: "ssl"
 
   - name: test-race
     tags: ["race"]


### PR DESCRIPTION
GODRIVER-2951

## Summary
Explicitly set the env variables used in `run-load-balancer-tests`.

## Background & Motivation
Variables were not being explicitly set.

