### PR TITLE
GODRIVER-961 Change IndexView.DropAll to not return bson.Raw

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -425,16 +425,18 @@ func (iv IndexView) DropOne(ctx context.Context, name string, opts ...*options.D
 	return iv.drop(ctx, name, opts...)
 }
 
-// DropAll executes a dropIndexes operation to drop all indexes on the collection. If the operation succeeds, this
-// returns a BSON document in the form {nIndexesWas: <int32>}. The "nIndexesWas" field in the response contains the
-// number of indexes that existed prior to the drop.
+// DropAll executes a dropIndexes operation to drop all indexes on the
+// collection.
 //
-// The opts parameter can be used to specify options for this operation (see the options.DropIndexesOptions
-// documentation).
+// The opts parameter can be used to specify options for this operation (see the
+// options.DropIndexesOptions documentation).
 //
-// For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/dropIndexes/.
-func (iv IndexView) DropAll(ctx context.Context, opts ...*options.DropIndexesOptions) (bson.Raw, error) {
-	return iv.drop(ctx, "*", opts...)
+// For more information about the command, see
+// https://www.mongodb.com/docs/manual/reference/command/dropIndexes/.
+func (iv IndexView) DropAll(ctx context.Context, opts ...*options.DropIndexesOptions) error {
+	_, err := iv.drop(ctx, "*", opts...)
+
+	return err
 }
 
 func getOrGenerateIndexName(keySpecDocument bsoncore.Document, model IndexModel) (string, error) {

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -618,7 +618,7 @@ func TestIndexView(t *testing.T) {
 		})
 		assert.Nil(mt, err, "CreateMany error: %v", err)
 		assert.Equal(mt, 2, len(names), "expected 2 index names, got %v", len(names))
-		_, err = iv.DropAll(context.Background())
+		err = iv.DropAll(context.Background())
 		assert.Nil(mt, err, "DropAll error: %v", err)
 
 		cursor, err := iv.List(context.Background())

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -607,8 +607,8 @@ func executeDropIndexes(ctx context.Context, operation *operation) (*operationRe
 		}
 	}
 
-	res, err := coll.Indexes().DropAll(ctx, dropIndexOpts)
-	return newDocumentResult(res, err), nil
+	err = coll.Indexes().DropAll(ctx, dropIndexOpts)
+	return newDocumentResult(nil, err), nil
 }
 
 func executeDropSearchIndex(ctx context.Context, operation *operation) (*operationResult, error) {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-961

## Summary
<!--- A summary of the changes proposed by this pull request. -->

Remove server response from IndexView.DropAll.

## Background & Motivation
<!--- Rationale for the pull request. -->
Dropping an index replies with a superset of the following message: `{nIndexesWas: n}`, where `n`  indicates the number of indexes there were prior to removing whichever index(es) were dropped. In the case of DropAll this number is always `m - 1`, where m is the total number of indexes. We can simplify the DropAll method by removing the server response.
