### PR TITLE
Remove redundant nil check in `HasErrorLabel`

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -281,11 +281,9 @@ func (e CommandError) HasErrorCode(code int) bool {
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (e CommandError) HasErrorLabel(label string) bool {
-	if e.Labels != nil {
-		for _, l := range e.Labels {
-			if l == label {
-				return true
-			}
+	for _, l := range e.Labels {
+		if l == label {
+			return true
 		}
 	}
 	return false
@@ -455,11 +453,9 @@ func (mwe WriteException) HasErrorCode(code int) bool {
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (mwe WriteException) HasErrorLabel(label string) bool {
-	if mwe.Labels != nil {
-		for _, l := range mwe.Labels {
-			if l == label {
-				return true
-			}
+	for _, l := range mwe.Labels {
+		if l == label {
+			return true
 		}
 	}
 	return false
@@ -569,11 +565,9 @@ func (bwe BulkWriteException) HasErrorCode(code int) bool {
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (bwe BulkWriteException) HasErrorLabel(label string) bool {
-	if bwe.Labels != nil {
-		for _, l := range bwe.Labels {
-			if l == label {
-				return true
-			}
+	for _, l := range bwe.Labels {
+		if l == label {
+			return true
 		}
 	}
 	return false

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -144,11 +144,9 @@ func (wce WriteCommandError) Retryable(wireVersion *description.VersionRange) bo
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (wce WriteCommandError) HasErrorLabel(label string) bool {
-	if wce.Labels != nil {
-		for _, l := range wce.Labels {
-			if l == label {
-				return true
-			}
+	for _, l := range wce.Labels {
+		if l == label {
+			return true
 		}
 	}
 	return false
@@ -282,11 +280,9 @@ func (e Error) Unwrap() error {
 
 // HasErrorLabel returns true if the error contains the specified label.
 func (e Error) HasErrorLabel(label string) bool {
-	if e.Labels != nil {
-		for _, l := range e.Labels {
-			if l == label {
-				return true
-			}
+	for _, l := range e.Labels {
+		if l == label {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary
<!--- A summary of the changes proposed by this pull request. -->

From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/eSKOAOz0K0M

## Background & Motivation
<!--- Rationale for the pull request. -->

