### PR TITLE
GODRIVER-3054 Handshake connection should not use legacy for LB

### DIFF
--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1367,7 +1367,7 @@ func (op Operation) createWireMessage(
 ) ([]byte, startedInformation, error) {
 	isInitialHandshake := desc.WireVersion == nil || desc.WireVersion.Max == 0
 
-	// Use the OP_LEGACY on non-load-balanced connection handshakes.
+	// Use OP_QUERY on non-load-balanced connection handshakes.
 	if op.ServerAPI == nil && desc.Kind != description.LoadBalanced && isInitialHandshake {
 		return op.createLegacyHandshakeWireMessage(maxTimeMS, dst, desc)
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1357,14 +1357,6 @@ func (op Operation) createMsgWireMessage(
 	return bsoncore.UpdateLength(dst, wmindex, int32(len(dst[wmindex:]))), info, nil
 }
 
-// isLegacyHandshake returns True if the operation is the first message of
-// the initial handshake and should use a legacy hello.
-func isLegacyHandshake(op Operation, desc description.SelectedServer) bool {
-	isInitialHandshake := desc.WireVersion == nil || desc.WireVersion.Max == 0
-
-	return op.Legacy == LegacyHandshake && isInitialHandshake
-}
-
 func (op Operation) createWireMessage(
 	ctx context.Context,
 	maxTimeMS uint64,
@@ -1373,7 +1365,10 @@ func (op Operation) createWireMessage(
 	conn Connection,
 	requestID int32,
 ) ([]byte, startedInformation, error) {
-	if isLegacyHandshake(op, desc) {
+	isInitialHandshake := desc.WireVersion == nil || desc.WireVersion.Max == 0
+
+	// Use the OP_LEGACY on non-load-balanced connection handshakes.
+	if op.ServerAPI == nil && desc.Kind != description.LoadBalanced && isInitialHandshake {
 		return op.createLegacyHandshakeWireMessage(maxTimeMS, dst, desc)
 	}
 

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -571,14 +571,6 @@ func (h *Hello) StreamResponse(ctx context.Context, conn driver.StreamerConnecti
 	return h.createOperation().ExecuteExhaust(ctx, conn)
 }
 
-// isLegacyHandshake returns True if server API version is not requested and
-// loadBalanced is False. If this is the case, then the drivers MUST use legacy
-// hello for the first message of the initial handshake with the OP_QUERY
-// protocol
-func isLegacyHandshake(srvAPI *driver.ServerAPIOptions, deployment driver.Deployment) bool {
-	return srvAPI == nil && deployment.Kind() != description.LoadBalanced
-}
-
 func (h *Hello) createOperation() driver.Operation {
 	op := driver.Operation{
 		Clock:      h.clock,
@@ -590,10 +582,6 @@ func (h *Hello) createOperation() driver.Operation {
 			return nil
 		},
 		ServerAPI: h.serverAPI,
-	}
-
-	if isLegacyHandshake(h.serverAPI, h.d) {
-		op.Legacy = driver.LegacyHandshake
 	}
 
 	return op
@@ -614,10 +602,6 @@ func (h *Hello) GetHandshakeInformation(ctx context.Context, _ address.Address, 
 			return nil
 		},
 		ServerAPI: h.serverAPI,
-	}
-
-	if isLegacyHandshake(h.serverAPI, deployment) {
-		op.Legacy = driver.LegacyHandshake
 	}
 
 	if err := op.Execute(ctx); err != nil {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3054

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Prevent handshake connection from using legacy OP_QUERY per the [specifications](https://github.com/mongodb/specifications/blob/master/source/load-balancers/load-balancers.rst#connection-establishment).

## Background & Motivation

<!--- Rationale for the pull request. -->

In re-organizing the operation logic in GODRIVER-2892 and GODRIVER-2935 , we assume that the connection description has been discovered before making the initial handshake. This assumption is incorrect and the logic for it needs to be reverted to the original logic.
