### PR TITLE
GODRIVER-3039 Support sending a security token section in wire messages.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -144,6 +144,7 @@ functions:
              export PKG_CONFIG_PATH=$(pwd)/install/libmongocrypt/lib/pkgconfig:$(pwd)/install/mongo-c-driver/lib/pkgconfig
              export LD_LIBRARY_PATH=$(pwd)/install/libmongocrypt/lib
              export PATH="$PATH"
+             export PROJECT_ORCHESTRATION_HOME="$PROJECT_DIRECTORY/.evergreen/orchestration"
           EOT
           # See what we variables we've set.
           cat expansion.yml
@@ -1172,6 +1173,16 @@ functions:
         script: |
           ${PREPARE_SHELL}
           ${PROJECT_DIRECTORY}/.evergreen/run-fuzz.sh
+
+  run-security-token-tests:
+    - command: shell.exec
+      type: test
+      params:
+        shell: "bash"
+        working_dir: src/go.mongodb.org/mongo-driver
+        script: |
+          ${PREPARE_SHELL}
+          ${PROJECT_DIRECTORY}/.evergreen/run-security-token.sh
 
   run-deployed-aws-lambda-tests:
     - command: ec2.assume_role
@@ -2267,6 +2278,17 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-fuzz-tests
 
+  - name: "test-security-token"
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "replica_set"
+          AUTH: "auth"
+          SSL: "ssl"
+          VERSION: "latest"
+          ORCHESTRATION_FILE: "security-token.json"
+      - func: run-security-token-tests
+
   - name: "test-aws-lambda"
     tags:
       - latest
@@ -2415,6 +2437,15 @@ axes:
       - id: "ubuntu2004-go-1-20"
         display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-build
+        variables:
+          GO_DIST: "/opt/golang/go1.20"
+
+  - id: os-security-token
+    display_name: OS
+    values:
+      - id: "rhel87-64-go-1-20"
+        display_name: "RHEL 8.7"
+        run_on: rhel8.7-large
         variables:
           GO_DIST: "/opt/golang/go1.20"
 
@@ -2729,6 +2760,12 @@ buildvariants:
     display_name: "Serverless ${os-serverless}"
     tasks:
       - "serverless_task_group"
+
+  - matrix_name: "security-token"
+    matrix_spec: { version: ["latest"], os-security-token: "*" }
+    display_name: "Security Token ${os-security-token}"
+    tasks:
+      - "test-security-token"
 
   - matrix_name: "kms-kmip-test"
     matrix_spec: { version: ["latest"], os-ssl-40: ["ubuntu1804-64-go-1-20"] }

--- a/.evergreen/orchestration/configs/replica_sets/security-token.json
+++ b/.evergreen/orchestration/configs/replica_sets/security-token.json
@@ -1,0 +1,55 @@
+{
+  "id": "repl0",
+  "members": [
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "oplogSize": 500,
+        "port": 27017,
+        "setParameter": {
+          "multitenancySupport": 1,
+          "enableTestCommands": 1
+        }
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "one",
+          "dc": "ny"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "oplogSize": 500,
+        "port": 27018,
+        "setParameter": {
+          "multitenancySupport": 1,
+          "enableTestCommands": 1
+        }
+      },
+      "rsParams": {
+        "tags": {
+          "ordinal": "two",
+          "dc": "pa"
+        }
+      }
+    },
+    {
+      "procParams": {
+        "ipv6": true,
+        "bind_ip": "127.0.0.1,::1",
+        "port": 27019,
+        "setParameter": {
+          "multitenancySupport": 1,
+          "enableTestCommands": 1
+        }
+      },
+      "rsParams": {
+        "arbiterOnly": true
+      }
+    }
+  ]
+}

--- a/.evergreen/run-security-token.sh
+++ b/.evergreen/run-security-token.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+
+export GOPATH=$(dirname $(dirname $(dirname `pwd`)))
+export GOCACHE="$(pwd)/.cache"
+export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
+
+if [ "Windows_NT" = "$OS" ]; then
+    export GOPATH=$(cygpath -m $GOPATH)
+    export GOCACHE=$(cygpath -m $GOCACHE)
+    export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
+fi
+
+export GOROOT="${GOROOT}"
+export PATH="${GOROOT}/bin:${GCC_PATH}:$GOPATH/bin:$PATH"
+export PROJECT="${project}"
+export GOFLAGS=-mod=vendor
+
+MONGODB_URI="${MONGODB_URI}" \
+TOPOLOGY=${TOPOLOGY} \
+MONGO_GO_DRIVER_COMPRESSOR=${MONGO_GO_DRIVER_COMPRESSOR} \
+# This JWT security token is for testing purposes only and does not authorize anything.
+MONGODB_SECURITY_TOKEN="eyJhbGciOiJub25lIiwidHlwIjoiSldUIiwia2lkIjoiIn0.eyJpc3MiOiJodHRwczovL2Zha2Vpc3MiLCJzdWIiOiJhbGljZSIsImF1ZCI6Imh0dHBzOi8vZmFrZWF1ZCIsIm1vbmdvZGIvdGVuYW50SWQiOiJhYmNkMTIzNGFiY2QxMjM0YWJjZDEyMzQiLCJtb25nb2RiL2V4cGVjdFByZWZpeCI6ZmFsc2UsIm1vbmdvZGIvcm9sZXMiOlsicm9sZTEiLCJyb2xlMiJdLCJleHAiOjE3OTM5ODM3MjR9." \
+make evg-test-security-token

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,10 @@ evg-test-versioned-api:
 	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration >> test.suite
 	go test -exec "env PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)" $(BUILD_TAGS) -v -timeout $(TEST_TIMEOUT)s ./mongo/integration/unified >> test.suite
 
+.PHONY: evg-test-security-token
+evg-test-security-token:
+	go test $(BUILD_TAGS) -run "Test(Database|Collection)" -v -timeout $(TEST_TIMEOUT)s ./mongo/integration >> test.suite
+
 .PHONY: build-kms-test
 build-kms-test:
 	go build $(BUILD_TAGS) ./cmd/testkms

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -185,7 +185,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 		Database(bw.collection.db.name).Collection(bw.collection.name).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).
 		ServerAPI(bw.collection.client.serverAPI).Timeout(bw.collection.client.timeout).
