### PR TITLE
GODRIVER-2432 Improve panic handling in background processes

### DIFF
--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -549,9 +549,7 @@ func (s *Server) update() {
 	checkNow := s.checkNow
 	done := s.done
 
-	defer func() {
-		_ = recover()
-	}()
+	defer logUnexpectedFailure(s.cfg.logger, "Encountered unexpected failure updating server")
 
 	closeServer := func() {
 		s.subLock.Lock()
@@ -683,10 +681,7 @@ func (s *Server) updateDescription(desc description.Server) {
 		return
 	}
 
-	defer func() {
-		//  ¯\_(ツ)_/¯
-		_ = recover()
-	}()
+	defer logUnexpectedFailure(s.cfg.logger, "Encountered unexpected failure updating server description")
 
 	// Anytime we update the server description to something other than "unknown", set the pool to
 	// "ready". Do this before updating the description so that connections can be checked out as

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -269,6 +269,29 @@ func logServerSelectionFailed(
 		logger.KeyFailure, err.Error())
 }
 
+// logUnexpectedFailure is a defer-recover function for logging unexpected
+// failures encountered while maintaining a topology.
+//
+// Most topology maintenance actions, such as updating a server, should not take
+// down a client's application. This function provides a best-effort to log
+// unexpected failures. If the logger passed to this function is nil, then the
+// recovery will be silent.
+func logUnexpectedFailure(log *logger.Logger, msg string, callbacks ...func()) {
+	defer func() {
+		for _, clbk := range callbacks {
+			clbk()
+		}
+	}()
+
+	r := recover()
+	if log == nil || r == nil {
+		return
+	}
+
+	//msg := fmt.Sprintf("Encountered unexpected failure updating server: %v", recover())
+	log.Print(logger.LevelInfo, logger.ComponentTopology, fmt.Sprintf("%s: %v", msg, r))
+}
+
 // Connect initializes a Topology and starts the monitoring process. This function
 // must be called to properly monitor the topology.
 func (t *Topology) Connect() error {
@@ -768,12 +791,11 @@ func (t *Topology) pollSRVRecords(hosts string) {
 	defer pollTicker.Stop()
 	t.pollHeartbeatTime.Store(false)
 	var doneOnce bool
-	defer func() {
-		//  ¯\_(ツ)_/¯
-		if r := recover(); r != nil && !doneOnce {
+	defer logUnexpectedFailure(t.cfg.logger, "Encountered unexpected failure polling SRV records", func() {
+		if !doneOnce {
 			<-t.pollingDone
 		}
-	}()
+	})
 
 	for {
 		select {

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -277,14 +277,18 @@ func logServerSelectionFailed(
 // unexpected failures. If the logger passed to this function is nil, then the
 // recovery will be silent.
 func logUnexpectedFailure(log *logger.Logger, msg string, callbacks ...func()) {
+	r := recover()
+	if r == nil {
+		return
+	}
+
 	defer func() {
 		for _, clbk := range callbacks {
 			clbk()
 		}
 	}()
 
-	r := recover()
-	if log == nil || r == nil {
+	if log == nil {
 		return
 	}
 

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -288,7 +288,6 @@ func logUnexpectedFailure(log *logger.Logger, msg string, callbacks ...func()) {
 		return
 	}
 
-	//msg := fmt.Sprintf("Encountered unexpected failure updating server: %v", recover())
 	log.Print(logger.LevelInfo, logger.ComponentTopology, fmt.Sprintf("%s: %v", msg, r))
 }
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

GODRIVER-2432

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Add a defer-recover function that logs unexpected failures encountered during topology maintenance.

## Background & Motivation

<!--- Rationale for the pull request. -->

Runtime fatals occurring in server maintenance methods are silently ignored. The rationale behind this is to prevent server maintenance, like updating a server, from disrupting a client's application. While there is currently no identified source for these fatals, it is presumed they may arise from the intricate locking system designed to facilitate concurrent updates. This pull request suggests the addition of a logging solution for these defer/recover blocks to learn more form clients, our unified spec test, and perhaps future telemetry. 