### PR TITLE
GODRIVER-2960 Improve Evergreen Runtime and Usability

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -166,7 +166,7 @@ functions:
           . ${DRIVERS_TOOLS}/.evergreen/venv-utils.sh
           . ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 
-          export PYTHON3_BINARY="$(find_python3)"
+          export PYTHON3_BINARY="$(find_python3 2>/dev/null)"
           venvcreate "$PYTHON3_BINARY" venv
 
           echo "PYTHON3_BINARY: $PYTHON3_BINARY" >>expansion.yml
@@ -264,16 +264,7 @@ functions:
         shell: "bash"
         script: |
           ${PREPARE_SHELL}
-          cd "$MONGO_ORCHESTRATION_HOME"
-          # source the mongo-orchestration virtualenv if it exists
-          if [ -f venv/bin/activate ]; then
-            . venv/bin/activate
-          elif [ -f venv/Scripts/activate ]; then
-            . venv/Scripts/activate
-          fi
-          mongo-orchestration stop
-          cd -
-          rm -rf $DRIVERS_TOOLS || true
+          bash ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
 
   fix-absolute-paths:
     - command: shell.exec
@@ -903,17 +894,11 @@ functions:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          if [ "Windows_NT" = "$OS" ]; then
-            kmstlsvenv/Scripts/python.exe -u kms_kmip_server.py \
+          . ./activate-kmstlsvenv.sh
+          python -u kms_kmip_server.py \
               --port 5698 \
               --ca_file "${PROJECT_DIRECTORY}/testdata/kmip-certs/ca-ec.pem" \
               --cert_file "${PROJECT_DIRECTORY}/testdata/kmip-certs/server-ec.pem"
-          else
-            ./kmstlsvenv/bin/python3 -u kms_kmip_server.py \
-              --port 5698 \
-              --ca_file "${PROJECT_DIRECTORY}/testdata/kmip-certs/ca-ec.pem" \
-              --cert_file "${PROJECT_DIRECTORY}/testdata/kmip-certs/server-ec.pem"
-          fi
 
     - command: shell.exec
       params:
@@ -921,11 +906,8 @@ functions:
         background: true
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/csfle
-          if [ "Windows_NT" = "$OS" ]; then
-            kmstlsvenv/Scripts/python.exe bottle.py fake_azure:imds
-          else
-            ./kmstlsvenv/bin/python3 bottle.py fake_azure:imds
-          fi
+          . ./activate-kmstlsvenv.sh
+          python bottle.py fake_azure:imds
 
     - command: shell.exec
       params:
@@ -1022,7 +1004,6 @@ pre:
   - func: windows-fix
   - func: fix-absolute-paths
   - func: make-files-executable
-  - func: start-cse-servers
 
 post:
   - command: gotest.parse_files
@@ -1065,6 +1046,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1079,6 +1061,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1094,6 +1077,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1109,6 +1093,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1124,6 +1109,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1138,6 +1124,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1152,6 +1139,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1167,6 +1155,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1182,6 +1171,7 @@ tasks:
           TOPOLOGY: "server"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "server"
@@ -1576,6 +1566,7 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
@@ -1590,6 +1581,7 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
@@ -1604,6 +1596,7 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
@@ -1621,6 +1614,7 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "auth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
@@ -1635,6 +1629,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1649,6 +1644,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1664,6 +1660,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1679,6 +1676,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1694,6 +1692,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1708,6 +1707,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1723,6 +1723,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1738,6 +1739,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "ssl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1753,6 +1755,7 @@ tasks:
           TOPOLOGY: "sharded_cluster"
           AUTH: "auth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "sharded_cluster"
@@ -1826,6 +1829,7 @@ tasks:
           AUTH: "auth"
           SSL: "nossl"
           REQUIRE_API_VERSION: true
+      - func: start-cse-servers
       - func: run-versioned-api-test
         vars:
           TOPOLOGY: "server"
@@ -1842,6 +1846,7 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
           ORCHESTRATION_FILE: "versioned-api-testing.json"
+      - func: start-cse-servers
       - func: run-versioned-api-test
         vars:
           TOPOLOGY: "server"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -203,6 +203,19 @@ functions:
         content_type: application/x-gzip
         display_name: "fuzz.tgz"
 
+  upload-raw-test-suite:
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: test.suite
+        optional: true
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test.suite.txt
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|text/plain}
+        display_name: "test.suite.txt"
+
   bootstrap-mongohoused:
     - command: shell.exec
       params:
@@ -1011,6 +1024,7 @@ post:
       files:
         - "src/go.mongodb.org/mongo-driver/*.suite"
   - func: upload-mo-artifacts
+  - func: upload-raw-test-suite
   - func: stop-load-balancer
   - func: teardown-aws
   - func: cleanup
@@ -1551,6 +1565,7 @@ tasks:
           TOPOLOGY: "replica_set"
           AUTH: "noauth"
           SSL: "nossl"
+      - func: start-cse-servers
       - func: run-tests
         vars:
           TOPOLOGY: "replica_set"
