### PR TITLE
GODRIVER-2958 Use AWS Secrets for Atlas tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -439,7 +439,7 @@ functions:
   run-atlas-test:
     - command: ec2.assume_role
       params:
-        role_arn: "arn:aws:iam::857654397073:role/drivers-test-secrets-role"
+        role_arn: "${aws_test_secrets_role}"
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -199,7 +199,9 @@ functions:
         shell: "bash"
         script: |
           ${PREPARE_SHELL}
-          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
+          if [ -f $MONGO_ORCHESTRATION_HOME/server.log ]; then
+            find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
+          fi
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -163,7 +163,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone --branch GODRIVER-2958 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone --branch GODRIVER-2958-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -447,7 +447,8 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash etc/run-atlas-test.sh
+          ${PREPARE_SHELL}
+          bash etc/run-atlas-test.sh
 
   run-ocsp-test:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -437,37 +437,17 @@ functions:
           make -s evg-test-enterprise-auth
 
   run-atlas-test:
+    - command: ec2.assume_role
+      params:
+        role_arn: "arn:aws:iam::857654397073:role/drivers-test-secrets-role"
     - command: shell.exec
       type: test
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
+        include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
         script: |
-          # DO NOT ECHO WITH XTRACE
-          if [ "Windows_NT" = "$OS" ]; then
-            export GOPATH=$(cygpath -w $(dirname $(dirname $(dirname `pwd`))))
-            export GOCACHE=$(cygpath -w "$(pwd)/.cache")
-          else
-            export GOPATH=$(dirname $(dirname $(dirname `pwd`)))
-            export GOCACHE="$(pwd)/.cache"
-          fi;
-          export GOPATH="$GOPATH"
-          export GOROOT="${GO_DIST}"
-          export GOCACHE="$GOCACHE"
-          export PATH="${GCC_PATH}:${GO_DIST}/bin:$PATH"
-          export ATLAS_FREE="${atlas_free_tier_uri}"
-          export ATLAS_REPLSET="${atlas_replica_set_uri}"
-          export ATLAS_SHARD="${atlas_sharded_uri}"
-          export ATLAS_TLS11="${atlas_tls_v11_uri}"
-          export ATLAS_TLS12="${atlas_tls_v12_uri}"
-          export ATLAS_FREE_SRV="${atlas_free_tier_uri_srv}"
-          export ATLAS_REPLSET_SRV="${atlas_replica_set_uri_srv}"
-          export ATLAS_SHARD_SRV="${atlas_sharded_uri_srv}"
-          export ATLAS_TLS11_SRV="${atlas_tls_v11_uri_srv}"
-          export ATLAS_TLS12_SRV="${atlas_tls_v12_uri_srv}"
-          export ATLAS_SERVERLESS="${atlas_serverless_uri}"
-          export ATLAS_SERVERLESS_SRV="${atlas_serverless_uri_srv}"
-          make -s evg-test-atlas
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash etc/run-atlas-test.sh
 
   run-ocsp-test:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -284,12 +284,14 @@ functions:
           ${PREPARE_SHELL}
           cd "$MONGO_ORCHESTRATION_HOME"
           # source the mongo-orchestration virtualenv if it exists
+          # and stop the orchestration
           if [ -f venv/bin/activate ]; then
             . venv/bin/activate
+            mongo-orchestration stop
           elif [ -f venv/Scripts/activate ]; then
             . venv/Scripts/activate
+            mongo-orchestration stop
           fi
-          mongo-orchestration stop
           cd -
           rm -rf $DRIVERS_TOOLS || true
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -163,7 +163,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone --branch GODRIVER-2958 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -163,7 +163,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone --branch GODRIVER-2958-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -440,9 +440,9 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: "arn:aws:iam::857654397073:role/drivers-test-secrets-role"
-     - command: shell.exec
-       type: test
-       params:
+    - command: shell.exec
+      type: test
+      params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
         include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -199,9 +199,7 @@ functions:
         shell: "bash"
         script: |
           ${PREPARE_SHELL}
-          if [ -f $MONGO_ORCHESTRATION_HOME/server.log ]; then
-            find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
-          fi
+          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -286,14 +284,12 @@ functions:
           ${PREPARE_SHELL}
           cd "$MONGO_ORCHESTRATION_HOME"
           # source the mongo-orchestration virtualenv if it exists
-          # and stop the orchestration
           if [ -f venv/bin/activate ]; then
             . venv/bin/activate
-            mongo-orchestration stop
           elif [ -f venv/Scripts/activate ]; then
             . venv/Scripts/activate
-            mongo-orchestration stop
           fi
