### PR TITLE
GODRIVER-2937 Copy BSONOptions when merging coll or db opts

### DIFF
--- a/mongo/options/collectionoptions.go
+++ b/mongo/options/collectionoptions.go
@@ -95,6 +95,9 @@ func MergeCollectionOptions(opts ...*CollectionOptions) *CollectionOptions {
 		if opt.Registry != nil {
 			c.Registry = opt.Registry
 		}
+		if opt.BSONOptions != nil {
+			c.BSONOptions = opt.BSONOptions
+		}
 	}
 
 	return c

--- a/mongo/options/dboptions.go
+++ b/mongo/options/dboptions.go
@@ -95,6 +95,9 @@ func MergeDatabaseOptions(opts ...*DatabaseOptions) *DatabaseOptions {
 		if opt.Registry != nil {
 			d.Registry = opt.Registry
 		}
+		if opt.BSONOptions != nil {
+			d.BSONOptions = opt.BSONOptions
+		}
 	}
 
 	return d


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2937

## Summary

<!--- A summary of the changes proposed by this pull request. -->
Copy BSONOptions when merging coll or db opts.

## Background & Motivation

<!--- Rationale for the pull request. -->
The copy logic was missed when implementing BSONOptions.