@@ -1920,6 +1935,7 @@ tasks:
   - name: "test-serverless"
     tags: ["serverless"]
     commands:
+      - func: start-cse-servers
       - func: "run-serverless-tests"
         vars:
           MONGO_GO_DRIVER_COMPRESSOR: "snappy"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,7 +175,11 @@ functions:
       params:
         file: src/go.mongodb.org/mongo-driver/expansion.yml
 
-  upload-mo-artifacts:
+  handle-test-artifacts:
+    - command: gotest.parse_files
+      params:
+        files:
+          - "src/go.mongodb.org/mongo-driver/*.suite"
     - command: shell.exec
       params:
         shell: "bash"
@@ -196,25 +200,30 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
+        optional: true
         local_file: ${PROJECT_DIRECTORY}/fuzz.tgz
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/${task_id}-${execution}-fuzz.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: application/x-gzip
         display_name: "fuzz.tgz"
-
-  upload-raw-test-suite:
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          ${PREPARE_SHELL}
+          tar czf test.suite.tgz test.suite
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/go.mongodb.org/mongo-driver/test.suite
+        local_file: src/go.mongodb.org/mongo-driver/test.suite.tgz
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test.suite.txt
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test.suite.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: ${content_type|text/plain}
-        display_name: "test.suite.txt"
+        display_name: "test.suite.tgz"
 
   bootstrap-mongohoused:
     - command: shell.exec
@@ -276,8 +285,28 @@ functions:
       params:
         shell: "bash"
         script: |
+          # Ensure the instance profile is reassigned for aws tests.
+          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
+          if [ -f "./aws_e2e_setup.json" ]; then
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
+          fi
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          # Attempt to shut down a running load balancer. Ignore any errors that happen if the load
+          # balancer is not running.
+          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop || echo "Ignoring load balancer stop error"
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
           ${PREPARE_SHELL}
+          # Stop orchestration and remove drivers tools.
           bash ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+          cd -
+          rm -rf $DRIVERS_TOOLS || true
 
   fix-absolute-paths:
     - command: shell.exec
@@ -707,26 +736,6 @@ functions:
           TEST_INDEX_URI="${TEST_INDEX_URI}" \
           make evg-test-search-index
 
-  stop-load-balancer:
-    - command: shell.exec
-      params:
-        shell: "bash"
-        script: |
-          # Attempt to shut down a running load balancer. Ignore any errors that happen if the load
-          # balancer is not running.
-          DRIVERS_TOOLS=${DRIVERS_TOOLS} MONGODB_URI=${MONGODB_URI} bash ${DRIVERS_TOOLS}/.evergreen/run-load-balancer.sh stop || echo "Ignoring load balancer stop error"
-
-  teardown-aws:
-    - command: shell.exec
-      params:
-        shell: "bash"
-        script: |
-          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
-          if [ -f "./aws_e2e_setup.json" ]; then
-            . ./activate-authawsvenv.sh
-            python ./lib/aws_assign_instance_profile.py
-          fi
-
   add-aws-auth-variables-to-file:
     - command: ec2.assume_role
       params:
@@ -1019,14 +1028,7 @@ pre:
   - func: make-files-executable
 
 post:
-  - command: gotest.parse_files
-    params:
-      files:
-        - "src/go.mongodb.org/mongo-driver/*.suite"
-  - func: upload-mo-artifacts
-  - func: upload-raw-test-suite
-  - func: stop-load-balancer
-  - func: teardown-aws
+  - func: handle-test-artifacts
   - func: cleanup
 
 tasks:
@@ -2372,21 +2374,8 @@ task_groups:
             SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
             SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
               bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
-      - command: gotest.parse_files
-        params:
-          files:
-            - "src/go.mongodb.org/mongo-driver/*.suite"
-      - func: upload-raw-test-suite
-      - command: s3.put
-        params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
-          local_file: mongodb-logs.tar.gz
-          remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
-          bucket: mciuploads
-          permissions: public-read
-          content_type: ${content_type|application/x-gzip}
-          display_name: "mongodb-logs.tar.gz"
+      - func: handle-test-artifacts
+      - func: cleanup
     tasks:
       - ".serverless"
 
@@ -2413,7 +2402,6 @@ task_groups:
         params:
           file: testgcpkms-expansions.yml
     teardown_group:
-      - func: upload-raw-test-suite
       - command: shell.exec
         params:
           shell: "bash"
@@ -2424,8 +2412,11 @@ task_groups:
             export GCPKMS_ZONE=${GCPKMS_ZONE}
             export GCPKMS_INSTANCENAME=${GCPKMS_INSTANCENAME}
             $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/delete-instance.sh
+      - func: handle-test-artifacts
+      - func: cleanup
     tasks:
       - testgcpkms-task
+
   - name: testazurekms_task_group
     setup_group_can_fail_task: true
     teardown_group_can_fail_task: true
