### PR TITLE
GODRIVER-2697 Rename BulkWriteException and WriteException errors

### DIFF
--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -59,8 +59,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			_, err = mt.Coll.InsertOne(context.Background(), doc)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteError{}, err)
 			assert.Equal(mt, 1, len(we.WriteErrors), "expected 1 write error, got %v", len(we.WriteErrors))
 			writeErr := we.WriteErrors[0]
 			assert.Equal(mt, errorDuplicateKey, writeErr.Code, "expected code %v, got %v", errorDuplicateKey, writeErr.Code)
@@ -71,8 +71,8 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			doc := bson.D{{"_id", 1}}
 			_, err := mt.Coll.InsertOne(context.Background(), doc)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
 		})
 
@@ -201,8 +201,8 @@ func TestCollection(t *testing.T) {
 					assert.Nil(mt, err, "InsertMany error: %v", err)
 					_, err = mt.Coll.InsertMany(context.Background(), docs, options.InsertMany().SetOrdered(tc.ordered))
 
-					we, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteException{}, err)
+					we, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteError{}, err)
 					numErrors := len(we.WriteErrors)
 					assert.Equal(mt, tc.numErrors, numErrors, "expected %v write errors, got %v", tc.numErrors, numErrors)
 					gotCode := we.WriteErrors[0].Code
@@ -240,8 +240,8 @@ func TestCollection(t *testing.T) {
 						assert.NotNil(mt, res.InsertedIDs[1], "expected ID but got nil")
 					}
 
-					we, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteException{}, err)
+					we, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteError{}, err)
 					numErrors := len(we.WriteErrors)
 					assert.Equal(mt, tc.numErrors, numErrors, "expected %v write errors, got %v", tc.numErrors, numErrors)
 					gotCode := we.WriteErrors[0].Code
@@ -269,8 +269,8 @@ func TestCollection(t *testing.T) {
 			_, err := mt.Coll.InsertMany(context.Background(), docs)
 			assert.NotNil(mt, err, "expected InsertMany error, got nil")
 
-			we, ok := err.(mongo.BulkWriteException)
-			assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteException{}, err)
+			we, ok := err.(mongo.BulkWriteError)
+			assert.True(mt, ok, "expected error type %T, got %T", mongo.BulkWriteError{}, err)
 			numErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, numErrors, "expected 1 write error, got %v", numErrors)
 			gotIndex := we.WriteErrors[0].Index
@@ -280,8 +280,8 @@ func TestCollection(t *testing.T) {
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet)
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			_, err := mt.Coll.InsertMany(context.Background(), []interface{}{bson.D{{"_id", 1}}})
-			we, ok := err.(mongo.BulkWriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
+			we, ok := err.(mongo.BulkWriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
 		})
 	})
@@ -315,8 +315,8 @@ func TestCollection(t *testing.T) {
 			}, true)
 			_, err := capped.DeleteOne(context.Background(), bson.D{{"x", 1}})
 
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteError{}, err)
 			numWriteErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
 			gotCode := we.WriteErrors[0].Code
@@ -331,8 +331,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.DeleteOne(context.Background(), filter)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got nil")
 		})
 		mt.RunOpts("single key map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
@@ -384,8 +384,8 @@ func TestCollection(t *testing.T) {
 			}, true)
 			_, err := capped.DeleteMany(context.Background(), bson.D{{"x", 1}})
 
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			numWriteErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, len(we.WriteErrors), "expected 1 write error, got %v", numWriteErrors)
 			gotCode := we.WriteErrors[0].Code
@@ -400,8 +400,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.DeleteMany(context.Background(), filter)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
 		})
 		mt.RunOpts("single key map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
@@ -468,8 +468,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			_, err = mt.Coll.UpdateOne(context.Background(), filter, update)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			numWriteErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
 			gotCode := we.WriteErrors[0].Code
@@ -484,8 +484,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.UpdateOne(context.Background(), filter, update)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
 		})
 		mt.RunOpts("special slice types", noClientOpts, func(mt *mtest.T) {
@@ -600,8 +600,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.UpdateByID(context.Background(), id, update)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
 		})
 	})
@@ -650,8 +650,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			_, err = mt.Coll.UpdateMany(context.Background(), filter, update)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			numWriteErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
 			gotCode := we.WriteErrors[0].Code
@@ -666,8 +666,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.UpdateMany(context.Background(), filter, update)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", we)
 		})
 	})
@@ -712,8 +712,8 @@ func TestCollection(t *testing.T) {
 			assert.Nil(mt, err, "InsertOne error: %v", err)
 
 			_, err = mt.Coll.ReplaceOne(context.Background(), filter, replacement)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			numWriteErrors := len(we.WriteErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
 			gotCode := we.WriteErrors[0].Code
@@ -729,8 +729,8 @@ func TestCollection(t *testing.T) {
 
 			mt.CloneCollection(options.Collection().SetWriteConcern(impossibleWc))
 			_, err = mt.Coll.ReplaceOne(context.Background(), filter, replacement)
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got nil")
 		})
 	})
@@ -1289,8 +1289,8 @@ func TestCollection(t *testing.T) {
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet).MinServerVersion("3.2")
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
 			err := mt.Coll.FindOneAndDelete(context.Background(), bson.D{{"x", 3}}).Err()
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
 		})
 	})
@@ -1367,8 +1367,8 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			replacement := bson.D{{"y", 3}}
 			err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement).Err()
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
 		})
 	})
@@ -1449,8 +1449,8 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 3}}
 			update := bson.D{{"$set", bson.D{{"x", 6}}}}
 			err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update).Err()
-			we, ok := err.(mongo.WriteException)
-			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteException{}, err)
+			we, ok := err.(mongo.WriteError)
+			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %v", err)
 		})
 	})
