### PR TITLE
DEVPROD-3871 Use teardown_task when there is one function/command

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2372,7 +2372,7 @@ task_groups:
       - command: expansions.update
         params:
           file: testgcpkms-expansions.yml
-    teardown_group:
+    teardown_task:
       - command: shell.exec
         params:
           shell: "bash"
@@ -2441,7 +2441,7 @@ task_groups:
       - command: expansions.update
         params:
           file: src/go.mongodb.org/mongo-driver/atlas-expansion.yml
-    teardown_group:
+    teardown_task:
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
@@ -2482,7 +2482,7 @@ task_groups:
       - command: expansions.update
         params:
           file: src/go.mongodb.org/mongo-driver/atlas-expansion.yml
-    teardown_group:
+    teardown_task:
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver


### PR DESCRIPTION
DEVPROD-3871

## Summary

Use `teardown_task` when there is one function/command.

## Background & Motivation

The `teardown_group` is currently not run if there is only one function/command.
