### PR TITLE
GODRIVER-3116 Ensure secrets are not logged in Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -383,6 +383,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           # DO NOT ECHO WITH XTRACE
@@ -413,6 +414,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           # DO NOT ECHO WITH XTRACE
@@ -477,6 +479,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -597,7 +600,6 @@ functions:
           MONGODB_URI="${SERVERLESS_URI}" \
           SERVERLESS="serverless" \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
-          SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
           MAKEFILE_TARGET=evg-test-serverless \
             sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
@@ -939,6 +941,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -967,6 +970,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -1968,6 +1972,7 @@ tasks:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}


### PR DESCRIPTION
GODRIVER-3116 

## Summary
Ensure secrets are not logged in Evergreen

## Background & Motivation
Ensure we do not accidentally print secrets in Evergreen logs.