@@ -1475,8 +1475,8 @@ func TestCollection(t *testing.T) {
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
 					_, err := mt.Coll.BulkWrite(context.Background(), tc.models)
-					bwe, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
+					bwe, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteError{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
 					assert.Equal(mt, 0, numWriteErrors, "expected 0 write errors, got %v", numWriteErrors)
 					assert.NotNil(mt, bwe.WriteConcernError, "expected write concern error, got %v", err)
@@ -1504,8 +1504,8 @@ func TestCollection(t *testing.T) {
 					assert.Equal(mt, tc.insertedCount, res.InsertedCount,
 						"expected inserted count %v, got %v", tc.insertedCount, res.InsertedCount)
 
-					bwe, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
+					bwe, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteError{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
 					assert.Equal(mt, tc.numWriteErrors, numWriteErrors,
 						"expected %v write errors, got %v", tc.numWriteErrors, numWriteErrors)
@@ -1536,8 +1536,8 @@ func TestCollection(t *testing.T) {
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
 					_, err := capped.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(tc.ordered))
-					bwe, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
+					bwe, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteError{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
 					assert.Equal(mt, tc.numWriteErrors, numWriteErrors,
 						"expected %v write errors, got %v", tc.numWriteErrors, numWriteErrors)
@@ -1570,8 +1570,8 @@ func TestCollection(t *testing.T) {
 					assert.Equal(mt, tc.modifiedCount, res.ModifiedCount,
 						"expected modified count %v, got %v", tc.modifiedCount, res.ModifiedCount)
 
-					bwe, ok := err.(mongo.BulkWriteException)
-					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
+					bwe, ok := err.(mongo.BulkWriteError)
+					assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteError{}, err)
 					numWriteErrors := len(bwe.WriteErrors)
 					assert.Equal(mt, tc.numWriteErrors, numWriteErrors,
 						"expected %v write errors, got %v", tc.numWriteErrors, numWriteErrors)
@@ -1605,12 +1605,12 @@ func TestCollection(t *testing.T) {
 			}
 
 			_, err := mt.Coll.BulkWrite(context.Background(), models)
-			bwException, ok := err.(mongo.BulkWriteException)
-			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteException{}, err)
+			bwException, ok := err.(mongo.BulkWriteError)
+			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteError{}, err)
 
 			expectedModel := models[3]
 			actualModel := bwException.WriteErrors[0].Request
-			assert.Equal(mt, expectedModel, actualModel, "expected model %v in BulkWriteException, got %v",
+			assert.Equal(mt, expectedModel, actualModel, "expected model %v in BulkWriteError, got %v",
 				expectedModel, actualModel)
 		})
 		mt.RunOpts("unordered writeError index", mtest.NewOptions().MaxServerVersion("5.0.7"), func(mt *mtest.T) {
@@ -1642,8 +1642,8 @@ func TestCollection(t *testing.T) {
 				mongo.NewUpdateManyModel().SetFilter(bson.D{{"_id", "id3"}}).SetUpdate(bson.D{{"$set", bson.D{{"_id", 3.14159}}}}),
 			}
 			_, err = capped.BulkWrite(context.Background(), models, options.BulkWrite().SetOrdered(false))
-			bwException, ok := err.(mongo.BulkWriteException)
-			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteException{}, err)
+			bwException, ok := err.(mongo.BulkWriteError)
+			assert.True(mt, ok, "expected error of type %T, got %T", mongo.BulkWriteError{}, err)
 
 			assert.Equal(mt, len(bwException.WriteErrors), 10, "expected 10 writeErrors, got %v", len(bwException.WriteErrors))
 			for _, writeErr := range bwException.WriteErrors {

--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -61,8 +61,8 @@ func TestCollection(t *testing.T) {
 			_, err = mt.Coll.InsertOne(context.Background(), doc)
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteError{}, err)
-			assert.Equal(mt, 1, len(we.WriteErrors), "expected 1 write error, got %v", len(we.WriteErrors))
-			writeErr := we.WriteErrors[0]
+			assert.Equal(mt, 1, len(we.WriteOpErrors), "expected 1 write error, got %v", len(we.WriteOpErrors))
+			writeErr := we.WriteOpErrors[0]
 			assert.Equal(mt, errorDuplicateKey, writeErr.Code, "expected code %v, got %v", errorDuplicateKey, writeErr.Code)
 		})
 
@@ -317,9 +317,9 @@ func TestCollection(t *testing.T) {
 
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %T, got %T", mongo.WriteError{}, err)
-			numWriteErrors := len(we.WriteErrors)
+			numWriteErrors := len(we.WriteOpErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
-			gotCode := we.WriteErrors[0].Code
+			gotCode := we.WriteOpErrors[0].Code
 			assert.True(mt, gotCode == errorCappedCollDeleteLegacy || gotCode == errorCappedCollDelete,
 				"expected error code %v or %v, got %v", errorCappedCollDeleteLegacy, errorCappedCollDelete, gotCode)
 		})
@@ -386,9 +386,9 @@ func TestCollection(t *testing.T) {
 
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
-			numWriteErrors := len(we.WriteErrors)
-			assert.Equal(mt, 1, len(we.WriteErrors), "expected 1 write error, got %v", numWriteErrors)
-			gotCode := we.WriteErrors[0].Code
+			numWriteErrors := len(we.WriteOpErrors)
+			assert.Equal(mt, 1, len(we.WriteOpErrors), "expected 1 write error, got %v", numWriteErrors)
+			gotCode := we.WriteOpErrors[0].Code
 			assert.True(mt, gotCode == errorCappedCollDeleteLegacy || gotCode == errorCappedCollDelete,
 				"expected error code %v or %v, got %v", errorCappedCollDeleteLegacy, errorCappedCollDelete, gotCode)
 		})
@@ -470,9 +470,9 @@ func TestCollection(t *testing.T) {
 			_, err = mt.Coll.UpdateOne(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
-			numWriteErrors := len(we.WriteErrors)
+			numWriteErrors := len(we.WriteOpErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
-			gotCode := we.WriteErrors[0].Code
+			gotCode := we.WriteOpErrors[0].Code
 			assert.Equal(mt, errorModifiedID, gotCode, "expected error code %v, got %v", errorModifiedID, gotCode)
 		})
 		mt.RunOpts("write concern error", mtest.NewOptions().Topologies(mtest.ReplicaSet), func(mt *mtest.T) {
@@ -652,9 +652,9 @@ func TestCollection(t *testing.T) {
 			_, err = mt.Coll.UpdateMany(context.Background(), filter, update)
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
-			numWriteErrors := len(we.WriteErrors)
+			numWriteErrors := len(we.WriteOpErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
-			gotCode := we.WriteErrors[0].Code
+			gotCode := we.WriteOpErrors[0].Code
 			assert.Equal(mt, errorModifiedID, gotCode, "expected error code %v, got %v", errorModifiedID, gotCode)
 		})
 		mt.RunOpts("write concern error", mtest.NewOptions().Topologies(mtest.ReplicaSet), func(mt *mtest.T) {
@@ -714,9 +714,9 @@ func TestCollection(t *testing.T) {
 			_, err = mt.Coll.ReplaceOne(context.Background(), filter, replacement)
 			we, ok := err.(mongo.WriteError)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.WriteError{}, err)
-			numWriteErrors := len(we.WriteErrors)
+			numWriteErrors := len(we.WriteOpErrors)
 			assert.Equal(mt, 1, numWriteErrors, "expected 1 write error, got %v", numWriteErrors)
-			gotCode := we.WriteErrors[0].Code
+			gotCode := we.WriteOpErrors[0].Code
 			assert.True(mt, gotCode == errorModifiedID || gotCode == errorModifiedIDLegacy,
 				"expected error code %v or %v, got %v", errorModifiedID, errorModifiedIDLegacy, gotCode)
 		})

--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -54,12 +54,12 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 			})
 		assert.NotNil(mt, err, "expected non-nil error, got nil")
 
-		we, ok := err.(mongo.BulkWriteException)
-		assert.True(mt, ok, "expected mongo.BulkWriteException, got %T", err)
+		we, ok := err.(mongo.BulkWriteError)
+		assert.True(mt, ok, "expected mongo.BulkWriteError, got %T", err)
 		assert.True(mt, we.HasErrorLabel(label), "expected error to have label: %v", label)
 	})
 
