### PR TITLE
GODRIVER-3108 Optimize writeServerSelector

### DIFF
--- a/mongo/description/selector_test.go
+++ b/mongo/description/selector_test.go
@@ -364,6 +364,27 @@ func BenchmarkSelector_Sharded(b *testing.B) {
 	}
 }
 
+func Benchmark_SelectServer_SelectServer(b *testing.B) {
+	topology := Topology{Kind: ReplicaSet} // You can change the topology as needed
+	candidates := []Server{
+		{Kind: Mongos},
+		{Kind: RSPrimary},
+		{Kind: Standalone},
+	}
+
+	selector := writeServerSelector{} // Assuming this is the receiver type
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := selector.SelectServer(topology, candidates)
+		if err != nil {
+			b.Fatalf("Error selecting server: %v", err)
+		}
+	}
+}
+
 func TestSelector_Single(t *testing.T) {
 	t.Parallel()
 

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -182,7 +182,7 @@ func (writeServerSelector) SelectServer(t Topology, candidates []Server) ([]Serv
 	case Single, LoadBalanced:
 		return candidates, nil
 	default:
-                // Determine the capacity of the results slice.
+		// Determine the capacity of the results slice.
 		selected := 0
 		for _, candidate := range candidates {
 			switch candidate.Kind {
@@ -191,7 +191,7 @@ func (writeServerSelector) SelectServer(t Topology, candidates []Server) ([]Serv
 			}
 		}
 
-                // Append candidates to the results slice.
+		// Append candidates to the results slice.
 		result := make([]Server, 0, selected)
 		for _, candidate := range candidates {
 			switch candidate.Kind {

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -182,7 +182,17 @@ func (writeServerSelector) SelectServer(t Topology, candidates []Server) ([]Serv
 	case Single, LoadBalanced:
 		return candidates, nil
 	default:
-		result := []Server{}
+		selected := 0
+		for _, candidate := range candidates {
+			switch candidate.Kind {
+			case Mongos, RSPrimary, Standalone:
+				selected++
+			}
+		}
+		if selected == len(candidates) {
+			return candidates, nil
+		}
+		result := make([]Server, 0, selected)
 		for _, candidate := range candidates {
 			switch candidate.Kind {
 			case Mongos, RSPrimary, Standalone:

--- a/mongo/description/server_selector.go
+++ b/mongo/description/server_selector.go
@@ -182,6 +182,7 @@ func (writeServerSelector) SelectServer(t Topology, candidates []Server) ([]Serv
 	case Single, LoadBalanced:
 		return candidates, nil
 	default:
+                // Determine the capacity of the results slice.
 		selected := 0
 		for _, candidate := range candidates {
 			switch candidate.Kind {
@@ -189,9 +190,8 @@ func (writeServerSelector) SelectServer(t Topology, candidates []Server) ([]Serv
 				selected++
 			}
 		}
-		if selected == len(candidates) {
-			return candidates, nil
-		}
+
+                // Append candidates to the results slice.
 		result := make([]Server, 0, selected)
 		for _, candidate := range candidates {
 			switch candidate.Kind {


### PR DESCRIPTION

## Summary

Optimize allocations of Server slices during writes.

## Background & Motivation

On one of my services this function allocates 295 GBs over several days.
<img width="1473" alt="image" src="https://github.com/mongodb/mongo-go-driver/assets/462800/79b167c8-0a47-4965-b374-ef5e128f4965">
This is very similar to #1107 #1108 #1111. NB: one of these optimizations was reverted for correctness - 26e6c8ac9da113e7e4398588bd9ffa42cdc4e2ea I used similar here, but cannot judge wether it may be used here.
