### PR TITLE
GODRIVER-3113 Skip unpin_after_TransientTransactionError_error_on_commit on latest

### DIFF
--- a/testdata/transactions/unified/mongos-unpin.json
+++ b/testdata/transactions/unified/mongos-unpin.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",
+      "maxServerVersion": "7.99",
       "topologies": [
         "sharded-replicaset"
       ]
@@ -52,9 +53,7 @@
       "description": "unpin after TransientTransactionError error on commit",
       "runOnRequirements": [
         {
-          "serverless": "forbid",
-          "maxServerVersion": "7.99"
-        }
+          "serverless": "forbid"
       ],
       "operations": [
         {

--- a/testdata/transactions/unified/mongos-unpin.json
+++ b/testdata/transactions/unified/mongos-unpin.json
@@ -52,7 +52,8 @@
       "description": "unpin after TransientTransactionError error on commit",
       "runOnRequirements": [
         {
-          "serverless": "forbid"
+          "serverless": "forbid",
+          "maxServerVersion": "7.99"
         }
       ],
       "operations": [

--- a/testdata/transactions/unified/mongos-unpin.yml
+++ b/testdata/transactions/unified/mongos-unpin.yml
@@ -4,6 +4,8 @@ schemaVersion: '1.4'
 
 runOnRequirements:
   - minServerVersion: '4.2'
+    # Skip pending GODRIVER-3113
+    maxServerVersion: "7.99"
     topologies: [ sharded-replicaset ]
 
 createEntities:

--- a/testdata/transactions/unified/mongos-unpin.yml
+++ b/testdata/transactions/unified/mongos-unpin.yml
@@ -4,8 +4,6 @@ schemaVersion: '1.4'
 
 runOnRequirements:
   - minServerVersion: '4.2'
-    # Workaround for GODRIVER-3113
-    maxServerVersion: '7.99'
     topologies: [ sharded-replicaset ]
 
 createEntities:

--- a/testdata/transactions/unified/mongos-unpin.yml
+++ b/testdata/transactions/unified/mongos-unpin.yml
@@ -38,6 +38,8 @@ tests:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)
       - serverless: "forbid"
+        # Workaround for GODRIVER-3113
+        maxServerVersion: '7.99'
     operations:
       - &startTransaction
         name: startTransaction

--- a/testdata/transactions/unified/mongos-unpin.yml
+++ b/testdata/transactions/unified/mongos-unpin.yml
@@ -4,6 +4,8 @@ schemaVersion: '1.4'
 
 runOnRequirements:
   - minServerVersion: '4.2'
+    # Workaround for GODRIVER-3113
+    maxServerVersion: '7.99'
     topologies: [ sharded-replicaset ]
 
 createEntities:
@@ -38,8 +40,6 @@ tests:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)
       - serverless: "forbid"
-        # Workaround for GODRIVER-3113
-        maxServerVersion: '7.99'
     operations:
       - &startTransaction
         name: startTransaction


### PR DESCRIPTION
GODRIVER-3113

## Summary

Skip failing test on latest until we address it for all drivers.
