### PR TITLE
GODRIVER-3081 Fix zero value detection for empty slices and maps.

### DIFF
--- a/bson/bsoncodec/struct_codec.go
+++ b/bson/bsoncodec/struct_codec.go
@@ -396,7 +396,10 @@ func isZero(v reflect.Value, omitZeroStruct bool) bool {
 	if (kind != reflect.Ptr || !v.IsNil()) && v.Type().Implements(tZeroer) {
 		return v.Interface().(Zeroer).IsZero()
 	}
-	if kind == reflect.Struct {
+	switch kind {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Struct:
 		if !omitZeroStruct {
 			return false
 		}

--- a/bson/bsoncodec/struct_codec_test.go
+++ b/bson/bsoncodec/struct_codec_test.go
@@ -140,6 +140,21 @@ func TestIsZero(t *testing.T) {
 			omitZeroStruct: true,
 			want:           false,
 		},
+		{
+			description: "empty map",
+			value:       map[string]string{},
+			want:        true,
+		},
+		{
+			description: "empty slice",
+			value:       []struct{}{},
+			want:        true,
+		},
+		{
+			description: "empty string",
+			value:       "",
+			want:        true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bson/primitive_codecs_test.go
+++ b/bson/primitive_codecs_test.go
@@ -261,6 +261,36 @@ func TestDefaultValueEncoders(t *testing.T) {
 				nil,
 			},
 			{
+				"omitempty map",
+				struct {
+					T map[string]string `bson:",omitempty"`
+				}{
+					T: map[string]string{},
+				},
+				docToBytes(D{}),
+				nil,
+			},
+			{
+				"omitempty slice",
+				struct {
+					T []struct{} `bson:",omitempty"`
+				}{
+					T: []struct{}{},
+				},
+				docToBytes(D{}),
+				nil,
+			},
+			{
+				"omitempty string",
+				struct {
+					T string `bson:",omitempty"`
+				}{
+					T: "",
+				},
+				docToBytes(D{}),
+				nil,
+			},
+			{
 				"struct{}",
 				struct {
 					A bool
@@ -598,7 +628,6 @@ func TestDefaultValueDecoders(t *testing.T) {
 						llvrw = rc.llvrw
 					}
 					llvrw.T = t
-					// var got interface{}
 					if rc.val == cansetreflectiontest { // We're doing a CanSet reflection test
 						err := tc.vd.DecodeValue(dc, llvrw, reflect.Value{})
 						if !compareErrors(err, rc.err) {


### PR DESCRIPTION
GODRIVER-3081

## Summary

[PR 1323](https://github.com/mongodb/mongo-go-driver/pull/1323/files#diff-3c3f341a8f86b629354e51009fb26d8325eab8c6b240f8d19f88ecf5c5278807) overlooked the zero-value detection for empty slices and maps.

## Background & Motivation

Fix the bug and make up the test cases.
