### PR TITLE
Fix encoder_example_test.go build.

### DIFF
--- a/bson/encoder_example_test.go
+++ b/bson/encoder_example_test.go
@@ -248,11 +248,7 @@ func ExampleEncoder_IntMinSize() {
 		panic(err)
 	}
 
-	enc, err := bson.NewEncoder(vw)
-	if err != nil {
-		panic(err)
-	}
-
+	enc := bson.NewEncoder(vw)
 	enc.IntMinSize()
 
 	err = enc.Encode(foo{2})


### PR DESCRIPTION
## Summary

Fix the build failure:
```
bson/encoder_example_test.go:251:14: assignment mismatch: 2 variables but bson.NewEncoder returns 1 value
```

## Background & Motivation

Code introduced in https://github.com/mongodb/mongo-go-driver/pull/1516 does not build with the updated `bson.Encoder` API.
