### PR TITLE
GODRIVER-3117 Ensure secrets are not logged in Evergreen #1542

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -376,6 +376,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           # DO NOT ECHO WITH XTRACE
@@ -406,6 +407,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           # DO NOT ECHO WITH XTRACE
@@ -470,6 +472,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -590,7 +593,6 @@ functions:
           MONGODB_URI="${SERVERLESS_URI}" \
           SERVERLESS="serverless" \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
-          SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
           MAKEFILE_TARGET=evg-test-serverless \
             sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
@@ -954,6 +956,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -982,6 +985,7 @@ functions:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
@@ -1989,6 +1993,7 @@ tasks:
       type: test
       params:
         shell: "bash"
+        silent: true
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}


### PR DESCRIPTION
GODRIVER-3117

## Summary
Ensure secrets are not logged in Evergreen

## Background & Motivation
Ensure we do not accidentally print secrets in Evergreen logs.
