### PR TITLE
GODRIVER-2979 Rename SingleResult DecodeBytes to Raw

### DIFF
--- a/mongo/client_side_encryption_examples_test.go
+++ b/mongo/client_side_encryption_examples_test.go
@@ -60,7 +60,7 @@ func Example_clientSideEncryption() {
 	if err != nil {
 		log.Fatalf("InsertOne error: %v", err)
 	}
-	res, err := collection.FindOne(context.TODO(), bson.D{}).DecodeBytes()
+	res, err := collection.FindOne(context.TODO(), bson.D{}).Raw()
 	if err != nil {
 		log.Fatalf("FindOne error: %v", err)
 	}

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -593,7 +593,7 @@ func (b *Bucket) createIndexes(ctx context.Context) error {
 
 	docRes := cloned.FindOne(ctx, bson.D{}, options.FindOne().SetProjection(bson.D{{"_id", 1}}))
 
-	_, err = docRes.DecodeBytes()
+	_, err = docRes.Raw()
 	if err != mongo.ErrNoDocuments {
 		// nil, or error that occurred during the FindOne operation
 		return err

--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -124,7 +124,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		// document from the collection.
 		coll := cse.kvClient.Database(kvDatabase).Collection(dkCollection)
 
-		keydoc, err := coll.FindOne(context.Background(), bson.D{}).DecodeBytes()
+		keydoc, err := coll.FindOne(context.Background(), bson.D{}).Raw()
 		assert.Nil(mt, err, "error in decoding bytes: %v", err)
 
 		// Remove the key document from the collection.
@@ -299,7 +299,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 
 				// find the inserted document. the value should be decrypted automatically
-				resBytes, err := cpt.cseColl.FindOne(context.Background(), bson.D{{"_id", tc.provider}}).DecodeBytes()
+				resBytes, err := cpt.cseColl.FindOne(context.Background(), bson.D{{"_id", tc.provider}}).Raw()
 				assert.Nil(mt, err, "Find error: %v", err)
 				foundVal := resBytes.Lookup("value").StringValue()
 				assert.Equal(mt, valueToEncrypt, foundVal, "expected value %v, got %v", valueToEncrypt, foundVal)
@@ -697,13 +697,13 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				assert.Nil(mt, err, "InsertOne error for corpus document: %v", err)
 
 				// find document using client with encryption and assert it matches original
-				decryptedDoc, err := cpt.cseColl.FindOne(context.Background(), bson.D{}).DecodeBytes()
+				decryptedDoc, err := cpt.cseColl.FindOne(context.Background(), bson.D{}).Raw()
 				assert.Nil(mt, err, "Find error with encrypted client: %v", err)
 				assert.Equal(mt, corpus, decryptedDoc, "expected document %v, got %v", corpus, decryptedDoc)
 
 				// find document using a client without encryption enabled and assert fields remain encrypted
 				corpusEncrypted := readJSONFile(mt, "corpus-encrypted.json")
-				foundDoc, err := cpt.coll.FindOne(context.Background(), bson.D{}).DecodeBytes()
+				foundDoc, err := cpt.coll.FindOne(context.Background(), bson.D{}).Raw()
 				assert.Nil(mt, err, "Find error with unencrypted client: %v", err)
 
 				encryptedElems, _ := corpusEncrypted.Elements()
@@ -1376,7 +1376,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				}
 				assert.Nil(mt, err, "InsertOne error: %v", err)
 
-				raw, err := coll.FindOne(context.Background(), bson.M{"_id": 0}).DecodeBytes()
+				raw, err := coll.FindOne(context.Background(), bson.M{"_id": 0}).Raw()
 				assert.Nil(mt, err, "FindOne error: %v", err)
 
 				expected := bsoncore.NewDocumentBuilder().
@@ -1727,8 +1727,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			// Find.
 			res := coll.FindOne(context.Background(), bson.D{{"encryptedIndexed", findPayload}})
 			assert.Nil(mt, res.Err(), "Error in FindOne: %v", res.Err())
-			got, err := res.DecodeBytes()
-			assert.Nil(mt, err, "error in DecodeBytes: %v", err)
+			got, err := res.Raw()
+			assert.Nil(mt, err, "error in Raw: %v", err)
 			gotValue, err := got.LookupErr("encryptedIndexed")
 			assert.Nil(mt, err, "error in LookupErr: %v", err)
 			assert.Equal(mt, gotValue.StringValue(), valueToEncrypt, "expected %q, got %q", valueToEncrypt, gotValue.StringValue())
@@ -1808,8 +1808,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			// Find.
 			res := coll.FindOne(context.Background(), bson.D{{"_id", 1}})
 			assert.Nil(mt, res.Err(), "Error in FindOne: %v", res.Err())
-			got, err := res.DecodeBytes()
-			assert.Nil(mt, err, "error in DecodeBytes: %v", err)
+			got, err := res.Raw()
+			assert.Nil(mt, err, "error in Raw: %v", err)
 			gotValue, err := got.LookupErr("encryptedUnindexed")
 			assert.Nil(mt, err, "error in LookupErr: %v", err)
 			assert.Equal(mt, gotValue.StringValue(), valueToEncrypt, "expected %q, got %q", valueToEncrypt, gotValue.StringValue())
@@ -1899,7 +1899,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		var validateAddKeyAltName = func(mt *mtest.T, cse *cseProseTest, res *mongo.SingleResult, expected ...string) {
 			assert.Nil(mt, res.Err(), "error adding key alt name: %v", res.Err())
 
-			resbytes, err := res.DecodeBytes()
+			resbytes, err := res.Raw()
 			assert.Nil(mt, err, "error decoding result bytes: %v", err)
 
 			idsubtype, iddata := bson.RawValue{Type: bsontype.EmbeddedDocument, Value: resbytes}.
@@ -1907,7 +1907,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			filter := bsoncore.NewDocumentBuilder().AppendBinary("_id", idsubtype, iddata).Build()
 
 			ctx := context.Background()
-			updatedData, err := cse.keyVaultColl.FindOne(ctx, filter).DecodeBytes()
+			updatedData, err := cse.keyVaultColl.FindOne(ctx, filter).Raw()
 			assert.Nil(mt, err, "error decoding result bytes: %v", err)
 
 			updated := bson.RawValue{Type: bsontype.EmbeddedDocument, Value: updatedData}

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -375,8 +375,8 @@ func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 		res := coll.FindOne(context.Background(), bson.D{{"foo", "bar"}})
 		assert.Nil(mt, res.Err(), "FindOne error: %v", err)
 
-		rawRes, err := res.DecodeBytes()
-		assert.Nil(mt, err, "DecodeBytes error: %v", err)
+		rawRes, err := res.Raw()
+		assert.Nil(mt, err, "Raw error: %v", err)
 		ssn, ok := rawRes.Lookup("ssn").StringValueOK()
 		assert.True(mt, ok, "expected 'ssn' value to be type string, got %T", ssn)
 		assert.Equal(mt, ssn, mySSN, "expected 'ssn' value %q, got %q", mySSN, ssn)
@@ -587,8 +587,8 @@ func TestFLE2DocsExample(t *testing.T) {
 			unencryptedColl := mt.Client.Database("docsExamples").Collection("encrypted")
 			res := unencryptedColl.FindOne(context.Background(), bson.M{"_id": 1})
 			assert.Nil(mt, res.Err(), "error in FindOne: %v", res.Err())
-			resBSON, err := res.DecodeBytes()
-			assert.Nil(mt, err, "error in DecodeBytes: %v", err)
+			resBSON, err := res.Raw()
+			assert.Nil(mt, err, "error in Raw: %v", err)
 
 			val := resBSON.Lookup("encryptedIndexed")
 			assert.Equal(mt, val.Type, bsontype.Binary, "expected encryptedIndexed to be Binary, got %v", val.Type)

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -187,7 +187,7 @@ func TestClient(t *testing.T) {
 
 				rdr, err := authClient.Database("test").RunCommand(context.Background(), bson.D{
 					{"connectionStatus", 1},
-				}).DecodeBytes()
+				}).Raw()
 				assert.Nil(mt, err, "connectionStatus error: %v", err)
 				users, err := rdr.LookupErr("authInfo", "authenticatedUsers")
 				assert.Nil(mt, err, "authenticatedUsers not found in response")
@@ -878,8 +878,8 @@ func TestClient_BSONOptions(t *testing.T) {
 			}
 
 			if tc.wantRaw != nil {
-				got, err := sr.DecodeBytes()
-				require.NoError(mt, err, "DecodeBytes error")
+				got, err := sr.Raw()
+				require.NoError(mt, err, "Raw error")
 
 				assert.EqualBSON(mt, tc.wantRaw, got)
 			}

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1108,7 +1108,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}).DecodeBytes()
+			res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}).Raw()
 			assert.Nil(mt, err, "FindOne error: %v", err)
 
 			x, err := res.LookupErr("x")
