### PR TITLE
GDORIVER-2934 Add list of possible OS and Go dep errors to case 6

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2238,7 +2238,15 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			crypt, err := mongocrypt.NewMongoCrypt(opts)
 			assert.Nil(mt, err, "error in NewMongoCrypt: %v", err)
 			_, err = crypt.GetKmsProviders(context.Background())
-			assert.ErrorContains(mt, err, "Client.Timeout or context cancellation while reading body")
+
+			possibleErrors := []string{
+				"error reading response body: context deadline exceeded",    // <= 1.19 + RHEL & macOS
+				"Client.Timeout or context cancellation while reading body", // > 1.20 on all OS
+			}
+
+			assert.True(t, containsSubstring(possibleErrors, err.Error()),
+				"expected possibleErrors=%v to contain %v, but it didn't",
+				possibleErrors, err.Error())
 		})
 	})
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2934

## Summary

<!--- A summary of the changes proposed by this pull request. -->
Add list of possible OS and Go dependent errors that can occur when timing out an HTTP client. Further investigation as to why there are suddenly noticeable differences needs to be done as part of the continuing work for 2934.

## Background & Motivation

<!--- Rationale for the pull request. -->
`TestClientSideEncryptionProse/18._Azure_IMDS_Credentials/Case_6:_Slow_Response` started failing as of https://github.com/mongodb-labs/drivers-evergreen-tools/commit/4393c2873d25dceaacd9ec27278d3b795e82c933 . These failures are independent of the Go implementation https://github.com/mongodb/mongo-go-driver/commit/a5a237e07ac14b2e75337bbb9be5b4fc5b97056c as they are also occurring on master, which does not yet have this change.
