### PR TITLE
Remove unnecessary error from GridFSBucket method.

### DIFF
--- a/internal/integration/gridfs_test.go
+++ b/internal/integration/gridfs_test.go
@@ -72,8 +72,7 @@ func TestGridFS(x *testing.T) {
 
 		for _, tc := range testcases {
 			mt.Run(tc.name, func(mt *mtest.T) {
-				bucket, err := mt.DB.GridFSBucket(options.GridFSBucket().SetChunkSizeBytes(chunkSize))
-				assert.Nil(mt, err, "NewBucket error: %v", err)
+				bucket := mt.DB.GridFSBucket(options.GridFSBucket().SetChunkSizeBytes(chunkSize))
 
 				ustream, err := bucket.OpenUploadStream(context.Background(), "foo")
 				assert.Nil(mt, err, "OpenUploadStream error: %v", err)
@@ -107,8 +106,7 @@ func TestGridFS(x *testing.T) {
 
 	mt.Run("index creation", func(mt *mtest.T) {
 		// Unit tests showing that UploadFromStream creates indexes on the chunks and files collections.
-		bucket, err := mt.DB.GridFSBucket()
-		assert.Nil(mt, err, "NewBucket error: %v", err)
+		bucket := mt.DB.GridFSBucket()
 
 		byteData := []byte("Hello, world!")
 		r := bytes.NewReader(byteData)
@@ -116,7 +114,7 @@ func TestGridFS(x *testing.T) {
 		uploadCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		mt.Cleanup(cancel)
 
-		_, err = bucket.UploadFromStream(uploadCtx, "filename", r)
+		_, err := bucket.UploadFromStream(uploadCtx, "filename", r)
 		assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 		findCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -186,13 +184,12 @@ func TestGridFS(x *testing.T) {
 
 					mt.ClearEvents()
 
-					bucket, err := mt.DB.GridFSBucket()
-					assert.Nil(mt, err, "NewBucket error: %v", err)
+					bucket := mt.DB.GridFSBucket()
 					defer func() {
 						_ = bucket.Drop(context.Background())
 					}()
 
-					_, err = bucket.OpenUploadStream(context.Background(), "filename")
+					_, err := bucket.OpenUploadStream(context.Background(), "filename")
 					assert.Nil(mt, err, "OpenUploadStream error: %v", err)
 
 					mt.FilterStartedEvents(func(evt *event.CommandStartedEvent) bool {
@@ -233,13 +230,13 @@ func TestGridFS(x *testing.T) {
 
 					mt.ClearEvents()
 					var fileContent []byte
-					bucket, err := mt.DB.GridFSBucket()
-					assert.Nil(mt, err, "NewBucket error: %v", err)
+					bucket := mt.DB.GridFSBucket()
+
 					defer func() {
 						_ = bucket.Drop(context.Background())
 					}()
 
-					_, err = bucket.UploadFromStream(context.Background(), "filename", bytes.NewBuffer(fileContent))
+					_, err := bucket.UploadFromStream(context.Background(), "filename", bytes.NewBuffer(fileContent))
 					assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 					mt.FilterStartedEvents(func(evt *event.CommandStartedEvent) bool {
@@ -281,8 +278,7 @@ func TestGridFS(x *testing.T) {
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
 					// Create a new GridFS bucket.
-					bucket, err := mt.DB.GridFSBucket()
-					assert.Nil(mt, err, "NewBucket error: %v", err)
+					bucket := mt.DB.GridFSBucket()
 					defer func() { _ = bucket.Drop(context.Background()) }()
 
 					// Upload the file and store the uploaded file ID.
@@ -331,8 +327,7 @@ func TestGridFS(x *testing.T) {
 			// Test that the chunk size for a file download is determined by the chunkSize field in the files
 			// collection document, not the bucket's chunk size.
 
-			bucket, err := mt.DB.GridFSBucket()
-			assert.Nil(mt, err, "NewBucket error: %v", err)
+			bucket := mt.DB.GridFSBucket()
 			defer func() { _ = bucket.Drop(context.Background()) }()
 
 			fileData := []byte("hello world")
@@ -362,8 +357,7 @@ func TestGridFS(x *testing.T) {
 			_, err := mt.DB.Collection("fs.files").InsertOne(context.Background(), filesDoc)
 			assert.Nil(mt, err, "InsertOne error for files collection: %v", err)
 
-			bucket, err := mt.DB.GridFSBucket()
-			assert.Nil(mt, err, "NewBucket error: %v", err)
+			bucket := mt.DB.GridFSBucket()
 			defer func() { _ = bucket.Drop(context.Background()) }()
 
 			_, err = bucket.OpenDownloadStream(context.Background(), oid)
@@ -378,12 +372,11 @@ func TestGridFS(x *testing.T) {
 			fileName := "read-error-test"
 			fileData := make([]byte, 17000000)
 
-			bucket, err := mt.DB.GridFSBucket()
-			assert.Nil(mt, err, "NewBucket error: %v", err)
+			bucket := mt.DB.GridFSBucket()
 			defer func() { _ = bucket.Drop(context.Background()) }()
 
 			dataReader := bytes.NewReader(fileData)
-			_, err = bucket.UploadFromStream(context.Background(), fileName, dataReader)
+			_, err := bucket.UploadFromStream(context.Background(), fileName, dataReader)
 			assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -406,12 +399,11 @@ func TestGridFS(x *testing.T) {
 			fileName := "skip-error-test"
 			fileData := make([]byte, 17000000)
 
-			bucket, err := mt.DB.GridFSBucket()
-			assert.Nil(mt, err, "NewBucket error: %v", err)
+			bucket := mt.DB.GridFSBucket()
 			defer func() { _ = bucket.Drop(context.Background()) }()
 
 			dataReader := bytes.NewReader(fileData)
-			_, err = bucket.UploadFromStream(context.Background(), fileName, dataReader)
+			_, err := bucket.UploadFromStream(context.Background(), fileName, dataReader)
 			assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -446,11 +438,10 @@ func TestGridFS(x *testing.T) {
 				if tc.bucketName != "" {
 					bucketOpts.SetName(tc.bucketName)
 				}
-				bucket, err := mt.DB.GridFSBucket(bucketOpts)
-				assert.Nil(mt, err, "NewBucket error: %v", err)
+				bucket := mt.DB.GridFSBucket(bucketOpts)
 				defer func() { _ = bucket.Drop(context.Background()) }()
 
-				_, err = bucket.UploadFromStream(context.Background(), "accessors-test-file", bytes.NewReader(fileData))
+				_, err := bucket.UploadFromStream(context.Background(), "accessors-test-file", bytes.NewReader(fileData))
 				assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 				bucketName := tc.bucketName
@@ -491,10 +482,9 @@ func TestGridFS(x *testing.T) {
 					chunkSize = &temp
 				}
 
-				bucket, err := mt.DB.GridFSBucket(&options.BucketOptions{
+				bucket := mt.DB.GridFSBucket(&options.BucketOptions{
 					ChunkSizeBytes: chunkSize,
 				})
-				assert.Nil(mt, err, "NewBucket error: %v", err)
 
 				timeout := 5 * time.Second
 				if israce.Enabled {
@@ -512,7 +502,7 @@ func TestGridFS(x *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), timeout)
 				mt.Cleanup(cancel)
 
-				_, err = bucket.UploadFromStream(ctx, "filename", bytes.NewReader(p))
+				_, err := bucket.UploadFromStream(ctx, "filename", bytes.NewReader(p))
 				assert.Nil(mt, err, "UploadFromStream error: %v", err)
 
 				var w *bytes.Buffer
@@ -531,8 +521,7 @@ func TestGridFS(x *testing.T) {
 
 	// Regression test for a bug introduced in GODRIVER-2346.
 	mt.Run("Find", func(mt *mtest.T) {
-		bucket, err := mt.DB.GridFSBucket()
-		assert.Nil(mt, err, "NewBucket error: %v", err)
+		bucket := mt.DB.GridFSBucket()
 		// Find the file back.
 		cursor, err := bucket.Find(context.Background(), bson.D{{"foo", "bar"}})
 		defer func() {

--- a/internal/integration/unified/entity.go
+++ b/internal/integration/unified/entity.go
@@ -796,12 +796,7 @@ func (em *EntityMap) addGridFSBucketEntity(entityOptions *entityOptions) error {
 		bucketOpts = entityOptions.GridFSBucketOptions.BucketOptions
 	}
 
-	bucket, err := db.GridFSBucket(bucketOpts)
-	if err != nil {
-		return fmt.Errorf("error creating GridFS bucket: %v", err)
-	}
-
-	em.gridfsBuckets[entityOptions.ID] = bucket
+	em.gridfsBuckets[entityOptions.ID] = db.GridFSBucket(bucketOpts)
 	return nil
 }
 

--- a/internal/integration/unified_spec_test.go
+++ b/internal/integration/unified_spec_test.go
@@ -363,9 +363,7 @@ func createBucket(mt *mtest.T, testFile testFile, testCase *testCase) {
 	}
 	bucketOpts.SetChunkSizeBytes(chunkSize)
 
-	var err error
-	testCase.bucket, err = mt.DB.GridFSBucket(bucketOpts)
-	assert.Nil(mt, err, "NewBucket error: %v", err)
+	testCase.bucket = mt.DB.GridFSBucket(bucketOpts)
 }
 
 func runOperation(mt *mtest.T, testCase *testCase, op *operation, sess0, sess1 mongo.Session) error {

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -970,7 +970,7 @@ func (db *Database) executeCreateOperation(ctx context.Context, op *operation.Cr
 
 // GridFSBucket is used to construct a GridFS bucket which can be used as a
 // container for files.
-func (db *Database) GridFSBucket(opts ...*options.BucketOptions) (*GridFSBucket, error) {
+func (db *Database) GridFSBucket(opts ...*options.BucketOptions) *GridFSBucket {
 	b := &GridFSBucket{
 		name:      "fs",
 		chunkSize: DefaultGridFSChunkSize,
@@ -1021,5 +1021,5 @@ func (db *Database) GridFSBucket(opts ...*options.BucketOptions) (*GridFSBucket,
 	b.readBuf = make([]byte, b.chunkSize)
 	b.writeBuf = make([]byte, b.chunkSize)
 
-	return b, nil
+	return b
 }

--- a/mongo/gridfs_bucket_test.go
+++ b/mongo/gridfs_bucket_test.go
@@ -46,9 +46,7 @@ func TestBucket_openDownloadStream(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			bucket, err := db.GridFSBucket()
-			assert.NoError(t, err)
-
+			bucket := db.GridFSBucket()
 			_, err = bucket.openDownloadStream(context.Background(), test.filter)
 			assert.ErrorIs(t, err, test.err)
 		})

--- a/mongo/gridfs_test.go
+++ b/mongo/gridfs_test.go
@@ -79,8 +79,7 @@ func TestGridFS(t *testing.T) {
 
 		for _, tt := range chunkSizeTests {
 			t.Run(tt.testName, func(t *testing.T) {
-				bucket, err := db.GridFSBucket(tt.bucketOpts)
-				assert.Nil(t, err, "NewBucket error: %v", err)
+				bucket := db.GridFSBucket(tt.bucketOpts)
 
 				us, err := bucket.OpenUploadStream(context.Background(), "filename", tt.uploadOpts)
 				assert.Nil(t, err, "OpenUploadStream error: %v", err)


### PR DESCRIPTION
## Summary

Remove the unused error returned by `Database.GridFSBucket`.

## Background & Motivation

The `Database.GridFSBucket` method currently returns an error that is never used. That error is also unconventional based on the existing pattern of the chainabe `Database` and `Collection` methods, which don't return errors. Similar to the way users can write
```go
coll := client.Database().Collection()
```
they should also be able to write
```go
bucket := client.Database().GridFSBucket()
```