### PR TITLE
GODRIVER-2952 Update context.Canceled equality comparisons to errors.Is

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -314,7 +314,7 @@ func transformNetworkError(ctx context.Context, originalError error, contextDead
 	}
 
 	// If there was an error and the context was cancelled, we assume it happened due to the cancellation.
-	if ctx.Err() == context.Canceled {
+	if errors.Is(ctx.Err(), context.Canceled) {
 		return context.Canceled
 	}
 
@@ -858,7 +858,7 @@ func newCancellListener() *cancellListener {
 
 // Listen blocks until the provided context is cancelled or listening is aborted
 // via the StopListening function. If this detects that the context has been
-// cancelled (i.e. ctx.Err() == context.Canceled), the provided callback is
+// cancelled (i.e. errors.Is(ctx.Err(), context.Canceled), the provided callback is
 // called to abort in-progress work. Even if the context expires, this function
 // will block until StopListening is called.
 func (c *cancellListener) Listen(ctx context.Context, abortFn func()) {
@@ -866,7 +866,7 @@ func (c *cancellListener) Listen(ctx context.Context, abortFn func()) {
 
 	select {
 	case <-ctx.Done():
-		if ctx.Err() == context.Canceled {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			c.aborted = true
 			abortFn()
 		}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -283,7 +283,7 @@ func TestConnection(t *testing.T) {
 						assert.True(t, ok, "expected error %v to be of type %T", connectErr, ConnectionError{})
 
 						isTimeout := func(err error) bool {
-							if err == context.DeadlineExceeded {
+							if errors.Is(err, context.DeadlineExceeded) {
 								return true
 							}
 							if ne, ok := err.(net.Error); ok {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -519,7 +519,7 @@ func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessE
 	if netErr, ok := wrappedConnErr.(net.Error); ok && netErr.Timeout() {
 		return driver.NoChange
 	}
-	if wrappedConnErr == context.Canceled || wrappedConnErr == context.DeadlineExceeded {
+	if errors.Is(wrappedConnErr, context.Canceled) || errors.Is(wrappedConnErr, context.DeadlineExceeded) {
 		return driver.NoChange
 	}
 
@@ -619,7 +619,7 @@ func (s *Server) update() {
 			// Retry after the first timeout before clearing the pool in case of a FAAS pause as
 			// described in GODRIVER-2577.
 			if err := unwrapConnectionError(desc.LastError); err != nil && timeoutCnt < 1 {
-				if err == context.Canceled || err == context.DeadlineExceeded {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					timeoutCnt++
 					// We want to immediately retry on timeout error. Continue to next loop.
 					return true


### PR DESCRIPTION
[GODRIVER-2952](https://jira.mongodb.org/browse/GODRIVER-2952)

## Summary
Updated instances of `ctx.Err() == context.Cancelled || ctx.Err() == context.DeadlineExceeded` with calls to `errors.Is()`

## Background & Motivation
This is a more idiomatic way of checking error types.