-	mt.Run("WriteException with label", func(mt *mtest.T) {
+	mt.Run("WriteError with label", func(mt *mtest.T) {
 		mt.SetFailPoint(mtest.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: mtest.FailPointMode{
@@ -77,12 +77,12 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 		_, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"a", 1}})
 		assert.NotNil(mt, err, "expected non-nil error, got nil")
 
-		we, ok := err.(mongo.WriteException)
-		assert.True(mt, ok, "expected mongo.WriteException, got %T", err)
+		we, ok := err.(mongo.WriteError)
+		assert.True(mt, ok, "expected mongo.WriteError, got %T", err)
 		assert.True(mt, we.HasErrorLabel(label), "expected error to have label: %v", label)
 	})
 
-	mt.Run("BulkWriteException with label", func(mt *mtest.T) {
+	mt.Run("BulkWriteError with label", func(mt *mtest.T) {
 		mt.SetFailPoint(mtest.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: mtest.FailPointMode{
@@ -104,8 +104,8 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 		_, err := mt.Coll.BulkWrite(context.Background(), models)
 		assert.NotNil(mt, err, "expected non-nil error, got nil")
 
-		we, ok := err.(mongo.BulkWriteException)
-		assert.True(mt, ok, "expected mongo.BulkWriteException, got %T", err)
+		we, ok := err.(mongo.BulkWriteError)
+		assert.True(mt, ok, "expected mongo.BulkWriteError, got %T", err)
 		assert.True(mt, we.HasErrorLabel(label), "expected error to have label: %v", label)
 	})
 
@@ -220,11 +220,11 @@ func TestWriteErrorsDetails(t *testing.T) {
 
 				var details bson.Raw
 				if tc.expectBulkError {
-					bwe, ok := err.(mongo.BulkWriteException)
+					bwe, ok := err.(mongo.BulkWriteError)
 					assert.True(
 						mt,
 						ok,
-						"expected error to be type mongo.BulkWriteException, got type %T (error %q)",
+						"expected error to be type mongo.BulkWriteError, got type %T (error %q)",
 						err,
 						err)
 					// Assert that there is one WriteError and that the Details field is populated.
@@ -237,11 +237,11 @@ func TestWriteErrorsDetails(t *testing.T) {
 						err)
 					details = bwe.WriteErrors[0].Details
 				} else {
-					we, ok := err.(mongo.WriteException)
+					we, ok := err.(mongo.WriteError)
 					assert.True(
 						mt,
 						ok,
-						"expected error to be type mongo.WriteException, got type %T (error %q)",
+						"expected error to be type mongo.WriteError, got type %T (error %q)",
 						err,
 						err)
 					// Assert that there is one WriteError and that the Details field is populated.
@@ -262,7 +262,7 @@ func TestWriteErrorsDetails(t *testing.T) {
 
 				// Assert that the most recent CommandSucceededEvent was triggered by the expected
 				// operation and contains the resulting write errors and that
-				// "writeErrors[0].errInfo" is the same as "WriteException.WriteErrors[0].Details".
+				// "writeErrors[0].errInfo" is the same as "WriteError.WriteErrors[0].Details".
 				evts := mt.GetAllSucceededEvents()
 				assert.True(
 					mt,
@@ -352,8 +352,8 @@ func TestWriteConcernError(t *testing.T) {
 
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 1}})
 		assert.NotNil(mt, err, "expected InsertOne error, got nil")
-		writeException, ok := err.(mongo.WriteException)
-		assert.True(mt, ok, "expected WriteException, got error %v of type %T", err, err)
+		writeException, ok := err.(mongo.WriteError)
+		assert.True(mt, ok, "expected WriteError, got error %v of type %T", err, err)
 		wcError := writeException.WriteConcernError
 		assert.NotNil(mt, wcError, "expected write-concern error, got %v", err)
 		assert.True(mt, bytes.Equal(wcError.Details, errInfoDoc), "expected errInfo document %v, got %v",
@@ -395,8 +395,8 @@ func TestErrorsCodeNamePropagated(t *testing.T) {
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
 		assert.NotNil(mt, err, "expected InsertOne error, got nil")
 
-		we, ok := err.(mongo.WriteException)
-		assert.True(mt, ok, "expected error of type %T, got %v of type %T", mongo.WriteException{}, err, err)
+		we, ok := err.(mongo.WriteError)
+		assert.True(mt, ok, "expected error of type %T, got %v of type %T", mongo.WriteError{}, err, err)
 		wce := we.WriteConcernError
 		assert.NotNil(mt, wce, "expected write concern error, got %v", we)
 

--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -248,11 +248,11 @@ func TestWriteErrorsDetails(t *testing.T) {
 					assert.Equal(
 						mt,
 						1,
-						len(we.WriteErrors),
+						len(we.WriteOpErrors),
 						"expected exactly 1 write error, but got %d write errors (error %q)",
-						len(we.WriteErrors),
+						len(we.WriteOpErrors),
 						err)
-					details = we.WriteErrors[0].Details
+					details = we.WriteOpErrors[0].Details
 				}
 
 				assert.True(

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -114,7 +114,7 @@ func TestDatabase(t *testing.T) {
 			assert.True(mt, ok, "expected n in response")
 			assert.Equal(mt, int32(1), n, "expected n value 1, got %v", n)
 
-			writeExcept, ok := gotErr.(mongo.WriteException)
+			writeExcept, ok := gotErr.(mongo.WriteError)
 			assert.True(mt, ok, "expected WriteCommandError, got %T", gotErr)
 			assert.NotNil(mt, writeExcept.WriteConcernError, "expected WriteConcernError to be non-nil")
 			assert.Equal(mt, writeExcept.WriteConcernError.Code, 100, "expected error code 100, got %v", writeExcept.WriteConcernError.Code)

--- a/internal/integration/errors_test.go
+++ b/internal/integration/errors_test.go
@@ -174,8 +174,8 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"WriteException all in writeConcernError",
-				mongo.WriteException{
+				"WriteError all in writeConcernError",
+				mongo.WriteError{
 					&mongo.WriteConcernError{"name", matchCode, "foo", nil, nil},
 					nil,
 					[]string{label},
@@ -188,12 +188,12 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"WriteException all in writeError",
-				mongo.WriteException{
+				"WriteError all in writeError",
+				mongo.WriteError{
 					nil,
-					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "bar", nil, nil},
-						mongo.WriteError{0, matchCode, "foo", nil, nil},
+					mongo.WriteOpErrors{
+						mongo.WriteOpError{0, otherCode, "bar", nil, nil},
+						mongo.WriteOpError{0, matchCode, "foo", nil, nil},
 					},
 					[]string{"otherError"},
 					nil,
@@ -205,11 +205,11 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"WriteException all false",
-				mongo.WriteException{
+				"WriteError all false",
+				mongo.WriteError{
 					&mongo.WriteConcernError{"name", otherCode, "bar", nil, nil},
-					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "baz", nil, nil},
+					mongo.WriteOpErrors{
+						mongo.WriteOpError{0, otherCode, "baz", nil, nil},
 					},
 					[]string{"otherError"},
 					nil,
@@ -221,11 +221,11 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"WriteException HasErrorCodeAndMessage false",
-				mongo.WriteException{
+				"WriteError HasErrorCodeAndMessage false",
+				mongo.WriteError{
 					&mongo.WriteConcernError{"name", matchCode, "bar", nil, nil},
-					mongo.WriteErrors{
-						mongo.WriteError{0, otherCode, "foo", nil, nil},
+					mongo.WriteOpErrors{
+						mongo.WriteOpError{0, otherCode, "foo", nil, nil},
 					},
 					[]string{"otherError"},
 					nil,
@@ -237,8 +237,8 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"BulkWriteException all in writeConcernError",
-				mongo.BulkWriteException{
+				"BulkWriteError all in writeConcernError",
+				mongo.BulkWriteError{
 					&mongo.WriteConcernError{"name", matchCode, "foo", nil, nil},
 					nil,
 					[]string{label},
@@ -250,12 +250,12 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"BulkWriteException all in writeError",
-				mongo.BulkWriteException{
+				"BulkWriteError all in writeError",
+				mongo.BulkWriteError{
 					nil,
-					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, matchCode, "foo", nil, nil}, &mongo.InsertOneModel{}},
-						{mongo.WriteError{0, otherCode, "bar", nil, nil}, &mongo.InsertOneModel{}},
+					[]mongo.BulkWriteOpError{
+						{mongo.WriteOpError{0, matchCode, "foo", nil, nil}, &mongo.InsertOneModel{}},
+						{mongo.WriteOpError{0, otherCode, "bar", nil, nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -266,11 +266,11 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"BulkWriteException all false",
-				mongo.BulkWriteException{
+				"BulkWriteError all false",
+				mongo.BulkWriteError{
 					&mongo.WriteConcernError{"name", otherCode, "bar", nil, nil},
-					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, otherCode, "baz", nil, nil}, &mongo.InsertOneModel{}},
+					[]mongo.BulkWriteOpError{
+						{mongo.WriteOpError{0, otherCode, "baz", nil, nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -281,11 +281,11 @@ func TestErrors(t *testing.T) {
 				false,
 			},
 			{
-				"BulkWriteException HasErrorCodeAndMessage false",
-				mongo.BulkWriteException{
+				"BulkWriteError HasErrorCodeAndMessage false",
+				mongo.BulkWriteError{
 					&mongo.WriteConcernError{"name", matchCode, "bar", nil, nil},
-					[]mongo.BulkWriteError{
-						{mongo.WriteError{0, otherCode, "foo", nil, nil}, &mongo.InsertOneModel{}},
+					[]mongo.BulkWriteOpError{
+						{mongo.WriteOpError{0, otherCode, "foo", nil, nil}, &mongo.InsertOneModel{}},
 					},
 					[]string{"otherError"},
 				},
@@ -352,8 +352,8 @@ func TestErrors(t *testing.T) {
 
 				_, err = mt.Coll.InsertOne(context.Background(), bson.D{{"_id", 1}})
 				assert.NotNil(mt, err, "expected InsertOne error, got nil")
-				we, ok := err.(mongo.WriteException)
-				assert.True(mt, ok, "expected InsertOne error to be WriteException, got %T", err)
+				we, ok := err.(mongo.WriteError)
+				assert.True(mt, ok, "expected InsertOne error to be WriteError, got %T", err)
 
 				assert.NotNil(mt, we.WriteErrors, "expected we.WriteErrors, got nil")
 				assert.NotNil(mt, we.WriteErrors[0], "expected at least one WriteError")
@@ -367,8 +367,8 @@ func TestErrors(t *testing.T) {
 				assert.True(mt, ok, "expected 'code' to be int64, got %v", val)
 				assert.Equal(mt, code, int64(11000), "expected 'code' 11000, got %d", code)
 			})
-			mt.Run("WriteException", func(mt *mtest.T) {
-				// Mock a WriteException via failpoint with an arbitrary WriteConcernError.
+			mt.Run("WriteError", func(mt *mtest.T) {
+				// Mock a WriteError via failpoint with an arbitrary WriteConcernError.
 				mt.SetFailPoint(mtest.FailPoint{
 					ConfigureFailPoint: "failCommand",
 					Mode: mtest.FailPointMode{
@@ -384,8 +384,8 @@ func TestErrors(t *testing.T) {
 
 				_, err := mt.Coll.DeleteMany(context.Background(), bson.D{})
 				assert.NotNil(mt, err, "expected DeleteMany error, got nil")
-				we, ok := err.(mongo.WriteException)
-				assert.True(mt, ok, "expected DeleteMany error to be WriteException, got %T", err)
+				we, ok := err.(mongo.WriteError)
+				assert.True(mt, ok, "expected DeleteMany error to be WriteError, got %T", err)
 
 				// Assert that raw response exists and contains error code 123.
 				assert.NotNil(mt, we.Raw, "expected RawResponse, got nil")
@@ -407,14 +407,14 @@ func TestErrors(t *testing.T) {
 			}{
 				{"CommandError true", mongo.CommandError{11000, "", nil, "blah", nil, nil}, true},
 				{"CommandError false", mongo.CommandError{100, "", nil, "blah", nil, nil}, false},
-				{"WriteError true", mongo.WriteError{0, 11000, "", nil, nil}, true},
-				{"WriteError false", mongo.WriteError{0, 100, "", nil, nil}, false},
+				{"WriteError true", mongo.WriteOpError{0, 11000, "", nil, nil}, true},
+				{"WriteError false", mongo.WriteOpError{0, 100, "", nil, nil}, false},
 				{
-					"WriteException true in writeConcernError",
-					mongo.WriteException{
+					"WriteError true in writeConcernError",
+					mongo.WriteError{
 						&mongo.WriteConcernError{"name", 11001, "bar", nil, nil},
-						mongo.WriteErrors{
-							mongo.WriteError{0, 100, "baz", nil, nil},
+						mongo.WriteOpErrors{
+							mongo.WriteOpError{0, 100, "baz", nil, nil},
 						},
 						nil,
 						nil,
@@ -422,11 +422,11 @@ func TestErrors(t *testing.T) {
 					true,
 				},
 				{
-					"WriteException true in writeErrors",
-					mongo.WriteException{
+					"WriteError true in writeErrors",
+					mongo.WriteError{
 						&mongo.WriteConcernError{"name", 100, "bar", nil, nil},
-						mongo.WriteErrors{
-							mongo.WriteError{0, 12582, "baz", nil, nil},
+						mongo.WriteOpErrors{
+							mongo.WriteOpError{0, 12582, "baz", nil, nil},
 						},
 						nil,
 						nil,
@@ -434,11 +434,11 @@ func TestErrors(t *testing.T) {
 					true,
 				},
 				{
-					"WriteException false",
-					mongo.WriteException{
+					"WriteError false",
+					mongo.WriteError{
 						&mongo.WriteConcernError{"name", 16460, "bar", nil, nil},
-						mongo.WriteErrors{
-							mongo.WriteError{0, 100, "blah E11000 blah", nil, nil},
+						mongo.WriteOpErrors{
+							mongo.WriteOpError{0, 100, "blah E11000 blah", nil, nil},
 						},
 						nil,
 						nil,
@@ -446,22 +446,22 @@ func TestErrors(t *testing.T) {
 					false,
 				},
 				{
-					"BulkWriteException true",
-					mongo.BulkWriteException{
+					"BulkWriteError true",
+					mongo.BulkWriteError{
 						&mongo.WriteConcernError{"name", 100, "bar", nil, nil},
-						[]mongo.BulkWriteError{
-							{mongo.WriteError{0, 16460, "blah E11000 blah", nil, nil}, &mongo.InsertOneModel{}},
+						[]mongo.BulkWriteOpError{
+							{mongo.WriteOpError{0, 16460, "blah E11000 blah", nil, nil}, &mongo.InsertOneModel{}},
 						},
 						[]string{"otherError"},
 					},
 					true,
 				},
 				{
-					"BulkWriteException false",
-					mongo.BulkWriteException{
+					"BulkWriteError false",
+					mongo.BulkWriteError{
 						&mongo.WriteConcernError{"name", 100, "bar", nil, nil},
-						[]mongo.BulkWriteError{
-							{mongo.WriteError{0, 110, "blah", nil, nil}, &mongo.InsertOneModel{}},
+						[]mongo.BulkWriteOpError{
+							{mongo.WriteOpError{0, 110, "blah", nil, nil}, &mongo.InsertOneModel{}},
 						},
 						[]string{"otherError"},
 					},

--- a/internal/integration/errors_test.go
+++ b/internal/integration/errors_test.go
@@ -355,11 +355,11 @@ func TestErrors(t *testing.T) {
 				we, ok := err.(mongo.WriteError)
 				assert.True(mt, ok, "expected InsertOne error to be WriteError, got %T", err)
 
-				assert.NotNil(mt, we.WriteErrors, "expected we.WriteErrors, got nil")
-				assert.NotNil(mt, we.WriteErrors[0], "expected at least one WriteError")
+				assert.NotNil(mt, we.WriteOpErrors, "expected we.WriteErrors, got nil")
+				assert.NotNil(mt, we.WriteOpErrors[0], "expected at least one WriteError")
 
 				// Assert that raw response exists for the WriteError and contains error code 11000.
-				raw := we.WriteErrors[0].Raw
+				raw := we.WriteOpErrors[0].Raw
 				assert.NotNil(mt, raw, "Raw of WriteError is nil")
 				val, err := raw.LookupErr("code")
 				assert.Nil(mt, err, "expected 'code' field in Raw field, got %v", raw)

--- a/internal/integration/json_helpers_test.go
+++ b/internal/integration/json_helpers_test.go
@@ -495,12 +495,12 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 	case mongo.CommandError:
 		details.name = converted.Name
 		details.labels = converted.Labels
-	case mongo.WriteException:
+	case mongo.WriteError:
 		if converted.WriteConcernError != nil {
 			details.name = converted.WriteConcernError.Name
 		}
 		details.labels = converted.Labels
-	case mongo.BulkWriteException:
+	case mongo.BulkWriteError:
 		if converted.WriteConcernError != nil {
 			details.name = converted.WriteConcernError.Name
 		}

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -282,7 +282,7 @@ func TestRetryableWritesProse(t *testing.T) {
 			require.True(mt, secondFailPointConfigured)
 
 			// Assert that the "ShutdownInProgress" error is returned.
-			require.True(mt, err.(mongo.WriteException).HasErrorCode(int(shutdownInProgressErrorCode)))
+			require.True(mt, err.(mongo.WriteError).HasErrorCode(int(shutdownInProgressErrorCode)))
 		})
 
 	mtOpts = mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.2")

--- a/internal/integration/unified/error.go
+++ b/internal/integration/unified/error.go
@@ -167,7 +167,7 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
 		}
-		for _, we := range converted.WriteErrors {
+		for _, we := range converted.WriteOpErrors {
 			details.codes = append(details.codes, int32(we.Code))
 		}
 		details.labels = converted.Labels

--- a/internal/integration/unified/error.go
+++ b/internal/integration/unified/error.go
@@ -162,7 +162,7 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 		details.codeNames = []string{converted.Name}
 		details.labels = converted.Labels
 		details.raw = converted.Raw
-	case mongo.WriteException:
+	case mongo.WriteError:
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)
@@ -172,7 +172,7 @@ func extractErrorDetails(err error) (errorDetails, bool) {
 		}
 		details.labels = converted.Labels
 		details.raw = converted.Raw
-	case mongo.BulkWriteException:
+	case mongo.BulkWriteError:
 		if converted.WriteConcernError != nil {
 			details.codes = append(details.codes, int32(converted.WriteConcernError.Code))
 			details.codeNames = append(details.codeNames, converted.WriteConcernError.Name)

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -52,8 +52,8 @@ func (bw *bulkWrite) execute(ctx context.Context) error {
 		UpsertedIDs: make(map[int64]interface{}),
 	}
 
-	bwErr := BulkWriteException{
-		WriteErrors: make([]BulkWriteError, 0),
+	bwErr := BulkWriteError{
+		WriteErrors: make([]BulkWriteOpError, 0),
 	}
 
 	var lastErr error
@@ -98,11 +98,11 @@ func (bw *bulkWrite) execute(ctx context.Context) error {
 	return nil
 }
 
-func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWriteResult, BulkWriteException, error) {
+func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWriteResult, BulkWriteError, error) {
 	batchRes := BulkWriteResult{
 		UpsertedIDs: make(map[int64]interface{}),
 	}
-	batchErr := BulkWriteException{}
+	batchErr := BulkWriteError{}
 
 	var writeErrors []driver.WriteError
 	switch batch.models[0].(type) {
@@ -149,14 +149,14 @@ func (bw *bulkWrite) runBatch(ctx context.Context, batch bulkWriteBatch) (BulkWr
 		}
 	}
 
-	batchErr.WriteErrors = make([]BulkWriteError, 0, len(writeErrors))
+	batchErr.WriteErrors = make([]BulkWriteOpError, 0, len(writeErrors))
 	convWriteErrors := writeErrorsFromDriverWriteErrors(writeErrors)
 	for _, we := range convWriteErrors {
 		request := batch.models[we.Index]
 		we.Index = batch.indexes[we.Index]
-		batchErr.WriteErrors = append(batchErr.WriteErrors, BulkWriteError{
-			WriteError: we,
-			Request:    request,
+		batchErr.WriteErrors = append(batchErr.WriteErrors, BulkWriteOpError{
+			WriteOpError: we,
+			Request:      request,
 		})
 	}
 	return batchRes, batchErr, nil

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -432,7 +432,7 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 }
 
 // InsertMany executes an insert command to insert multiple documents into the collection. If write errors occur
-// during the operation (e.g. duplicate key error), this method returns a BulkWriteException error.
+// during the operation (e.g. duplicate key error), this method returns a BulkWriteError error.
 //
 // The documents parameter must be a slice of documents to insert. The slice cannot be nil or empty. The elements must
 // all be non-nil. For any document that does not have an _id field when transformed into BSON, one will be added
@@ -465,21 +465,21 @@ func (coll *Collection) InsertMany(ctx context.Context, documents interface{},
 	}
 
 	imResult := &InsertManyResult{InsertedIDs: result}
-	var writeException WriteException
+	var writeException WriteError
 	if !errors.As(err, &writeException) {
 		return imResult, err
 	}
 
-	// create and return a BulkWriteException
-	bwErrors := make([]BulkWriteError, 0, len(writeException.WriteErrors))
+	// create and return a BulkWriteError
+	bwErrors := make([]BulkWriteOpError, 0, len(writeException.WriteErrors))
 	for _, we := range writeException.WriteErrors {
-		bwErrors = append(bwErrors, BulkWriteError{
-			WriteError: we,
-			Request:    nil,
+		bwErrors = append(bwErrors, BulkWriteOpError{
+			WriteOpError: we,
+			Request:      nil,
 		})
 	}
 
-	return imResult, BulkWriteException{
+	return imResult, BulkWriteError{
 		WriteErrors:       bwErrors,
 		WriteConcernError: writeException.WriteConcernError,
 		Labels:            writeException.Labels,

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -471,8 +471,8 @@ func (coll *Collection) InsertMany(ctx context.Context, documents interface{},
 	}
 
 	// create and return a BulkWriteError
-	bwErrors := make([]BulkWriteOpError, 0, len(writeException.WriteErrors))
-	for _, we := range writeException.WriteErrors {
+	bwErrors := make([]BulkWriteOpError, 0, len(writeException.WriteOpErrors))
+	for _, we := range writeException.WriteOpErrors {
 		bwErrors = append(bwErrors, BulkWriteOpError{
 			WriteOpError: we,
 			Request:      nil,

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -312,8 +312,7 @@ func (e CommandError) IsMaxTimeMSExpiredError() bool {
 func (e CommandError) serverError() {}
 
 // WriteOpError is an error that occurred during execution of a write operation.
-// This error type is only returned as part of a WriteError or
-// BulkWriteError.
+// This error type is only returned as part of a WriteError or BulkWriteError.
 type WriteOpError struct {
 	// The index of the write in the slice passed to an InsertMany or BulkWrite
 	// operation that caused this error.
@@ -359,7 +358,8 @@ func (we WriteOpError) HasErrorCodeWithMessage(code int, message string) bool {
 // serverError implements the ServerError interface.
 func (we WriteOpError) serverError() {}
 
-// WriteOpErrors is a group of write errors that occurred during execution of a write operation.
+// WriteOpErrors is a group of write errors that occurred during execution of a
+// write operation.
 type WriteOpErrors []WriteOpError
 
 // Error implements the error interface.
@@ -416,7 +416,7 @@ type WriteError struct {
 	WriteConcernError *WriteConcernError
 
 	// The write errors that occurred during operation execution.
-	WriteErrors WriteOpErrors
+	WriteOpErrors WriteOpErrors
 
 	// The categories to which the exception belongs.
 	Labels []string
@@ -431,10 +431,10 @@ func (mwe WriteError) Error() string {
 	if mwe.WriteConcernError != nil {
 		causes = append(causes, "write concern error: "+mwe.WriteConcernError.Error())
 	}
-	if len(mwe.WriteErrors) > 0 {
+	if len(mwe.WriteOpErrors) > 0 {
 		// The WriteErrors error message already starts with "write errors:", so don't add it to the
 		// error message again.
-		causes = append(causes, mwe.WriteErrors.Error())
+		causes = append(causes, mwe.WriteOpErrors.Error())
 	}
 
 	message := "write exception: "
@@ -449,7 +449,7 @@ func (mwe WriteError) HasErrorCode(code int) bool {
 	if mwe.WriteConcernError != nil && mwe.WriteConcernError.Code == code {
 		return true
 	}
-	for _, we := range mwe.WriteErrors {
+	for _, we := range mwe.WriteOpErrors {
 		if we.Code == code {
 			return true
 		}
@@ -472,7 +472,7 @@ func (mwe WriteError) HasErrorMessage(message string) bool {
 	if mwe.WriteConcernError != nil && strings.Contains(mwe.WriteConcernError.Message, message) {
 		return true
 	}
-	for _, we := range mwe.WriteErrors {
+	for _, we := range mwe.WriteOpErrors {
 		if strings.Contains(we.Message, message) {
 			return true
 		}
@@ -486,7 +486,7 @@ func (mwe WriteError) HasErrorCodeWithMessage(code int, message string) bool {
 		mwe.WriteConcernError.Code == code && strings.Contains(mwe.WriteConcernError.Message, message) {
 		return true
 	}
-	for _, we := range mwe.WriteErrors {
+	for _, we := range mwe.WriteOpErrors {
 		if we.Code == code && strings.Contains(we.Message, message) {
 			return true
 		}
@@ -638,7 +638,7 @@ func processWriteError(err error) (returnResult, error) {
 		case driver.WriteCommandError:
 			return rrMany, WriteError{
 				WriteConcernError: convertDriverWriteConcernError(tt.WriteConcernError),
-				WriteErrors:       writeErrorsFromDriverWriteErrors(tt.WriteErrors),
+				WriteOpErrors:     writeErrorsFromDriverWriteErrors(tt.WriteErrors),
 				Labels:            tt.Labels,
 				Raw:               bson.Raw(tt.Raw),
 			}

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -26,7 +26,7 @@ func TestErrorMessages(t *testing.T) {
 		{
 			desc: "WriteError error message should contain the WriteError Message and Details",
 			err: WriteError{
-				WriteErrors: WriteOpErrors{
+				WriteOpErrors: WriteOpErrors{
 					{
 						Message: "test message 1",
 						Details: details,

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -24,9 +24,9 @@ func TestErrorMessages(t *testing.T) {
 		expected string
 	}{
 		{
-			desc: "WriteException error message should contain the WriteError Message and Details",
-			err: WriteException{
-				WriteErrors: WriteErrors{
+			desc: "WriteError error message should contain the WriteError Message and Details",
+			err: WriteError{
+				WriteErrors: WriteOpErrors{
 					{
 						Message: "test message 1",
 						Details: details,
@@ -40,17 +40,17 @@ func TestErrorMessages(t *testing.T) {
 			expected: `write exception: write errors: [test message 1: {"details": {"operatorName": "$jsonSchema"}}, test message 2: {"details": {"operatorName": "$jsonSchema"}}]`,
 		},
 		{
-			desc: "BulkWriteException error message should contain the WriteError Message and Details",
-			err: BulkWriteException{
-				WriteErrors: []BulkWriteError{
+			desc: "BulkWriteError error message should contain the WriteError Message and Details",
+			err: BulkWriteError{
+				WriteErrors: []BulkWriteOpError{
 					{
-						WriteError: WriteError{
+						WriteOpError: WriteOpError{
 							Message: "test message 1",
 							Details: details,
 						},
 					},
 					{
-						WriteError: WriteError{
+						WriteOpError: WriteOpError{
 							Message: "test message 2",
 							Details: details,
 						},

--- a/testdata/crud/README.rst
+++ b/testdata/crud/README.rst
@@ -135,7 +135,7 @@ For each test file:
     - Given the ``name`` and ``arguments``, execute the operation on the object
       under test. Capture the result of the operation, if any, and observe
       whether an error occurred. If an error is encountered that includes a
-      result (e.g. BulkWriteException), extract the result object.
+      result (e.g. BulkWriteError), extract the result object.
 
     - If ``error`` is present and true, assert that the operation encountered an
       error. Otherwise, assert that no error was encountered.

--- a/testdata/crud/unified/bulkWrite-errorResponse.yml
+++ b/testdata/crud/unified/bulkWrite-errorResponse.yml
@@ -19,7 +19,7 @@ tests:
   # This test intentionally executes only a single insert operation in the bulk
   # write to make the error code and response assertions less ambiguous. That
   # said, some drivers may still need to skip this test because the CRUD spec
-  # does not prescribe how drivers should formulate a BulkWriteException beyond
+  # does not prescribe how drivers should formulate a BulkWriteError beyond
   # collecting write and write concern errors.
   - description: "bulkWrite operations support errorResponse assertions"
     runOnRequirements:

--- a/testdata/crud/unified/deleteOne-errorResponse.yml
+++ b/testdata/crud/unified/deleteOne-errorResponse.yml
@@ -17,7 +17,7 @@ createEntities:
 
 tests:
   # Some drivers may still need to skip this test because the CRUD spec does not
-  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # prescribe how drivers should formulate a WriteError beyond collecting a
   # write or write concern error.
   - description: "delete operations support errorResponse assertions"
     runOnRequirements:

--- a/testdata/crud/unified/insertOne-errorResponse.yml
+++ b/testdata/crud/unified/insertOne-errorResponse.yml
@@ -17,7 +17,7 @@ createEntities:
 
 tests:
   # Some drivers may still need to skip this test because the CRUD spec does not
-  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # prescribe how drivers should formulate a WriteError beyond collecting a
   # write or write concern error.
   - description: "insert operations support errorResponse assertions"
     runOnRequirements:

--- a/testdata/crud/unified/updateOne-errorResponse.yml
+++ b/testdata/crud/unified/updateOne-errorResponse.yml
@@ -17,7 +17,7 @@ createEntities:
 
 tests:
   # Some drivers may still need to skip this test because the CRUD spec does not
-  # prescribe how drivers should formulate a WriteException beyond collecting a
+  # prescribe how drivers should formulate a WriteError beyond collecting a
   # write or write concern error.
   - description: "update operations support errorResponse assertions"
     runOnRequirements:

--- a/testdata/retryable-writes/README.rst
+++ b/testdata/retryable-writes/README.rst
@@ -202,7 +202,7 @@ Each YAML file has the following keys:
       and ``error`` is ``true`` (generally for multi-statement tests), the
       result reports information about operations that succeeded before an
       unrecoverable failure. In that case, drivers may choose to check the
-      result object if their BulkWriteException (or equivalent) provides access
+      result object if their BulkWriteError (or equivalent) provides access
       to a write result object.
 
       - ``errorLabelsContain``: A list of error label strings that the

--- a/testdata/unified-test-format/valid-pass/poc-crud.yml
+++ b/testdata/unified-test-format/valid-pass/poc-crud.yml
@@ -101,7 +101,7 @@ tests:
           ordered: false
         expectError:
           expectResult:
-            # insertMany throws BulkWriteException, which may optionally include
+            # insertMany throws BulkWriteError, which may optionally include
             # an intermediary BulkWriteResult
             $$unsetOrMatches:
               deletedCount: 0


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

GODRIVER-2697

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Suggest naming the operation errors *OpError and the exceptions to *Error to be language idiomatic.

## Background & Motivation

<!--- Rationale for the pull request. -->

From the ticket:

> "Exception" implies a different type of error that does not exist in Go, so error type names ending in "Exception" are confusing. Rename the errors to prevent confusion and follow Go error type naming idioms.

> While the CRUD spec is pretty lenient about the naming of types and methods based on language idioms, it's worth noting that the terms WriteError , WriteException , BulkWriteError and BulkWriteException all come directly from the [spec](https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#writeerror).
