### PR TITLE
GODRIVER-979 Remove context.Context parameter to mongo.Connect

### DIFF
--- a/benchmark/operation_test.go
+++ b/benchmark/operation_test.go
@@ -32,7 +32,7 @@ func BenchmarkClientWrite(b *testing.B) {
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			client, err := mongo.Connect(context.Background(), bm.opt)
+			client, err := mongo.Connect(bm.opt)
 			if err != nil {
 				b.Fatalf("error creating client: %v", err)
 			}
@@ -71,7 +71,7 @@ func BenchmarkClientBulkWrite(b *testing.B) {
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			client, err := mongo.Connect(context.Background(), bm.opt)
+			client, err := mongo.Connect(bm.opt)
 			if err != nil {
 				b.Fatalf("error creating client: %v", err)
 			}
@@ -115,7 +115,7 @@ func BenchmarkClientRead(b *testing.B) {
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			client, err := mongo.Connect(context.Background(), bm.opt)
+			client, err := mongo.Connect(bm.opt)
 			if err != nil {
 				b.Fatalf("error creating client: %v", err)
 			}

--- a/benchmark/single.go
+++ b/benchmark/single.go
@@ -29,7 +29,7 @@ func getClientDB(ctx context.Context) (*mongo.Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(cs.String()))
+	client, err := mongo.Connect(options.Client().ApplyURI(cs.String()))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/testatlas/main.go
+++ b/cmd/testatlas/main.go
@@ -50,7 +50,7 @@ func main() {
 }
 
 func runTest(ctx context.Context, clientOpts *options.ClientOptions) error {
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		return fmt.Errorf("Connect error: %v", err)
 	}

--- a/cmd/testaws/main.go
+++ b/cmd/testaws/main.go
@@ -20,7 +20,7 @@ func main() {
 	uri := os.Getenv("MONGODB_URI")
 	ctx := context.Background()
 
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	client, err := mongo.Connect(options.Client().ApplyURI(uri))
 	if err != nil {
 		panic(fmt.Sprintf("Connect error: %v", err))
 	}

--- a/cmd/testentauth/main.go
+++ b/cmd/testentauth/main.go
@@ -21,9 +21,7 @@ func main() {
 	uri := os.Getenv("MONGODB_URI")
 	compressor := os.Getenv("MONGO_GO_DRIVER_COMPRESSOR")
 
-	client, err := mongo.Connect(
-		context.Background(),
-		options.Client().ApplyURI(uri).SetCompressors([]string{compressor}))
+	client, err := mongo.Connect(options.Client().ApplyURI(uri).SetCompressors([]string{compressor}))
 	if err != nil {
 		log.Fatalf("Error connecting client: %v", err)
 	}

--- a/cmd/testkms/main.go
+++ b/cmd/testkms/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	cOpts := options.Client().ApplyURI(uri)
-	keyVaultClient, err := mongo.Connect(context.Background(), cOpts)
+	keyVaultClient, err := mongo.Connect(cOpts)
 	if err != nil {
 		panic(fmt.Sprintf("Connect error: %v", err))
 	}

--- a/event/examples_test.go
+++ b/event/examples_test.go
@@ -47,7 +47,7 @@ func ExampleCommandMonitor() {
 		},
 	}
 	clientOpts := options.Client().ApplyURI("mongodb://localhost:27017").SetMonitor(cmdMonitor)
-	client, err := mongo.Connect(context.Background(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/documentation_examples/examples.go
+++ b/examples/documentation_examples/examples.go
@@ -1964,7 +1964,7 @@ func WithTransactionExample(ctx context.Context) error {
 	uri := mtest.ClusterURI()
 
 	clientOpts := options.Client().ApplyURI(uri)
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		return err
 	}
@@ -2770,7 +2770,6 @@ func IndexExamples(t *testing.T, db *mongo.Database) {
 
 // StableAPIExample is an example of creating a client with stable API.
 func StableAPIExample() {
-	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2779,11 +2778,11 @@ func StableAPIExample() {
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = client.Disconnect(ctx) }()
+	defer func() { _ = client.Disconnect(context.TODO()) }()
 }
 
 // End Versioned API Example 1
@@ -2792,7 +2791,6 @@ func StableAPIExample() {
 
 // StableAPIStrictExample is an example of creating a client with strict stable API.
 func StableAPIStrictExample() {
-	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2801,11 +2799,11 @@ func StableAPIStrictExample() {
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = client.Disconnect(ctx) }()
+	defer func() { _ = client.Disconnect(context.TODO()) }()
 }
 
 // End Versioned API Example 2
@@ -2814,7 +2812,6 @@ func StableAPIStrictExample() {
 
 // StableAPINonStrictExample is an example of creating a client with non-strict stable API.
 func StableAPINonStrictExample() {
-	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2823,11 +2820,11 @@ func StableAPINonStrictExample() {
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(false)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = client.Disconnect(ctx) }()
+	defer func() { _ = client.Disconnect(context.TODO()) }()
 }
 
 // End Versioned API Example 3
@@ -2837,7 +2834,6 @@ func StableAPINonStrictExample() {
 // StableAPIDeprecationErrorsExample is an example of creating a client with stable API
 // with deprecation errors.
 func StableAPIDeprecationErrorsExample() {
-	ctx := context.TODO()
 	// For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
 	// uri := "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl"
 	// For a sharded cluster, connect to the mongos instances; e.g.
@@ -2846,11 +2842,11 @@ func StableAPIDeprecationErrorsExample() {
 
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetDeprecationErrors(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = client.Disconnect(ctx) }()
+	defer func() { _ = client.Disconnect(context.TODO()) }()
 }
 
 // End Versioned API Example 4
@@ -2867,7 +2863,7 @@ func StableAPIStrictCountExample(t *testing.T) {
 	serverAPIOptions := options.ServerAPI(options.ServerAPIVersion1).SetStrict(true)
 	clientOpts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPIOptions)
 
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	require.Nil(t, err, "Connect error: %v", err)
 	defer func() { _ = client.Disconnect(context.TODO()) }()
 

--- a/examples/documentation_examples/examples_test.go
+++ b/examples/documentation_examples/examples_test.go
@@ -44,7 +44,7 @@ func TestDocumentationExamples(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(mtest.ClusterURI()))
+	client, err := mongo.Connect(options.Client().ApplyURI(mtest.ClusterURI()))
 	require.NoError(t, err)
 	defer client.Disconnect(ctx)
 

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -102,12 +102,12 @@ type Client struct {
 //
 // The Client.Ping method can be used to verify that the deployment is successfully connected and the
 // Client was correctly configured.
-func Connect(ctx context.Context, opts ...*options.ClientOptions) (*Client, error) {
+func Connect(opts ...*options.ClientOptions) (*Client, error) {
 	c, err := newClient(opts...)
 	if err != nil {
 		return nil, err
 	}
-	err = c.connect(ctx)
+	err = c.connect()
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func newClient(opts ...*options.ClientOptions) (*Client, error) {
 //
 // Connect starts background goroutines to monitor the state of the deployment and does not do any I/O in the main
 // goroutine. The Client.Ping method can be used to verify that the connection was created successfully.
-func (c *Client) connect(ctx context.Context) error {
+func (c *Client) connect() error {
 	if connector, ok := c.deployment.(driver.Connector); ok {
 		err := connector.Connect()
 		if err != nil {
@@ -246,25 +246,25 @@ func (c *Client) connect(ctx context.Context) error {
 	}
 
 	if c.mongocryptdFLE != nil {
-		if err := c.mongocryptdFLE.connect(ctx); err != nil {
+		if err := c.mongocryptdFLE.connect(); err != nil {
 			return err
 		}
 	}
 
 	if c.internalClientFLE != nil {
-		if err := c.internalClientFLE.connect(ctx); err != nil {
+		if err := c.internalClientFLE.connect(); err != nil {
 			return err
 		}
 	}
 
 	if c.keyVaultClientFLE != nil && c.keyVaultClientFLE != c.internalClientFLE && c.keyVaultClientFLE != c {
-		if err := c.keyVaultClientFLE.connect(ctx); err != nil {
+		if err := c.keyVaultClientFLE.connect(); err != nil {
 			return err
 		}
 	}
 
 	if c.metadataClientFLE != nil && c.metadataClientFLE != c.internalClientFLE && c.metadataClientFLE != c {
-		if err := c.metadataClientFLE.connect(ctx); err != nil {
+		if err := c.metadataClientFLE.connect(); err != nil {
 			return err
 		}
 	}

--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -20,9 +20,7 @@ import (
 func ExampleClient() {
 	// Create a Client and execute a ListDatabases operation.
 
-	client, err := mongo.Connect(
-		context.TODO(),
-		options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +43,7 @@ func ExampleConnect_ping() {
 	// server is running.
 
 	clientOpts := options.Client().ApplyURI("mongodb://localhost:27017")
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +72,7 @@ func ExampleConnect_replicaSet() {
 
 	clientOpts := options.Client().ApplyURI(
 		"mongodb://localhost:27017,localhost:27018/?replicaSet=replset")
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,7 +86,7 @@ func ExampleConnect_sharded() {
 
 	clientOpts := options.Client().ApplyURI(
 		"mongodb://localhost:27017,localhost:27018")
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -106,7 +104,7 @@ func ExampleConnect_sRV() {
 	// requires driver version 1.1.0 or higher.
 
 	clientOpts := options.Client().ApplyURI("mongodb+srv://mongodb.example.com")
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -120,7 +118,7 @@ func ExampleConnect_direct() {
 
 	clientOpts := options.Client().ApplyURI(
 		"mongodb://localhost:27017/?connect=direct")
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -143,7 +141,7 @@ func ExampleConnect_sCRAM() {
 	}
 	clientOpts := options.Client().ApplyURI("mongodb://localhost:27017").
 		SetAuth(credential)
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -179,7 +177,7 @@ func ExampleConnect_x509() {
 	}
 	clientOpts := options.Client().ApplyURI(uri).SetAuth(credential)
 
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -204,7 +202,7 @@ func ExampleConnect_pLAIN() {
 	clientOpts := options.Client().ApplyURI("mongodb://localhost:27017").
 		SetAuth(credential)
 
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -239,7 +237,7 @@ func ExampleConnect_kerberos() {
 	uri := "mongo-server.example.com:27017"
 	clientOpts := options.Client().ApplyURI(uri).SetAuth(credential)
 
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -288,9 +286,7 @@ func ExampleConnect_aWS() {
 		Username:      accessKeyID,
 		Password:      secretAccessKey,
 	}
-	awsIAMClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetAuth(awsCredential))
+	awsIAMClient, err := mongo.Connect(options.Client().SetAuth(awsCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -310,9 +306,7 @@ func ExampleConnect_aWS() {
 			"AWS_SESSION_TOKEN": sessionToken,
 		},
 	}
-	assumeRoleClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetAuth(assumeRoleCredential))
+	assumeRoleClient, err := mongo.Connect(options.Client().SetAuth(assumeRoleCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -332,9 +326,7 @@ func ExampleConnect_aWS() {
 	envVariablesCredential := options.Credential{
 		AuthMechanism: "MONGODB-AWS",
 	}
-	envVariablesClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetAuth(envVariablesCredential))
+	envVariablesClient, err := mongo.Connect(options.Client().SetAuth(envVariablesCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -350,9 +342,7 @@ func ExampleConnect_aWS() {
 	ecCredential := options.Credential{
 		AuthMechanism: "MONGODB-AWS",
 	}
-	ecClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetAuth(ecCredential))
+	ecClient, err := mongo.Connect(options.Client().SetAuth(ecCredential))
 	if err != nil {
 		panic(err)
 	}
@@ -381,9 +371,7 @@ func ExampleConnect_stableAPI() {
 	// ServerAPIOptions must be declared with an API version. ServerAPIVersion1
 	// is a constant equal to "1".
 	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
-	serverAPIClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetServerAPIOptions(serverAPI))
+	serverAPIClient, err := mongo.Connect(options.Client().SetServerAPIOptions(serverAPI))
 	if err != nil {
 		panic(err)
 	}
@@ -396,9 +384,7 @@ func ExampleConnect_stableAPI() {
 	// would fail because the distinct command is not part of API version 1:
 	serverAPIStrict := options.ServerAPI(options.ServerAPIVersion1).
 		SetStrict(true)
-	serverAPIStrictClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetServerAPIOptions(serverAPIStrict))
+	serverAPIStrictClient, err := mongo.Connect(options.Client().SetServerAPIOptions(serverAPIStrict))
 	if err != nil {
 		panic(err)
 	}
@@ -415,9 +401,7 @@ func ExampleConnect_stableAPI() {
 	// at the time of this writing, no deprecations in API version 1 exist.
 	serverAPIDeprecation := options.ServerAPI(options.ServerAPIVersion1).
 		SetDeprecationErrors(true)
-	serverAPIDeprecationClient, err := mongo.Connect(
-		context.TODO(),
-		options.Client().SetServerAPIOptions(serverAPIDeprecation))
+	serverAPIDeprecationClient, err := mongo.Connect(options.Client().SetServerAPIOptions(serverAPIDeprecation))
 	if err != nil {
 		panic(err)
 	}
@@ -442,7 +426,7 @@ func ExampleConnect_bSONOptions() {
 		ApplyURI("mongodb://localhost:27017").
 		SetBSONOptions(bsonOpts)
 
-	client, err := mongo.Connect(context.TODO(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}

--- a/mongo/client_side_encryption_examples_test.go
+++ b/mongo/client_side_encryption_examples_test.go
@@ -39,7 +39,7 @@ func Example_clientSideEncryption() {
 	clientOpts := options.Client().
 		ApplyURI(uri).
 		SetAutoEncryptionOptions(autoEncryptionOpts)
-	client, err := Connect(context.TODO(), clientOpts)
+	client, err := Connect(clientOpts)
 	if err != nil {
 		log.Fatalf("Connect error: %v", err)
 	}
@@ -78,9 +78,7 @@ func Example_clientSideEncryptionCreateKey() {
 	clientEncryptionOpts := options.ClientEncryption().
 		SetKeyVaultNamespace(keyVaultNamespace).
 		SetKmsProviders(kmsProviders)
-	keyVaultClient, err := Connect(
-		context.TODO(),
-		options.Client().ApplyURI(uri))
+	keyVaultClient, err := Connect(options.Client().ApplyURI(uri))
 	if err != nil {
 		log.Fatalf("Connect error for keyVaultClient: %v", err)
 	}
@@ -142,7 +140,7 @@ func Example_clientSideEncryptionCreateKey() {
 	clientOptions := options.Client().
 		ApplyURI(uri).
 		SetAutoEncryptionOptions(autoEncryptionOpts)
-	client, err := Connect(context.TODO(), clientOptions)
+	client, err := Connect(clientOptions)
 	if err != nil {
 		log.Fatalf("Connect error for encrypted client: %v", err)
 	}
@@ -169,9 +167,7 @@ func Example_explictEncryption() {
 	keyVaultNamespace := keyVaultDBName + "." + keyVaultCollName
 
 	// The Client used to read/write application data.
-	client, err := Connect(
-		context.TODO(),
-		options.Client().ApplyURI("mongodb://localhost:27017"))
+	client, err := Connect(options.Client().ApplyURI("mongodb://localhost:27017"))
 	if err != nil {
 		panic(err)
 	}
@@ -294,7 +290,7 @@ func Example_explictEncryptionWithAutomaticDecryption() {
 	clientOpts := options.Client().
 		ApplyURI("mongodb://localhost:27017").
 		SetAutoEncryptionOptions(autoEncryptionOpts)
-	client, err := Connect(context.TODO(), clientOpts)
+	client, err := Connect(clientOpts)
 	if err != nil {
 		panic(err)
 	}

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -357,7 +357,7 @@ func TestClient(t *testing.T) {
 				clientOpts := options.Client().ApplyURI(cs.Original).SetReadPreference(readpref.Primary()).
 					SetWriteConcern(writeconcern.Majority()).SetMonitor(cmdMonitor)
 				integtest.AddTestServerAPIVersion(clientOpts)
-				client, err := Connect(bgCtx, clientOpts)
+				client, err := Connect(clientOpts)
 				assert.Nil(t, err, "Connect error: %v", err)
 				defer func() {
 					_ = client.Disconnect(bgCtx)

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -1080,7 +1080,7 @@ func ExampleCollection_Find_primitiveRegex() {
 	clientOptions := options.Client().ApplyURI("mongodb://localhost:27017")
 
 	// Connect to a mongodb server.
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		panic(err)
 	}
@@ -1121,7 +1121,7 @@ func ExampleCollection_Find_regex() {
 	clientOptions := options.Client().ApplyURI("mongodb://localhost:27017")
 
 	// Connect to a mongodb server.
-	client, err := mongo.Connect(ctx, clientOptions)
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		panic(err)
 	}

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -97,7 +97,7 @@ func TestDatabase(t *testing.T) {
 	})
 	t.Run("TransientTransactionError label", func(t *testing.T) {
 		client := setupClient(options.Client().ApplyURI("mongodb://nonexistent").SetServerSelectionTimeout(3 * time.Second))
-		err := client.connect(bgCtx)
+		err := client.connect()
 		defer func() { _ = client.Disconnect(bgCtx) }()
 		assert.Nil(t, err, "expected nil, got %v", err)
 

--- a/mongo/gridfs/gridfs_test.go
+++ b/mongo/gridfs/gridfs_test.go
@@ -49,7 +49,7 @@ func TestGridFS(t *testing.T) {
 		// will discover the other hosts during SDAM checks.
 		SetHosts(cs.Hosts[:1])
 
-	client, err := mongo.Connect(context.Background(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	assert.Nil(t, err, "Connect error: %v", err)
 	db := client.Database("gridfs")
 	defer func() {

--- a/mongo/integration/clam_prose_test.go
+++ b/mongo/integration/clam_prose_test.go
@@ -314,20 +314,20 @@ func TestCommandLoggingAndMonitoringProse(t *testing.T) {
 			if tcase.setup != nil {
 				clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
 
-				// Create a context with a deadline so that the
-				// test setup doesn't hang forever.
-				ctx, cancel := context.WithTimeout(ctx, deadline)
-				defer cancel()
-
 				integtest.AddTestServerAPIVersion(clientOpts)
 
-				client, err := mongo.Connect(ctx, clientOpts)
+				client, err := mongo.Connect(clientOpts)
 				assert.Nil(mt, err, "Connect error in setup: %v", err)
 
 				coll := mt.CreateCollection(mtest.Collection{
 					Name:   tcase.collectionName,
 					Client: client,
 				}, false)
+
+				// Create a context with a deadline so that the
+				// test setup doesn't hang forever.
+				ctx, cancel := context.WithTimeout(ctx, deadline)
+				defer cancel()
 
 				tcase.setup(ctx, mt, coll)
 			}
@@ -379,7 +379,7 @@ func TestCommandLoggingAndMonitoringProse(t *testing.T) {
 
 			integtest.AddTestServerAPIVersion(clientOpts)
 
-			client, err := mongo.Connect(context.Background(), clientOpts)
+			client, err := mongo.Connect(clientOpts)
 			assert.Nil(mt, err, "Connect error: %v", err)
 
 			coll := mt.CreateCollection(mtest.Collection{

--- a/mongo/integration/client_options_test.go
+++ b/mongo/integration/client_options_test.go
@@ -24,7 +24,7 @@ func TestClientOptions_CustomDialer(t *testing.T) {
 	cs := integtest.ConnString(t)
 	opts := options.Client().ApplyURI(cs.String()).SetDialer(td)
 	integtest.AddTestServerAPIVersion(opts)
-	client, err := mongo.Connect(context.Background(), opts)
+	client, err := mongo.Connect(opts)
 	require.NoError(t, err)
 	_, err = client.ListDatabases(context.Background(), bson.D{})
 	require.NoError(t, err)

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -181,7 +181,7 @@ func TestClient(t *testing.T) {
 				)
 				authClientOpts := options.Client().ApplyURI(cs)
 				integtest.AddTestServerAPIVersion(authClientOpts)
-				authClient, err := mongo.Connect(context.Background(), authClientOpts)
+				authClient, err := mongo.Connect(authClientOpts)
 				assert.Nil(mt, err, "authClient Connect error: %v", err)
 				defer func() { _ = authClient.Disconnect(context.Background()) }()
 
@@ -326,7 +326,7 @@ func TestClient(t *testing.T) {
 				SetServerSelectionTimeout(100 * time.Millisecond).SetHosts([]string{"invalid:123"}).
 				SetConnectTimeout(500 * time.Millisecond).SetSocketTimeout(500 * time.Millisecond)
 			integtest.AddTestServerAPIVersion(invalidClientOpts)
-			client, err := mongo.Connect(context.Background(), invalidClientOpts)
+			client, err := mongo.Connect(invalidClientOpts)
 			assert.Nil(mt, err, "Connect error: %v", err)
 			err = client.Ping(context.Background(), readpref.Primary())
 			assert.NotNil(mt, err, "expected error for pinging invalid host, got nil")

--- a/mongo/integration/crud_helpers_test.go
+++ b/mongo/integration/crud_helpers_test.go
@@ -124,7 +124,7 @@ func runCommandOnAllServers(commandFn func(client *mongo.Client) error) error {
 	integtest.AddTestServerAPIVersion(opts)
 
 	if mtest.ClusterTopologyKind() != mtest.Sharded {
-		client, err := mongo.Connect(context.Background(), opts)
+		client, err := mongo.Connect(opts)
 		if err != nil {
 			return fmt.Errorf("error creating replica set client: %v", err)
 		}
@@ -134,7 +134,7 @@ func runCommandOnAllServers(commandFn func(client *mongo.Client) error) error {
 	}
 
 	for _, host := range opts.Hosts {
-		shardClient, err := mongo.Connect(context.Background(), opts.SetHosts([]string{host}))
+		shardClient, err := mongo.Connect(opts.SetHosts([]string{host}))
 		if err != nil {
 			return fmt.Errorf("error creating client for mongos %v: %v", host, err)
 		}
@@ -1385,7 +1385,7 @@ func executeAdminCommand(mt *mtest.T, op *operation) {
 	// Per the streamable hello test format description, a separate client must be used to execute this operation.
 	clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
 	integtest.AddTestServerAPIVersion(clientOpts)
-	client, err := mongo.Connect(context.Background(), clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	assert.Nil(mt, err, "Connect error: %v", err)
 	defer func() {
 		_ = client.Disconnect(context.Background())

--- a/mongo/integration/csot_prose_test.go
+++ b/mongo/integration/csot_prose_test.go
@@ -57,7 +57,7 @@ func TestCSOTProse(t *testing.T) {
 			SetMonitor(cm).
 			ApplyURI(mtest.ClusterURI())
 		integtest.AddTestServerAPIVersion(cliOptions)
-		cli, err := mongo.Connect(context.Background(), cliOptions)
+		cli, err := mongo.Connect(cliOptions)
 		assert.Nil(mt, err, "Connect error: %v", err)
 
 		// Insert 50 1MB documents (OP_MSG payloads can only fit 48MB in one batch).

--- a/mongo/integration/errors_test.go
+++ b/mongo/integration/errors_test.go
@@ -86,7 +86,7 @@ func TestErrors(t *testing.T) {
 
 			clientOpts := options.Client().ApplyURI(mtest.ClusterURI())
 			integtest.AddTestServerAPIVersion(clientOpts)
-			client, err := mongo.Connect(context.Background(), clientOpts)
+			client, err := mongo.Connect(clientOpts)
 			assert.Nil(mt, err, "Connect error: %v", err)
 			defer func() { _ = client.Disconnect(context.Background()) }()
 

--- a/mongo/integration/initial_dns_seedlist_discovery_test.go
+++ b/mongo/integration/initial_dns_seedlist_discovery_test.go
@@ -76,7 +76,7 @@ func runSeedlistDiscoveryDirectory(mt *mtest.T, subdirectory string) {
 func runSeedlistDiscoveryPingTest(mt *mtest.T, clientOpts *options.ClientOptions) {
 	ctx := context.Background()
 
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	assert.Nil(mt, err, "Connect error: %v", err)
 
 	defer func() { _ = client.Disconnect(ctx) }()

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -684,13 +684,13 @@ func (t *T) createTestClient() {
 		// pin to first mongos
 		pinnedHostList := []string{testContext.connString.Hosts[0]}
 		uriOpts := options.Client().ApplyURI(testContext.connString.Original).SetHosts(pinnedHostList)
-		t.Client, err = mongo.Connect(context.Background(), uriOpts, clientOpts)
+		t.Client, err = mongo.Connect(uriOpts, clientOpts)
 	case Mock:
 		// clear pool monitor to avoid configuration error
 		clientOpts.PoolMonitor = nil
 		t.mockDeployment = newMockDeployment()
 		clientOpts.Deployment = t.mockDeployment
-		t.Client, err = mongo.Connect(context.Background(), clientOpts)
+		t.Client, err = mongo.Connect(clientOpts)
 	case Proxy:
 		t.proxyDialer = newProxyDialer()
 		clientOpts.SetDialer(t.proxyDialer)
@@ -708,7 +708,7 @@ func (t *T) createTestClient() {
 		}
 
 		// Pass in uriOpts first so clientOpts wins if there are any conflicting settings.
-		t.Client, err = mongo.Connect(context.Background(), uriOpts, clientOpts)
+		t.Client, err = mongo.Connect(uriOpts, clientOpts)
 	}
 	if err != nil {
 		t.Fatalf("error creating client: %v", err)

--- a/mongo/integration/mtest/setup.go
+++ b/mongo/integration/mtest/setup.go
@@ -65,7 +65,7 @@ func setupClient(opts *options.ClientOptions) (*mongo.Client, error) {
 	}
 	// for sharded clusters, pin to one host. Due to how the cache is implemented on 4.0 and 4.2, behavior
 	// can be inconsistent when multiple mongoses are used
-	return mongo.Connect(context.Background(), opts.SetWriteConcern(wcMajority).SetHosts(opts.Hosts[:1]))
+	return mongo.Connect(opts.SetWriteConcern(wcMajority).SetHosts(opts.Hosts[:1]))
 }
 
 // Setup initializes the current testing context.

--- a/mongo/integration/sessions_mongocryptd_prose_test.go
+++ b/mongo/integration/sessions_mongocryptd_prose_test.go
@@ -100,9 +100,7 @@ func newTestSessionMongocryptdProseClient(mt *mtest.T) *mongo.Client {
 		ApplyURI(uri.String()).
 		SetMonitor(cmdMonitor)
 
-	ctx := context.Background()
-
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	require.NoError(mt, err, "could not connect to mongocryptd: %v", err)
 
 	return client

--- a/mongo/integration/unified/admin_helpers.go
+++ b/mongo/integration/unified/admin_helpers.go
@@ -86,7 +86,7 @@ func runCommandOnHost(ctx context.Context, host string, commandFn func(context.C
 		SetHosts([]string{host})
 	integtest.AddTestServerAPIVersion(clientOpts)
 
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		return fmt.Errorf("error creating client to host %q: %v", host, err)
 	}

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -189,7 +189,7 @@ func newClientEntity(ctx context.Context, em *EntityMap, entityOptions *entityOp
 		entity.ignoredCommands[cmd] = struct{}{}
 	}
 
-	client, err := mongo.Connect(ctx, clientOpts)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error creating mongo.Client: %w", err)
 	}

--- a/mongo/integration/unified_spec_test.go
+++ b/mongo/integration/unified_spec_test.go
@@ -468,7 +468,7 @@ func executeTestRunnerOperation(mt *mtest.T, testCase *testCase, op *operation, 
 		targetHost := clientSession.PinnedServer.Addr.String()
 		opts := options.Client().ApplyURI(mtest.ClusterURI()).SetHosts([]string{targetHost})
 		integtest.AddTestServerAPIVersion(opts)
-		client, err := mongo.Connect(context.Background(), opts)
+		client, err := mongo.Connect(opts)
 		if err != nil {
 			return fmt.Errorf("Connect error for targeted client: %v", err)
 		}

--- a/mongo/mongocryptd.go
+++ b/mongo/mongocryptd.go
@@ -113,8 +113,8 @@ func (mc *mongocryptdClient) markCommand(ctx context.Context, dbName string, cmd
 }
 
 // connect connects the underlying Client instance. This must be called before performing any mark operations.
-func (mc *mongocryptdClient) connect(ctx context.Context) error {
-	return mc.client.connect(ctx)
+func (mc *mongocryptdClient) connect() error {
+	return mc.client.connect()
 }
 
 // disconnect disconnects the underlying Client instance. This should be called after all operations have completed.

--- a/mongo/ocsp_test.go
+++ b/mongo/ocsp_test.go
@@ -32,7 +32,7 @@ func TestOCSP(t *testing.T) {
 
 	t.Run("tls", func(t *testing.T) {
 		clientOpts := createOCSPClientOptions(cs.Original)
-		client, err := Connect(bgCtx, clientOpts)
+		client, err := Connect(clientOpts)
 		assert.Nil(t, err, "Connect error: %v", err)
 		defer func() { _ = client.Disconnect(bgCtx) }()
 
@@ -47,7 +47,7 @@ func TestOCSP(t *testing.T) {
 	})
 	t.Run("tlsInsecure", func(t *testing.T) {
 		clientOpts := createInsecureOCSPClientOptions(cs.Original)
-		client, err := Connect(bgCtx, clientOpts)
+		client, err := Connect(clientOpts)
 		assert.Nil(t, err, "Connect error: %v", err)
 		defer func() { _ = client.Disconnect(bgCtx) }()
 

--- a/mongo/options/example_test.go
+++ b/mongo/options/example_test.go
@@ -53,7 +53,7 @@ func ExampleClientOptions_SetLoggerOptions_customLogger() {
 		ApplyURI("mongodb://localhost:27017").
 		SetLoggerOptions(loggerOptions)
 
-	client, err := mongo.Connect(context.TODO(), clientOptions)
+	client, err := mongo.Connect(clientOptions)
 
 	if err != nil {
 		log.Fatalf("error connecting to MongoDB: %v", err)

--- a/mongo/readpref/options_example_test.go
+++ b/mongo/readpref/options_example_test.go
@@ -7,8 +7,6 @@
 package readpref_test
 
 import (
-	"context"
-
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -27,7 +25,7 @@ func ExampleWithTags() {
 		ApplyURI("mongodb://localhost:27017").
 		SetReadPreference(rp)
 
-	_, err := mongo.Connect(context.Background(), opts)
+	_, err := mongo.Connect(opts)
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +53,7 @@ func ExampleWithTagSets() {
 		ApplyURI("mongodb://localhost").
 		SetReadPreference(rp)
 
-	_, err := mongo.Connect(context.Background(), opts)
+	_, err := mongo.Connect(opts)
 	if err != nil {
 		panic(err)
 	}

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -587,7 +587,7 @@ func setupConvenientTransactions(t *testing.T, extraClientOpts ...*options.Clien
 	fullClientOpts := []*options.ClientOptions{baseClientOpts}
 	fullClientOpts = append(fullClientOpts, extraClientOpts...)
 
-	client, err := Connect(bgCtx, fullClientOpts...)
+	client, err := Connect(fullClientOpts...)
 	assert.Nil(t, err, "Connect error: %v", err)
 
 	version, err := getServerVersion(client.Database("admin"))
@@ -604,7 +604,7 @@ func setupConvenientTransactions(t *testing.T, extraClientOpts ...*options.Clien
 	// For sharded clusters, disconnect the previous Client and create a new one that's pinned to a single mongos.
 	_ = client.Disconnect(bgCtx)
 	fullClientOpts = append(fullClientOpts, options.Client().SetHosts([]string{cs.Hosts[0]}))
-	client, err = Connect(bgCtx, fullClientOpts...)
+	client, err = Connect(fullClientOpts...)
 	assert.Nil(t, err, "Connect error: %v", err)
 	return client
 }

--- a/mongo/writeconcern/writeconcern_example_test.go
+++ b/mongo/writeconcern/writeconcern_example_test.go
@@ -7,8 +7,6 @@
 package writeconcern_test
 
 import (
-	"context"
-
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
@@ -23,7 +21,7 @@ func Example_majority() {
 		ApplyURI("mongodb://localhost:27017").
 		SetWriteConcern(wc)
 
-	_, err := mongo.Connect(context.Background(), opts)
+	_, err := mongo.Connect(opts)
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +39,7 @@ func Example_w2Journaled() {
 		ApplyURI("mongodb://localhost:27017").
 		SetWriteConcern(wc)
 
-	_, err := mongo.Connect(context.Background(), opts)
+	_, err := mongo.Connect(opts)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
[GODRIVER-979](https://jira.mongodb.org/browse/GODRIVER-979)

## Summary
Removed `context.context` parameter from `Connect()` and `client.connect()` and updated all calls to `client.connect()`

## Background & Motivation
The context parameter is not being used and misleads the user. See [GO-DRIVER-1031](https://jira.mongodb.org/browse/GODRIVER-1031).