### PR TITLE
GODRIVER-2986 Resolve failures in Race Detector Test

### DIFF
--- a/mongo/integration/change_stream_test.go
+++ b/mongo/integration/change_stream_test.go
@@ -770,7 +770,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			require.NoError(mt, err, "failed to update idValue")
 		}()
 
-		nextCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		nextCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		t.Cleanup(cancel)
 
 		type splitEvent struct {

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -66,6 +66,7 @@ type clientEntity struct {
 
 	eventsCountLock                         sync.RWMutex
 	serverDescriptionChangedEventsCountLock sync.RWMutex
+	eventProcessMu                          sync.RWMutex
 
 	entityMap *EntityMap
 
@@ -471,6 +472,9 @@ func (c *clientEntity) processPoolEvent(evt *event.PoolEvent) {
 }
 
 func (c *clientEntity) processServerDescriptionChangedEvent(evt *event.ServerDescriptionChangedEvent) {
+	c.eventProcessMu.Lock()
+	defer c.eventProcessMu.Unlock()
+
 	if !c.getRecordEvents() {
 		return
 	}
@@ -487,6 +491,9 @@ func (c *clientEntity) processServerDescriptionChangedEvent(evt *event.ServerDes
 }
 
 func (c *clientEntity) processServerHeartbeatFailedEvent(evt *event.ServerHeartbeatFailedEvent) {
+	c.eventProcessMu.Lock()
+	defer c.eventProcessMu.Unlock()
+
 	if !c.getRecordEvents() {
 		return
 	}
@@ -499,6 +506,9 @@ func (c *clientEntity) processServerHeartbeatFailedEvent(evt *event.ServerHeartb
 }
 
 func (c *clientEntity) processServerHeartbeatStartedEvent(evt *event.ServerHeartbeatStartedEvent) {
+	c.eventProcessMu.Lock()
+	defer c.eventProcessMu.Unlock()
+
 	if !c.getRecordEvents() {
 		return
 	}
@@ -511,6 +521,9 @@ func (c *clientEntity) processServerHeartbeatStartedEvent(evt *event.ServerHeart
 }
 
 func (c *clientEntity) processServerHeartbeatSucceededEvent(evt *event.ServerHeartbeatSucceededEvent) {
+	c.eventProcessMu.Lock()
+	defer c.eventProcessMu.Unlock()
+
 	if !c.getRecordEvents() {
 		return
 	}
@@ -523,6 +536,9 @@ func (c *clientEntity) processServerHeartbeatSucceededEvent(evt *event.ServerHea
 }
 
 func (c *clientEntity) processTopologyDescriptionChangedEvent(evt *event.TopologyDescriptionChangedEvent) {
+	c.eventProcessMu.Lock()
+	defer c.eventProcessMu.Unlock()
+
 	if !c.getRecordEvents() {
 		return
 	}

--- a/mongo/integration/unified/context.go
+++ b/mongo/integration/unified/context.go
@@ -37,7 +37,7 @@ const (
 func newTestContext(
 	ctx context.Context,
 	entityMap *EntityMap,
-	expectedLogMessageCount int,
+	expectedLogMessageCount uint64,
 	hasOperationalFailPoint bool,
 ) context.Context {
 	ctx = context.WithValue(ctx, operationalFailPointKey, hasOperationalFailPoint)
@@ -84,6 +84,6 @@ func entities(ctx context.Context) *EntityMap {
 	return ctx.Value(entitiesKey).(*EntityMap)
 }
 
-func expectedLogMessageCount(ctx context.Context) int {
-	return ctx.Value(expectedLogMessageCountKey).(int)
+func expectedLogMessageCount(ctx context.Context) uint64 {
+	return ctx.Value(expectedLogMessageCountKey).(uint64)
 }

--- a/mongo/integration/unified/context.go
+++ b/mongo/integration/unified/context.go
@@ -37,7 +37,7 @@ const (
 func newTestContext(
 	ctx context.Context,
 	entityMap *EntityMap,
-	expectedLogMessageCount uint64,
+	expectedLogMessageCount int,
 	hasOperationalFailPoint bool,
 ) context.Context {
 	ctx = context.WithValue(ctx, operationalFailPointKey, hasOperationalFailPoint)
@@ -84,6 +84,6 @@ func entities(ctx context.Context) *EntityMap {
 	return ctx.Value(entitiesKey).(*EntityMap)
 }
 
-func expectedLogMessageCount(ctx context.Context) uint64 {
-	return ctx.Value(expectedLogMessageCountKey).(uint64)
+func expectedLogMessageCount(ctx context.Context) int {
+	return ctx.Value(expectedLogMessageCountKey).(int)
 }

--- a/mongo/integration/unified/logger.go
+++ b/mongo/integration/unified/logger.go
@@ -7,8 +7,6 @@
 package unified
 
 import (
-	"sync/atomic"
-
 	"go.mongodb.org/mongo-driver/internal/logger"
 )
 
@@ -23,7 +21,7 @@ type orderedLogMessage struct {
 // the unified spec tests.
 type Logger struct {
 	bufSize   int
-	lastOrder int32
+	lastOrder int
 	logQueue  chan orderedLogMessage
 }
 
@@ -48,7 +46,7 @@ func (log *Logger) Info(level int, msg string, args ...interface{}) {
 
 	// If the order is greater than the buffer size, we must return. This
 	// would indicate that the logQueue channel has been closed.
-	if log.lastOrder > int32(log.bufSize) {
+	if log.lastOrder > log.bufSize {
 		return
 	}
 
@@ -69,11 +67,11 @@ func (log *Logger) Info(level int, msg string, args ...interface{}) {
 	}
 
 	// If the order has reached the buffer size, then close the channel.
-	if log.lastOrder == int32(log.bufSize) {
+	if log.lastOrder == log.bufSize {
 		close(log.logQueue)
 	}
 
-	atomic.AddInt32(&log.lastOrder, 1)
+	log.lastOrder++
 }
 
 // Error implements the logger.Sink interface's "Error" method for printing log

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -224,9 +224,9 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 	}
 
 	// Count the number of expected log messages over all clients.
-	expectedLogCount := 0
+	var expectedLogCount uint64
 	for _, clientLog := range tc.ExpectLogMessages {
-		expectedLogCount += len(clientLog.LogMessages)
+		expectedLogCount += uint64(len(clientLog.LogMessages))
 	}
 
 	testCtx := newTestContext(context.Background(), tc.entities, expectedLogCount, tc.setsFailPoint())

--- a/mongo/integration/unified/unified_spec_runner.go
+++ b/mongo/integration/unified/unified_spec_runner.go
@@ -224,9 +224,9 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 	}
 
 	// Count the number of expected log messages over all clients.
-	var expectedLogCount uint64
+	var expectedLogCount int
 	for _, clientLog := range tc.ExpectLogMessages {
-		expectedLogCount += uint64(len(clientLog.LogMessages))
+		expectedLogCount += len(clientLog.LogMessages)
 	}
 
 	testCtx := newTestContext(context.Background(), tc.entities, expectedLogCount, tc.setsFailPoint())


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

GODRIVER-2986

## Summary
<!--- A summary of the changes proposed by this pull request. -->

- Extend the change stream timeout in the "split large changes" change stream prose test added in GODRIVER-2827 
- Guard read / write to the UST logger's lastOrder field, which is incremented every time the "info" method is called

## Background & Motivation
<!--- Rationale for the pull request. -->

