### PR TITLE
GODRIVER-2963 Use more environment variables in Azure KMS test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2250,7 +2250,7 @@ tasks:
           LD_LIBRARY_PATH=./install/libmongocrypt/lib \
           MONGODB_URI='mongodb://localhost:27017' \
           EXPECT_ERROR='unable to retrieve azure credentials' \
-          PROVIDER='azure' \
+          PROVIDER='azure' AZUREKMS_KEY_NAME='${AZUREKMS_KEY_NAME}' AZUREKMS_KEY_VAULT_ENDPOINT='${AZUREKMS_KEY_VAULT_ENDPOINT}' \
             ./testkms
 
   - name: "test-fuzz"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2228,7 +2228,7 @@ tasks:
           export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}
           echo '${testazurekms_privatekey}' > /tmp/testazurekms.prikey
           export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms.prikey
-          AZUREKMS_CMD="LD_LIBRARY_PATH=./install/libmongocrypt/lib MONGODB_URI='mongodb://localhost:27017' PROVIDER='azure' ./testkms" $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
+          AZUREKMS_CMD="LD_LIBRARY_PATH=./install/libmongocrypt/lib MONGODB_URI='mongodb://localhost:27017' PROVIDER='azure' AZUREKMS_KEY_NAME='${AZUREKMS_KEY_NAME}' AZUREKMS_KEY_VAULT_ENDPOINT='${AZUREKMS_KEY_VAULT_ENDPOINT}' ./testkms" $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
 
   - name: "testazurekms-fail-task"
     # testazurekms-fail-task runs without environment variables.

--- a/cmd/testkms/main.go
+++ b/cmd/testkms/main.go
@@ -24,8 +24,8 @@ var datakeyopts = map[string]primitive.M{
 		"key":    "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 	},
 	"azure": bson.M{
-		"keyVaultEndpoint": "https://keyvault-drivers-2411.vault.azure.net/keys/",
-		"keyName":          "KEY-NAME",
+		"keyVaultEndpoint": "",
+		"keyName":          "",
 	},
 	"gcp": bson.M{
 		"projectId": "devprod-drivers",
@@ -53,6 +53,18 @@ func main() {
 	default:
 		ok = true
 	}
+	azurekms_key_name := os.Getenv("AZUREKMS_KEY_NAME")
+	azurekms_key_vault_endpoint := os.Getenv("AZUREKMS_KEY_VAULT_ENDPOINT")
+	if provider == "azure" {
+		if azurekms_key_name == "" {
+			fmt.Println("ERROR: Please set required AZUREKMS_KEY_NAME environment variable.")
+			ok = false
+		}
+		if azurekms_key_vault_endpoint == "" {
+			fmt.Println("ERROR: Please set required AZUREKMS_KEY_VAULT_ENDPOINT environment variable.")
+			ok = false
+		}
+	}
 	if !ok {
 		providers := make([]string, 0, len(datakeyopts))
 		for p := range datakeyopts {
@@ -63,6 +75,8 @@ func main() {
 		fmt.Println("- MONGODB_URI as a MongoDB URI. Example: 'mongodb://localhost:27017'")
 		fmt.Println("- EXPECT_ERROR as an optional expected error substring.")
 		fmt.Println("- PROVIDER as a KMS provider, which supports:", strings.Join(providers, ", "))
+		fmt.Println("- AZUREKMS_KEY_NAME as the Azure key name. Required if PROVIDER=azure.")
+		fmt.Println("- AZUREKMS_KEY_VAULT_ENDPOINT as the Azure key name. Required if PROVIDER=azure.")
 		os.Exit(1)
 	}
 

--- a/cmd/testkms/main.go
+++ b/cmd/testkms/main.go
@@ -53,19 +53,19 @@ func main() {
 	default:
 		ok = true
 	}
-	azurekms_key_name := os.Getenv("AZUREKMS_KEY_NAME")
-	azurekms_key_vault_endpoint := os.Getenv("AZUREKMS_KEY_VAULT_ENDPOINT")
+	azureKmsKeyName := os.Getenv("AZUREKMS_KEY_NAME")
+	azureKmsKeyVaultEndpoint := os.Getenv("AZUREKMS_KEY_VAULT_ENDPOINT")
 	if provider == "azure" {
-		if azurekms_key_name == "" {
+		if azureKmsKeyName == "" {
 			fmt.Println("ERROR: Please set required AZUREKMS_KEY_NAME environment variable.")
 			ok = false
 		}
-		if azurekms_key_vault_endpoint == "" {
+		if azureKmsKeyVaultEndpoint == "" {
 			fmt.Println("ERROR: Please set required AZUREKMS_KEY_VAULT_ENDPOINT environment variable.")
 			ok = false
 		}
-		datakeyopts["azure"]["keyName"] = azurekms_key_name
-		datakeyopts["azure"]["keyVaultEndpoint"] = azurekms_key_vault_endpoint
+		datakeyopts["azure"]["keyName"] = azureKmsKeyName
+		datakeyopts["azure"]["keyVaultEndpoint"] = azureKmsKeyVaultEndpoint
 	}
 	if !ok {
 		providers := make([]string, 0, len(datakeyopts))

--- a/cmd/testkms/main.go
+++ b/cmd/testkms/main.go
@@ -53,9 +53,9 @@ func main() {
 	default:
 		ok = true
 	}
-	azureKmsKeyName := os.Getenv("AZUREKMS_KEY_NAME")
-	azureKmsKeyVaultEndpoint := os.Getenv("AZUREKMS_KEY_VAULT_ENDPOINT")
 	if provider == "azure" {
+		azureKmsKeyName := os.Getenv("AZUREKMS_KEY_NAME")
+		azureKmsKeyVaultEndpoint := os.Getenv("AZUREKMS_KEY_VAULT_ENDPOINT")
 		if azureKmsKeyName == "" {
 			fmt.Println("ERROR: Please set required AZUREKMS_KEY_NAME environment variable.")
 			ok = false

--- a/cmd/testkms/main.go
+++ b/cmd/testkms/main.go
@@ -64,6 +64,8 @@ func main() {
 			fmt.Println("ERROR: Please set required AZUREKMS_KEY_VAULT_ENDPOINT environment variable.")
 			ok = false
 		}
+		datakeyopts["azure"]["keyName"] = azurekms_key_name
+		datakeyopts["azure"]["keyVaultEndpoint"] = azurekms_key_vault_endpoint
 	}
 	if !ok {
 		providers := make([]string, 0, len(datakeyopts))


### PR DESCRIPTION
GODRIVER-2963
## Summary
- Use environment variables for the `keyName` and `keyVaultVndpoint` in the Azure KMS test.

Changes were verified with this patch: https://spruce.mongodb.com/version/64ee53e7c9ec449533606004

## Background & Motivation

The `test-azure-kms` task currently uses credentials and data from a personal MongoDB account.
DRIVERS-2709 gives MongoDB managed credentials for the Azure KMS tests.

`AZUREKMS_KEY_NAME` and `AZUREKMS_KEY_VAULT_ENDPOINT` were added as Variables to the Evergreen Projects:
- `mongo-go-driver-cloud`
- `mongo-go-driver`
- `mongo-go-driver-release`
- `mongo-go-driver-previous`

The old values were used. After this PR is merged, the Variables can be migrated to the new MongoDB managed values.