-		Logger(bw.collection.client.logger)
+		Logger(bw.collection.client.logger).SecurityToken(bw.collection.client.securityToken)
 	if bw.comment != nil {
 		comment, err := marshalValue(bw.comment, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {
@@ -255,7 +255,7 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		Database(bw.collection.db.name).Collection(bw.collection.name).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ServerAPI(bw.collection.client.serverAPI).Timeout(bw.collection.client.timeout).
-		Logger(bw.collection.client.logger)
+		Logger(bw.collection.client.logger).SecurityToken(bw.collection.client.securityToken)
 	if bw.comment != nil {
 		comment, err := marshalValue(bw.comment, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {
@@ -386,7 +386,8 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		Database(bw.collection.db.name).Collection(bw.collection.name).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ArrayFilters(hasArrayFilters).ServerAPI(bw.collection.client.serverAPI).
-		Timeout(bw.collection.client.timeout).Logger(bw.collection.client.logger)
+		Timeout(bw.collection.client.timeout).Logger(bw.collection.client.logger).
+		SecurityToken(bw.collection.client.securityToken)
 	if bw.comment != nil {
 		comment, err := marshalValue(bw.comment, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -133,7 +133,8 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 		ReadPreference(config.readPreference).ReadConcern(config.readConcern).
 		Deployment(cs.client.deployment).ClusterClock(cs.client.clock).
 		CommandMonitor(cs.client.monitor).Session(cs.sess).ServerSelector(cs.selector).Retry(driver.RetryNone).
-		ServerAPI(cs.client.serverAPI).Crypt(config.crypt).Timeout(cs.client.timeout)
+		ServerAPI(cs.client.serverAPI).Crypt(config.crypt).Timeout(cs.client.timeout).
+		SecurityToken(cs.client.securityToken)
 
 	if cs.options.Collation != nil {
 		cs.aggregate.Collation(bsoncore.Document(cs.options.Collation.ToDocument()))

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -291,7 +291,8 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).Ordered(true).
-		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).Logger(coll.client.logger)
+		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).Logger(coll.client.logger).
+		SecurityToken(coll.client.securityToken)
 	imo := options.MergeInsertManyOptions(opts...)
 	if imo.BypassDocumentValidation != nil && *imo.BypassDocumentValidation {
 		op = op.BypassDocumentValidation(*imo.BypassDocumentValidation)
@@ -471,7 +472,8 @@ func (coll *Collection) delete(ctx context.Context, filter interface{}, deleteOn
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).Ordered(true).
-		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).Logger(coll.client.logger)
+		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).Logger(coll.client.logger).
+		SecurityToken(coll.client.securityToken)
 	if do.Comment != nil {
 		comment, err := marshalValue(do.Comment, coll.bsonOpts, coll.registry)
 		if err != nil {
@@ -588,7 +590,8 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).Hint(uo.Hint != nil).
 		ArrayFilters(uo.ArrayFilters != nil).Ordered(true).ServerAPI(coll.client.serverAPI).
-		Timeout(coll.client.timeout).Logger(coll.client.logger)
+		Timeout(coll.client.timeout).Logger(coll.client.logger).
+		SecurityToken(coll.client.securityToken)
 	if uo.Let != nil {
 		let, err := marshal(uo.Let, coll.bsonOpts, coll.registry)
 		if err != nil {
@@ -858,7 +861,8 @@ func aggregate(a aggregateParams) (cur *Cursor, err error) {
 		ServerAPI(a.client.serverAPI).
 		HasOutputStage(hasOutputStage).
 		Timeout(a.client.timeout).
-		MaxTime(ao.MaxTime)
+		MaxTime(ao.MaxTime).
+		SecurityToken(a.client.securityToken)
 
 	if ao.AllowDiskUse != nil {
 		op.AllowDiskUse(*ao.AllowDiskUse)
@@ -980,7 +984,7 @@ func (coll *Collection) CountDocuments(ctx context.Context, filter interface{},
 	op := operation.NewAggregate(pipelineArr).Session(sess).ReadConcern(rc).ReadPreference(coll.readPreference).
 		CommandMonitor(coll.client.monitor).ServerSelector(selector).ClusterClock(coll.client.clock).Database(coll.db.name).
 		Collection(coll.name).Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
-		Timeout(coll.client.timeout).MaxTime(countOpts.MaxTime)
+		Timeout(coll.client.timeout).MaxTime(countOpts.MaxTime).SecurityToken(coll.client.securityToken)
 	if countOpts.Collation != nil {
 		op.Collation(bsoncore.Document(countOpts.Collation.ToDocument()))
 	}
@@ -1065,7 +1069,7 @@ func (coll *Collection) EstimatedDocumentCount(ctx context.Context,
 		Database(coll.db.name).Collection(coll.name).CommandMonitor(coll.client.monitor).
 		Deployment(coll.client.deployment).ReadConcern(rc).ReadPreference(coll.readPreference).
 		ServerSelector(selector).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
-		Timeout(coll.client.timeout).MaxTime(co.MaxTime)
+		Timeout(coll.client.timeout).MaxTime(co.MaxTime).SecurityToken(coll.client.securityToken)
 
 	if co.Comment != nil {
 		comment, err := marshalValue(co.Comment, coll.bsonOpts, coll.registry)
@@ -1132,7 +1136,7 @@ func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter i
 		Database(coll.db.name).Collection(coll.name).CommandMonitor(coll.client.monitor).
 		Deployment(coll.client.deployment).ReadConcern(rc).ReadPreference(coll.readPreference).
 		ServerSelector(selector).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
-		Timeout(coll.client.timeout).MaxTime(option.MaxTime)
+		Timeout(coll.client.timeout).MaxTime(option.MaxTime).SecurityToken(coll.client.securityToken)
 
 	if option.Collation != nil {
 		op.Collation(bsoncore.Document(option.Collation.ToDocument()))
@@ -1227,7 +1231,8 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 		CommandMonitor(coll.client.monitor).ServerSelector(selector).
 		ClusterClock(coll.client.clock).Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
-		Timeout(coll.client.timeout).MaxTime(fo.MaxTime).Logger(coll.client.logger)
+		Timeout(coll.client.timeout).MaxTime(fo.MaxTime).Logger(coll.client.logger).
+		SecurityToken(coll.client.securityToken)
 
 	cursorOpts := coll.client.createBaseCursorOptions()
 	if fo.AllowDiskUse != nil {
@@ -1488,7 +1493,7 @@ func (coll *Collection) FindOneAndDelete(ctx context.Context, filter interface{}
 	}
 	fod := options.MergeFindOneAndDeleteOptions(opts...)
 	op := operation.NewFindAndModify(f).Remove(true).ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).
-		MaxTime(fod.MaxTime)
+		MaxTime(fod.MaxTime).SecurityToken(coll.client.securityToken)
 	if fod.Collation != nil {
 		op = op.Collation(bsoncore.Document(fod.Collation.ToDocument()))
 	}
@@ -1568,7 +1573,8 @@ func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{
 
 	fo := options.MergeFindOneAndReplaceOptions(opts...)
 	op := operation.NewFindAndModify(f).Update(bsoncore.Value{Type: bsontype.EmbeddedDocument, Data: r}).
-		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).MaxTime(fo.MaxTime)
+		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).MaxTime(fo.MaxTime).
+		SecurityToken(coll.client.securityToken)
 	if fo.BypassDocumentValidation != nil && *fo.BypassDocumentValidation {
 		op = op.BypassDocumentValidation(*fo.BypassDocumentValidation)
 	}
@@ -1655,7 +1661,7 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 
 	fo := options.MergeFindOneAndUpdateOptions(opts...)
 	op := operation.NewFindAndModify(f).ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).
-		MaxTime(fo.MaxTime)
+		MaxTime(fo.MaxTime).SecurityToken(coll.client.securityToken)
 
 	u, err := marshalUpdateValue(update, coll.bsonOpts, coll.registry, true)
 	if err != nil {
@@ -1851,7 +1857,8 @@ func (coll *Collection) drop(ctx context.Context) error {
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).
-		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout)
+		ServerAPI(coll.client.serverAPI).Timeout(coll.client.timeout).
+		SecurityToken(coll.client.securityToken)
 	err = op.Execute(ctx)
 
 	// ignore namespace not found erorrs

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -91,7 +91,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 		ServerSelector(selector).ClusterClock(iv.coll.client.clock).
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI).
-		Timeout(iv.coll.client.timeout)
+		Timeout(iv.coll.client.timeout).SecurityToken(iv.coll.client.securityToken)
 
 	cursorOpts := iv.coll.client.createBaseCursorOptions()
 	lio := options.MergeListIndexesOptions(opts...)
@@ -252,7 +252,7 @@ func (iv IndexView) CreateMany(ctx context.Context, models []IndexModel, opts ..
 		Session(sess).WriteConcern(wc).ClusterClock(iv.coll.client.clock).
 		Database(iv.coll.db.name).Collection(iv.coll.name).CommandMonitor(iv.coll.client.monitor).
 		Deployment(iv.coll.client.deployment).ServerSelector(selector).ServerAPI(iv.coll.client.serverAPI).
-		Timeout(iv.coll.client.timeout).MaxTime(option.MaxTime)
+		Timeout(iv.coll.client.timeout).MaxTime(option.MaxTime).SecurityToken(iv.coll.client.securityToken)
 	if option.CommitQuorum != nil {
 		commitQuorum, err := marshalValue(option.CommitQuorum, iv.coll.bsonOpts, iv.coll.registry)
 		if err != nil {
@@ -389,7 +389,8 @@ func (iv IndexView) drop(ctx context.Context, name string, opts ...*options.Drop
 		ServerSelector(selector).ClusterClock(iv.coll.client.clock).
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI).
-		Timeout(iv.coll.client.timeout).MaxTime(dio.MaxTime)
+		Timeout(iv.coll.client.timeout).MaxTime(dio.MaxTime).
+		SecurityToken(iv.coll.client.securityToken)
 
 	err = op.Execute(ctx)
 	if err != nil {

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1973,24 +1972,4 @@ func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn
 	assert.Equal(mt, cmdName, evt.CommandName, "expected command %q, got %q", cmdName, evt.CommandName)
 	evt = mt.GetStartedEvent()
 	assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
-}
-
-func TestSecurityToken(t *testing.T) {
-	mt := mtest.New(t)
-
-	opts := mtest.NewOptions().ClientType(mtest.Proxy)
-	mt.RunOpts("", opts, func(mt *mtest.T) {
-		_, err := mt.Coll.DeleteOne(context.Background(), bson.M{})
-		// assert.NoError(mt, err)
-		fmt.Println(err)
-
-		msgs := mt.GetProxiedMessages()
-		for _, msg := range msgs {
-			if msg.CommandName != "delete" {
-				continue
-			}
-			fmt.Printf("%q\n", msg.Sent.RawMessage)
-			fmt.Println(msg.Sent.SecurityToken)
-		}
-	})
 }

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1972,4 +1973,24 @@ func assertKillCursorsCommandsAreMonitored(mt *mtest.T, cmdName string, cursorFn
 	assert.Equal(mt, cmdName, evt.CommandName, "expected command %q, got %q", cmdName, evt.CommandName)
 	evt = mt.GetStartedEvent()
 	assert.Equal(mt, "killCursors", evt.CommandName, "expected command 'killCursors', got %q", evt.CommandName)
+}
+
+func TestSecurityToken(t *testing.T) {
+	mt := mtest.New(t)
+
+	opts := mtest.NewOptions().ClientType(mtest.Proxy)
+	mt.RunOpts("", opts, func(mt *mtest.T) {
+		_, err := mt.Coll.DeleteOne(context.Background(), bson.M{})
+		// assert.NoError(mt, err)
+		fmt.Println(err)
+
+		msgs := mt.GetProxiedMessages()
+		for _, msg := range msgs {
+			if msg.CommandName != "delete" {
+				continue
+			}
+			fmt.Printf("%q\n", msg.Sent.RawMessage)
+			fmt.Println(msg.Sent.SecurityToken)
+		}
+	})
 }

--- a/mongo/integration/mtest/mongotest.go
+++ b/mongo/integration/mtest/mongotest.go
@@ -9,6 +9,7 @@ package mtest
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -630,6 +631,10 @@ func (t *T) createTestClient() {
 	// set ServerAPIOptions to latest version if required
 	if clientOpts.Deployment == nil && t.clientType != Mock && clientOpts.ServerAPIOptions == nil && testContext.requireAPIVersion {
 		clientOpts.SetServerAPIOptions(options.ServerAPI(driver.TestServerAPIVersion))
+	}
+
+	if tok := os.Getenv("MONGODB_SECURITY_TOKEN"); tok != "" {
+		clientOpts = clientOpts.SetSecurityToken(tok)
 	}
 
 	// Setup command monitor

--- a/mongo/integration/mtest/sent_message.go
+++ b/mongo/integration/mtest/sent_message.go
@@ -185,7 +185,7 @@ func parseSentOpMsg(wm []byte) (*SentMessage, error) {
 			}
 		case wiremessage.SecurityToken:
 			var securityToken string
-			securityToken, wm, ok = wiremessage.ReadSecurityToken(wm)
+			securityToken, wm, ok = wiremessage.ReadMsgSectionSecurityToken(wm)
 			if !ok {
 				return nil, errors.New("failed to read security token")
 			}

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -205,6 +205,7 @@ type ClientOptions struct {
 	ReplicaSet               *string
 	RetryReads               *bool
 	RetryWrites              *bool
+	SecurityToken            *string
 	ServerAPIOptions         *ServerAPIOptions
 	ServerSelectionTimeout   *time.Duration
 	SRVMaxHosts              *int
@@ -805,6 +806,12 @@ func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 	return c
 }
 
+func (c *ClientOptions) SetSecurityToken(token string) *ClientOptions {
+	c.SecurityToken = &token
+
+	return c
+}
+
 // SetServerSelectionTimeout specifies how long the driver will wait to find an available, suitable server to execute an
 // operation. This can also be set through the "serverSelectionTimeoutMS" URI option (e.g.
 // "serverSelectionTimeoutMS=30000"). The default value is 30 seconds.
@@ -1107,6 +1114,9 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.LoggerOptions != nil {
 			c.LoggerOptions = opt.LoggerOptions
+		}
+		if opt.SecurityToken != nil {
+			c.SecurityToken = opt.SecurityToken
 		}
 	}
 

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -205,7 +205,6 @@ type ClientOptions struct {
 	ReplicaSet               *string
 	RetryReads               *bool
 	RetryWrites              *bool
-	SecurityToken            *string
 	ServerAPIOptions         *ServerAPIOptions
 	ServerSelectionTimeout   *time.Duration
 	SRVMaxHosts              *int
@@ -245,6 +244,12 @@ type ClientOptions struct {
 	// may be used in its place to control the amount of time that a single operation can run before returning
 	// an error. Setting SocketTimeout and Timeout on a single client will result in undefined behavior.
 	SocketTimeout *time.Duration
+
+	// SecurityToken specifies a security token that is sent with every command.
+	//
+	// Deprecated: This option is for internal use only and should not be set.
+	// It may be changed or removed in any release.
+	SecurityToken *string
 }
 
 // Client creates a new ClientOptions instance.
@@ -806,6 +811,10 @@ func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 	return c
 }
 
+// SetSecurityToken sets a security token that is sent with every command.
+//
+// Deprecated: This option is for internal use only and should not be set. It
+// may be changed or removed in any release.
 func (c *ClientOptions) SetSecurityToken(token string) *ClientOptions {
 	c.SecurityToken = &token
 

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -297,7 +297,8 @@ func (s *sessionImpl) AbortTransaction(ctx context.Context) error {
 	_ = operation.NewAbortTransaction().Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").
 		Deployment(s.deployment).WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).
 		Retry(driver.RetryOncePerCommand).CommandMonitor(s.client.monitor).
-		RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).ServerAPI(s.client.serverAPI).Execute(ctx)
+		RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).ServerAPI(s.client.serverAPI).
+		SecurityToken(s.client.securityToken).Execute(ctx)
 
 	s.clientSession.Aborting = false
 	_ = s.clientSession.AbortTransaction()

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -42,6 +42,7 @@ type BatchCursor struct {
 	postBatchResumeToken bsoncore.Document
 	crypt                Crypt
 	serverAPI            *ServerAPIOptions
+	securityToken        string
 
 	// legacy server (< 3.2) fields
 	limit       int32
@@ -140,6 +141,7 @@ type CursorOptions struct {
 	CommandMonitor *event.CommandMonitor
 	Crypt          Crypt
 	ServerAPI      *ServerAPIOptions
+	SecurityToken  string
 }
 
 // NewBatchCursor creates a new BatchCursor from the provided parameters.
@@ -163,6 +165,7 @@ func NewBatchCursor(cr CursorResponse, clientSession *session.Client, clock *ses
 		crypt:                opts.Crypt,
 		serverAPI:            opts.ServerAPI,
 		serverDescription:    cr.Desc,
+		securityToken:        opts.SecurityToken,
 	}
 
 	if ds != nil {
@@ -305,6 +308,7 @@ func (bc *BatchCursor) KillCursor(ctx context.Context) error {
 		Legacy:         LegacyKillCursors,
 		CommandMonitor: bc.cmdMonitor,
 		ServerAPI:      bc.serverAPI,
+		SecurityToken:  bc.securityToken,
 	}.Execute(ctx)
 }
 
@@ -398,6 +402,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		CommandMonitor: bc.cmdMonitor,
 		Crypt:          bc.crypt,
 		ServerAPI:      bc.serverAPI,
+		SecurityToken:  bc.securityToken,
 	}.Execute(ctx)
 
 	// Once the cursor has been drained, we can unpin the connection if one is currently pinned.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -306,6 +306,8 @@ type Operation struct {
 
 	Logger *logger.Logger
 
+	SecurityToken string
+
 	// cmdName is only set when serializing OP_MSG and is used internally in readWireMessage.
 	cmdName string
 }
@@ -1248,7 +1250,18 @@ func (op Operation) createMsgWireMessage(ctx context.Context, maxTimeMS uint64, 
 		dst = bsoncore.UpdateLength(dst, idx, int32(len(dst[idx:])))
 	}
 
+	if len(op.SecurityToken) > 0 {
+		dst = wiremessage.AppendMsgSectionType(dst, wiremessage.SecurityToken)
+		dst = appendCString(dst, op.SecurityToken)
+	}
+
 	return bsoncore.UpdateLength(dst, wmindex, int32(len(dst[wmindex:]))), info, nil
+}
+
+func appendCString(buf []byte, s string) []byte {
+	buf = append(buf, s...)
+	buf = append(buf, 0)
+	return buf
 }
 
 // addCommandFields adds the fields for a command to the wire message in dst. This assumes that the start of the document

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -32,6 +32,7 @@ type AbortTransaction struct {
 	writeConcern  *writeconcern.WriteConcern
 	retry         *driver.RetryMode
 	serverAPI     *driver.ServerAPIOptions
+	securityToken string
 }
 
 // NewAbortTransaction constructs and returns a new AbortTransaction.
@@ -64,6 +65,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 		Selector:          at.selector,
 		WriteConcern:      at.writeConcern,
 		ServerAPI:         at.serverAPI,
+		SecurityToken:     at.securityToken,
 	}.Execute(ctx)
 
 }
@@ -195,5 +197,16 @@ func (at *AbortTransaction) ServerAPI(serverAPI *driver.ServerAPIOptions) *Abort
 	}
 
 	at.serverAPI = serverAPI
+	return at
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (at *AbortTransaction) SecurityToken(token string) *AbortTransaction {
+	if at == nil {
+		at = new(AbortTransaction)
+	}
+
+	at.securityToken = token
+
 	return at
 }

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -49,6 +49,7 @@ type Aggregate struct {
 	hasOutputStage           bool
 	customOptions            map[string]bsoncore.Value
 	timeout                  *time.Duration
+	securityToken            string
 
 	result driver.CursorResponse
 }
@@ -67,6 +68,7 @@ func (a *Aggregate) Result(opts driver.CursorOptions) (*driver.BatchCursor, erro
 
 	clock := a.clock
 	opts.ServerAPI = a.serverAPI
+	opts.SecurityToken = a.securityToken
 	return driver.NewBatchCursor(a.result, clientSession, clock, opts)
 }
 
@@ -111,6 +113,7 @@ func (a *Aggregate) Execute(ctx context.Context) error {
 		IsOutputAggregate:              a.hasOutputStage,
 		MaxTime:                        a.maxTime,
 		Timeout:                        a.timeout,
+		SecurityToken:                  a.securityToken,
 	}.Execute(ctx)
 
 }
@@ -415,5 +418,16 @@ func (a *Aggregate) Timeout(timeout *time.Duration) *Aggregate {
 	}
 
 	a.timeout = timeout
+	return a
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (a *Aggregate) SecurityToken(token string) *Aggregate {
+	if a == nil {
+		a = new(Aggregate)
+	}
+
+	a.securityToken = token
+
 	return a
 }

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -40,6 +40,7 @@ type Command struct {
 	cursorOpts     driver.CursorOptions
 	timeout        *time.Duration
 	logger         *logger.Logger
+	securityToken  string
 }
 
 // NewCommand constructs and returns a new Command. Once the operation is executed, the result may only be accessed via
@@ -110,6 +111,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		ServerAPI:      c.serverAPI,
 		Timeout:        c.timeout,
 		Logger:         c.logger,
+		SecurityToken:  c.securityToken,
 	}.Execute(ctx)
 }
 
@@ -230,5 +232,16 @@ func (c *Command) Logger(logger *logger.Logger) *Command {
 	}
 
 	c.logger = logger
+	return c
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (c *Command) SecurityToken(token string) *Command {
+	if c == nil {
+		c = new(Command)
+	}
+
+	c.securityToken = token
+
 	return c
 }

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -33,6 +33,7 @@ type CommitTransaction struct {
 	writeConcern  *writeconcern.WriteConcern
 	retry         *driver.RetryMode
 	serverAPI     *driver.ServerAPIOptions
+	securityToken string
 }
 
 // NewCommitTransaction constructs and returns a new CommitTransaction.
@@ -66,6 +67,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 		Selector:          ct.selector,
 		WriteConcern:      ct.writeConcern,
 		ServerAPI:         ct.serverAPI,
+		SecurityToken:     ct.securityToken,
 	}.Execute(ctx)
 
 }
@@ -197,5 +199,16 @@ func (ct *CommitTransaction) ServerAPI(serverAPI *driver.ServerAPIOptions) *Comm
 	}
 
 	ct.serverAPI = serverAPI
+	return ct
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (ct *CommitTransaction) SecurityToken(token string) *CommitTransaction {
+	if ct == nil {
+		ct = new(CommitTransaction)
+	}
+
+	ct.securityToken = token
+
 	return ct
 }

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -41,6 +41,7 @@ type Count struct {
 	result         CountResult
 	serverAPI      *driver.ServerAPIOptions
 	timeout        *time.Duration
+	securityToken  string
 }
 
 // CountResult represents a count result returned by the server.
@@ -126,6 +127,7 @@ func (c *Count) Execute(ctx context.Context) error {
 		Selector:          c.selector,
 		ServerAPI:         c.serverAPI,
 		Timeout:           c.timeout,
+		SecurityToken:     c.securityToken,
 	}.Execute(ctx)
 
 	// Swallow error if NamespaceNotFound(26) is returned from aggregate on non-existent namespace
@@ -307,5 +309,16 @@ func (c *Count) Timeout(timeout *time.Duration) *Count {
 	}
 
 	c.timeout = timeout
+	return c
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (c *Count) SecurityToken(token string) *Count {
+	if c == nil {
+		c = new(Count)
+	}
+
+	c.securityToken = token
+
 	return c
 }

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -46,6 +46,7 @@ type Create struct {
 	timeSeries                   bsoncore.Document
 	encryptedFields              bsoncore.Document
 	clusteredIndex               bsoncore.Document
+	securityToken                string
 }
 
 // NewCreate constructs and returns a new Create.
@@ -77,6 +78,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		Selector:          c.selector,
 		WriteConcern:      c.writeConcern,
 		ServerAPI:         c.serverAPI,
+		SecurityToken:     c.securityToken,
 	}.Execute(ctx)
 
 }
