### PR TITLE
GODRIVER-2976 Re-add Marshal optimizations.

### DIFF
--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -74,6 +74,7 @@ func Marshal(val interface{}) ([]byte, error) {
 			bufPool.Put(sw)
 		}
 	}()
+	sw.Reset()
 	vw := bsonrw.NewValueWriter(sw)
 	enc := encPool.Get().(*Encoder)
 	defer encPool.Put(enc)


### PR DESCRIPTION
GODRIVER-2976

## Summary
Re-add bufPool to `Marshal`.

## Background & Motivation
The [PR #1410](https://github.com/mongodb/mongo-go-driver/pull/1410/files#diff-fc67ccfcf8fb7020e05412e10e0f43e715369aab368160f6255c4fdfe1a4470dL146) removed some of the buffer reuse optimizations
