### PR TITLE
GODRIVER-3009 Fix concurrent panic in struct codec.

### DIFF
--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -388,6 +388,9 @@ func (r *Registry) RegisterTypeMapEntry(bt bsontype.Type, rt reflect.Type) {
 // If no encoder is found, an error of type ErrNoEncoder is returned. LookupEncoder is safe for
 // concurrent use by multiple goroutines after all codecs and encoders are registered.
 func (r *Registry) LookupEncoder(valueType reflect.Type) (ValueEncoder, error) {
+	if valueType == nil {
+		return nil, ErrNoEncoder{Type: valueType}
+	}
 	enc, found := r.lookupTypeEncoder(valueType)
 	if found {
 		if enc == nil {
@@ -400,15 +403,10 @@ func (r *Registry) LookupEncoder(valueType reflect.Type) (ValueEncoder, error) {
 	if found {
 		return r.typeEncoders.LoadOrStore(valueType, enc), nil
 	}
-	if valueType == nil {
-		r.storeTypeEncoder(valueType, nil)
-		return nil, ErrNoEncoder{Type: valueType}
-	}
 
 	if v, ok := r.kindEncoders.Load(valueType.Kind()); ok {
 		return r.storeTypeEncoder(valueType, v), nil
 	}
-	r.storeTypeEncoder(valueType, nil)
 	return nil, ErrNoEncoder{Type: valueType}
 }
 
@@ -474,7 +472,6 @@ func (r *Registry) LookupDecoder(valueType reflect.Type) (ValueDecoder, error) {
 	if v, ok := r.kindDecoders.Load(valueType.Kind()); ok {
 		return r.storeTypeDecoder(valueType, v), nil
 	}
-	r.storeTypeDecoder(valueType, nil)
 	return nil, ErrNoDecoder{Type: valueType}
 }
 

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -389,7 +389,7 @@ func (r *Registry) RegisterTypeMapEntry(bt bsontype.Type, rt reflect.Type) {
 // concurrent use by multiple goroutines after all codecs and encoders are registered.
 func (r *Registry) LookupEncoder(valueType reflect.Type) (ValueEncoder, error) {
 	if valueType == nil {
-		return nil, ErrNilType
+		return nil, ErrNoEncoder{Type: valueType}
 	}
 	enc, found := r.lookupTypeEncoder(valueType)
 	if found {

--- a/bson/bsoncodec/registry.go
+++ b/bson/bsoncodec/registry.go
@@ -389,7 +389,7 @@ func (r *Registry) RegisterTypeMapEntry(bt bsontype.Type, rt reflect.Type) {
 // concurrent use by multiple goroutines after all codecs and encoders are registered.
 func (r *Registry) LookupEncoder(valueType reflect.Type) (ValueEncoder, error) {
 	if valueType == nil {
-		return nil, ErrNoEncoder{Type: valueType}
+		return nil, ErrNilType
 	}
 	enc, found := r.lookupTypeEncoder(valueType)
 	if found {

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -750,13 +750,6 @@ func TestRegistry(t *testing.T) {
 					ErrNoEncoder{Type: ft3},
 					false,
 				},
-				{
-					"nil",
-					nil,
-					nil,
-					ErrNilType,
-					false,
-				},
 			}
 
 			allowunexported := cmp.AllowUnexported(fakeCodec{}, fakeStructCodec{}, fakeSliceCodec{}, fakeMapCodec{})
@@ -796,6 +789,36 @@ func TestRegistry(t *testing.T) {
 					})
 				})
 			}
+			t.Run("nil type", func(t *testing.T) {
+				t.Parallel()
+
+				t.Run("Encoder", func(t *testing.T) {
+					t.Parallel()
+
+					wanterr := ErrNoEncoder{Type: reflect.TypeOf(nil)}
+
+					gotcodec, goterr := reg.LookupEncoder(nil)
+					if !cmp.Equal(goterr, wanterr, cmp.Comparer(compareErrors)) {
+						t.Errorf("errors did not match: got %#v, want %#v", goterr, wanterr)
+					}
+					if !cmp.Equal(gotcodec, nil, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("codecs did not match: got %#v, want nil", gotcodec)
+					}
+				})
+				t.Run("Decoder", func(t *testing.T) {
+					t.Parallel()
+
+					wanterr := ErrNilType
+
+					gotcodec, goterr := reg.LookupDecoder(nil)
+					if !cmp.Equal(goterr, wanterr, cmp.Comparer(compareErrors)) {
+						t.Errorf("errors did not match: got %#v, want %#v", goterr, wanterr)
+					}
+					if !cmp.Equal(gotcodec, nil, allowunexported, cmp.Comparer(comparepc)) {
+						t.Errorf("codecs did not match: got %v: want nil", gotcodec)
+					}
+				})
+			})
 			// lookup a type whose pointer implements an interface and expect that the registered hook is
 			// returned
 			t.Run("interface implementation with hook (pointer)", func(t *testing.T) {

--- a/bson/bsoncodec/registry_test.go
+++ b/bson/bsoncodec/registry_test.go
@@ -750,6 +750,13 @@ func TestRegistry(t *testing.T) {
 					ErrNoEncoder{Type: ft3},
 					false,
 				},
+				{
+					"nil",
+					nil,
+					nil,
+					ErrNilType,
+					false,
+				},
 			}
 
 			allowunexported := cmp.AllowUnexported(fakeCodec{}, fakeStructCodec{}, fakeSliceCodec{}, fakeMapCodec{})

--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -18,7 +18,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"golang.org/x/sync/singleflight"
 )
 
 // DecodeError represents an error that occurs when unmarshalling BSON bytes into a native Go type.
@@ -66,8 +65,6 @@ type Zeroer interface {
 type StructCodec struct {
 	cache  sync.Map // map[reflect.Type]*structDescription
 	parser StructTagParser
-
-	group *singleflight.Group
 
 	// DecodeZeroStruct causes DecodeValue to delete any existing values from Go structs in the
 	// destination value passed to Decode before unmarshaling BSON documents into them.
@@ -118,7 +115,6 @@ func NewStructCodec(p StructTagParser, opts ...*bsonoptions.StructCodecOptions) 
 
 	codec := &StructCodec{
 		parser: p,
-		group:  new(singleflight.Group),
 	}
 
 	if structOpt.DecodeZeroStruct != nil {
@@ -482,13 +478,12 @@ func (sc *StructCodec) describeStruct(
 	if v, ok := sc.cache.Load(t); ok {
 		return v.(*structDescription), nil
 	}
-	v, err, _ := sc.group.Do(t.String(), func() (interface{}, error) {
-		return sc.describeStructSlow(r, t, useJSONStructTags, errorOnDuplicates)
-	})
+	// TODO(charlie): Only describe the struct once when called
+	// concurrently with the same type.
+	ds, err := sc.describeStructSlow(r, t, useJSONStructTags, errorOnDuplicates)
 	if err != nil {
 		return nil, err
 	}
-	ds := v.(*structDescription)
 	if v, loaded := sc.cache.LoadOrStore(t, ds); loaded {
 		ds = v.(*structDescription)
 	}

--- a/bson/marshal_test.go
+++ b/bson/marshal_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -379,4 +380,20 @@ func TestMarshalExtJSONIndent(t *testing.T) {
 			assert.Equal(t, expectedExtJSONBytes, extJSONBytes, "expected:\n%s\ngot:\n%s", expectedExtJSONBytes, extJSONBytes)
 		})
 	}
+}
+
+func TestMarshalConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const size = 10_000
+
+	wg := sync.WaitGroup{}
+	wg.Add(size)
+	for i := 0; i < size; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = Marshal(struct{ LastError error }{})
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
GODRIVER-3009

## Summary
Remove the unnecessary nil cache, so nil encoder/decoder will not be stored.

## Background & Motivation
The original panic was:
> interface conversion: interface is nil, not bsoncodec.ValueEncoder

from bson/bsoncodec/codec_cache.go:45

The root cause is at https://github.com/mongodb/mongo-go-driver/blob/master/bson/bsoncodec/struct_codec.go#L481