@@ -398,5 +400,16 @@ func (c *Create) ClusteredIndex(ci bsoncore.Document) *Create {
 	}
 
 	c.clusteredIndex = ci
+	return c
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (c *Create) SecurityToken(token string) *Create {
+	if c == nil {
+		c = new(Create)
+	}
+
+	c.securityToken = token
+
 	return c
 }

--- a/x/mongo/driver/operation/createIndexes.go
+++ b/x/mongo/driver/operation/createIndexes.go
@@ -23,21 +23,22 @@ import (
 
 // CreateIndexes performs a createIndexes operation.
 type CreateIndexes struct {
-	commitQuorum bsoncore.Value
-	indexes      bsoncore.Document
-	maxTime      *time.Duration
-	session      *session.Client
-	clock        *session.ClusterClock
-	collection   string
-	monitor      *event.CommandMonitor
-	crypt        driver.Crypt
-	database     string
-	deployment   driver.Deployment
-	selector     description.ServerSelector
-	writeConcern *writeconcern.WriteConcern
-	result       CreateIndexesResult
-	serverAPI    *driver.ServerAPIOptions
-	timeout      *time.Duration
+	commitQuorum  bsoncore.Value
+	indexes       bsoncore.Document
+	maxTime       *time.Duration
+	session       *session.Client
+	clock         *session.ClusterClock
+	collection    string
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	writeConcern  *writeconcern.WriteConcern
+	result        CreateIndexesResult
+	serverAPI     *driver.ServerAPIOptions
+	timeout       *time.Duration
+	securityToken string
 }
 
 // CreateIndexesResult represents a createIndexes result returned by the server.
@@ -117,6 +118,7 @@ func (ci *CreateIndexes) Execute(ctx context.Context) error {
 		WriteConcern:      ci.writeConcern,
 		ServerAPI:         ci.serverAPI,
 		Timeout:           ci.timeout,
+		SecurityToken:     ci.securityToken,
 	}.Execute(ctx)
 
 }