@@ -1150,7 +1150,7 @@ func TestCollection(t *testing.T) {
 				SetShowRecordID(false).
 				SetSkip(0).
 				SetSort(bson.D{{"x", int32(1)}})
-			res, err := mt.Coll.FindOne(context.Background(), bson.D{}, opts).DecodeBytes()
+			res, err := mt.Coll.FindOne(context.Background(), bson.D{}, opts).Raw()
 			assert.Nil(mt, err, "FindOne error: %v", err)
 
 			x, err := res.LookupErr("x")
@@ -1210,7 +1210,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOne(context.Background(), bson.D{{"x", 1}}, tc.opts).Raw()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1231,7 +1231,7 @@ func TestCollection(t *testing.T) {
 	mt.RunOpts("find one and delete", noClientOpts, func(mt *mtest.T) {
 		mt.Run("found", func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).DecodeBytes()
+			res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).Raw()
 			assert.Nil(mt, err, "FindOneAndDelete error: %v", err)
 
 			elem, err := res.LookupErr("x")
@@ -1270,7 +1270,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 1}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 1}}, tc.opts).Raw()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1302,7 +1302,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			replacement := bson.D{{"y", 3}}
 
-			res, err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).DecodeBytes()
+			res, err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).Raw()
 			assert.Nil(mt, err, "FindOneAndReplace error: %v", err)
 			elem, err := res.LookupErr("x")
 			assert.Nil(mt, err, "x not found in result %v", res)
