### PR TITLE
GODRIVER-2904 Add environment log.

### DIFF
--- a/x/mongo/driver/topology/polling_srv_records_test.go
+++ b/x/mongo/driver/topology/polling_srv_records_test.go
@@ -105,6 +105,7 @@ func (ss serverSorter) Less(i, j int) bool {
 }
 
 func compareHosts(t *testing.T, received []description.Server, expected []string) {
+	t.Helper()
 	if len(received) != len(expected) {
 		t.Fatalf("Number of hosts in topology does not match expected value. Got %v; want %v.", len(received), len(expected))
 	}

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -78,8 +78,8 @@ const (
 )
 
 var (
-	CosmosDBLog  = `You appear to be connected to a CosmosDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/cosmosdb`
-	DoumentDBLog = `You appear to be connected to a DoumentDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/documentdb`
+	cosmosDBLog  = `You appear to be connected to a CosmosDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/cosmosdb`
+	doumentDBLog = `You appear to be connected to a DoumentDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/documentdb`
 )
 
 type envMap struct {
@@ -102,8 +102,8 @@ func newHostLogger(l *logger.Logger) *hostLogger {
 			{".docdb-elastic.amazonaws.com", doumentDB},
 		},
 		logs: map[hostEnv]*string{
-			cosmosDB:  &CosmosDBLog,
-			doumentDB: &DoumentDBLog,
+			cosmosDB:  &cosmosDBLog,
+			doumentDB: &doumentDBLog,
 		},
 	}
 }

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -78,8 +78,8 @@ const (
 )
 
 var (
-	cosmosDBLog  = `You appear to be connected to a CosmosDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/cosmosdb`
-	doumentDBLog = `You appear to be connected to a DoumentDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/documentdb`
+	cosmosDBLog   = `You appear to be connected to a CosmosDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/cosmosdb`
+	documentDBLog = `You appear to be connected to a DocumentDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/documentdb`
 )
 
 type envMap struct {
@@ -103,7 +103,7 @@ func newHostLogger(l *logger.Logger) *hostLogger {
 		},
 		logs: map[hostEnv]*string{
 			cosmosDB:  &cosmosDBLog,
-			doumentDB: &doumentDBLog,
+			doumentDB: &documentDBLog,
 		},
 	}
 }

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -707,12 +707,21 @@ func (*mockLogSink) Error(error, string, ...interface{}) {
 // Note: SRV connection strings are intentionally untested, since initial
 // lookup responses cannot be easily mocked.
 func TestTopologyConstructionLogging(t *testing.T) {
-	sink := &mockLogSink{}
-	loggerOptions := options.
-		Logger().
-		SetSink(sink).
-		SetComponentLevel(options.LogComponentTopology, options.LogLevelInfo)
+	const (
+		cosmosDBMsg   = `You appear to be connected to a CosmosDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/cosmosdb`
+		documentDBMsg = `You appear to be connected to a DocumentDB cluster. For more information regarding feature compatibility and support please visit https://www.mongodb.com/supportability/documentdb`
+	)
+
+	newLoggerOptions := func(sink options.LogSink) *options.LoggerOptions {
+		return options.
+			Logger().
+			SetSink(sink).
+			SetComponentLevel(options.LogComponentTopology, options.LogLevelInfo)
+	}
+
 	t.Run("CosmosDB URIs", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name string
 			uri  string
@@ -740,24 +749,28 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
-				defer func() {
-					sink.msgs = []string{}
-				}()
-				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				t.Parallel()
+
+				sink := &mockLogSink{}
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(newLoggerOptions(sink)), nil)
 				require.Nil(t, err, "error constructing topology config: %v", err)
 
 				topo, err := New(cfg)
 				require.Nil(t, err, "topology.New error: %v", err)
 
 				err = topo.Connect()
-				require.Nil(t, err, "Connect error: %v", err)
+				assert.Nil(t, err, "Connect error: %v", err)
 
-				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+				assert.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
 			})
 		}
 	})
 	t.Run("DocumentDB URIs", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name string
 			uri  string
@@ -800,24 +813,28 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
-				defer func() {
-					sink.msgs = []string{}
-				}()
-				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				t.Parallel()
+
+				sink := &mockLogSink{}
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(newLoggerOptions(sink)), nil)
 				require.Nil(t, err, "error constructing topology config: %v", err)
 
 				topo, err := New(cfg)
 				require.Nil(t, err, "topology.New error: %v", err)
 
 				err = topo.Connect()