@@ -274,5 +276,16 @@ func (ci *CreateIndexes) Timeout(timeout *time.Duration) *CreateIndexes {
 	}
 
 	ci.timeout = timeout
+	return ci
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (ci *CreateIndexes) SecurityToken(token string) *CreateIndexes {
+	if ci == nil {
+		ci = new(CreateIndexes)
+	}
+
+	ci.securityToken = token
+
 	return ci
 }

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -24,25 +24,26 @@ import (
 
 // Delete performs a delete operation
 type Delete struct {
-	comment      bsoncore.Value
-	deletes      []bsoncore.Document
-	ordered      *bool
-	session      *session.Client
-	clock        *session.ClusterClock
-	collection   string
-	monitor      *event.CommandMonitor
-	crypt        driver.Crypt
-	database     string
-	deployment   driver.Deployment
-	selector     description.ServerSelector
-	writeConcern *writeconcern.WriteConcern
-	retry        *driver.RetryMode
-	hint         *bool
-	result       DeleteResult
-	serverAPI    *driver.ServerAPIOptions
-	let          bsoncore.Document
-	timeout      *time.Duration
-	logger       *logger.Logger
+	comment       bsoncore.Value
+	deletes       []bsoncore.Document
+	ordered       *bool
+	session       *session.Client
+	clock         *session.ClusterClock
+	collection    string
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	writeConcern  *writeconcern.WriteConcern
+	retry         *driver.RetryMode
+	hint          *bool
+	result        DeleteResult
+	serverAPI     *driver.ServerAPIOptions
+	let           bsoncore.Document
+	timeout       *time.Duration
+	logger        *logger.Logger
+	securityToken string
 }
 
 // DeleteResult represents a delete result returned by the server.
@@ -114,6 +115,7 @@ func (d *Delete) Execute(ctx context.Context) error {
 		ServerAPI:         d.serverAPI,
 		Timeout:           d.timeout,
 		Logger:            d.logger,
+		SecurityToken:     d.securityToken,
 	}.Execute(ctx)
 
 }
