### PR TITLE
GODRIVER-2981 API comment doesn't work when job approver isn't PR author

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,6 +1,7 @@
 name: PR API Report
 on:
   pull_request_target:
+    types: [review_requested]
 
 jobs:
   comment:
@@ -25,7 +26,7 @@ jobs:
         set -eux
         git clone https://github.com/mongodb/mongo-go-driver
         cd mongo-go-driver
-        git remote add source https://github.com/$GITHUB_ACTOR/mongo-go-driver
+        git remote add source https://github.com/$GITHUB_REPOSITORY_OWNER/mongo-go-driver
         git fetch origin $GITHUB_BASE_REF
         git fetch source $GITHUB_HEAD_REF
         git checkout $GITHUB_HEAD_REF


### PR DESCRIPTION
GODRIVER-2981

## Summary
Use the owner of the repository when running the workflow.  Only request the workflow run when a review is requested.

## Background & Motivation
Allows the workflow to be run for someone else's PR, and reduces GitHub notification noise.

