### PR TITLE
GODRIVER-2955 Add user-facing network compression documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ if err == mongo.ErrNoDocuments {
 
 Additional examples and documentation can be found under the examples directory and [on the MongoDB Documentation website](https://www.mongodb.com/docs/drivers/go/current/).
 
+### Network Compression
+
+Network Compression will reduce bandwidth requirements between MongoDB and the application. 
+
+The Go Driver supports the following compression algorithms:
+
+1. [Snappy](https://google.github.io/snappy/) (`snappy`): available in MongoDB 3.4 and later.
+2. [Zlib](https://zlib.net/) (`zlib`): available in MongoDB 3.6 and later.
+3. [Zstandard](https://github.com/facebook/zstd/) (`zstd`): available in MongoDB 4.2 and later.
+
+#### Specify Compression Algorithms
+
+Compression can be enabled using the `compressors` parameter on the connection string or by using [`ClientOptions.SetCompressor`](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo/options#ClientOptions.SetCompressors):
+
+```
+opts := options.Client().ApplyURI("mongodb://localhost:27017/?compressors=snappy,zlib,zstd")
+client, _ := mongo.Connect(context.TODO(), opts)
+```
+
+```
+opts := options.Client().SetCompressors([]string{"snappy", "zlib", "zstd"})
+client, _ := mongo.Connect(context.TODO(), opts)
+```
+
+If compressors are set, the Go Driver negotiates with the server to select the first common compressor. For server configuration and defaults, refer to [`networkMessageCompressors`](https://www.mongodb.com/docs/manual/reference/program/mongod/#std-option-mongod.--networkMessageCompressors).
+
+Messages compress when both parties enable network compression; otherwise, messages remain uncompressed
+
 -------------------------
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Additional examples and documentation can be found under the examples directory 
 
 ### Network Compression
 
-Network Compression will reduce bandwidth requirements between MongoDB and the application. 
+Network compression will reduce bandwidth requirements between MongoDB and the application. 
 
 The Go Driver supports the following compression algorithms:
 
@@ -160,7 +160,7 @@ The Go Driver supports the following compression algorithms:
 
 #### Specify Compression Algorithms
 
-Compression can be enabled using the `compressors` parameter on the connection string or by using [`ClientOptions.SetCompressor`](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo/options#ClientOptions.SetCompressors):
+Compression can be enabled using the `compressors` parameter on the connection string or by using [`ClientOptions.SetCompressors`](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo/options#ClientOptions.SetCompressors):
 
 ```
 opts := options.Client().ApplyURI("mongodb://localhost:27017/?compressors=snappy,zlib,zstd")

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -573,7 +573,7 @@ func (c *ClientOptions) SetAuth(auth Credential) *ClientOptions {
 // 3. "zstd" - requires server version >= 4.2, and driver version >= 1.2.0 with cgo support enabled or driver
 // version >= 1.3.0 without cgo.
 //
-// If this option is specified, the driver will perform a negotiation with the server to determine a common list of of
+// If this option is specified, the driver will perform a negotiation with the server to determine a common list of
 // compressors and will use the first one in that list when performing operations. See
 // https://www.mongodb.com/docs/manual/reference/program/mongod/#cmdoption-mongod-networkmessagecompressors for more
 // information about configuring compression on the server and the server-side defaults.


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2955

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Add top-level documentation for network compression.

Once the team agrees on the documentation, I will create a DOCSP ticket to add a "Network Compression" to the connection section of the Go Driver documentation , in the style of Java: https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/network-compression/

## Background & Motivation
<!--- Rationale for the pull request. -->

> Network compression info should be clearly documented and easy to find by our users via a top-level section/tutorial in the docs.