@@ -323,6 +325,17 @@ func (d *Delete) Logger(logger *logger.Logger) *Delete {
 	}
 
 	d.logger = logger
+
+	return d
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (d *Delete) SecurityToken(token string) *Delete {
+	if d == nil {
+		d = new(Delete)
+	}
+
+	d.securityToken = token
 
 	return d
 }

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -42,6 +42,7 @@ type Distinct struct {
 	result         DistinctResult
 	serverAPI      *driver.ServerAPIOptions
 	timeout        *time.Duration
+	securityToken  string
 }
 
 // DistinctResult represents a distinct result returned by the server.
@@ -105,6 +106,7 @@ func (d *Distinct) Execute(ctx context.Context) error {
 		Selector:          d.selector,
 		ServerAPI:         d.serverAPI,
 		Timeout:           d.timeout,
+		SecurityToken:     d.securityToken,
 	}.Execute(ctx)
 
 }
@@ -307,5 +309,16 @@ func (d *Distinct) Timeout(timeout *time.Duration) *Distinct {
 	}
 
 	d.timeout = timeout
+	return d
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (d *Distinct) SecurityToken(token string) *Distinct {
+	if d == nil {
+		d = new(Distinct)
+	}
+
+	d.securityToken = token
+
 	return d
 }

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -22,18 +22,19 @@ import (
 
 // DropCollection performs a drop operation.
 type DropCollection struct {
-	session      *session.Client
-	clock        *session.ClusterClock
-	collection   string
-	monitor      *event.CommandMonitor
-	crypt        driver.Crypt
-	database     string
-	deployment   driver.Deployment
-	selector     description.ServerSelector
-	writeConcern *writeconcern.WriteConcern
-	result       DropCollectionResult
-	serverAPI    *driver.ServerAPIOptions
-	timeout      *time.Duration
+	session       *session.Client
+	clock         *session.ClusterClock
+	collection    string
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	writeConcern  *writeconcern.WriteConcern
+	result        DropCollectionResult
+	serverAPI     *driver.ServerAPIOptions
+	timeout       *time.Duration
+	securityToken string
 }
 
 // DropCollectionResult represents a dropCollection result returned by the server.
@@ -102,6 +103,7 @@ func (dc *DropCollection) Execute(ctx context.Context) error {
 		WriteConcern:      dc.writeConcern,
 		ServerAPI:         dc.serverAPI,
 		Timeout:           dc.timeout,
+		SecurityToken:     dc.securityToken,
 	}.Execute(ctx)
 
 }
