### PR TITLE
GODRIVER-2616 Change CommandFailedEvent.Failure type to error

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -55,7 +55,7 @@ type CommandSucceededEvent struct {
 // CommandFailedEvent represents an event generated when a command's execution fails.
 type CommandFailedEvent struct {
 	CommandFinishedEvent
-	Failure string
+	Failure error
 }
 
 // CommandMonitor represents a monitor that is triggered for different events.

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -341,7 +341,7 @@ func TestClient(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Setup a client and skip the test based on server version.
 				var started []*event.CommandStartedEvent
-				var failureReasons []string
+				var failureReasons []error
 				cmdMonitor := &event.CommandMonitor{
 					Started: func(_ context.Context, evt *event.CommandStartedEvent) {
 						if evt.CommandName == "endSessions" {

--- a/mongo/integration/unified/client_entity.go
+++ b/mongo/integration/unified/client_entity.go
@@ -408,7 +408,7 @@ func (c *clientEntity) processFailedEvent(_ context.Context, evt *event.CommandF
 		AppendString("commandName", evt.CommandName).
 		AppendInt64("requestId", evt.RequestID).
 		AppendString("connectionId", evt.ConnectionID).
-		AppendString("failure", evt.Failure)
+		AppendString("failure", evt.Failure.Error())
 	if evt.ServiceID != nil {
 		bsonBuilder.AppendString("serviceId", evt.ServiceID.String())
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -2032,7 +2032,7 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 	}
 
 	failedEvent := &event.CommandFailedEvent{
-		Failure:              info.cmdErr.Error(),
+		Failure:              info.cmdErr,
 		CommandFinishedEvent: finished,
 	}
 	op.CommandMonitor.Failed(ctx, failedEvent)


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2616

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Change CommadFailedEvent.Failure type from string to error. 

## Background & Motivation

<!--- Rationale for the pull request. -->

The original proposal for the command monitoring event api was given in ecbcd69 . It is unclear why a string type was chosen for failure. The [specifications](https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst#events-api) concerning a failed event states the following about the failure type:

> Returns the failure. Based on the language, this SHOULD be a message string, exception object, or error document.

Since a [Go error](https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/builtin/builtin.go;l=307) is a wrapper for a function that returns a string, I think it is reasonable to assume that a Go error falls under the "string" type. 

The original POC is given in PR #1105 