### PR TITLE
GODRIVER-3056 fix panic on type conversion of nil val in bson codec_cache

### DIFF
--- a/bson/bsoncodec/codec_cache.go
+++ b/bson/bsoncodec/codec_cache.go
@@ -41,7 +41,7 @@ func (c *typeEncoderCache) Load(rt reflect.Type) (ValueEncoder, bool) {
 }
 
 func (c *typeEncoderCache) LoadOrStore(rt reflect.Type, enc ValueEncoder) ValueEncoder {
-	if v, loaded := c.cache.LoadOrStore(rt, enc); loaded {
+	if v, loaded := c.cache.LoadOrStore(rt, enc); loaded && v != nil {
 		enc = v.(ValueEncoder)
 	}
 	return enc
@@ -74,7 +74,7 @@ func (c *typeDecoderCache) Load(rt reflect.Type) (ValueDecoder, bool) {
 }
 
 func (c *typeDecoderCache) LoadOrStore(rt reflect.Type, dec ValueDecoder) ValueDecoder {
-	if v, loaded := c.cache.LoadOrStore(rt, dec); loaded {
+	if v, loaded := c.cache.LoadOrStore(rt, dec); loaded && v != nil {
 		dec = v.(ValueDecoder)
 	}
 	return dec


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3056
(~~i created an issue in the jira but it vanished never to be found again~~ - also for a opensource project hosted in github it is a bit of a stretch to login to yet another server just to file an issue)

## Summary

> [ERROR] interface conversion: interface is nil, not bsoncodec.Value

v1.13.0 (in fact v1.12.2 also) introduces panics and hence a breaking change with the bson codec_cache
below is stack trace from the system that encountered issue - and it is confirmed that v1.12.1 does not have this issue which i re tested by reverting the version back.

<details>
<summary>Stack trace:</summary>

```
goroutine 292 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/adhocore/module/web.errlogc(0xc00090a480, {0xc0004bdb58?, 0x1, 0xc000000b40?})
	~/projects/my/module/web/helper.go:297 +0xcc
github.com/adhocore/module/web.errlog(0xc18500?, {0xc0004bdb58, 0x1, 0x1})
	~/projects/my/module/web/helper.go:282 +0x39
github.com/adhocore/module/web.errorx(0xc000209800, {0x7f77785800b8?, 0xc000300390})
	~/projects/my/module/web/helper.go:175 +0x66e
github.com/adhocore/module/web.bootstrap.func2(0x10?, {0xc17300?, 0xc000300390?})
	~/projects/my/module/web/app.go:150 +0x3e
github.com/adhocore/module/web.bootstrap.New.func3.1()
	~/go/pkg/mod/github.com/gofiber/fiber/v2@v2.51.0/middleware/recover/recover.go:31 +0x72
panic({0xc17300?, 0xc000300390?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
go.mongodb.org/mongo-driver/bson/bsoncodec.(*typeEncoderCache).LoadOrStore(...)
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/codec_cache.go:45
go.mongodb.org/mongo-driver/bson/bsoncodec.(*Registry).storeTypeEncoder(0xc00032e2a0?, {0xf48e88?, 0xc17100?}, {0x0, 0x0})
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/registry.go:416 +0x77
go.mongodb.org/mongo-driver/bson/bsoncodec.(*Registry).LookupEncoder(0xc00032e2a0, {0xf48e88, 0xc17100})
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/registry.go:411 +0x1fa
go.mongodb.org/mongo-driver/bson/bsoncodec.(*StructCodec).describeStructSlow(0xc0001db4c0, 0xcc0380?, {0xf48e88, 0xcce820}, 0x0, 0x0)
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/struct_codec.go:515 +0x225
go.mongodb.org/mongo-driver/bson/bsoncodec.(*StructCodec).describeStruct(0xc0001db4c0, 0x1c?, {0xf48e88?, 0xcce820}, 0x53?, 0x5c?)
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/struct_codec.go:483 +0x9a
go.mongodb.org/mongo-driver/bson/bsoncodec.(*StructCodec).DecodeValue(0xc0001db4c0, {0xc00032e2a0, 0x0, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, 0x0, ...}, ...)
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/struct_codec.go:282 +0x111
go.mongodb.org/mongo-driver/bson/bsoncodec.(*PointerCodec).DecodeValue(0xc0001db500, {0xc00032e2a0, 0x0, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, 0x0, ...}, ...)
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/bsoncodec/pointer_codec.go:91 +0x2ab
go.mongodb.org/mongo-driver/bson.(*Decoder).Decode(0xc0006a00f0, {0xbc92a0, 0xc0003e8108})
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/bson/decoder.go:134 +0x3e3
go.mongodb.org/mongo-driver/mongo.(*Cursor).Decode(0x7f777857e6b0?, {0xbc92a0, 0xc0003e8108})
	~/go/pkg/mod/go.mongodb.org/mongo-driver@v1.13.0/mongo/cursor.go:275 +0x8e
github.com/adhocore/module/model.(*Scrip).fromCursor(0xc00035e1c0, 0xf40328?)
	~/projects/my/module/model/scrip.go:150 +0x6b
github.com/adhocore/module/model.(*Stocks).loadScrips(0xc000aaac60, 0x0, {0x0, 0x0, 0x0})
	~/projects/my/module/model/stocks.go:234 +0x2a9
```
</details>

for some reason the cache returned nil as value with true as loaded flag but this is buggy.

## Background & Motivation

the issue is noticed in `LoadOrStore()` but not in `Load()` and i am sure they both need to work similarly. Load() already checks if the value itself is nil or not but LoadOrStore doesn't, this PR fixes that