### PR TITLE
GODRIVER-2256 Replace production context.TODO() with context.Backgrou…

### DIFF
--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -149,7 +149,7 @@ func New(cfg *Config) (*Topology, error) {
 	}
 	t.desc.Store(description.Topology{})
 	t.updateCallback = func(desc description.Server) description.Server {
-		return t.apply(context.TODO(), desc)
+		return t.apply(context.Background(), desc)
 	}
 
 	if t.cfg.URI != "" {


### PR DESCRIPTION
[GODRIVER-2256](https://jira.mongodb.org/browse/GODRIVER-2256)

## Summary
Replaced instance of `context.TODO()` with `context.Background()` from `x/mongo/driver/topology/topology.go`.

## Background & Motivation
There is just one instance of `context.TODO()` outside of examples and tests.  
Trivial but closes an issue.