-				require.Nil(t, err, "Connect error: %v", err)
+				assert.Nil(t, err, "Connect error: %v", err)
 
-				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+				assert.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
 			})
 		}
 	})
 	t.Run("Mixing CosmosDB and DocumentDB URIs", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name string
 			uri  string
@@ -830,24 +847,28 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
-				defer func() {
-					sink.msgs = []string{}
-				}()
-				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				t.Parallel()
+
+				sink := &mockLogSink{}
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(newLoggerOptions(sink)), nil)
 				require.Nil(t, err, "error constructing topology config: %v", err)
 
 				topo, err := New(cfg)
 				require.Nil(t, err, "topology.New error: %v", err)
 
 				err = topo.Connect()
-				require.Nil(t, err, "Connect error: %v", err)
+				assert.Nil(t, err, "Connect error: %v", err)
 
-				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+				assert.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
 			})
 		}
 	})
 	t.Run("genuine URIs", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name string
 			uri  string
@@ -885,20 +906,22 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
-				defer func() {
-					sink.msgs = []string{}
-				}()
-				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				t.Parallel()
+
+				sink := &mockLogSink{}
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(newLoggerOptions(sink)), nil)
 				require.Nil(t, err, "error constructing topology config: %v", err)
 
 				topo, err := New(cfg)
 				require.Nil(t, err, "topology.New error: %v", err)
 
 				err = topo.Connect()
-				require.Nil(t, err, "Connect error: %v", err)
+				assert.Nil(t, err, "Connect error: %v", err)
 
-				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+				assert.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
 			})
 		}
 	})

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -721,12 +721,12 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:19555/",
-				msgs: []string{cosmosDBLog},
+				msgs: []string{cosmosDBMsg},
 			},
 			{
 				name: "multiple hosts",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:1955,b.mongo.cosmos.azure.com:19555/",
-				msgs: []string{cosmosDBLog},
+				msgs: []string{cosmosDBMsg},
 			},
 			{
 				name: "case-insensitive matching",
@@ -736,7 +736,7 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.mongo.cosmos.azure.com:19555/",
-				msgs: []string{cosmosDBLog},
+				msgs: []string{cosmosDBMsg},
 			},
 		}
 		for _, tc := range testCases {
@@ -766,17 +766,17 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017/",
-				msgs: []string{documentDBLog},
+				msgs: []string{documentDBMsg},
 			},
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{documentDBLog},
+				msgs: []string{documentDBMsg},
 			},
 			{
 				name: "multiple hosts",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017,a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{documentDBLog},
+				msgs: []string{documentDBMsg},
 			},
 			{
 				name: "case-insensitive matching",
@@ -791,12 +791,12 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb.amazonaws.com:27017/",
-				msgs: []string{documentDBLog},
+				msgs: []string{documentDBMsg},
 			},
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{documentDBLog},
+				msgs: []string{documentDBMsg},
 			},
 		}
 		for _, tc := range testCases {
@@ -826,7 +826,7 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing hosts",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:19555,a.docdb.amazonaws.com:27017/",
-				msgs: []string{cosmosDBLog, documentDBLog},
+				msgs: []string{cosmosDBMsg, documentDBMsg},
 			},
 		}
 		for _, tc := range testCases {
@@ -856,6 +856,11 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.example.com:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "srv",
+				uri:  "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
 				msgs: []string{},
 			},
 			{

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -697,7 +697,7 @@ type mockLogSink struct {
 	msgs []string
 }
 
-func (s *mockLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+func (s *mockLogSink) Info(_ int, msg string, _ ...interface{}) {
 	s.msgs = append(s.msgs, msg)
 }
 func (*mockLogSink) Error(error, string, ...interface{}) {
@@ -721,12 +721,12 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:19555/",
-				msgs: []string{CosmosDBLog},
+				msgs: []string{cosmosDBLog},
 			},
 			{
 				name: "multiple hosts",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:1955,b.mongo.cosmos.azure.com:19555/",
-				msgs: []string{CosmosDBLog},
+				msgs: []string{cosmosDBLog},
 			},
 			{
 				name: "case-insensitive matching",
@@ -736,7 +736,7 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.mongo.cosmos.azure.com:19555/",
-				msgs: []string{CosmosDBLog},
+				msgs: []string{cosmosDBLog},
 			},
 		}
 		for _, tc := range testCases {
@@ -766,17 +766,17 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017/",
-				msgs: []string{DoumentDBLog},
+				msgs: []string{doumentDBLog},
 			},
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{DoumentDBLog},
+				msgs: []string{doumentDBLog},
 			},
 			{
 				name: "multiple hosts",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017,a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{DoumentDBLog},
+				msgs: []string{doumentDBLog},
 			},
 			{
 				name: "case-insensitive matching",
@@ -791,12 +791,12 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb.amazonaws.com:27017/",
-				msgs: []string{DoumentDBLog},
+				msgs: []string{doumentDBLog},
 			},
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{DoumentDBLog},
+				msgs: []string{doumentDBLog},
 			},
 		}
 		for _, tc := range testCases {
@@ -826,7 +826,7 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing hosts",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:19555,a.docdb.amazonaws.com:27017/",
-				msgs: []string{CosmosDBLog, DoumentDBLog},
+				msgs: []string{cosmosDBLog, doumentDBLog},
 			},
 		}
 		for _, tc := range testCases {

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -766,17 +766,17 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017/",
-				msgs: []string{doumentDBLog},
+				msgs: []string{documentDBLog},
 			},
 			{
 				name: "normal",
 				uri:  "mongodb://a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{doumentDBLog},
+				msgs: []string{documentDBLog},
 			},
 			{
 				name: "multiple hosts",
 				uri:  "mongodb://a.docdb.amazonaws.com:27017,a.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{doumentDBLog},
+				msgs: []string{documentDBLog},
 			},
 			{
 				name: "case-insensitive matching",
@@ -791,12 +791,12 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb.amazonaws.com:27017/",
-				msgs: []string{doumentDBLog},
+				msgs: []string{documentDBLog},
 			},
 			{
 				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
 				uri:  "mongodb://a.example.com:27017,b.docdb-elastic.amazonaws.com:27017/",
-				msgs: []string{doumentDBLog},
+				msgs: []string{documentDBLog},
 			},
 		}
 		for _, tc := range testCases {
@@ -826,7 +826,7 @@ func TestTopologyConstructionLogging(t *testing.T) {
 			{
 				name: "Mixing hosts",
 				uri:  "mongodb://a.mongo.cosmos.azure.com:19555,a.docdb.amazonaws.com:27017/",
-				msgs: []string{cosmosDBLog, doumentDBLog},
+				msgs: []string{cosmosDBLog, documentDBLog},
 			},
 		}
 		for _, tc := range testCases {

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -693,6 +693,212 @@ func TestTopologyConstruction(t *testing.T) {
 	})
 }
 
