### PR TITLE
Generate new ObjectID only when required

### DIFF
--- a/bson/primitive/objectid_test.go
+++ b/bson/primitive/objectid_test.go
@@ -37,6 +37,13 @@ func BenchmarkObjectIDFromHex(b *testing.B) {
 	}
 }
 
+func BenchmarkNewObjectIDFromTimestamp(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		timestamp := time.Now().Add(time.Duration(i) * time.Millisecond)
+		_ = NewObjectIDFromTimestamp(timestamp)
+	}
+}
+
 func TestFromHex_RoundTrip(t *testing.T) {
 	before := NewObjectID()
 	after, err := ObjectIDFromHex(before.Hex())

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -171,7 +171,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 		if err != nil {
 			return operation.InsertResult{}, err
 		}
-		doc, _, err = ensureID(doc, primitive.NewObjectID(), bw.collection.bsonOpts, bw.collection.registry)
+		doc, _, err = ensureID(doc, primitive.NilObjectID, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {
 			return operation.InsertResult{}, err
 		}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -256,7 +256,7 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 		if err != nil {
 			return nil, err
 		}
-		bsoncoreDoc, id, err := ensureID(bsoncoreDoc, primitive.NewObjectID(), coll.bsonOpts, coll.registry)
+		bsoncoreDoc, id, err := ensureID(bsoncoreDoc, primitive.NilObjectID, coll.bsonOpts, coll.registry)
 		if err != nil {
 			return nil, err
 		}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -177,8 +177,11 @@ func marshal(
 }
 
 // ensureID inserts the given ObjectID as an element named "_id" at the
-// beginning of the given BSON document if there is not an "_id" already. If
-// there is already an element named "_id", the document is not modified. It
+// beginning of the given BSON document if there is not an "_id" already.
+// If the given ObjectID is primitive.NilObjectID, a new object ID will be
+// generated with time.Now().
+//
+// If there is already an element named "_id", the document is not modified. It
 // returns the resulting document and the decoded Go value of the "_id" element.
 func ensureID(
 	doc bsoncore.Document,

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -219,6 +219,9 @@ func ensureID(
 	const extraSpace = 17
 	doc = make(bsoncore.Document, 0, len(olddoc)+extraSpace)
 	_, doc = bsoncore.ReserveLength(doc)
+	if oid.IsZero() {
+		oid = primitive.NewObjectID()
+	}
 	doc = bsoncore.AppendObjectIDElement(doc, "_id", oid)
 
 	// Remove and re-write the BSON document length header.

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -148,7 +148,7 @@ func TestEnsureID_NilObjectID(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.NotEqual(t, primitive.NilObjectID, gotID)
- 
+
 	want := bsoncore.NewDocumentBuilder().
 		AppendObjectID("_id", gotID).
 		AppendString("foo", "bar").

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -134,6 +134,29 @@ func TestEnsureID(t *testing.T) {
 	}
 }
 
+func TestEnsureID_NilObjectID(t *testing.T) {
+	t.Parallel()
+
+	doc := bsoncore.NewDocumentBuilder().
+		AppendString("foo", "bar").
+		Build()
+
+	got, gotIDI, err := ensureID(doc, primitive.NilObjectID, nil, nil)
+	assert.NoError(t, err)
+
+	gotID, ok := gotIDI.(primitive.ObjectID)
+
+	assert.True(t, ok)
+	assert.NotEqual(t, primitive.NilObjectID, gotID)
+ 
+	want := bsoncore.NewDocumentBuilder().
+		AppendObjectID("_id", gotID).
+		AppendString("foo", "bar").
+		Build()
+
+	assert.Equal(t, want, got)
+}
+
 func TestMarshalAggregatePipeline(t *testing.T) {
 	// []byte of [{{"$limit", 12345}}]
 	index, arr := bsoncore.AppendArrayStart(nil)


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

any insert operation preemptively generates new ObjectID to check/ensure if `_id` exists in doc or not - but chances are that goes to waste. this waste is more pronounced in scenarios where _id is a mix of custom userland id and system generated one across collections of a db or even across documents of same collection

#### snippet
```go
type IDO struct {
    ID primitive.ObjectID `bson:"_id,omitempty"`
}

dsn := os.Getenv("MONGO_DSN")
client, _ := mongo.Connect(context.Background(), options.Client().ApplyURI(dsn))
coll := client.Database("db_name").Collection("id_test")

fmt.Println(coll.InsertOne(context.Background(), IDO{primitive.NewObjectID()}))
fmt.Println(coll.InsertOne(context.Background(), IDO{}))
fmt.Println(coll.InsertOne(context.Background(), IDO{primitive.NewObjectID()}))
fmt.Println(coll.InsertOne(context.Background(), IDO{}))
fmt.Println(coll.InsertOne(context.Background(), IDO{primitive.NewObjectID()}))
fmt.Println(coll.InsertOne(context.Background(), IDO{primitive.NewObjectID()}))
fmt.Println(coll.InsertOne(context.Background(), IDO{}))
fmt.Println(coll.InsertOne(context.Background(), IDO{}))
```

#### output before (4 wastes)

```
&{ObjectID("655ff7039326bc5b41e6652a")} <nil>
&{ObjectID("655ff7039326bc5b41e6652c")} <nil> // missing ***2b
&{ObjectID("655ff7039326bc5b41e6652d")} <nil>
&{ObjectID("655ff7039326bc5b41e6652f")} <nil> // missing ***2e
&{ObjectID("655ff7039326bc5b41e66530")} <nil>
&{ObjectID("655ff7039326bc5b41e66532")} <nil> // missing ***31
&{ObjectID("655ff7039326bc5b41e66534")} <nil> // missing ***33
&{ObjectID("655ff7039326bc5b41e66535")} <nil>
```

#### output after (no wastes)

```
&{ObjectID("655ff6d1dd10f377136f9b71")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b72")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b73")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b74")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b75")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b76")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b77")} <nil>
&{ObjectID("655ff6d1dd10f377136f9b78")} <nil>
```

## Background & Motivation

ID burning is a **thing** in [sql world](https://lefred.be/content/mysql-keep-an-eye-on-your-auto_increment-values/), while this one is different world here, i believe it does not hurt to be cautious of resource we use/disuse. quoting from summary above:

> any insert operation preemptively generates new ObjectID to check/ensure if `_id` exists in doc or not - but chances are that goes to waste.

isn't it more logical to generate it if only we ever really need it?