@@ -218,5 +220,16 @@ func (dc *DropCollection) Timeout(timeout *time.Duration) *DropCollection {
 	}
 
 	dc.timeout = timeout
+	return dc
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (dc *DropCollection) SecurityToken(token string) *DropCollection {
+	if dc == nil {
+		dc = new(DropCollection)
+	}
+
+	dc.securityToken = token
+
 	return dc
 }

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -20,15 +20,16 @@ import (
 
 // DropDatabase performs a dropDatabase operation
 type DropDatabase struct {
-	session      *session.Client
-	clock        *session.ClusterClock
-	monitor      *event.CommandMonitor
-	crypt        driver.Crypt
-	database     string
-	deployment   driver.Deployment
-	selector     description.ServerSelector
-	writeConcern *writeconcern.WriteConcern
-	serverAPI    *driver.ServerAPIOptions
+	session       *session.Client
+	clock         *session.ClusterClock
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	writeConcern  *writeconcern.WriteConcern
+	serverAPI     *driver.ServerAPIOptions
+	securityToken string
 }
 
 // NewDropDatabase constructs and returns a new DropDatabase.
@@ -53,6 +54,7 @@ func (dd *DropDatabase) Execute(ctx context.Context) error {
 		Selector:       dd.selector,
 		WriteConcern:   dd.writeConcern,
 		ServerAPI:      dd.serverAPI,
+		SecurityToken:  dd.securityToken,
 	}.Execute(ctx)
 
 }
@@ -150,5 +152,16 @@ func (dd *DropDatabase) ServerAPI(serverAPI *driver.ServerAPIOptions) *DropDatab
 	}
 
 	dd.serverAPI = serverAPI
+	return dd
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (dd *DropDatabase) SecurityToken(token string) *DropDatabase {
+	if dd == nil {
+		dd = new(DropDatabase)
+	}
+
+	dd.securityToken = token
+
 	return dd
 }

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -22,20 +22,21 @@ import (
 
 // DropIndexes performs an dropIndexes operation.
 type DropIndexes struct {
-	index        *string
-	maxTime      *time.Duration
-	session      *session.Client
-	clock        *session.ClusterClock
-	collection   string
-	monitor      *event.CommandMonitor
-	crypt        driver.Crypt
-	database     string
-	deployment   driver.Deployment
-	selector     description.ServerSelector
-	writeConcern *writeconcern.WriteConcern
-	result       DropIndexesResult
-	serverAPI    *driver.ServerAPIOptions
-	timeout      *time.Duration
+	index         *string
+	maxTime       *time.Duration
+	session       *session.Client
+	clock         *session.ClusterClock
+	collection    string
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	writeConcern  *writeconcern.WriteConcern
+	result        DropIndexesResult
+	serverAPI     *driver.ServerAPIOptions
+	timeout       *time.Duration
+	securityToken string
 }
 
 // DropIndexesResult represents a dropIndexes result returned by the server.
@@ -99,6 +100,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 		WriteConcern:      di.writeConcern,
 		ServerAPI:         di.serverAPI,
 		Timeout:           di.timeout,
+		SecurityToken:     di.securityToken,
 	}.Execute(ctx)
 
 }
