### PR TITLE
Append maxTimeMS and use a timeout-feedback mechanism to adjust it.

### DIFF
--- a/internal/csot_util.go
+++ b/internal/csot_util.go
@@ -21,11 +21,13 @@ type timeoutKey struct{}
 // TODO default behavior.
 func MakeTimeoutContext(ctx context.Context, to time.Duration) (context.Context, context.CancelFunc) {
 	// Only use the passed in Duration as a timeout on the Context if it
-	// is non-zero.
+	// is non-zero and if the Context doesn't already have a timeout.
 	cancelFunc := func() {}
-	if to != 0 {
+	if _, deadlineSet := ctx.Deadline(); to != 0 && !deadlineSet {
 		ctx, cancelFunc = context.WithTimeout(ctx, to)
 	}
+
+	// Add timeoutKey either way to indicate CSOT is enabled.
 	return context.WithValue(ctx, timeoutKey{}, true), cancelFunc
 }
 

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -273,7 +273,7 @@ func (cs *ChangeStream) executeOperation(ctx context.Context, resuming bool) err
 	// If no deadline is set on the passed-in context, cs.client.timeout is set, and context is not already
 	// a Timeout context, honor cs.client.timeout in new Timeout context for change stream operation execution
 	// and potential retry.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && cs.client.timeout != nil && !internal.IsTimeoutContext(ctx) {
+	if cs.client.timeout != nil && !internal.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := internal.MakeTimeoutContext(ctx, *cs.client.timeout)
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -260,7 +260,7 @@ func (b *Bucket) DeleteContext(ctx context.Context, fileID interface{}) error {
 	// If no deadline is set on the passed-in context, Timeout is set on the Client, and context is
 	// not already a Timeout context, honor Timeout in new Timeout context for operation execution to
 	// be shared by both delete operations.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && b.db.Client().Timeout() != nil && !internal.IsTimeoutContext(ctx) {
+	if b.db.Client().Timeout() != nil && !internal.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := internal.MakeTimeoutContext(ctx, *b.db.Client().Timeout())
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx
@@ -387,7 +387,7 @@ func (b *Bucket) DropContext(ctx context.Context) error {
 	// If no deadline is set on the passed-in context, Timeout is set on the Client, and context is
 	// not already a Timeout context, honor Timeout in new Timeout context for operation execution to
 	// be shared by both drop operations.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && b.db.Client().Timeout() != nil && !internal.IsTimeoutContext(ctx) {
+	if b.db.Client().Timeout() != nil && !internal.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := internal.MakeTimeoutContext(ctx, *b.db.Client().Timeout())
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx

--- a/mongo/integration/client_test.go
+++ b/mongo/integration/client_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,9 +17,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal"
@@ -907,5 +910,140 @@ func TestClientStress(t *testing.T) {
 				assert.True(mt, len(errs) == 0, "expected no errors, but got %d (%v)", len(errs), errs)
 			})
 		}
+	})
+}
+
+func TestCSOTExperiment(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+	defer mt.Close()
+
+	csotOpts := mtest.NewOptions().ClientOptions(options.Client().SetTimeout(10 * time.Second))
+	mt.RunOpts("includes maxTimeMS if CSOT timeout is set", csotOpts, func(mt *mtest.T) {
+		mt.Run("with context.Background", func(mt *mtest.T) {
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+			require.NoError(mt, err, "InsertOne error")
+
+			maxTimeVal := mt.GetStartedEvent().Command.Lookup("maxTimeMS")
+
+			require.NotEmpty(mt, maxTimeVal.Value, "expected maxTimeMS BSON value to be non-empty")
+			require.Equal(mt, maxTimeVal.Type, bsontype.Int64, "expected maxTimeMS value to be type Int64")
+
+			maxTimeMS := maxTimeVal.Int64()
+			assert.True(mt, maxTimeMS > 0, "expected maxTimeMS value to be greater than 0")
+		})
+		mt.Run("with context.WithTimeout", func(mt *mtest.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			_, err := mt.Coll.InsertOne(ctx, bson.D{})
+			require.NoError(mt, err, "InsertOne error")
+
+			maxTimeVal := mt.GetStartedEvent().Command.Lookup("maxTimeMS")
+			require.NotEmpty(mt, maxTimeVal.Value, "expected maxTimeMS BSON value to be non-empty")
+			require.Equal(mt, maxTimeVal.Type, bsontype.Int64, "expected maxTimeMS value to be type Int64")
+
+			maxTimeMS := maxTimeVal.Int64()
+			assert.True(mt,
+				maxTimeMS > 60_000,
+				"expected maxTimeMS value to be greater than 60000, but got %v",
+				maxTimeMS)
+		})
+	})
+
+	mt.RunOpts("timeout errors wrap context.DeadlineExceeded", csotOpts, func(mt *mtest.T) {
+		// Test that a client-side timeout is a context.DeadlineExceeded
+		mt.Run("MaxTimeMSExceeded", func(mt *mtest.T) {
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+			require.NoError(mt, err, "InsertOne error")
+
+			mt.SetFailPoint(mtest.FailPoint{
+				ConfigureFailPoint: "failCommand",
+				Mode: mtest.FailPointMode{
+					Times: 1,
+				},
+				Data: mtest.FailPointData{
+					FailCommands: []string{"find"},
+					ErrorCode:    50, // MaxTimeMSExceeded
+				},
+			})
+
+			err = mt.Coll.FindOne(context.Background(), bson.D{}).Err()
+
+			assert.True(mt,
+				errors.Is(err, context.DeadlineExceeded),
+				"expected error %[1]T(%[1]q) to wrap context.DeadlineExceeded",
+				err)
+			assert.True(mt,
+				mongo.IsTimeout(err),
+				"expected error %[1]T(%[1]q) to be a timeout error",
+				err)
+		})
+		// Test that a server-side timeout is a context.DeadlineExceeded
+		mt.Run("ErrDeadlineWouldBeExceeded", func(mt *mtest.T) {
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+			require.NoError(mt, err, "InsertOne error")
+
+			mt.SetFailPoint(mtest.FailPoint{
+				ConfigureFailPoint: "failCommand",
+				Mode: mtest.FailPointMode{
+					Times: 1,
+				},
+				Data: mtest.FailPointData{
+					FailCommands:    []string{"find"},
+					BlockConnection: true,
+					BlockTimeMS:     1000,
+				},
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
+			defer cancel()
+			err = mt.Coll.FindOne(ctx, bson.D{}).Err()
+
+			assert.True(mt,
+				errors.Is(err, driver.ErrDeadlineWouldBeExceeded),
+				"expected error %[1]T(%[1]q) to wrap driver.ErrDeadlineWouldBeExceeded",
+				err)
+			assert.True(mt,
+				errors.Is(err, context.DeadlineExceeded),
+				"expected error %[1]T(%[1]q) to wrap context.DeadlineExceeded",
+				err)
+			assert.True(mt,
+				mongo.IsTimeout(err),
+				"expected error %[1]T(%[1]q) to be a timeout error",
+				err)
+		})
+		mt.Run("context.DeadlineExceeded", func(mt *mtest.T) {
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+			require.NoError(mt, err, "InsertOne error")
+
+			mt.SetFailPoint(mtest.FailPoint{
+				ConfigureFailPoint: "failCommand",
+				Mode: mtest.FailPointMode{
+					Times: 1,
+				},
+				Data: mtest.FailPointData{
+					FailCommands:    []string{"find"},
+					BlockConnection: true,
+					BlockTimeMS:     1000,
+				},
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			defer cancel()
+			err = mt.Coll.FindOne(ctx, bson.D{}).Err()
+
+			assert.False(mt,
+				errors.Is(err, driver.ErrDeadlineWouldBeExceeded),
+				"expected error %[1]T(%[1]q) to not wrap driver.ErrDeadlineWouldBeExceeded",
+				err)
+			assert.True(mt,
+				errors.Is(err, context.DeadlineExceeded),
+				"expected error %[1]T(%[1]q) to wrap context.DeadlineExceeded",
+				err)
+			assert.True(mt,
+				mongo.IsTimeout(err),
+				"expected error %[1]T(%[1]q) to be a timeout error",
+				err)
+		})
 	})
 }

--- a/x/experiment/metrics.go
+++ b/x/experiment/metrics.go
@@ -1,0 +1,37 @@
+// TODO: Remove this package.
+
+package experiment
+
+import (
+	"context"
+	"time"
+)
+
+type Metrics struct {
+	Time              time.Time
+	Server            string
+	OriginalTimeout   time.Duration
+	RemainingTimeout  time.Duration
+	MinRTT            time.Duration
+	AdjustmentPct     float64
+	Adjustment        time.Duration
+	MaxTimeMS         int64
+	OpDuration        time.Duration
+	Retries           int
+	ConnectionsClosed int
+	Err               error
+}
+
+type metricsValue struct{}
+
+func WithMetrics(ctx context.Context, metrics *Metrics) context.Context {
+	return context.WithValue(ctx, metricsValue{}, metrics)
+}
+
+func GetMetrics(ctx context.Context) *Metrics {
+	val := ctx.Value(metricsValue{})
+	if val == nil {
+		return nil
+	}
+	return val.(*Metrics)
+}

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -165,6 +165,10 @@ type ErrorProcessor interface {
 	ProcessError(err error, conn Connection) ProcessErrorResult
 }
 
+type MaxTimeAdjuster interface {
+	MaxTimeAdjust() int64
+}
+
 // HandshakeInformation contains information extracted from a MongoDB connection handshake. This is a helper type that
 // augments description.Server by also tracking server connection ID and authentication-related fields. We use this type
 // rather than adding authentication-related fields to description.Server to avoid retaining sensitive information in a

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -27,6 +27,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/experiment"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 )
@@ -420,6 +421,10 @@ func (op Operation) Execute(ctx context.Context) error {
 	// resetForRetry records the error that caused the retry, decrements retries, and resets the
 	// retry loop variables to request a new server and a new connection for the next attempt.
 	resetForRetry := func(err error) {
+		if metrics := experiment.GetMetrics(ctx); metrics != nil {
+			metrics.Retries++
+		}
+
 		retries--
 		prevErr = err
 
@@ -499,6 +504,10 @@ func (op Operation) Execute(ctx context.Context) error {
 					return err
 				}
 			}
+		}
+
+		if metrics := experiment.GetMetrics(ctx); metrics != nil {
+			metrics.Server = conn.Address().String()
 		}
 
 		// Run steps that must only be run on the first attempt, but not again for retries.
@@ -1393,22 +1402,20 @@ func (op Operation) calculateMaxTimeMS(
 				adjustDur = 500 * time.Millisecond
 			}
 			subRTTAdj := subRTT - adjustDur
-
-			// if rand.Float32() < 0.01 {
-			// 	fmt.Printf("MAXTIME METHOD1: rem:%v, rtt:%v, pre:%v, adj:%v(%v), res:%v\n",
-			// 		remainingTimeout,
-			// 		rttMin,
-			// 		subRTT,
-			// 		maxTimeAdjust,
-			// 		adjustDur,
-			// 		subRTTAdj)
-			// }
-
 			maxTime := subRTTAdj
 
 			// Always round up to the next millisecond value so we never truncate the calculated
 			// maxTimeMS value (e.g. 400 microseconds evaluates to 1ms, not 0ms).
 			maxTimeMS := int64((maxTime + (time.Millisecond - 1)) / time.Millisecond)
+
+			if metrics := experiment.GetMetrics(ctx); metrics != nil {
+				metrics.RemainingTimeout = remainingTimeout
+				metrics.MinRTT = rttMin
+				metrics.AdjustmentPct = float64(maxTimeAdjust) * 0.001
+				metrics.Adjustment = adjustDur
+				metrics.MaxTimeMS = maxTimeMS
+			}
+
 			if maxTimeMS <= 0 {
 				return 0, fmt.Errorf(
 					"maxTimeMS calculated by context deadline is negative "+

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -310,6 +310,10 @@ func (op Operation) getServerAndConnection(ctx context.Context) (Server, Connect
 		return nil, nil, err
 	}
 
+	if metrics := experiment.GetMetrics(ctx); metrics != nil {
+		metrics.Server = conn.Address().String()
+	}
+
 	// If we're in load balanced mode and this is the first operation in a transaction, pin the session to a connection.
 	if conn.Description().LoadBalanced() && op.Client != nil && op.Client.TransactionStarting() {
 		pinnedConn, ok := conn.(PinnedConnection)
@@ -504,10 +508,6 @@ func (op Operation) Execute(ctx context.Context) error {
 					return err
 				}
 			}
-		}
-
-		if metrics := experiment.GetMetrics(ctx); metrics != nil {
-			metrics.Server = conn.Address().String()
 		}
 
 		// Run steps that must only be run on the first attempt, but not again for retries.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -361,9 +361,9 @@ func (op Operation) Execute(ctx context.Context) error {
 		return err
 	}
 
-	// If no deadline is set on the passed-in context, op.Timeout is set, and context is not already
-	// a Timeout context, honor op.Timeout in new Timeout context for operation execution.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && op.Timeout != nil && !internal.IsTimeoutContext(ctx) {
+	// If op.Timeout is set, and context is not already a Timeout context, honor
+	// op.Timeout in new Timeout context for operation execution.
+	if op.Timeout != nil && !internal.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := internal.MakeTimeoutContext(ctx, *op.Timeout)
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx
@@ -532,7 +532,11 @@ func (op Operation) Execute(ctx context.Context) error {
 		}
 
 		// Calculate maxTimeMS value to potentially be appended to the wire message.
-		maxTimeMS, err := op.calculateMaxTimeMS(ctx, srvr.RTTMonitor().P90(), srvr.RTTMonitor().Stats())
+		var maxTimeAdjust int64
+		if mta, ok := srvr.(MaxTimeAdjuster); ok {
+			maxTimeAdjust = mta.MaxTimeAdjust()
+		}
+		maxTimeMS, err := op.calculateMaxTimeMS(ctx, srvr.RTTMonitor().Min(), maxTimeAdjust)
 		if err != nil {
 			return err
 		}
@@ -611,8 +615,11 @@ func (op Operation) Execute(ctx context.Context) error {
 			err = ctx.Err()
 		} else if deadline, ok := ctx.Deadline(); ok {
 			if internal.IsTimeoutContext(ctx) && time.Now().Add(srvr.RTTMonitor().P90()).After(deadline) {
-				err = internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
-					"remaining time %v until context deadline is less than 90th percentile RTT\n%v", time.Until(deadline), srvr.RTTMonitor().Stats())
+				err = fmt.Errorf(
+					"remaining time %v until context deadline is less than 90th percentile RTT: %w\n%v",
+					time.Until(deadline),
+					ErrDeadlineWouldBeExceeded,
+					srvr.RTTMonitor().Stats())
 			} else if time.Now().Add(srvr.RTTMonitor().Min()).After(deadline) {
 				err = context.DeadlineExceeded
 			}
@@ -919,7 +926,7 @@ func (op Operation) readWireMessage(ctx context.Context, conn Connection) (resul
 	}
 
 	// decode
-	res, err := op.decodeResult(opcode, rem)
+	res, err := op.decodeResult(opcode, rem, internal.IsTimeoutContext(ctx))
 	// Update cluster/operation time and recovery tokens before handling the error to ensure we're properly updating
 	// everything.
 	op.updateClusterTimes(res)
@@ -1361,24 +1368,55 @@ func (op Operation) addClusterTime(dst []byte, desc description.SelectedServer) 
 	// return bsoncore.AppendDocumentElement(dst, "$clusterTime", clusterTime)
 }
 
-// calculateMaxTimeMS calculates the value of the 'maxTimeMS' field to potentially append
-// to the wire message based on the current context's deadline and the 90th percentile RTT
-// if the ctx is a Timeout context. If the context is not a Timeout context, it uses the
-// operation's MaxTimeMS if set. If no MaxTimeMS is set on the operation, and context is
-// not a Timeout context, calculateMaxTimeMS returns 0.
-func (op Operation) calculateMaxTimeMS(ctx context.Context, rtt90 time.Duration, rttStats string) (uint64, error) {
+// calculateMaxTimeMS calculates the value of the 'maxTimeMS' field to
+// potentially append to the wire message based on the current context's
+// deadline and the min RTT if the ctx is a Timeout context. If the context is
+// not a Timeout context, it uses the operation's MaxTimeMS if set. If no
+// MaxTimeMS is set on the operation, and context is not a Timeout context,
+// calculateMaxTimeMS returns 0.
+func (op Operation) calculateMaxTimeMS(
+	ctx context.Context,
+	rttMin time.Duration,
+	maxTimeAdjust int64,
+) (uint64, error) {
 	if internal.IsTimeoutContext(ctx) {
 		if deadline, ok := ctx.Deadline(); ok {
 			remainingTimeout := time.Until(deadline)
-			maxTime := remainingTimeout - rtt90
+
+			subRTT := remainingTimeout - rttMin
+
+			// Calculate percentage of remaining maxTime to subtract. The maxTimeAdjust
+			// value will be between 0-300, so multiply it by 0.001 so it ranges from
+			// 0.0 to 0.3 (0-30%).
+			adjustDur := time.Duration(float64(subRTT) * float64(maxTimeAdjust) * 0.001)
+			if adjustDur > 500*time.Millisecond {
+				adjustDur = 500 * time.Millisecond
+			}
+			subRTTAdj := subRTT - adjustDur
+
+			// if rand.Float32() < 0.01 {
+			// 	fmt.Printf("MAXTIME METHOD1: rem:%v, rtt:%v, pre:%v, adj:%v(%v), res:%v\n",
+			// 		remainingTimeout,
+			// 		rttMin,
+			// 		subRTT,
+			// 		maxTimeAdjust,
+			// 		adjustDur,
+			// 		subRTTAdj)
+			// }
+
+			maxTime := subRTTAdj
 
 			// Always round up to the next millisecond value so we never truncate the calculated
 			// maxTimeMS value (e.g. 400 microseconds evaluates to 1ms, not 0ms).
 			maxTimeMS := int64((maxTime + (time.Millisecond - 1)) / time.Millisecond)
 			if maxTimeMS <= 0 {
-				return 0, internal.WrapErrorf(ErrDeadlineWouldBeExceeded,
-					"remaining time %v until context deadline is less than or equal to 90th percentile RTT\n%v",
-					remainingTimeout, rttStats)
+				return 0, fmt.Errorf(
+					"maxTimeMS calculated by context deadline is negative "+
+						"(remaining time: %v, minimum RTT %v, feedback adjustment %v): %w",
+					remainingTimeout,
+					rttMin,
+					subRTTAdj,
+					context.DeadlineExceeded)
 			}
 			return uint64(maxTimeMS), nil
 		}
@@ -1615,7 +1653,7 @@ func (Operation) decodeOpReply(wm []byte) opReply {
 	return reply
 }
 
-func (op Operation) decodeResult(opcode wiremessage.OpCode, wm []byte) (bsoncore.Document, error) {
+func (op Operation) decodeResult(opcode wiremessage.OpCode, wm []byte, isCSOT bool) (bsoncore.Document, error) {
 	switch opcode {
 	case wiremessage.OpReply:
 		reply := op.decodeOpReply(wm)
@@ -1633,7 +1671,7 @@ func (op Operation) decodeResult(opcode wiremessage.OpCode, wm []byte) (bsoncore
 			return nil, NewCommandResponseError("malformed OP_REPLY: invalid document", err)
 		}
 
-		return rdr, ExtractErrorFromServerResponse(rdr)
+		return rdr, ExtractErrorFromServerResponse(rdr, isCSOT)
 	case wiremessage.OpMsg:
 		_, wm, ok := wiremessage.ReadMsgFlags(wm)
 		if !ok {
@@ -1670,7 +1708,7 @@ func (op Operation) decodeResult(opcode wiremessage.OpCode, wm []byte) (bsoncore
 			return nil, NewCommandResponseError("malformed OP_MSG: invalid document", err)
 		}
 
-		return res, ExtractErrorFromServerResponse(res)
+		return res, ExtractErrorFromServerResponse(res, isCSOT)
 	default:
 		return nil, fmt.Errorf("cannot decode result from %s", opcode)
 	}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -22,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/experiment"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/ocsp"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
@@ -358,6 +359,9 @@ func (c *connection) writeWireMessage(ctx context.Context, wm []byte) error {
 
 	err = c.write(ctx, wm)
 	if err != nil {
+		if metrics := experiment.GetMetrics(ctx); metrics != nil {
+			metrics.ConnectionsClosed++
+		}
 		c.close()
 		return ConnectionError{
 			ConnectionID: c.id,
@@ -409,6 +413,9 @@ func (c *connection) readWireMessage(ctx context.Context) ([]byte, error) {
 
 	dst, errMsg, err := c.read(ctx)
 	if err != nil {
+		if metrics := experiment.GetMetrics(ctx); metrics != nil {
+			metrics.ConnectionsClosed++
+		}
 		// We closeConnection the connection because we don't know if there are other bytes left to read.
 		c.close()
 		message := errMsg

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -8,7 +8,9 @@ package topology
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
 )
@@ -46,6 +48,11 @@ func (e ConnectionError) Error() string {
 // Unwrap returns the underlying error.
 func (e ConnectionError) Unwrap() error {
 	return e.Wrapped
+}
+
+func (e ConnectionError) Timeout() bool {
+	var nerr net.Error
+	return errors.As(e.Wrapped, &nerr) && nerr.Timeout()
 }
 
 // ServerSelectionError represents a Server Selection error.

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -421,12 +421,12 @@ func setMaxTimeRatio(maxTimeRatio *int64, err error) {
 
 	// If the error is a client-side timeout, increase by 40 (4%). If it's not,
 	// reduce by 1 (0.1%).
-	var derr driver.Error
-	isMaxTimeMSExpired := errors.As(err, &derr) && derr.Code == 50
-
-	var nerr net.Error
-	isClientTimeout := ((errors.As(err, &nerr) && nerr.Timeout()) || errors.Is(err, context.DeadlineExceeded)) && !isMaxTimeMSExpired
-	if isClientTimeout {
+	//
+	// TODO: Add a test to ensure that this always indicates a connection
+	// read/write timeout.
+	var cerr ConnectionError
+	isNetTimeout := errors.As(err, &cerr) && cerr.Timeout()
+	if isNetTimeout {
 		v += maxTimeRatioInc
 		// TODO: Special condition for server-side timeout?
 	} else {

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -1282,3 +1282,7 @@ func newServerDescription(
 		LastError: lastError,
 	}
 }
+
+func TestUpdateMaxTimeOffset(t *testing.T) {
+	updateMaxTimeOffset(nil, nil)
+}


### PR DESCRIPTION
DO NOT MERGE!

## Summary

Experimental change to minimize connection churn during lots-of-timeout events caused by increased database latency.

Changes:
* Fix a bug that prevents `maxTimeMS` from being added to commands when a context with deadline is used on an operation, even if `timeoutMS` is set on the client.
  * Omit `maxTimeMS` from operations that create a cursor (`Find`, `Aggregate`) because the default behavior of `maxTimeMS` is to limit the lifetime of the cursor as well as the initial command, which may be surprising. `FindOne` operations still send `maxTimeMS`.
* Use minimum round-trip time instead of 90th percentile round-trip time to calculate `maxTimeMS`
* Add a feedback mechanism that reduces the `maxTimeMS` value when an operation encounters a client-side timeout error. The adjustment is made per-server, so different `mongod` or `mongos` nodes may get different `maxTimeMS` values.
  * The maximum reduction is `([remaining time] - [minimum RTT]) * 0.3` or 500ms, whichever is smaller.

Based on the v1.11.7 release.

## Background & Motivation

The automatic `maxTimeMS` mechanism as described in the [CSOT spec](https://github.com/mongodb/specifications/blob/master/source/client-side-operations-timeout/client-side-operations-timeout.md#command-execution) currently does not sufficiently mitigate high connection churn under certain timeout scenarios. Additionally, there is a bug in the Go Driver that prevents automatic `maxTimeMS` values from being added to commands if the Context passed to an operation has a deadline.
