### PR TITLE
GODRIVER-2996 Fix search index matrix config.yml.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2824,7 +2824,7 @@ buildvariants:
       - test-aws-lambda-task-group
 
   - matrix_name: "searchindex-test"
-    matrix_spec: { version: ["7.0"], os-faas-80: ["rhel80-large-go-1-20"] }
+    matrix_spec: { version: ["7.0"], os-faas-80: ["rhel87-large-go-1-20"] }
     display_name: "Search Index ${version} ${os-faas-80}"
     tasks:
       - test-search-index-task-group


### PR DESCRIPTION
GODRIVER-2996

## Summary
Fix search index matrix "config.yml".

## Background & Motivation
The issue was caused by: [https://github.com/mongodb/mongo-go-driver/commit/f192906799a33a2c777e74b4153481ef99ee1c45#diff-2bc841e86ce96b7b422ae2[…]ecbe0e096420656fc3fb12R2827](https://github.com/mongodb/mongo-go-driver/commit/f192906799a33a2c777e74b4153481ef99ee1c45#diff-2bc841e86ce96b7b422ae203fd8315d0b2a461956cecbe0e096420656fc3fb12R2827)
