### PR TITLE
GODRIVER-3059 Retract v1.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,11 @@ module go.mongodb.org/mongo-driver
 go 1.13
 
 retract (
+	// GODRIVER-3059: The v1.13.0 Git tag changed, causing security errors when
+	// users downloaded the Go driver module. Also, the BSON performance
+	// improvements introduced a panic when marshaling/unmarshaling Go errors.
+	v1.13.0
+
 	v1.11.8 // Contains minor changes meant for v1.12.1.
 	v1.11.5 // Contains import failure.
 


### PR DESCRIPTION
[GODRIVER-3059](https://jira.mongodb.org/browse/GODRIVER-3059)

## Summary

Retract release v1.13.0.

## Background & Motivation

There are some issues with the v1.13.0 release:
Some users get a security error when attempting to download Go driver v1.13.0:
```
go: go.mongodb.org/mongo-driver@v1.13.0: verifying module: checksum mismatch
        downloaded: h1:c+OsvIAc3LCdc9dcfowGjT2bWjvLOccxhdguqHJUvbo=
        sum.golang.org: h1:67DgFFjYOCMWdtTEmKFpV3ffWlFnh+CYZ8ZS/tXWUfY=

SECURITY ERROR
This download does NOT match the one reported by the checksum server.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```

Also, the BSON library may panic when marshaling/unmarshaling Go error.

