### PR TITLE
GODRIVER-2978 Fix branch synching workflow

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2333,7 +2333,7 @@ axes:
           VENV_BIN_DIR: "Scripts"
       - id: "rhel87-64-go-1-20"
         display_name: "RHEL 8.7"
-        run_on: rhel8.7-large 
+        run_on: rhel8.7-large
         variables:
           GO_DIST: "/opt/golang/go1.20"
       - id: "macos11-go-1-20"
@@ -2704,12 +2704,12 @@ buildvariants:
       GO_DIST: "/opt/golang/go1.20"
     tasks:
       - name: ".compile-check"
-  
+
   - name: atlas-test
     tags: ["pullrequest"]
     display_name: "Atlas test"
     run_on:
-      - rhel8.7-large 
+      - rhel8.7-large
     expansions:
       GO_DIST: "/opt/golang/go1.20"
     tasks:
@@ -2719,7 +2719,7 @@ buildvariants:
     tags: ["pullrequest"]
     display_name: "Atlas Data Lake Test"
     run_on:
-      - rhel8.7-large 
+      - rhel8.7-large
     expansions:
       GO_DIST: "/opt/golang/go1.20"
     tasks:
@@ -2835,7 +2835,7 @@ buildvariants:
       - test-aws-lambda-task-group
 
   - matrix_name: "searchindex-test"
-    matrix_spec: { version: ["7.0"], os-faas-80: ["rhel80-large-go-1-20"] }
+    matrix_spec: { version: ["7.0"], os-faas-80: ["rhel87-large-go-1-20"] }
     display_name: "Search Index ${version} ${os-faas-80}"
     tasks:
       - test-search-index-task-group

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Create a sync PR
         run: |
             git config --global github.user $GITHUB_ACTOR
-            git config user.email $GITHUB_ACTOR@users.noreply.github.com
-            git config user.name $GITHUB_ACTOR
+            git config --global user.email $GITHUB_ACTOR@users.noreply.github.com
+            git config --global user.name $GITHUB_ACTOR
             export AUTH_TOKEN=${{secrets.GITHUB_TOKEN}}
             sha=$(git rev-parse HEAD)
             bash ./etc/cherry-picker.sh $sha


### PR DESCRIPTION
GODRIVER-2978

## Summary
Fix the branch synching workflow.

## Background & Motivation
The synch run [failed](https://github.com/mongodb/mongo-go-driver/actions/runs/6299987566) due to not configuring the github user globally.

