### PR TITLE
GODRIVER-2693 Rename event constants to match event names

### DIFF
--- a/event/doc.go
+++ b/event/doc.go
@@ -30,9 +30,9 @@
 //	poolMonitor := &event.PoolMonitor{
 //	  Event: func(evt *event.PoolEvent) {
 //	    switch evt.Type {
-//	    case event.GetSucceeded:
+//	    case event.ConnectionCheckedOut:
 //	      connsCheckedOut++
-//	    case event.ConnectionReturned:
+//	    case event.ConnectionCheckedIn:
 //	      connsCheckedOut--
 //	    }
 //	  },

--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -77,17 +77,17 @@ const (
 
 // strings for pool command monitoring types
 const (
-	PoolCreated        = "ConnectionPoolCreated"
-	PoolReady          = "ConnectionPoolReady"
-	PoolCleared        = "ConnectionPoolCleared"
-	PoolClosedEvent    = "ConnectionPoolClosed"
-	ConnectionCreated  = "ConnectionCreated"
-	ConnectionReady    = "ConnectionReady"
-	ConnectionClosed   = "ConnectionClosed"
-	GetStarted         = "ConnectionCheckOutStarted"
-	GetFailed          = "ConnectionCheckOutFailed"
-	GetSucceeded       = "ConnectionCheckedOut"
-	ConnectionReturned = "ConnectionCheckedIn"
+	PoolCreated               = "ConnectionPoolCreated"
+	PoolReady                 = "ConnectionPoolReady"
+	PoolCleared               = "ConnectionPoolCleared"
+	PoolClosedEvent           = "ConnectionPoolClosed"
+	ConnectionCreated         = "ConnectionCreated"
+	ConnectionReady           = "ConnectionReady"
+	ConnectionClosed          = "ConnectionClosed"
+	ConnectionCheckOutStarted = "ConnectionCheckOutStarted"
+	ConnectionCheckOutFailed  = "ConnectionCheckOutFailed"
+	ConnectionCheckedOut      = "ConnectionCheckedOut"
+	ConnectionCheckedIn       = "ConnectionCheckedIn"
 )
 
 // MonitorPoolOptions contains pool options as formatted in pool events

--- a/mongo/gridfs/gridfs_test.go
+++ b/mongo/gridfs/gridfs_test.go
@@ -32,9 +32,9 @@ func TestGridFS(t *testing.T) {
 	poolMonitor := &event.PoolMonitor{
 		Event: func(evt *event.PoolEvent) {
 			switch evt.Type {
-			case event.GetSucceeded:
+			case event.ConnectionCheckedOut:
 				connsCheckedOut++
-			case event.ConnectionReturned:
+			case event.ConnectionCheckedIn:
 				connsCheckedOut--
 			}
 		},

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -669,9 +669,9 @@ func (t *T) createTestClient() {
 				}
 
 				switch evt.Type {
-				case event.GetSucceeded:
+				case event.ConnectionCheckedOut:
 					atomic.AddInt64(&t.connsCheckedOut, 1)
-				case event.ConnectionReturned:
+				case event.ConnectionCheckedIn:
 					atomic.AddInt64(&t.connsCheckedOut, -1)
 				}
 			},

--- a/mongo/integration/retryable_reads_prose_test.go
+++ b/mongo/integration/retryable_reads_prose_test.go
@@ -75,22 +75,22 @@ func TestRetryableReadsProse(t *testing.T) {
 		}
 		wg.Wait()
 
-		// Gather GetSucceeded, GetFailed and PoolCleared pool events.
+		// Gather ConnectionCheckedOut, ConnectionCheckOutFailed and PoolCleared pool events.
 		events := tpm.Events(func(e *event.PoolEvent) bool {
-			getSucceeded := e.Type == event.GetSucceeded
-			getFailed := e.Type == event.GetFailed
+			connectionCheckedOut := e.Type == event.ConnectionCheckedOut
+			connectionCheckOutFailed := e.Type == event.ConnectionCheckOutFailed
 			poolCleared := e.Type == event.PoolCleared
-			return getSucceeded || getFailed || poolCleared
+			return connectionCheckedOut || connectionCheckOutFailed || poolCleared
 		})
 
 		// Assert that first check out succeeds, pool is cleared, and second check
 		// out fails due to connection error.
 		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
-		assert.Equal(mt, event.GetSucceeded, events[0].Type,
+		assert.Equal(mt, event.ConnectionCheckedOut, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
 		assert.Equal(mt, event.PoolCleared, events[1].Type,
 			"expected ConnectionPoolCleared event, got %v", events[1].Type)
-		assert.Equal(mt, event.GetFailed, events[2].Type,
+		assert.Equal(mt, event.ConnectionCheckOutFailed, events[2].Type,
 			"expected ConnectionCheckedOutFailed event, got %v", events[2].Type)
 		assert.Equal(mt, event.ReasonConnectionErrored, events[2].Reason,
 			"expected check out failure due to connection error, failed due to %q", events[2].Reason)

--- a/mongo/integration/retryable_writes_prose_test.go
+++ b/mongo/integration/retryable_writes_prose_test.go
@@ -188,22 +188,22 @@ func TestRetryableWritesProse(t *testing.T) {
 		}
 		wg.Wait()
 
-		// Gather GetSucceeded, GetFailed and PoolCleared pool events.
+		// Gather ConnectionCheckedOut, ConnectionCheckOutFailed and PoolCleared pool events.
 		events := tpm.Events(func(e *event.PoolEvent) bool {
-			getSucceeded := e.Type == event.GetSucceeded
-			getFailed := e.Type == event.GetFailed
+			connectionCheckedOut := e.Type == event.ConnectionCheckedOut
+			connectionCheckOutFailed := e.Type == event.ConnectionCheckOutFailed
 			poolCleared := e.Type == event.PoolCleared
-			return getSucceeded || getFailed || poolCleared
+			return connectionCheckedOut || connectionCheckOutFailed || poolCleared
 		})
 
 		// Assert that first check out succeeds, pool is cleared, and second check
 		// out fails due to connection error.
 		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
-		assert.Equal(mt, event.GetSucceeded, events[0].Type,
+		assert.Equal(mt, event.ConnectionCheckedOut, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
 		assert.Equal(mt, event.PoolCleared, events[1].Type,
 			"expected ConnectionPoolCleared event, got %v", events[1].Type)
-		assert.Equal(mt, event.GetFailed, events[2].Type,
+		assert.Equal(mt, event.ConnectionCheckOutFailed, events[2].Type,
 			"expected ConnectionCheckedOutFailed event, got %v", events[2].Type)
 		assert.Equal(mt, event.ReasonConnectionErrored, events[2].Reason,
 			"expected check out failure due to connection error, failed due to %q", events[2].Reason)

--- a/mongo/integration/server_selection_prose_test.go
+++ b/mongo/integration/server_selection_prose_test.go
@@ -90,7 +90,7 @@ func runsServerSelection(mt *mtest.T, monitor *eventtest.TestPoolMonitor,
 	// Get all checkOut events and calculate the number of times each server was selected. The prose test spec says to
 	// use command monitoring events, but those don't include the server address, so use checkOut events instead.
 	checkOutEvents := monitor.Events(func(evt *event.PoolEvent) bool {
-		return evt.Type == event.GetStarted
+		return evt.Type == event.ConnectionCheckOutStarted
 	})
 	counts := make(map[string]int)
 	for _, evt := range checkOutEvents {

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -450,9 +450,9 @@ func (c *clientEntity) processPoolEvent(evt *event.PoolEvent) {
 
 	// Update the connection counter. This happens even if we're not storing any events.
 	switch evt.Type {
-	case event.GetSucceeded:
+	case event.ConnectionCheckedOut:
 		c.numConnsCheckedOut++
-	case event.ConnectionReturned:
+	case event.ConnectionCheckedIn:
 		c.numConnsCheckedOut--
 	}
 

--- a/mongo/integration/unified/event.go
+++ b/mongo/integration/unified/event.go
@@ -99,13 +99,13 @@ func monitoringEventTypeFromPoolEvent(evt *event.PoolEvent) monitoringEventType 
 		return connectionReadyEvent
 	case event.ConnectionClosed:
 		return connectionClosedEvent
-	case event.GetStarted:
+	case event.ConnectionCheckOutStarted:
 		return connectionCheckOutStartedEvent
-	case event.GetFailed:
+	case event.ConnectionCheckOutFailed:
 		return connectionCheckOutFailedEvent
-	case event.GetSucceeded:
+	case event.ConnectionCheckedOut:
 		return connectionCheckedOutEvent
-	case event.ConnectionReturned:
+	case event.ConnectionCheckedIn:
 		return connectionCheckedInEvent
 	default:
 		return ""

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -333,12 +333,12 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 				}
 			}
 		case evt.ConnectionCheckedOutEvent != nil:
-			if _, pooled, err = getNextPoolEvent(pooled, event.GetSucceeded); err != nil {
+			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckedOut); err != nil {
 				return newEventVerificationError(idx, client, err.Error())
 			}
 		case evt.ConnectionCheckOutFailedEvent != nil:
 			var actual *event.PoolEvent
-			if actual, pooled, err = getNextPoolEvent(pooled, event.GetFailed); err != nil {
+			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckOutFailed); err != nil {
 				return newEventVerificationError(idx, client, err.Error())
 			}
 
@@ -348,7 +348,7 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 				}
 			}
 		case evt.ConnectionCheckedInEvent != nil:
-			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionReturned); err != nil {
+			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckedIn); err != nil {
 				return newEventVerificationError(idx, client, err.Error())
 			}
 		case evt.PoolClearedEvent != nil:

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -570,9 +570,9 @@ func setupConvenientTransactions(t *testing.T, extraClientOpts ...*options.Clien
 	poolMonitor := &event.PoolMonitor{
 		Event: func(evt *event.PoolEvent) {
 			switch evt.Type {
-			case event.GetSucceeded:
+			case event.ConnectionCheckedOut:
 				connsCheckedOut++
-			case event.ConnectionReturned:
+			case event.ConnectionCheckedIn:
 				connsCheckedOut--
 			}
 		},

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -455,7 +455,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 	// TODO checkout.
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
-			Type:    event.GetStarted,
+			Type:    event.ConnectionCheckOutStarted,
 			Address: p.address.String(),
 		})
 	}
@@ -480,7 +480,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
-				Type:    event.GetFailed,
+				Type:    event.ConnectionCheckOutFailed,
 				Address: p.address.String(),
 				Reason:  event.ReasonPoolClosed,
 			})
@@ -500,7 +500,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
-				Type:    event.GetFailed,
+				Type:    event.ConnectionCheckOutFailed,
 				Address: p.address.String(),
 				Reason:  event.ReasonConnectionErrored,
 				Error:   err,
@@ -543,7 +543,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 			if p.monitor != nil {
 				p.monitor.Event(&event.PoolEvent{
-					Type:    event.GetFailed,
+					Type:    event.ConnectionCheckOutFailed,
 					Address: p.address.String(),
 					Reason:  event.ReasonConnectionErrored,
 					Error:   w.err,
@@ -562,7 +562,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
-				Type:         event.GetSucceeded,
+				Type:         event.ConnectionCheckedOut,
 				Address:      p.address.String(),
 				ConnectionID: w.conn.driverConnectionID,
 			})
@@ -592,7 +592,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 			if p.monitor != nil {
 				p.monitor.Event(&event.PoolEvent{
-					Type:    event.GetFailed,
+					Type:    event.ConnectionCheckOutFailed,
 					Address: p.address.String(),
 					Reason:  event.ReasonConnectionErrored,
 					Error:   w.err,
@@ -612,7 +612,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
-				Type:         event.GetSucceeded,
+				Type:         event.ConnectionCheckedOut,
 				Address:      p.address.String(),
 				ConnectionID: w.conn.driverConnectionID,
 			})
@@ -631,7 +631,7 @@ func (p *pool) checkOut(ctx context.Context) (conn *connection, err error) {
 
 		if p.monitor != nil {
 			p.monitor.Event(&event.PoolEvent{
-				Type:    event.GetFailed,
+				Type:    event.ConnectionCheckOutFailed,
 				Address: p.address.String(),
 				Reason:  event.ReasonTimedOut,
 				Error:   ctx.Err(),
@@ -755,7 +755,7 @@ func (p *pool) checkIn(conn *connection) error {
 
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
-			Type:         event.ConnectionReturned,
+			Type:         event.ConnectionCheckedIn,
 			ConnectionID: conn.driverConnectionID,
 			Address:      conn.addr.String(),
 		})


### PR DESCRIPTION
[GODRIVER-2693](https://jira.mongodb.org/browse/GODRIVER-2693)

## Summary
Renamed event constants in `event/monitoring.go` and all references.

## Background & Motivation
The changed event constants did not match their string values.