### PR TITLE
GODRIVER-2954 Add WCMajority const to wc package

### DIFF
--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -20,7 +20,8 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
-const majority = "majority"
+// WCMajority can be used to create a WriteConcern with a W value of "majority".
+const WCMajority = "majority"
 
 // ErrInconsistent indicates that an inconsistent write concern was specified.
 //
@@ -131,7 +132,7 @@ func Journaled() *WriteConcern {
 // For more information about write concern "w: majority", see
 // https://www.mongodb.com/docs/manual/reference/write-concern/#mongodb-writeconcern-writeconcern.-majority-
 func Majority() *WriteConcern {
-	return &WriteConcern{W: majority}
+	return &WriteConcern{W: WCMajority}
 }
 
 // Custom returns a WriteConcern that requests acknowledgment that write


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2954

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Add WCMajority constant to the writeconcern package.

## Background & Motivation

<!--- Rationale for the pull request. -->

Add a convenience constant to help user's of the writeconcern package avoid using magic strings.