### PR TITLE
GODRIVER-2906 Add container Env to Handshake.

### DIFF
--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -297,6 +297,14 @@ func appendClientEnv(dst []byte, omitNonName, omitDoc bool) ([]byte, error) {
 		return dst, nil
 	}
 
+	var idx int32
+
+	idx, dst = bsoncore.AppendDocumentElementStart(dst, "env")
+
+	if name != "" {
+		dst = bsoncore.AppendStringElement(dst, "name", name)
+	}
+
 	addMem := func(envVar string) []byte {
 		mem := os.Getenv(envVar)
 		if mem == "" {
@@ -337,23 +345,17 @@ func appendClientEnv(dst []byte, omitNonName, omitDoc bool) ([]byte, error) {
 		return bsoncore.AppendInt32Element(dst, "timeout_sec", timeoutInt32)
 	}
 
-	var idx int32
-	idx, dst = bsoncore.AppendDocumentElementStart(dst, "env")
-
-	if name != "" {
-		dst = bsoncore.AppendStringElement(dst, "name", name)
-		if !omitNonName {
-			switch name {
-			case envNameAWSLambda:
-				dst = addMem(envVarAWSLambdaFunctionMemorySize)
-				dst = addRegion(envVarAWSRegion)
-			case envNameGCPFunc:
-				dst = addMem(envVarFunctionMemoryMB)
-				dst = addRegion(envVarFunctionRegion)
-				dst = addTimeout(envVarFunctionTimeoutSec)
-			case envNameVercel:
-				dst = addRegion(envVarVercelRegion)
-			}
+	if !omitNonName {
+		switch name {
+		case envNameAWSLambda:
+			dst = addMem(envVarAWSLambdaFunctionMemorySize)
+			dst = addRegion(envVarAWSRegion)
+		case envNameGCPFunc:
+			dst = addMem(envVarFunctionMemoryMB)
+			dst = addRegion(envVarFunctionRegion)
+			dst = addTimeout(envVarFunctionTimeoutSec)
+		case envNameVercel:
+			dst = addRegion(envVarVercelRegion)
 		}
 	}
 

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -293,6 +293,8 @@ func appendClientEnv(dst []byte, omitNonName, omitDoc bool) ([]byte, error) {
 
 	name := getFaasEnvName()
 	container := getContainerEnvInfo()
+	// Omit the entire 'env' if both name and container are empty because other
+	// fields depend on either of them.
 	if name == "" && container == nil {
 		return dst, nil
 	}
@@ -346,6 +348,7 @@ func appendClientEnv(dst []byte, omitNonName, omitDoc bool) ([]byte, error) {
 	}
 
 	if !omitNonName {
+		// No other FaaS fields will be populated if the name is empty.
 		switch name {
 		case envNameAWSLambda:
 			dst = addMem(envVarAWSLambdaFunctionMemorySize)


### PR DESCRIPTION
GODRIVER-2906

## Summary

- Update the metadata handshake `client.env.name` field to optional.
- Add `client.env.container`.

The values for `client.env.container` are sourced from the environment, see [here](https://github.com/mongodb/specifications/blob/611ecb5d624708b81a4d96a16f98aa8f71fcc189/source/mongodb-handshake/handshake.rst#container).

## Background & Motivation
`client.env.container.runtime` is untested since it requires "/.dockerenv", which exists in the root directory.