+          mongo-orchestration stop
           cd -
           rm -rf $DRIVERS_TOOLS || true
 
@@ -444,9 +440,9 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: "arn:aws:iam::857654397073:role/drivers-test-secrets-role"
-    - command: shell.exec
-      type: test
-      params:
+     - command: shell.exec
+       type: test
+       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
         include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ internal/test/compilecheck/compilecheck.so
 # Ignore api report files
 api-report.md
 api-report.txt
+
+# Ignore secrets files
+secrets-expansion.yml
+secrets-export.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-ATLAS_URIS = "$(ATLAS_FREE)" "$(ATLAS_REPLSET)" "$(ATLAS_SHARD)" "$(ATLAS_TLS11)" "$(ATLAS_TLS12)" "$(ATLAS_FREE_SRV)" "$(ATLAS_REPLSET_SRV)" "$(ATLAS_SHARD_SRV)" "$(ATLAS_TLS11_SRV)" "$(ATLAS_TLS12_SRV)" "$(ATLAS_SERVERLESS)" "$(ATLAS_SERVERLESS_SRV)"
 TEST_TIMEOUT = 1800
 
 ### Utility targets. ###
@@ -127,10 +126,6 @@ build-aws-ecs-test:
 .PHONY: evg-test
 evg-test:
 	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s -p 1 ./... >> test.suite
-
-.PHONY: evg-test-atlas
-evg-test-atlas:
-	go run ./cmd/testatlas/main.go $(ATLAS_URIS)
 
 .PHONY: evg-test-atlas-data-lake
 evg-test-atlas-data-lake:

--- a/cmd/testatlas/main.go
+++ b/cmd/testatlas/main.go
@@ -45,6 +45,8 @@ func main() {
 			panic(fmt.Sprintf("error running test with tlsInsecure at index %d: %v", idx, err))
 		}
 	}
