### PR TITLE
GODRIVER-2985 Enable api changes report on all branches.

### DIFF
--- a/etc/api_report.sh
+++ b/etc/api_report.sh
@@ -10,6 +10,7 @@ if [ -z $cmd ]; then
 fi
 
 branch=${GITHUB_BASE_REF:-master}
+git fetch origin $branch:$branch
 sha=$(git merge-base $branch HEAD)
 
 gorelease -base=$sha > api-report.txt || true


### PR DESCRIPTION
GODRIVER-2985

## Summary
This is a quick update for the API changes report to make it work for new branches such as `v1`.

## Background & Motivation
Maybe we need to merge to v1 as well.

