### PR TITLE
GODRIVER-3150 Make Docker Test More Robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
   export TZ=Etc/UTC && \
   export LC_ALL=C.UTF-8 && \
   sudo -E apt-add-repository "ppa:longsleep/golang-backports" && \
-  apt-get -qq update && \
-  apt-get -qqy install --no-install-recommends golang-go && \
+  apt-get -qq update --option Acquire::Retries=100 --option Acquire::http::Timeout="60" && \
+  apt-get -qqy install --option Acquire::Retries=100 --option Acquire::http::Timeout="60" --no-install-recommends golang-go && \
   rm -rf /var/lib/apt/lists/*
 
 COPY ./etc/docker_entry.sh /root/docker_entry.sh


### PR DESCRIPTION
[GODRIVER-3150](https://jira.mongodb.org/browse/GODRIVER-3150)

## Summary

Make Dockerfile more robust.

## Background & Motivation

Prevent intermittent connection errors to the golang PPA.
