### PR TITLE
GODRIVER-2582 Accept any value for "documents" in InsertMany

### DIFF
--- a/mongo/collection_test.go
+++ b/mongo/collection_test.go
@@ -141,10 +141,13 @@ func TestCollection(t *testing.T) {
 		assert.Equal(t, ErrNilDocument, err, "expected error %v, got %v", ErrNilDocument, err)
 
 		_, err = coll.InsertMany(bgCtx, nil)
-		assert.Equal(t, ErrEmptySlice, err, "expected error %v, got %v", ErrEmptySlice, err)
+		assert.Equal(t, ErrNotSlice, err, "expected error %v, got %v", ErrNotSlice, err)
 
 		_, err = coll.InsertMany(bgCtx, []interface{}{})
 		assert.Equal(t, ErrEmptySlice, err, "expected error %v, got %v", ErrEmptySlice, err)
+
+		_, err = coll.InsertMany(bgCtx, "x")
+		assert.Equal(t, ErrNotSlice, err, "expected error %v, got %v", ErrNotSlice, err)
 
 		_, err = coll.DeleteOne(bgCtx, nil)
 		assert.Equal(t, ErrNilDocument, err, "expected error %v, got %v", ErrNilDocument, err)

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -36,6 +36,9 @@ var ErrNilValue = errors.New("value is nil")
 // ErrEmptySlice is returned when an empty slice is passed to a CRUD method that requires a non-empty slice.
 var ErrEmptySlice = errors.New("must provide at least one element in input slice")
 
+// ErrNotSlice is returned when a type other than slice is passed to InsertMany.
+var ErrNotSlice = errors.New("must provide a non-empty slice")
+
 // ErrMapForOrderedArgument is returned when a map with multiple keys is passed to a CRUD method for an ordered parameter
 type ErrMapForOrderedArgument struct {
 	ParamName string


### PR DESCRIPTION
[GODRIVER-2582](https://jira.mongodb.org/projects/GODRIVER/issues/GODRIVER-2582)

## Summary
Update `collection.InsertMany()` to accept `interface{}` instead of `[]interface{}`. Use reflection to convert to `[]interface{}` internally.

## Background & Motivation
Accepting `[]interface{}` forces the users to do this every time.