### PR TITLE
GODRIVER-2046 Return clearer error when truncating a float64 to float32

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	defaultValueDecoders DefaultValueDecoders
-	errCannotTruncate    = errors.New("float64 can only be truncated to an integer type when truncation is enabled")
+	errCannotTruncate    = errors.New("float64 can only be truncated to a lower precision type when truncation is enabled")
 )
 
 type decodeBinaryError struct {


### PR DESCRIPTION
GODRIVER-2046

## Summary
Update error text.

## Background & Motivation
Just ran into this today and it caused me a little friction. It seems like a simple enough fix.
