### PR TITLE
GODRIVER-2392 Remove all "import comments" on Go Driver packages

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package event // import "go.mongodb.org/mongo-driver/event"
+package event
 
 import (
 	"context"

--- a/internal/benchmark/harness.go
+++ b/internal/benchmark/harness.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package benchmark // import "go.mongodb.org/mongo-driver/benchmark"
+package benchmark
 
 import (
 	"context"

--- a/mongo/address/addr.go
+++ b/mongo/address/addr.go
@@ -5,7 +5,7 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package address provides structured representations of network addresses.
-package address // import "go.mongodb.org/mongo-driver/mongo/address"
+package address
 
 import (
 	"net"

--- a/mongo/description/description.go
+++ b/mongo/description/description.go
@@ -5,7 +5,7 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package description contains types and functions for describing the state of MongoDB clusters.
-package description // import "go.mongodb.org/mongo-driver/mongo/description"
+package description
 
 // Unknown is an unknown server or topology kind.
 const Unknown = 0

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package gridfs // import "go.mongodb.org/mongo-driver/mongo/gridfs"
+package gridfs
 
 import (
 	"bytes"

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package mongo // import "go.mongodb.org/mongo-driver/mongo"
+package mongo
 
 import (
 	"bytes"

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package options // import "go.mongodb.org/mongo-driver/mongo/options"
+package options
 
 import (
 	"bytes"

--- a/mongo/readconcern/readconcern.go
+++ b/mongo/readconcern/readconcern.go
@@ -8,7 +8,7 @@
 //
 // For more information about MongoDB read concerns, see
 // https://www.mongodb.com/docs/manual/reference/read-concern/
-package readconcern // import "go.mongodb.org/mongo-driver/mongo/readconcern"
+package readconcern
 
 import (
 	"errors"

--- a/mongo/readpref/readpref.go
+++ b/mongo/readpref/readpref.go
@@ -5,7 +5,7 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package readpref defines read preferences for MongoDB queries.
-package readpref // import "go.mongodb.org/mongo-driver/mongo/readpref"
+package readpref
 
 import (
 	"bytes"

--- a/mongo/writeconcern/writeconcern.go
+++ b/mongo/writeconcern/writeconcern.go
@@ -8,7 +8,7 @@
 //
 // For more information about MongoDB write concerns, see
 // https://www.mongodb.com/docs/manual/reference/write-concern/
-package writeconcern // import "go.mongodb.org/mongo-driver/mongo/writeconcern"
+package writeconcern
 
 import (
 	"errors"

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -8,7 +8,7 @@
 //
 // For more information about read preference tags, see
 // https://www.mongodb.com/docs/manual/core/read-preference-tags/
-package tag // import "go.mongodb.org/mongo-driver/tag"
+package tag
 
 import (
 	"bytes"

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package version defines the Go Driver version.
-package version // import "go.mongodb.org/mongo-driver/version"
+package version
 
 // Driver is the current version of the driver.
 var Driver = "v2.0.0-prerelease"

--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package bsoncore // import "go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+package bsoncore
 
 import (
 	"bytes"

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package connstring // import "go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
+package connstring
 
 import (
 	"errors"

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package driver // import "go.mongodb.org/mongo-driver/x/mongo/driver"
+package driver
 
 import (
 	"context"

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -4,7 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-package session // import "go.mongodb.org/mongo-driver/x/mongo/driver/session"
+package session
 
 import (
 	"context"

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -8,7 +8,7 @@
 // of servers. This package is designed to expose enough inner workings of service discovery
 // and monitoring to allow low level applications to have fine grained control, while hiding
 // most of the detailed implementation of the algorithms.
-package topology // import "go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+package topology
 
 import (
 	"context"


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

GODRIVER-2392

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Remove all vestigial "import comments" from the Go Driver. See [GODRIVER-2977](https://jira.mongodb.org/browse/GODRIVER-2977) for the ticket for removing import comments from the BSON library.

## Background & Motivation

<!--- Rationale for the pull request. -->
