### PR TITLE
GODRIVER-3158 Invoke all Drivers Evergreen Tools Scripts with Bash

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -259,7 +259,7 @@ functions:
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           LOAD_BALANCER=${LOAD_BALANCER} \
-          sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
         file: mo-expansion.yml
@@ -276,7 +276,7 @@ functions:
           AUTH=${AUTH} \
           SSL=${SSL} \
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
-          sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
         file: mo-expansion.yml


### PR DESCRIPTION
GODRIVER-3158

## Summary

Invoke all drivers evergreen tools scripts with bash.

## Background & Motivation

Bash has more features, that we can utilize once all drivers complete the ticket.
