### PR TITLE
GODRIVER-3071 Correct uint Encoding BSON Documentation

### DIFF
--- a/bson/doc.go
+++ b/bson/doc.go
@@ -68,7 +68,7 @@
 //  2. int8, int16, and int32 marshal to a BSON int32.
 //  3. int marshals to a BSON int32 if the value is between math.MinInt32 and math.MaxInt32, inclusive, and a BSON int64
 //     otherwise.
-//  4. int64 marshals to BSON int64.
+//  4. int64 marshals to BSON int64 (unless [Encoder.IntMinSize] is set).
 //  5. uint8 and uint16 marshal to a BSON int32.
 //  6. When encoding with EncodeContext.MinSize set to true, uint, uint32, and uint64 will marshal to a BSON int32 if
 //     the value falls within the inclusive range of math.MinInt32 to math.MaxInt32. Otherwise, they will marshal to a

--- a/bson/doc.go
+++ b/bson/doc.go
@@ -70,8 +70,9 @@
 //     otherwise.
 //  4. int64 marshals to BSON int64.
 //  5. uint8 and uint16 marshal to a BSON int32.
-//  6. uint, uint32, and uint64 marshal to a BSON int32 if the value is between math.MinInt32 and math.MaxInt32,
-//     inclusive, and BSON int64 otherwise.
+//  6. When encoding with EncodeContext.MinSize set to true, uint, uint32, and uint64 will marshal to a BSON int32 if
+//     the value falls within the inclusive range of math.MinInt32 to math.MaxInt32. Otherwise, they will marshal to a
+//     BSON int64. See Encoder examples for usage of EncodeContext.MinSize.
 //  7. BSON null and undefined values will unmarshal into the zero value of a field (e.g. unmarshalling a BSON null or
 //     undefined value into a string will yield the empty string.).
 //

--- a/bson/doc.go
+++ b/bson/doc.go
@@ -70,9 +70,7 @@
 //     otherwise.
 //  4. int64 marshals to BSON int64 (unless [Encoder.IntMinSize] is set).
 //  5. uint8 and uint16 marshal to a BSON int32.
-//  6. When encoding with EncodeContext.MinSize set to true, uint, uint32, and uint64 will marshal to a BSON int32 if
-//     the value falls within the inclusive range of math.MinInt32 to math.MaxInt32. Otherwise, they will marshal to a
-//     BSON int64. See Encoder examples for usage of Encoder.IntMinSize.
+//  6. uint, uint32, and uint64 marshal to a BSON int64 (unless [Encoder.IntMinSize] is set).
 //  7. BSON null and undefined values will unmarshal into the zero value of a field (e.g. unmarshalling a BSON null or
 //     undefined value into a string will yield the empty string.).
 //

--- a/bson/doc.go
+++ b/bson/doc.go
@@ -72,7 +72,7 @@
 //  5. uint8 and uint16 marshal to a BSON int32.
 //  6. When encoding with EncodeContext.MinSize set to true, uint, uint32, and uint64 will marshal to a BSON int32 if
 //     the value falls within the inclusive range of math.MinInt32 to math.MaxInt32. Otherwise, they will marshal to a
-//     BSON int64. See Encoder examples for usage of EncodeContext.MinSize.
+//     BSON int64. See Encoder examples for usage of Encoder.IntMinSize.
 //  7. BSON null and undefined values will unmarshal into the zero value of a field (e.g. unmarshalling a BSON null or
 //     undefined value into a string will yield the empty string.).
 //

--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -252,3 +252,33 @@ func ExampleEncoder_multipleExtendedJSONDocuments() {
 	// {"x":{"$numberInt":"3"},"y":{"$numberInt":"4"}}
 	// {"x":{"$numberInt":"4"},"y":{"$numberInt":"5"}}
 }
+
+func ExampleEncoder_IntMinSize() {
+	// Create an encoder that will marshal integers as the minimum BSON int size
+	// (either 32 or 64 bits) that can represent the integer value.
+	type foo struct {
+		Bar uint32
+	}
+
+	buf := new(bytes.Buffer)
+	vw, err := bsonrw.NewBSONValueWriter(buf)
+	if err != nil {
+		panic(err)
+	}
+
+	enc, err := bson.NewEncoder(vw)
+	if err != nil {
+		panic(err)
+	}
+
+	enc.IntMinSize()
+
+	err = enc.Encode(foo{2})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(bson.Raw(buf.Bytes()).String())
+	// Output:
+	// {"bar": {"$numberInt":"2"}}
+}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3071

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Update documentation for when the Go Driver will marshal Go integer values (int, int8, int16, int32, int64, uint, uint8, uint16, uint32, or uint64) as the minimum BSON int size (either 32 or 64 bits) that can represent the integer value.

## Background & Motivation

<!--- Rationale for the pull request. -->

A user submitted [this](https://www.mongodb.com/community/forums/t/mongo-go-driver-uint-always-marshals-to-bson-int64/257633) community issue describing how the Go Driver does not work as described in the following documentation:

> uint, uint32, and uint64 marshal to a BSON int32 if the value is between math.MinInt32 and math.MaxInt32, inclusive, and BSON int64 otherwise.

The logic for this, added in [GODRIVER-1358](https://jira.mongodb.org/browse/GODRIVER-1358), is contradictory. The default case for the "min int" condition in the UintCodec is false / nil, which means that an type >= 32-bits will be considered int64. This can also be effected by [EncodeContext.MinSize](https://pkg.go.dev/go.mongodb.org/mongo-driver/bson/bsoncodec#EncodeContext).

