### PR TITLE
GODRIVER-2966 Remove the heartbeat events after a connection is closed / a check is canceled.

### DIFF
--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -807,18 +807,18 @@ func (s *Server) check() (description.Server, error) {
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
 		duration = time.Since(start)
+		connID = "0"
+		if s.conn != nil {
+			connID = s.conn.ID()
+		}
 		if err == nil {
 			// Use the description from the connection handshake as the value for this check.
 			s.rttMonitor.addSample(s.conn.helloRTT)
 			descPtr = &s.conn.desc
-			if s.conn != nil {
-				s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, s.conn.desc, false)
-			}
+			s.publishServerHeartbeatSucceededEvent(connID, duration, s.conn.desc, false)
 		} else {
 			err = unwrapConnectionError(err)
-			if s.conn != nil {
-				s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, false)
-			}
+			s.publishServerHeartbeatFailedEvent(connID, duration, err, false)
 		}
 	} else {
 		// An existing connection is being used. Use the server description properties to execute the right heartbeat.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -801,10 +801,19 @@ func (s *Server) check() (description.Server, error) {
 	if s.conn == nil || s.conn.closed() || s.checkWasCancelled() {
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
+		duration = time.Since(start)
 		if err == nil {
 			// Use the description from the connection handshake as the value for this check.
 			s.rttMonitor.addSample(s.conn.helloRTT)
 			descPtr = &s.conn.desc
+			if s.conn != nil {
+				s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, s.conn.desc, false)
+			}
+		} else {
+			err = unwrapConnectionError(err)
+			if s.conn != nil {
+				s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, false)
+			}
 		}
 	} else {
 		// An existing connection is being used. Use the server description properties to execute the right heartbeat.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -795,12 +795,10 @@ func (s *Server) check() (description.Server, error) {
 	var duration time.Duration
 
 	start := time.Now()
+
+	// Create a new connection if this is the first check, the connection was closed after an error during the previous
+	// check, or the previous check was cancelled.
 	if s.conn == nil || s.conn.closed() || s.checkWasCancelled() {
-		// Create a new connection if this is the first check, the connection was closed after an error during the previous
-		// check, or the previous check was cancelled.
-		if s.conn != nil {
-			s.publishServerHeartbeatStartedEvent(s.conn.ID(), false)
-		}
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
 		duration = time.Since(start)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -801,19 +801,10 @@ func (s *Server) check() (description.Server, error) {
 	if s.conn == nil || s.conn.closed() || s.checkWasCancelled() {
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
-		duration = time.Since(start)
 		if err == nil {
 			// Use the description from the connection handshake as the value for this check.
 			s.rttMonitor.addSample(s.conn.helloRTT)
 			descPtr = &s.conn.desc
-			if s.conn != nil {
-				s.publishServerHeartbeatSucceededEvent(s.conn.ID(), duration, s.conn.desc, false)
-			}
-		} else {
-			err = unwrapConnectionError(err)
-			if s.conn != nil {
-				s.publishServerHeartbeatFailedEvent(s.conn.ID(), duration, err, false)
-			}
 		}
 	} else {
 		// An existing connection is being used. Use the server description properties to execute the right heartbeat.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -799,6 +799,11 @@ func (s *Server) check() (description.Server, error) {
 	// Create a new connection if this is the first check, the connection was closed after an error during the previous
 	// check, or the previous check was cancelled.
 	if s.conn == nil || s.conn.closed() || s.checkWasCancelled() {
+		connID := "0"
+		if s.conn != nil {
+			connID = s.conn.ID()
+		}
+		s.publishServerHeartbeatStartedEvent(connID, false)
 		// Create a new connection and add it's handshake RTT as a sample.
 		err = s.setupHeartbeatConnection()
 		duration = time.Since(start)

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -203,7 +203,7 @@ func TestServerHeartbeatTimeout(t *testing.T) {
 			)
 			require.NoError(t, server.Connect(nil))
 
-			timeout := time.After(10 * heartbeatInterval)
+			timeout := time.After(50 * heartbeatInterval)
 			var l int
 		loop:
 			for {

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -175,7 +175,12 @@ func TestServerHeartbeatTimeout(t *testing.T) {
 				}),
 				WithServerMonitor(func(*event.ServerMonitor) *event.ServerMonitor {
 					return &event.ServerMonitor{
-						ServerHeartbeatStarted: func(e *event.ServerHeartbeatStartedEvent) {
+						ServerHeartbeatSucceeded: func(e *event.ServerHeartbeatSucceededEvent) {
+							if !errors.dequeue() {
+								wg.Done()
+							}
+						},
+						ServerHeartbeatFailed: func(e *event.ServerHeartbeatFailedEvent) {
 							if !errors.dequeue() {
 								wg.Done()
 							}


### PR DESCRIPTION
GODRIVER-2966

## Summary
Remove the heartbeat events when checking on the server after a connection is closed / a check is canceled.

## Background & Motivation
<!--- Rationale for the pull request. -->