@@ -2462,6 +2453,8 @@ task_groups:
             export AZUREKMS_SCOPE=${AZUREKMS_SCOPE}
             export AZUREKMS_RESOURCEGROUP=${AZUREKMS_RESOURCEGROUP}
             $DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete-vm.sh
+      - func: handle-test-artifacts
+      - func: cleanup
     tasks:
       - testazurekms-task
 
@@ -2493,6 +2486,8 @@ task_groups:
             AWS_REGION: us-east-1
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+      - func: handle-test-artifacts
+      - func: cleanup
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
@@ -2524,7 +2519,6 @@ task_groups:
         params:
           file: src/go.mongodb.org/mongo-driver/atlas-expansion.yml
     teardown_group:
-      - func: upload-raw-test-suite
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
@@ -2532,6 +2526,8 @@ task_groups:
           add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+      - func: handle-test-artifacts
+      - func: cleanup
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -208,7 +208,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: test.suite
+        local_file: src/go.mongodb.org/mongo-driver/test.suite
         optional: true
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test.suite.txt
         bucket: mciuploads

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -213,12 +213,12 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          find . -name \*.suite | xargs tar czf test_suite.tar.gz
+          find . -name \*.suite | xargs tar czf test_suite.tgz
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/go.mongodb.org/mongo-driver/test.suite.tgz
+        local_file: src/go.mongodb.org/mongo-driver/test_suite.tgz
         optional: true
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test_suite.tgz
         bucket: mciuploads

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -210,20 +210,21 @@ functions:
     - command: shell.exec
       params:
         shell: "bash"
+        working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
-          tar czf test.suite.tgz test.suite
+          find . -name \*.suite | xargs tar czf test_suite.tar.gz
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/go.mongodb.org/mongo-driver/test.suite.tgz
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test.suite.tgz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-test_suite.tgz
         bucket: mciuploads
         permissions: public-read
         content_type: ${content_type|text/plain}
-        display_name: "test.suite.tgz"
+        display_name: "test_suite.tgz"
 
   bootstrap-mongohoused:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2376,6 +2376,7 @@ task_groups:
         params:
           files:
             - "src/go.mongodb.org/mongo-driver/*.suite"
+      - func: upload-raw-test-suite
       - command: s3.put
         params:
           aws_key: ${aws_key}
@@ -2412,6 +2413,7 @@ task_groups:
         params:
           file: testgcpkms-expansions.yml
     teardown_group:
+      - func: upload-raw-test-suite
       - command: shell.exec
         params:
           shell: "bash"
@@ -2522,6 +2524,7 @@ task_groups:
         params:
           file: src/go.mongodb.org/mongo-driver/atlas-expansion.yml
     teardown_group:
+      - func: upload-raw-test-suite
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -21,4 +21,4 @@ set -x
 
 # For Go 1.16+, Go builds requires a go.mod file in the current working directory or a parent
 # directory. Spawn a new subshell, "cd" to the project directory, then run "go run".
-(cd ${PROJECT_DIRECTORY} && go run "./cmd/testaws/main.go")
+(cd ${PROJECT_DIRECTORY} && go run "./cmd/testaws/main.go" | tee test.suite)

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ build-kms-test:
 ### Benchmark specific targets and support. ###
 .PHONY: benchmark
 benchmark:perf
-	go test $(BUILD_TAGS) -benchmem -bench=. ./benchmark
+	go test $(BUILD_TAGS) -benchmem -bench=. ./benchmark | test benchmark.suite
 
 .PHONY: driver-benchmark
 driver-benchmark:perf

--- a/etc/run-atlas-test.sh
+++ b/etc/run-atlas-test.sh
@@ -8,4 +8,4 @@ set +x
 . etc/get_aws_secrets.sh drivers/atlas_connect
 
 echo "Running cmd/testatlas/main.go"
-go run ./cmd/testatlas/main.go "$ATLAS_REPL" "$ATLAS_SHRD" "$ATLAS_FREE" "$ATLAS_TLS11" "$ATLAS_TLS12" "$ATLAS_SERVERLESS" "$ATLAS_SRV_REPL" "$ATLAS_SRV_SHRD" "$ATLAS_SRV_FREE" "$ATLAS_SRV_TLS11" "$ATLAS_SRV_TLS12" "$ATLAS_SRV_SERVERLESS"
+go run ./cmd/testatlas/main.go "$ATLAS_REPL" "$ATLAS_SHRD" "$ATLAS_FREE" "$ATLAS_TLS11" "$ATLAS_TLS12" "$ATLAS_SERVERLESS" "$ATLAS_SRV_REPL" "$ATLAS_SRV_SHRD" "$ATLAS_SRV_FREE" "$ATLAS_SRV_TLS11" "$ATLAS_SRV_TLS12" "$ATLAS_SRV_SERVERLESS" | tee test.suite


### PR DESCRIPTION
GODRIVER-2960

## Summary

- Make Evergreen output less verbose.
- Attach `test_suite.tgz` file even in failure so we see the reason.
- Only start CSE servers when we need to.
- Clean up CSE startup code.

## Background & Motivation

Improve Evergreen Runtime and Usability.