+
+	fmt.Println("Finished!")
 }
 
 func runTest(ctx context.Context, clientOpts *options.ClientOptions) error {

--- a/cmd/testatlas/main.go
+++ b/cmd/testatlas/main.go
@@ -23,7 +23,11 @@ func main() {
 	uris := flag.Args()
 	ctx := context.Background()
 
+	fmt.Printf("Running atlas tests for %d uris\n", len(uris))
+
 	for idx, uri := range uris {
+		fmt.Printf("Running test %d\n", idx)
+
 		// Set a low server selection timeout so we fail fast if there are errors.
 		clientOpts := options.Client().
 			ApplyURI(uri).

--- a/etc/get_aws_secrets.sh
+++ b/etc/get_aws_secrets.sh
@@ -14,6 +14,7 @@ pushd ${DRIVERS_TOOLS}/.evergreen/auth_aws
 . ./activate-authawsvenv.sh
 # TODO: this should be built into activate-authawsvenv.sh
 pip install pyyaml
+# TODO: make the python3 finder less verbose
 popd
 
 # TODO: add note in setup_secrets.py about setup and using

--- a/etc/get_aws_secrets.sh
+++ b/etc/get_aws_secrets.sh
@@ -8,16 +8,5 @@ if [ -z "$DRIVERS_TOOLS" ]; then
     exit 1
 fi
 
-pushd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-. ./activate-authawsvenv.sh
-popd
-
-# TODO: Add a section to https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets
-# about using a bash script that can be run locally
-# Add this note:
-# Note: for local testing using AWS SSO credentials,
-# you may need to set the AWS_PROFILE environment variable
-# to point to your local profile name.
-echo "Getting secrets: $@"
-python ${DRIVERS_TOOLS}/.evergreen/auth_aws/setup_secrets.py $@
-echo "Got secrets"
+bash $DRIVERS_TOOLS/.evergreen/auth_aws/setup_secrets.sh $@
+. ./secrets-export.sh

--- a/etc/get_aws_secrets.sh
+++ b/etc/get_aws_secrets.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# get-aws-secrets
+# Gets AWS secrets from the vault
+set -eux
+
+if [ -z "$DRIVERS_TOOLS" ]; then
+    echo "Please define DRIVERS_TOOLS variable"
+    exit 1
+fi
+
+# TODO: this should be built into activate-authawsvenv.sh
+export PIP_QUIET=1
+pushd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+. ./activate-authawsvenv.sh
+# TODO: this should be built into activate-authawsvenv.sh
+pip install pyyaml
+popd
+
+# TODO: add note in setup_secrets.py about setup and using
+# AWS_PROFILE
+# TODO: Add a section to https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets
+# about using a bash script that can be run locally
+python ${DRIVERS_TOOLS}/.evergreen/auth_aws/setup_secrets.py $@

--- a/etc/get_aws_secrets.sh
+++ b/etc/get_aws_secrets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # get-aws-secrets
 # Gets AWS secrets from the vault
-set -eux
+set -eu
 
 if [ -z "$DRIVERS_TOOLS" ]; then
     echo "Please define DRIVERS_TOOLS variable"
@@ -12,8 +12,12 @@ pushd ${DRIVERS_TOOLS}/.evergreen/auth_aws
 . ./activate-authawsvenv.sh
 popd
 
-# TODO: add note in setup_secrets.py about setup and using
-# AWS_PROFILE
 # TODO: Add a section to https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets
 # about using a bash script that can be run locally
+# Add this note:
+# Note: for local testing using AWS SSO credentials,
+# you may need to set the AWS_PROFILE environment variable
+# to point to your local profile name.
+echo "Getting secrets: $@"
 python ${DRIVERS_TOOLS}/.evergreen/auth_aws/setup_secrets.py $@
+echo "Got secrets"

--- a/etc/get_aws_secrets.sh
+++ b/etc/get_aws_secrets.sh
@@ -8,13 +8,8 @@ if [ -z "$DRIVERS_TOOLS" ]; then
     exit 1
 fi
 
-# TODO: this should be built into activate-authawsvenv.sh
-export PIP_QUIET=1
 pushd ${DRIVERS_TOOLS}/.evergreen/auth_aws
 . ./activate-authawsvenv.sh
-# TODO: this should be built into activate-authawsvenv.sh
-pip install pyyaml
-# TODO: make the python3 finder less verbose
 popd
 
 # TODO: add note in setup_secrets.py about setup and using

--- a/etc/run-atlas-test.sh
+++ b/etc/run-atlas-test.sh
@@ -4,8 +4,8 @@
 set -eu
 set +x
 
-bash etc/get_aws_secrets.sh drivers/atlas_connect
-. ./secrets-export.sh
+# Get the atlas secrets.
+. etc/get_aws_secrets.sh drivers/atlas_connect
 
 echo "Running cmd/testatlas/main.go"
 go run ./cmd/testatlas/main.go "$ATLAS_REPL" "$ATLAS_SHRD" "$ATLAS_FREE" "$ATLAS_TLS11" "$ATLAS_TLS12" "$ATLAS_SERVERLESS" "$ATLAS_SRV_REPL" "$ATLAS_SRV_SHRD" "$ATLAS_SRV_FREE" "$ATLAS_SRV_TLS11" "$ATLAS_SRV_TLS12" "$ATLAS_SRV_SERVERLESS"

--- a/etc/run-atlas-test.sh
+++ b/etc/run-atlas-test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# run-atlas-test
+# Run atlas connectivity tests.
+set -eux
+
+bash etc/get_aws_secrets.sh drivers/atlas_connect
+. ./secrets-export.sh
+
+set +x  # Disable xtrace
+echo "Running cmd/testatlas/main.go"
+go run ./cmd/testatlas/main.go "$ATLAS_REPL" "$ATLAS_SHRD" "$ATLAS_FREE" "$ATLAS_TLS11" "$ATLAS_TLS12" "$ATLAS_SERVERLESS" "$ATLAS_SRV_REPL" "$ATLAS_SRV_SHRD" "$ATLAS_SRV_FREE" "$ATLAS_SRV_TLS11" "$ATLAS_SRV_TLS12" "$ATLAS_SRV_SERVERLESS"

--- a/etc/run-atlas-test.sh
+++ b/etc/run-atlas-test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # run-atlas-test
 # Run atlas connectivity tests.
-set -eux
+set -eu
+set +x
 
 bash etc/get_aws_secrets.sh drivers/atlas_connect
 . ./secrets-export.sh
 
-set +x  # Disable xtrace
 echo "Running cmd/testatlas/main.go"
 go run ./cmd/testatlas/main.go "$ATLAS_REPL" "$ATLAS_SHRD" "$ATLAS_FREE" "$ATLAS_TLS11" "$ATLAS_TLS12" "$ATLAS_SERVERLESS" "$ATLAS_SRV_REPL" "$ATLAS_SRV_SHRD" "$ATLAS_SRV_FREE" "$ATLAS_SRV_TLS11" "$ATLAS_SRV_TLS12" "$ATLAS_SRV_SERVERLESS"


### PR DESCRIPTION
[GODRIVER-2958](https://jira.mongodb.org/browse/GODRIVER-2958)

## Summary
Use AWS Secrets for variables instead of Evergreen project variables for Atlas tests.

## Background & Motivation
Centralizes location of secrets and allows them to be accessed for local development.

