### PR TITLE
GODRIVER-2964 Fix failing "TestClient/tls_connection".

### DIFF
--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -126,8 +126,6 @@ func TestClient(t *testing.T) {
 			"expected security field to be type %v, got %v", bson.TypeMaxKey, security.Type)
 		_, found := security.Document().LookupErr("SSLServerSubjectName")
 		assert.Nil(mt, found, "SSLServerSubjectName not found in result")
-		_, found = security.Document().LookupErr("SSLServerHasCertificateAuthority")
-		assert.Nil(mt, found, "SSLServerHasCertificateAuthority not found in result")
 	})
 	mt.RunOpts("x509", mtest.NewOptions().Auth(true).SSL(true), func(mt *mtest.T) {
 		testCases := []struct {


### PR DESCRIPTION
GODRIVER-2964

## Summary
Fix failing "TestClient/tls_connection".

## Background & Motivation
Remove the "SSLServerHasCertificateAuthority" assertion in "TestClient/tls_connection" to sync with the upstream server [changes](https://github.com/mongodb/mongo/commit/3e37b1e2a4c341cd456125c804f7700b3056519a#diff-18f4cd1556fcc866bba814f9240a5ade449626b19bbe15107d30ea3e74f6d10bL881).