@@ -1346,7 +1346,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndReplace(context.Background(), bson.D{{"x", 1}}, bson.D{{"y", 3}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndReplace(context.Background(), bson.D{{"x", 1}}, bson.D{{"y", 3}}, tc.opts).Raw()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}
@@ -1380,7 +1380,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			update := bson.D{{"$set", bson.D{{"x", 6}}}}
 
-			res, err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).DecodeBytes()
+			res, err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).Raw()
 			assert.Nil(mt, err, "FindOneAndUpdate error: %v", err)
 			elem, err := res.LookupErr("x")
 			assert.Nil(mt, err, "x not found in result %v", res)
@@ -1428,7 +1428,7 @@ func TestCollection(t *testing.T) {
 					})
 					assert.Nil(mt, err, "CreateOne error: %v", err)
 
-					res, err := mt.Coll.FindOneAndUpdate(context.Background(), bson.D{{"x", 1}}, bson.D{{"$set", bson.D{{"x", 6}}}}, tc.opts).DecodeBytes()
+					res, err := mt.Coll.FindOneAndUpdate(context.Background(), bson.D{{"x", 1}}, bson.D{{"$set", bson.D{{"x", 6}}}}, tc.opts).Raw()
 
 					if tc.errParam != "" {
 						expErr := mongo.ErrMapForOrderedArgument{tc.errParam}

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -1646,7 +1646,7 @@ func verifySingleResult(mt *mtest.T, actualResult *mongo.SingleResult, expectedR
 	}
 
 	expected := expectedResult.(bson.Raw)
-	actual, _ := actualResult.DecodeBytes()
+	actual, _ := actualResult.Raw()
 	if err := compareDocs(mt, expected, actual); err != nil {
 		mt.Fatalf("SingleResult document mismatch: %s", err)
 	}

--- a/mongo/integration/database_test.go
+++ b/mongo/integration/database_test.go
@@ -41,7 +41,7 @@ func TestDatabase(t *testing.T) {
 
 	mt.RunOpts("run command", noClientOpts, func(mt *mtest.T) {
 		mt.Run("decode raw", func(mt *mtest.T) {
-			res, err := mt.DB.RunCommand(context.Background(), bson.D{{handshake.LegacyHello, 1}}).DecodeBytes()
+			res, err := mt.DB.RunCommand(context.Background(), bson.D{{handshake.LegacyHello, 1}}).Raw()
 			assert.Nil(mt, err, "RunCommand error: %v", err)
 
 			ok, err := res.LookupErr("ok")
@@ -105,7 +105,7 @@ func TestDatabase(t *testing.T) {
 				{"insert", "test"},
 				{"documents", bson.A{bson.D{{"a", 1}}}},
 			}
-			res, gotErr := mt.DB.RunCommand(context.Background(), cmd).DecodeBytes()
+			res, gotErr := mt.DB.RunCommand(context.Background(), cmd).Raw()
 
 			n, ok := res.Lookup("n").Int32OK()
 			assert.True(mt, ok, "expected n in response")

--- a/mongo/integration/gridfs_test.go
+++ b/mongo/integration/gridfs_test.go
@@ -297,7 +297,7 @@ func TestGridFS(x *testing.T) {
 					// The uploadDate field is calculated when the upload is complete. Manually fetch it from the
 					// fs.files collection to use in assertions.
 					filesColl := mt.DB.Collection("fs.files")
-					uploadedFileDoc, err := filesColl.FindOne(context.Background(), bson.D{}).DecodeBytes()
+					uploadedFileDoc, err := filesColl.FindOne(context.Background(), bson.D{}).Raw()
 					assert.Nil(mt, err, "FindOne error: %v", err)
 					uploadTime := uploadedFileDoc.Lookup("uploadDate").Time().UTC()
 

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -196,7 +196,7 @@ func Setup(setupOpts ...*SetupOptions) error {
 
 	testContext.authEnabled = os.Getenv("AUTH") == "auth"
 	testContext.sslEnabled = os.Getenv("SSL") == "ssl"
-	biRes, err := testContext.client.Database("admin").RunCommand(context.Background(), bson.D{{"buildInfo", 1}}).DecodeBytes()
+	biRes, err := testContext.client.Database("admin").RunCommand(context.Background(), bson.D{{"buildInfo", 1}}).Raw()
 	if err != nil {
 		return fmt.Errorf("buildInfo error: %v", err)
 	}
@@ -215,7 +215,7 @@ func Setup(setupOpts ...*SetupOptions) error {
 	// Get server parameters if test is not running against ADL; ADL does not have "getParameter" command.
 	if !testContext.dataLake {
 		db := testContext.client.Database("admin")
-		testContext.serverParameters, err = db.RunCommand(context.Background(), bson.D{{"getParameter", "*"}}).DecodeBytes()
+		testContext.serverParameters, err = db.RunCommand(context.Background(), bson.D{{"getParameter", "*"}}).Raw()
 		if err != nil {
 			return fmt.Errorf("error getting serverParameters: %v", err)
 		}

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -86,7 +86,7 @@ func TestRetryableWritesProse(t *testing.T) {
 	})
 	errorOpts := mtest.NewOptions().Topologies(mtest.ReplicaSet, mtest.Sharded)
 	mt.RunOpts("wrap mmapv1 error", errorOpts, func(mt *mtest.T) {
-		res, err := mt.DB.RunCommand(context.Background(), bson.D{{"serverStatus", 1}}).DecodeBytes()
+		res, err := mt.DB.RunCommand(context.Background(), bson.D{{"serverStatus", 1}}).Raw()
 		assert.Nil(mt, err, "serverStatus error: %v", err)
 		storageEngine, ok := res.Lookup("storageEngine", "name").StringValueOK()
 		if !ok || storageEngine != "mmapv1" {

--- a/mongo/integration/unified/client_encryption_operation_execution.go
+++ b/mongo/integration/unified/client_encryption_operation_execution.go
@@ -83,9 +83,9 @@ func executeAddKeyAltName(ctx context.Context, operation *operation) (*operation
 		}
 	}
 
-	res, err := cee.AddKeyAltName(ctx, id, keyAltName).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor returned in a find operation has no
-	// associated documents, DecodeBytes will return ErrNoDocuments.
+	res, err := cee.AddKeyAltName(ctx, id, keyAltName).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor returned in a find operation has no
+	// associated documents, Raw will return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
 	}
@@ -199,9 +199,9 @@ func executeGetKeyByAltName(ctx context.Context, operation *operation) (*operati
 		}
 	}
 
-	res, err := cee.GetKeyByAltName(ctx, keyAltName).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor returned in a find operation has no
-	// associated documents, DecodeBytes will return ErrNoDocuments.
+	res, err := cee.GetKeyByAltName(ctx, keyAltName).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor returned in a find operation has no
+	// associated documents, Raw will return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
 	}
@@ -235,9 +235,9 @@ func executeGetKey(ctx context.Context, operation *operation) (*operationResult,
 		}
 	}
 
-	res, err := cee.GetKey(ctx, id).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor returned in a find operation has no
-	// associated documents, DecodeBytes will return ErrNoDocuments.
+	res, err := cee.GetKey(ctx, id).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor returned in a find operation has no
+	// associated documents, Raw will return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
 	}
@@ -291,9 +291,9 @@ func executeRemoveKeyAltName(ctx context.Context, operation *operation) (*operat
 		}
 	}
 
-	res, err := cee.RemoveKeyAltName(ctx, id, keyAltName).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor returned in a find operation has no
-	// associated documents, DecodeBytes will return ErrNoDocuments.
+	res, err := cee.RemoveKeyAltName(ctx, id, keyAltName).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor returned in a find operation has no
+	// associated documents, Raw will return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
 	}

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -752,9 +752,9 @@ func executeFindOne(ctx context.Context, operation *operation) (*operationResult
 		return nil, newMissingArgumentError("filter")
 	}
 
-	res, err := coll.FindOne(ctx, filter, opts).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor
-	// returned in a find operation has no associated documents, DecodeBytes will
+	res, err := coll.FindOne(ctx, filter, opts).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor
+	// returned in a find operation has no associated documents, Raw will
 	// return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
@@ -813,9 +813,9 @@ func executeFindOneAndDelete(ctx context.Context, operation *operation) (*operat
 		return nil, newMissingArgumentError("filter")
 	}
 
-	res, err := coll.FindOneAndDelete(ctx, filter, opts).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor
-	// returned in a find operation has no associated documents, DecodeBytes will
+	res, err := coll.FindOneAndDelete(ctx, filter, opts).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor
+	// returned in a find operation has no associated documents, Raw will
 	// return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
@@ -893,9 +893,9 @@ func executeFindOneAndReplace(ctx context.Context, operation *operation) (*opera
 		return nil, newMissingArgumentError("replacement")
 	}
 
-	res, err := coll.FindOneAndReplace(ctx, filter, replacement, opts).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor
-	// returned in a find operation has no associated documents, DecodeBytes will
+	res, err := coll.FindOneAndReplace(ctx, filter, replacement, opts).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor
+	// returned in a find operation has no associated documents, Raw will
 	// return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
@@ -980,9 +980,9 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 		return nil, newMissingArgumentError("update")
 	}
 
-	res, err := coll.FindOneAndUpdate(ctx, filter, update, opts).DecodeBytes()
-	// Ignore ErrNoDocuments errors from DecodeBytes. In the event that the cursor
-	// returned in a find operation has no associated documents, DecodeBytes will
+	res, err := coll.FindOneAndUpdate(ctx, filter, update, opts).Raw()
+	// Ignore ErrNoDocuments errors from Raw. In the event that the cursor
+	// returned in a find operation has no associated documents, Raw will
 	// return ErrNoDocuments.
 	if err == mongo.ErrNoDocuments {
 		err = nil
@@ -1202,7 +1202,7 @@ func executeRenameCollection(ctx context.Context, operation *operation) (*operat
 	}
 	// rename can only be run on the 'admin' database.
 	admin := coll.Database().Client().Database("admin")
-	res, err := admin.RunCommand(context.Background(), renameCmd).DecodeBytes()
+	res, err := admin.RunCommand(context.Background(), renameCmd).Raw()
 	return newDocumentResult(res, err), nil
 }
 

--- a/mongo/integration/unified/database_operation_execution.go
+++ b/mongo/integration/unified/database_operation_execution.go
@@ -269,7 +269,7 @@ func executeRunCommand(ctx context.Context, operation *operation) (*operationRes
 		return nil, newMissingArgumentError("command")
 	}
 
-	res, err := db.RunCommand(ctx, command, opts).DecodeBytes()
+	res, err := db.RunCommand(ctx, command, opts).Raw()
 	return newDocumentResult(res, err), nil
 }
 

--- a/mongo/mongocryptd.go
+++ b/mongo/mongocryptd.go
@@ -91,7 +91,7 @@ func (mc *mongocryptdClient) markCommand(ctx context.Context, dbName string, cmd
 	ctx = NewSessionContext(ctx, nil)
 	db := mc.client.Database(dbName, databaseOpts)
 
-	res, err := db.RunCommand(ctx, cmd).DecodeBytes()
+	res, err := db.RunCommand(ctx, cmd).Raw()
 	// propagate original result
 	if err == nil {
 		return bsoncore.Document(res), nil
@@ -105,7 +105,7 @@ func (mc *mongocryptdClient) markCommand(ctx context.Context, dbName string, cmd
 	if err = mc.spawnProcess(); err != nil {
 		return nil, err
 	}
-	res, err = db.RunCommand(ctx, cmd).DecodeBytes()
+	res, err = db.RunCommand(ctx, cmd).Raw()
 	if err != nil {
 		return nil, MongocryptdError{Wrapped: err}
 	}

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -83,10 +83,11 @@ func (sr *SingleResult) Decode(v interface{}) error {
 	return dec.Decode(v)
 }
 
-// DecodeBytes will return the document represented by this SingleResult as a bson.Raw. If there was an error from the
-// operation that created this SingleResult, both the result and that error will be returned. If the operation returned
-// no documents, this will return (nil, ErrNoDocuments).
-func (sr *SingleResult) DecodeBytes() (bson.Raw, error) {
+// Raw returns the document represented by this SingleResult as a bson.Raw. If
+// there was an error from the operation that created this SingleResult, both
+// the result and that error will be returned. If the operation returned no
+// documents, this will return (nil, ErrNoDocuments).
+func (sr *SingleResult) Raw() (bson.Raw, error) {
 	if sr.err != nil {
 		return sr.rdr, sr.err
 	}
@@ -95,6 +96,15 @@ func (sr *SingleResult) DecodeBytes() (bson.Raw, error) {
 		return nil, sr.err
 	}
 	return sr.rdr, nil
+}
+
+// DecodeBytes will return the document represented by this SingleResult as a bson.Raw. If there was an error from the
+// operation that created this SingleResult, both the result and that error will be returned. If the operation returned
+// no documents, this will return (nil, ErrNoDocuments).
+//
+// Deprecated: Use [SingleResult.Raw] instead.
+func (sr *SingleResult) DecodeBytes() (bson.Raw, error) {
+	return sr.Raw()
 }
 
 // setRdrContents will set the contents of rdr by iterating the underlying cursor if necessary.

--- a/mongo/single_result.go
+++ b/mongo/single_result.go
@@ -98,15 +98,6 @@ func (sr *SingleResult) Raw() (bson.Raw, error) {
 	return sr.rdr, nil
 }
 
-// DecodeBytes will return the document represented by this SingleResult as a bson.Raw. If there was an error from the
-// operation that created this SingleResult, both the result and that error will be returned. If the operation returned
-// no documents, this will return (nil, ErrNoDocuments).
-//
-// Deprecated: Use [SingleResult.Raw] instead.
-func (sr *SingleResult) DecodeBytes() (bson.Raw, error) {
-	return sr.Raw()
-}
-
 // setRdrContents will set the contents of rdr by iterating the underlying cursor if necessary.
 func (sr *SingleResult) setRdrContents() error {
 	switch {

--- a/mongo/single_result_test.go
+++ b/mongo/single_result_test.go
@@ -21,7 +21,7 @@ import (
 func TestSingleResult(t *testing.T) {
 	t.Run("Decode", func(t *testing.T) {
 		t.Run("decode twice", func(t *testing.T) {
-			// Test that Decode and DecodeBytes can be called more than once
+			// Test that Decode and Raw can be called more than once
 			c, err := newCursor(newTestBatchCursor(1, 1), nil, bson.DefaultRegistry)
 			assert.Nil(t, err, "newCursor error: %v", err)
 
@@ -32,16 +32,16 @@ func TestSingleResult(t *testing.T) {
 			err = sr.Decode(&secondDecode)
 			assert.Nil(t, err, "Decode error: %v", err)
 
-			decodeBytes, err := sr.DecodeBytes()
-			assert.Nil(t, err, "DecodeBytes error: %v", err)
+			rawBytes, err := sr.Raw()
+			assert.Nil(t, err, "Raw error: %v", err)
 
 			assert.Equal(t, firstDecode, secondDecode, "expected contents %v, got %v", firstDecode, secondDecode)
-			assert.Equal(t, firstDecode, decodeBytes, "expected contents %v, got %v", firstDecode, decodeBytes)
+			assert.Equal(t, firstDecode, rawBytes, "expected contents %v, got %v", firstDecode, rawBytes)
 		})
 		t.Run("decode with error", func(t *testing.T) {
 			r := []byte("foo")
-			sr := &SingleResult{rdr: r, err: errors.New("DecodeBytes error")}
-			res, err := sr.DecodeBytes()
+			sr := &SingleResult{rdr: r, err: errors.New("Raw error")}
+			res, err := sr.Raw()
 			resBytes := []byte(res)
 			assert.Equal(t, r, resBytes, "expected contents %v, got %v", r, resBytes)
 			assert.Equal(t, sr.err, err, "expected error %v, got %v", sr.err, err)
@@ -88,16 +88,16 @@ func TestNewSingleResultFromDocument(t *testing.T) {
 		// Assert that first, decoded document is as expected.
 		findOneResultBytes, err := bson.Marshal(findOneResult)
 		assert.Nil(t, err, "Marshal error: %v", err)
-		expectedDecoded := bson.Raw(findOneResultBytes)
-		decoded, err := res.DecodeBytes()
-		assert.Nil(t, err, "DecodeBytes error: %v", err)
-		assert.Equal(t, expectedDecoded, decoded,
-			"expected decoded SingleResult to be %v, got %v", expectedDecoded, decoded)
+		expectedRawBytes := bson.Raw(findOneResultBytes)
+		rawBytes, err := res.Raw()
+		assert.Nil(t, err, "Raw error: %v", err)
+		assert.Equal(t, expectedRawBytes, rawBytes,
+			"expected decoded SingleResult to be %v, got %v", expectedRawBytes, rawBytes)
 
 		// Assert that RDR contents are set correctly after Decode.
 		assert.NotNil(t, res.rdr, "expected non-nil rdr contents")
-		assert.Equal(t, expectedDecoded, res.rdr,
-			"expected RDR contents to be %v, got %v", expectedDecoded, res.rdr)
+		assert.Equal(t, expectedRawBytes, res.rdr,
+			"expected RDR contents to be %v, got %v", expectedRawBytes, res.rdr)
 
 		// Assert that a call to cur.Next will return false, as there was only one document in
 		// the slice passed to NewSingleResultFromDocument.
@@ -117,9 +117,9 @@ func TestNewSingleResultFromDocument(t *testing.T) {
 		mockErr := fmt.Errorf("mock error")
 		res := NewSingleResultFromDocument(bson.D{}, mockErr, nil)
 
-		// Assert that decoding returns the mocked error.
-		_, err := res.DecodeBytes()
-		assert.NotNil(t, err, "expected DecodeBytes error, got nil")
+		// Assert that the raw bytes returns the mocked error.
+		_, err := res.Raw()
+		assert.NotNil(t, err, "expected Raw error, got nil")
 		assert.Equal(t, mockErr, err, "expected error %v, got %v", mockErr, err)
 
 		// Check for error on SingleResult.

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -613,7 +613,7 @@ func getServerVersion(db *Database) (string, error) {
 	serverStatus, err := db.RunCommand(
 		context.Background(),
 		bson.D{{"serverStatus", 1}},
-	).DecodeBytes()
+	).Raw()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2979

## Summary
<!--- A summary of the changes proposed by this pull request. -->
Cherry-pick https://github.com/mongodb/mongo-go-driver/commit/da5f54a90326fa5c90796b1a0fffc8429c644f70 and remove SingleResult.DecodeBytes .


## Background & Motivation
<!--- Rationale for the pull request. -->
The method SingleResult.DecodeBytes is a misnomer because it does not decode the result, but returns the raw bytes. It would be better to rename it SingleResult.Raw instead.
