### PR TITLE
GODRIVER-2982 Add PR build tags.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2669,18 +2669,21 @@ buildvariants:
       - name: "test-atlas-data-lake"
 
   - matrix_name: "tests-36-with-zlib-support"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["3.6"], os-ssl-32: "*" }
     display_name: "${version} ${os-ssl-32}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy !.zstd"
 
   - matrix_name: "tests-40-with-zlib-support"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["4.0"], os-ssl-40: "*" }
     display_name: "${version} ${os-ssl-40}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy !.zstd"
 
   - matrix_name: "tests-42-plus-zlib-zstd-support"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0", "latest"], os-ssl-40: "*" }
     display_name: "${version} ${os-ssl-40}"
     tasks:
@@ -2729,6 +2732,7 @@ buildvariants:
       - name: ".race"
 
   - matrix_name: "versioned-api-test"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["5.0", "6.0", "7.0", "latest"], os-ssl-40: "*" }
     display_name: "API Version ${version} ${os-ssl-40}"
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2741,12 +2741,14 @@ buildvariants:
       - name: ".kms-tls"
 
   - matrix_name: "load-balancer-test"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["5.0", "6.0", "7.0", "latest", "rapid"], os-ssl-40: ["rhel87-64-go-1-20"] }
     display_name: "Load Balancer Support ${version} ${os-ssl-40}"
     tasks:
       - name: ".load-balancer"
 
   - matrix_name: "serverless"
+    tags: ["pullrequest"]
     matrix_spec: { os-serverless: "*" }
     display_name: "Serverless ${os-serverless}"
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2638,6 +2638,7 @@ buildvariants:
       - name: ".performance"
 
   - name: build-check
+    tags: ["pullrequest"]
     display_name: "Compile Only Checks"
     run_on:
       - rhel8.7-large
@@ -2718,6 +2719,7 @@ buildvariants:
       - name: ".ocsp-rsa !.ocsp-staple"
 
   - matrix_name: "race-test"
+    tags: ["pullrequest"]
     matrix_spec: { version: ["latest"], os-ssl-40: ["rhel87-64-go-1-20"] }
     display_name: "Race Detector Test"
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2620,6 +2620,7 @@ task_groups:
 
 buildvariants:
   - name: static-analysis
+    tags: ["pullrequest"]
     display_name: "Static Analysis"
     run_on:
       - rhel8.7-large
@@ -2648,6 +2649,7 @@ buildvariants:
       - name: ".compile-check"
   
   - name: atlas-test
+    tags: ["pullrequest"]
     display_name: "Atlas test"
     run_on:
       - rhel8.7-large 
@@ -2657,6 +2659,7 @@ buildvariants:
       - name: "atlas-test"
 
   - name: atlas-data-lake-test
+    tags: ["pullrequest"]
     display_name: "Atlas Data Lake Test"
     run_on:
       - rhel8.7-large 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2670,21 +2670,21 @@ buildvariants:
 
   - matrix_name: "tests-36-with-zlib-support"
     tags: ["pullrequest"]
-    matrix_spec: { version: ["3.6"], os-ssl-32: "*" }
+    matrix_spec: { version: ["3.6"], os-ssl-32: ["windows-64-go-1-20", "rhel87-64-go-1-20"] }
     display_name: "${version} ${os-ssl-32}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy !.zstd"
 
   - matrix_name: "tests-40-with-zlib-support"
     tags: ["pullrequest"]
-    matrix_spec: { version: ["4.0"], os-ssl-40: "*" }
+    matrix_spec: { version: ["4.0"], os-ssl-40: ["windows-64-go-1-20", "rhel87-64-go-1-20"] }
     display_name: "${version} ${os-ssl-40}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy !.zstd"
 
   - matrix_name: "tests-42-plus-zlib-zstd-support"
     tags: ["pullrequest"]
-    matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0", "latest"], os-ssl-40: "*" }
+    matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0", "latest"], os-ssl-40: ["windows-64-go-1-20", "rhel87-64-go-1-20"] }
     display_name: "${version} ${os-ssl-40}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy"
@@ -2733,7 +2733,7 @@ buildvariants:
 
   - matrix_name: "versioned-api-test"
     tags: ["pullrequest"]
-    matrix_spec: { version: ["5.0", "6.0", "7.0", "latest"], os-ssl-40: "*" }
+    matrix_spec: { version: ["5.0", "6.0", "7.0", "latest"], os-ssl-40: ["windows-64-go-1-20", "rhel87-64-go-1-20"] }
     display_name: "API Version ${version} ${os-ssl-40}"
     tasks:
       - name: ".versioned-api"


### PR DESCRIPTION
GODRIVER-2982

## Summary
Add PR build tags ("pullrequest") for easier Evergreen config.

## Background & Motivation
A tag, "pullrequest", has been added to current variants as well as the "race detector" tasks so the Go driver Evergreen project can use tags instead of regexes.

Go driver Evergreen project configs will be updated later after the PR merging.

I think it would be better if we could manage the Evergreen project settings under the version control for tracking purpose. But it can be in a separate PR/ticket.