@@ -238,5 +240,16 @@ func (di *DropIndexes) Timeout(timeout *time.Duration) *DropIndexes {
 	}
 
 	di.timeout = timeout
+	return di
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (di *DropIndexes) SecurityToken(token string) *DropIndexes {
+	if di == nil {
+		di = new(DropIndexes)
+	}
+
+	di.securityToken = token
+
 	return di
 }

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -19,15 +19,16 @@ import (
 
 // EndSessions performs an endSessions operation.
 type EndSessions struct {
-	sessionIDs bsoncore.Document
-	session    *session.Client
-	clock      *session.ClusterClock
-	monitor    *event.CommandMonitor
-	crypt      driver.Crypt
-	database   string
-	deployment driver.Deployment
-	selector   description.ServerSelector
-	serverAPI  *driver.ServerAPIOptions
+	sessionIDs    bsoncore.Document
+	session       *session.Client
+	clock         *session.ClusterClock
+	monitor       *event.CommandMonitor
+	crypt         driver.Crypt
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	serverAPI     *driver.ServerAPIOptions
+	securityToken string
 }
 
 // NewEndSessions constructs and returns a new EndSessions.
@@ -59,6 +60,7 @@ func (es *EndSessions) Execute(ctx context.Context) error {
 		Deployment:        es.deployment,
 		Selector:          es.selector,
 		ServerAPI:         es.serverAPI,
+		SecurityToken:     es.securityToken,
 	}.Execute(ctx)
 
 }
@@ -157,5 +159,16 @@ func (es *EndSessions) ServerAPI(serverAPI *driver.ServerAPIOptions) *EndSession
 	}
 
 	es.serverAPI = serverAPI
+	return es
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (es *EndSessions) SecurityToken(token string) *EndSessions {
+	if es == nil {
+		es = new(EndSessions)
+	}
+
+	es.securityToken = token
+
 	return es
 }

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -62,6 +62,7 @@ type Find struct {
 	serverAPI           *driver.ServerAPIOptions
 	timeout             *time.Duration
 	logger              *logger.Logger
+	securityToken       string
 }
 
 // NewFind constructs and returns a new Find.
@@ -74,6 +75,7 @@ func NewFind(filter bsoncore.Document) *Find {
 // Result returns the result of executing this operation.
 func (f *Find) Result(opts driver.CursorOptions) (*driver.BatchCursor, error) {
 	opts.ServerAPI = f.serverAPI
+	opts.SecurityToken = f.securityToken
 	return driver.NewBatchCursor(f.result, f.session, f.clock, opts)
 }
 
@@ -108,6 +110,7 @@ func (f *Find) Execute(ctx context.Context) error {
 		ServerAPI:         f.serverAPI,
 		Timeout:           f.timeout,
 		Logger:            f.logger,
+		SecurityToken:     f.securityToken,
 	}.Execute(ctx)
 
 }
@@ -557,5 +560,16 @@ func (f *Find) Logger(logger *logger.Logger) *Find {
 	}
 
 	f.logger = logger
+	return f
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (f *Find) SecurityToken(token string) *Find {
+	if f == nil {
+		f = new(Find)
+	}
+
+	f.securityToken = token
+
 	return f
 }

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -50,6 +50,7 @@ type FindAndModify struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	timeout                  *time.Duration
+	securityToken            string
 
 	result FindAndModifyResult
 }
@@ -143,6 +144,7 @@ func (fam *FindAndModify) Execute(ctx context.Context) error {
 		Crypt:          fam.crypt,
 		ServerAPI:      fam.serverAPI,
 		Timeout:        fam.timeout,
+		SecurityToken:  fam.securityToken,
 	}.Execute(ctx)
 
 }
@@ -473,5 +475,16 @@ func (fam *FindAndModify) Timeout(timeout *time.Duration) *FindAndModify {
 	}
 
 	fam.timeout = timeout
+	return fam
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (fam *FindAndModify) SecurityToken(token string) *FindAndModify {
+	if fam == nil {
+		fam = new(FindAndModify)
+	}
+
+	fam.securityToken = token
+
 	return fam
 }

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -42,6 +42,7 @@ type Insert struct {
 	serverAPI                *driver.ServerAPIOptions
 	timeout                  *time.Duration
 	logger                   *logger.Logger
+	securityToken            string
 }
 
 // InsertResult represents an insert result returned by the server.
@@ -113,6 +114,7 @@ func (i *Insert) Execute(ctx context.Context) error {
 		ServerAPI:         i.serverAPI,
 		Timeout:           i.timeout,
 		Logger:            i.logger,
+		SecurityToken:     i.securityToken,
 	}.Execute(ctx)
 
 }
@@ -302,5 +304,16 @@ func (i *Insert) Logger(logger *logger.Logger) *Insert {
 	}
 
 	i.logger = logger
+	return i
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (i *Insert) SecurityToken(token string) *Insert {
+	if i == nil {
+		i = new(Insert)
+	}
+
+	i.securityToken = token
+
 	return i
 }

--- a/x/mongo/driver/operation/listDatabases.go
+++ b/x/mongo/driver/operation/listDatabases.go
@@ -37,6 +37,7 @@ type ListDatabases struct {
 	crypt               driver.Crypt
 	serverAPI           *driver.ServerAPIOptions
 	timeout             *time.Duration
+	securityToken       string
 
 	result ListDatabasesResult
 }
@@ -163,6 +164,7 @@ func (ld *ListDatabases) Execute(ctx context.Context) error {
 		Crypt:          ld.crypt,
 		ServerAPI:      ld.serverAPI,
 		Timeout:        ld.timeout,
+		SecurityToken:  ld.securityToken,
 	}.Execute(ctx)
 
 }
@@ -323,5 +325,16 @@ func (ld *ListDatabases) Timeout(timeout *time.Duration) *ListDatabases {
 	}
 
 	ld.timeout = timeout
+	return ld
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (ld *ListDatabases) SecurityToken(token string) *ListDatabases {
+	if ld == nil {
+		ld = new(ListDatabases)
+	}
+
+	ld.securityToken = token
+
 	return ld
 }

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -37,6 +37,7 @@ type ListCollections struct {
 	batchSize             *int32
 	serverAPI             *driver.ServerAPIOptions
 	timeout               *time.Duration
+	securityToken         string
 }
 
 // NewListCollections constructs and returns a new ListCollections.
