### PR TITLE
GODRIVER-3111 Combine the identical if-else branches in bson/primitive/decimal.go

### DIFF
--- a/bson/primitive/decimal.go
+++ b/bson/primitive/decimal.go
@@ -164,9 +164,6 @@ func (d Decimal128) BigInt() (*big.Int, int, error) {
 
 	// Would be handled by the logic below, but that's trivial and common.
 	if high == 0 && low == 0 && exp == 0 {
-		if posSign {
-			return new(big.Int), 0, nil
-		}
 		return new(big.Int), 0, nil
 	}
 


### PR DESCRIPTION
## Summary

In bson/primitive/decimal.go around line 167, the following if-else branches contain the same logic, and should be combined:
```go
if high == 0 && low == 0 && exp == 0 {
  if posSign {
    return new(big.Int), 0, nil
  }
  return new(big.Int), 0, nil
```
 ## Background & Motivation

Make the code more readable and robust