+type mockLogSink struct {
+	msgs []string
+}
+
+func (s *mockLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+	s.msgs = append(s.msgs, msg)
+}
+func (*mockLogSink) Error(error, string, ...interface{}) {
+	// Do nothing.
+}
+
+// Note: SRV connection strings are intentionally untested, since initial
+// lookup responses cannot be easily mocked.
+func TestTopologyConstructionLogging(t *testing.T) {
+	sink := &mockLogSink{}
+	loggerOptions := options.
+		Logger().
+		SetSink(sink).
+		SetComponentLevel(options.LogComponentTopology, options.LogLevelInfo)
+	t.Run("CosmosDB URIs", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			uri  string
+			msgs []string
+		}{
+			{
+				name: "normal",
+				uri:  "mongodb://a.mongo.cosmos.azure.com:19555/",
+				msgs: []string{CosmosDBLog},
+			},
+			{
+				name: "multiple hosts",
+				uri:  "mongodb://a.mongo.cosmos.azure.com:1955,b.mongo.cosmos.azure.com:19555/",
+				msgs: []string{CosmosDBLog},
+			},
+			{
+				name: "case-insensitive matching",
+				uri:  "mongodb://a.MONGO.COSMOS.AZURE.COM:19555/",
+				msgs: []string{},
+			},
+			{
+				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
+				uri:  "mongodb://a.example.com:27017,b.mongo.cosmos.azure.com:19555/",
+				msgs: []string{CosmosDBLog},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer func() {
+					sink.msgs = []string{}
+				}()
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				require.Nil(t, err, "error constructing topology config: %v", err)
+
+				topo, err := New(cfg)
+				require.Nil(t, err, "topology.New error: %v", err)
+
+				err = topo.Connect()
+				require.Nil(t, err, "Connect error: %v", err)
+
+				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+			})
+		}
+	})
+	t.Run("DocumentDB URIs", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			uri  string
+			msgs []string
+		}{
+			{
+				name: "normal",
+				uri:  "mongodb://a.docdb.amazonaws.com:27017/",
+				msgs: []string{DoumentDBLog},
+			},
+			{
+				name: "normal",
+				uri:  "mongodb://a.docdb-elastic.amazonaws.com:27017/",
+				msgs: []string{DoumentDBLog},
+			},
+			{
+				name: "multiple hosts",
+				uri:  "mongodb://a.docdb.amazonaws.com:27017,a.docdb-elastic.amazonaws.com:27017/",
+				msgs: []string{DoumentDBLog},
+			},
+			{
+				name: "case-insensitive matching",
+				uri:  "mongodb://a.DOCDB.AMAZONAWS.COM:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "case-insensitive matching",
+				uri:  "mongodb://a.DOCDB-ELASTIC.AMAZONAWS.COM:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
+				uri:  "mongodb://a.example.com:27017,b.docdb.amazonaws.com:27017/",
+				msgs: []string{DoumentDBLog},
+			},
+			{
+				name: "Mixing genuine and nongenuine hosts (unlikely in practice)",
+				uri:  "mongodb://a.example.com:27017,b.docdb-elastic.amazonaws.com:27017/",
+				msgs: []string{DoumentDBLog},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer func() {
+					sink.msgs = []string{}
+				}()
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				require.Nil(t, err, "error constructing topology config: %v", err)
+
+				topo, err := New(cfg)
+				require.Nil(t, err, "topology.New error: %v", err)
+
+				err = topo.Connect()
+				require.Nil(t, err, "Connect error: %v", err)
+
+				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+			})
+		}
+	})
+	t.Run("Mixing CosmosDB and DocumentDB URIs", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			uri  string
+			msgs []string
+		}{
+			{
+				name: "Mixing hosts",
+				uri:  "mongodb://a.mongo.cosmos.azure.com:19555,a.docdb.amazonaws.com:27017/",
+				msgs: []string{CosmosDBLog, DoumentDBLog},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer func() {
+					sink.msgs = []string{}
+				}()
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				require.Nil(t, err, "error constructing topology config: %v", err)
+
+				topo, err := New(cfg)
+				require.Nil(t, err, "topology.New error: %v", err)
+
+				err = topo.Connect()
+				require.Nil(t, err, "Connect error: %v", err)
+
+				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+			})
+		}
+	})
+	t.Run("genuine URIs", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			uri  string
+			msgs []string
+		}{
+			{
+				name: "normal",
+				uri:  "mongodb://a.example.com:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "multiple hosts",
+				uri:  "mongodb://a.example.com:27017,b.example.com:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "unexpected suffix",
+				uri:  "mongodb://a.mongo.cosmos.azure.com.tld:19555/",
+				msgs: []string{},
+			},
+			{
+				name: "unexpected suffix",
+				uri:  "mongodb://a.docdb.amazonaws.com.tld:27017/",
+				msgs: []string{},
+			},
+			{
+				name: "unexpected suffix",
+				uri:  "mongodb://a.docdb-elastic.amazonaws.com.tld:27017/",
+				msgs: []string{},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer func() {
+					sink.msgs = []string{}
+				}()
+				cfg, err := NewConfig(options.Client().ApplyURI(tc.uri).SetLoggerOptions(loggerOptions), nil)
+				require.Nil(t, err, "error constructing topology config: %v", err)
+
+				topo, err := New(cfg)
+				require.Nil(t, err, "topology.New error: %v", err)
+
+				err = topo.Connect()
+				require.Nil(t, err, "Connect error: %v", err)
+
+				require.ElementsMatch(t, tc.msgs, sink.msgs, "expected messages to be %v, got %v", tc.msgs, sink.msgs)
+			})
+		}
+	})
+}
+
 type inWindowServer struct {
 	Address  string `json:"address"`
 	Type     string `json:"type"`


### PR DESCRIPTION
GODRIVER-2904

## Summary
Log informational message client-side based on detected environment (DocumentDB or CosmosDB)

## Background & Motivation
Log informational messages by examining host names added to a topology.
SRV connection strings are not tested, since initial lookup responses cannot be easily mocked.