@@ -49,6 +50,7 @@ func NewListCollections(filter bsoncore.Document) *ListCollections {
 // Result returns the result of executing this operation.
 func (lc *ListCollections) Result(opts driver.CursorOptions) (*driver.ListCollectionsBatchCursor, error) {
 	opts.ServerAPI = lc.serverAPI
+	opts.SecurityToken = lc.securityToken
 	bc, err := driver.NewBatchCursor(lc.result, lc.session, lc.clock, opts)
 	if err != nil {
 		return nil, err
@@ -88,6 +90,7 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 		Legacy:            driver.LegacyListCollections,
 		ServerAPI:         lc.serverAPI,
 		Timeout:           lc.timeout,
+		SecurityToken:     lc.securityToken,
 	}.Execute(ctx)
 
 }
@@ -262,5 +265,16 @@ func (lc *ListCollections) Timeout(timeout *time.Duration) *ListCollections {
 	}
 
 	lc.timeout = timeout
+	return lc
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (lc *ListCollections) SecurityToken(token string) *ListCollections {
+	if lc == nil {
+		lc = new(ListCollections)
+	}
+
+	lc.securityToken = token
+
 	return lc
 }

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -20,19 +20,20 @@ import (
 
 // ListIndexes performs a listIndexes operation.
 type ListIndexes struct {
-	batchSize  *int32
-	maxTime    *time.Duration
-	session    *session.Client
-	clock      *session.ClusterClock
-	collection string
-	monitor    *event.CommandMonitor
-	database   string
-	deployment driver.Deployment
-	selector   description.ServerSelector
-	retry      *driver.RetryMode
-	crypt      driver.Crypt
-	serverAPI  *driver.ServerAPIOptions
-	timeout    *time.Duration
+	batchSize     *int32
+	maxTime       *time.Duration
+	session       *session.Client
+	clock         *session.ClusterClock
+	collection    string
+	monitor       *event.CommandMonitor
+	database      string
+	deployment    driver.Deployment
+	selector      description.ServerSelector
+	retry         *driver.RetryMode
+	crypt         driver.Crypt
+	serverAPI     *driver.ServerAPIOptions
+	timeout       *time.Duration
+	securityToken string
 
 	result driver.CursorResponse
 }
@@ -49,6 +50,7 @@ func (li *ListIndexes) Result(opts driver.CursorOptions) (*driver.BatchCursor, e
 
 	clock := li.clock
 	opts.ServerAPI = li.serverAPI
+	opts.SecurityToken = li.securityToken
 	return driver.NewBatchCursor(li.result, clientSession, clock, opts)
 }
 
@@ -83,6 +85,7 @@ func (li *ListIndexes) Execute(ctx context.Context) error {
 		Type:           driver.Read,
 		ServerAPI:      li.serverAPI,
 		Timeout:        li.timeout,
+		SecurityToken:  li.securityToken,
 	}.Execute(ctx)
 
 }
@@ -229,5 +232,16 @@ func (li *ListIndexes) Timeout(timeout *time.Duration) *ListIndexes {
 	}
 
 	li.timeout = timeout
+	return li
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (li *ListIndexes) SecurityToken(token string) *ListIndexes {
+	if li == nil {
+		li = new(ListIndexes)
+	}
+
+	li.securityToken = token
+
 	return li
 }

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -46,6 +46,7 @@ type Update struct {
 	let                      bsoncore.Document
 	timeout                  *time.Duration
 	logger                   *logger.Logger
+	securityToken            string
 }
 
 // Upsert contains the information for an upsert in an Update operation.
@@ -165,6 +166,7 @@ func (u *Update) Execute(ctx context.Context) error {
 		ServerAPI:         u.serverAPI,
 		Timeout:           u.timeout,
 		Logger:            u.logger,
+		SecurityToken:     u.securityToken,
 	}.Execute(ctx)
 
 }
@@ -410,5 +412,16 @@ func (u *Update) Logger(logger *logger.Logger) *Update {
 	}
 
 	u.logger = logger
+	return u
+}
+
+// SecurityToken sets the JWT security token for this operation.
+func (u *Update) SecurityToken(token string) *Update {
+	if u == nil {
+		u = new(Update)
+	}
+
+	u.securityToken = token
+
 	return u
 }

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -426,6 +426,11 @@ func ReadMsgSectionRawDocumentSequence(src []byte) (identifier string, data []by
 	return identifier, rem, rest, true
 }
 
+// ReadMsgSectionSecurityToken reads a security token from src.
+func ReadMsgSectionSecurityToken(src []byte) (securityToken string, rem []byte, ok bool) {
+	return readcstring(src)
+}
+
 // ReadMsgChecksum reads a checksum from src.
 func ReadMsgChecksum(src []byte) (checksum uint32, rem []byte, ok bool) {
 	i32, rem, ok := readi32(src)
@@ -556,10 +561,6 @@ func ReadKillCursorsCursorIDs(src []byte, numIDs int32) (cursorIDs []int64, rem 
 		cursorIDs = append(cursorIDs, id)
 	}
 	return cursorIDs, src, true
-}
-
-func ReadSecurityToken(src []byte) (securityToken string, rem []byte, ok bool) {
-	return readcstring(src)
 }
 
 func appendi32(dst []byte, i32 int32) []byte {

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -172,6 +172,7 @@ type SectionType uint8
 const (
 	SingleDocument SectionType = iota
 	DocumentSequence
+	SecurityToken
 )
 
 // OpmsgWireVersion is the minimum wire version needed to use OP_MSG
@@ -555,6 +556,10 @@ func ReadKillCursorsCursorIDs(src []byte, numIDs int32) (cursorIDs []int64, rem 
 		cursorIDs = append(cursorIDs, id)
 	}
 	return cursorIDs, src, true
+}
+
+func ReadSecurityToken(src []byte) (securityToken string, rem []byte, ok bool) {
+	return readcstring(src)
 }
 
 func appendi32(dst []byte, i32 int32) []byte {


### PR DESCRIPTION
[GODRIVER-3039](https://jira.mongodb.org/browse/GODRIVER-3039)

## Summary

* Support the new "security token" section to the wiremessage format.
* Add a `Client` configuration for the security token string.
* If set, send the security token string with all commands (except hello / legacy hello).
* Add a new CI task that starts a replica set with parameter "multitenancySupport: 1" set and runs the Collection and Database tests against the replica set.

Note that this is specific for the `cloud-1.12.0` branch. This feature will be ported to a public release after [GODRIVER-3037](https://jira.mongodb.org/browse/GODRIVER-3037) is complete.

## Background & Motivation

See [GODRIVER-3039](https://jira.mongodb.org/browse/GODRIVER-3039).
