### PR TITLE
Append maxTimeMS and use a timeout-feedback mechanism to adjust it (based on v1.14.0)

### DIFF
--- a/internal/csot/csot.go
+++ b/internal/csot/csot.go
@@ -21,11 +21,13 @@ type timeoutKey struct{}
 // TODO default behavior.
 func MakeTimeoutContext(ctx context.Context, to time.Duration) (context.Context, context.CancelFunc) {
 	// Only use the passed in Duration as a timeout on the Context if it
-	// is non-zero.
+	// is non-zero and if the Context doesn't already have a timeout.
 	cancelFunc := func() {}
-	if to != 0 {
+	if _, deadlineSet := ctx.Deadline(); to != 0 && !deadlineSet {
 		ctx, cancelFunc = context.WithTimeout(ctx, to)
 	}
+
+	// Add timeoutKey either way to indicate CSOT is enabled.
 	return context.WithValue(ctx, timeoutKey{}, true), cancelFunc
 }
 

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -280,7 +280,7 @@ func (cs *ChangeStream) executeOperation(ctx context.Context, resuming bool) err
 	// If no deadline is set on the passed-in context, cs.client.timeout is set, and context is not already
 	// a Timeout context, honor cs.client.timeout in new Timeout context for change stream operation execution
 	// and potential retry.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && cs.client.timeout != nil && !csot.IsTimeoutContext(ctx) {
+	if cs.client.timeout != nil && !csot.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := csot.MakeTimeoutContext(ctx, *cs.client.timeout)
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx

--- a/mongo/gridfs/bucket.go
+++ b/mongo/gridfs/bucket.go
@@ -260,7 +260,7 @@ func (b *Bucket) DeleteContext(ctx context.Context, fileID interface{}) error {
 	// If no deadline is set on the passed-in context, Timeout is set on the Client, and context is
 	// not already a Timeout context, honor Timeout in new Timeout context for operation execution to
 	// be shared by both delete operations.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && b.db.Client().Timeout() != nil && !csot.IsTimeoutContext(ctx) {
+	if b.db.Client().Timeout() != nil && !csot.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := csot.MakeTimeoutContext(ctx, *b.db.Client().Timeout())
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx
@@ -387,7 +387,7 @@ func (b *Bucket) DropContext(ctx context.Context) error {
 	// If no deadline is set on the passed-in context, Timeout is set on the Client, and context is
 	// not already a Timeout context, honor Timeout in new Timeout context for operation execution to
 	// be shared by both drop operations.
-	if _, deadlineSet := ctx.Deadline(); !deadlineSet && b.db.Client().Timeout() != nil && !csot.IsTimeoutContext(ctx) {
+	if b.db.Client().Timeout() != nil && !csot.IsTimeoutContext(ctx) {
 		newCtx, cancelFunc := csot.MakeTimeoutContext(ctx, *b.db.Client().Timeout())
 		// Redefine ctx to be the new timeout-derived context.
 		ctx = newCtx

--- a/x/experiment/metrics.go
+++ b/x/experiment/metrics.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2024-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 // TODO: Remove this package.
 
 package experiment

--- a/x/experiment/metrics.go
+++ b/x/experiment/metrics.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// Metrics is a collector for timing trace values for the "maxTimeMS" feedback
+// mechanism experiment.
 type Metrics struct {
 	Time              time.Time
 	Server            string
@@ -24,10 +26,13 @@ type Metrics struct {
 
 type metricsValue struct{}
 
+// WithMetrics adds a Metrics to the given context.
 func WithMetrics(ctx context.Context, metrics *Metrics) context.Context {
 	return context.WithValue(ctx, metricsValue{}, metrics)
 }
 
+// GetMetrics returns the Metrics from the given context, or nil if there is no
+// Metrics.
 func GetMetrics(ctx context.Context) *Metrics {
 	val := ctx.Value(metricsValue{})
 	if val == nil {

--- a/x/experiment/metrics.go
+++ b/x/experiment/metrics.go
@@ -1,0 +1,37 @@
+// TODO: Remove this package.
+
+package experiment
+
+import (
+	"context"
+	"time"
+)
+
+type Metrics struct {
+	Time              time.Time
+	Server            string
+	OriginalTimeout   time.Duration
+	RemainingTimeout  time.Duration
+	MinRTT            time.Duration
+	AdjustmentPct     float64
+	Adjustment        time.Duration
+	MaxTimeMS         int64
+	OpDuration        time.Duration
+	Retries           int
+	ConnectionsClosed int
+	Err               error
+}
+
+type metricsValue struct{}
+
+func WithMetrics(ctx context.Context, metrics *Metrics) context.Context {
+	return context.WithValue(ctx, metricsValue{}, metrics)
+}
+
+func GetMetrics(ctx context.Context) *Metrics {
+	val := ctx.Value(metricsValue{})
+	if val == nil {
+		return nil
+	}
+	return val.(*Metrics)
+}

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -165,6 +165,10 @@ type ErrorProcessor interface {
 	ProcessError(err error, conn Connection) ProcessErrorResult
 }
 
+type MaxTimeAdjuster interface {
+	MaxTimeAdjust() int64
+}
+
 // HandshakeInformation contains information extracted from a MongoDB connection handshake. This is a helper type that
 // augments description.Server by also tracking server connection ID and authentication-related fields. We use this type
 // rather than adding authentication-related fields to description.Server to avoid retaining sensitive information in a

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -168,6 +168,8 @@ type ErrorProcessor interface {
 // MaxTimeAdjuster describes types that provide a "maxTimeMS" adjustment value.
 type MaxTimeAdjuster interface {
 	MaxTimeAdjust() int64
+	AddTimeoutSample(error, time.Duration, uint64)
+	MaxTimeoutSample() time.Duration
 }
 
 // HandshakeInformation contains information extracted from a MongoDB connection handshake. This is a helper type that

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -169,7 +169,7 @@ type ErrorProcessor interface {
 type MaxTimeAdjuster interface {
 	MaxTimeAdjust() int64
 	AddTimeoutSample(time.Duration, uint64)
-	MaxTimeoutSample() time.Duration
+	MaxTimeoutSample() (time.Duration, time.Duration)
 }
 
 // HandshakeInformation contains information extracted from a MongoDB connection handshake. This is a helper type that

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -168,7 +168,7 @@ type ErrorProcessor interface {
 // MaxTimeAdjuster describes types that provide a "maxTimeMS" adjustment value.
 type MaxTimeAdjuster interface {
 	MaxTimeAdjust() int64
-	AddTimeoutSample(error, time.Duration, uint64)
+	AddTimeoutSample(time.Duration, uint64)
 	MaxTimeoutSample() time.Duration
 }
 

--- a/x/mongo/driver/driver.go
+++ b/x/mongo/driver/driver.go
@@ -165,6 +165,7 @@ type ErrorProcessor interface {
 	ProcessError(err error, conn Connection) ProcessErrorResult
 }
 
+// MaxTimeAdjuster describes types that provide a "maxTimeMS" adjustment value.
 type MaxTimeAdjuster interface {
 	MaxTimeAdjust() int64
 }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -815,8 +815,8 @@ func (op Operation) Execute(ctx context.Context) error {
 			}
 			res, err = roundTrip(ctx, conn, *wm)
 
-			if mta, ok := srvr.(MaxTimeAdjuster); ok {
-				mta.AddTimeoutSample(err, timeUntilRTDeadline, maxTimeMS)
+			if mta, ok := srvr.(MaxTimeAdjuster); ok && errors.Is(err, context.DeadlineExceeded) {
+				mta.AddTimeoutSample(timeUntilRTDeadline, maxTimeMS)
 			}
 
 			if ep, ok := srvr.(ErrorProcessor); ok {
@@ -1615,7 +1615,7 @@ func (op Operation) calculateMaxTimeMS(
 
 			mtd := time.Duration(maxTimeMS) * time.Millisecond
 			if maxTimeoutSample > 0 && remainingTimeout-mtd < maxTimeoutSample {
-				return 0, fmt.Errorf("calcualte maxTimeMS has a high liklihood of connection churn: %w",
+				return 0, fmt.Errorf("calculated maxTimeMS has a high liklihood of failure: %w",
 					ErrDeadlineWouldBeExceeded)
 			}
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1615,7 +1615,7 @@ func (op Operation) calculateMaxTimeMS(
 
 			mtd := time.Duration(maxTimeMS) * time.Millisecond
 			if maxTimeoutSample > 0 && remainingTimeout-mtd < maxTimeoutSample {
-				return 0, fmt.Errorf("calculated maxTimeMS has a high liklihood of failure: %w",
+				return 0, fmt.Errorf("calculated maxTimeMS has a high likelihood of failure: %w",
 					ErrDeadlineWouldBeExceeded)
 			}
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -1588,9 +1588,9 @@ func (op Operation) calculateMaxTimeMS(
 			subRTT := remainingTimeout - rttMin
 
 			// Calculate percentage of remaining maxTime to subtract. The maxTimeAdjust
-			// value will be between 0-300, so multiply it by 0.001 so it ranges from
+			// value will be between 0-3000, so multiply it by 0.0001 so it ranges from
 			// 0.0 to 0.3 (0-30%).
-			adjustDur := time.Duration(float64(subRTT) * float64(maxTimeAdjust) * 0.001)
+			adjustDur := time.Duration(float64(subRTT) * float64(maxTimeAdjust) * 0.0001)
 			if adjustDur > 500*time.Millisecond {
 				adjustDur = 500 * time.Millisecond
 			}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -448,6 +448,10 @@ func (op Operation) getServerAndConnection(
 		return nil, nil, err
 	}
 
+	if metrics := experiment.GetMetrics(ctx); metrics != nil {
+		metrics.Server = conn.Address().String()
+	}
+
 	// If we're in load balanced mode and this is the first operation in a transaction, pin the session to a connection.
 	if conn.Description().LoadBalanced() && op.Client != nil && op.Client.TransactionStarting() {
 		pinnedConn, ok := conn.(PinnedConnection)
@@ -656,10 +660,6 @@ func (op Operation) Execute(ctx context.Context) error {
 					return err
 				}
 			}
-		}
-
-		if metrics := experiment.GetMetrics(ctx); metrics != nil {
-			metrics.Server = conn.Address().String()
 		}
 
 		// Run steps that must only be run on the first attempt, but not again for retries.

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -328,7 +328,7 @@ func TestOperation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, 0, 0)
+				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, 0, 0, 0)
 
 				// Assert that the calculated maxTimeMS is less than or equal to the expected value. A few
 				// milliseconds will have elapsed toward the context deadline, and (remainingTimeout

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -328,7 +328,7 @@ func TestOperation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, "")
+				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, 0)
 
 				// Assert that the calculated maxTimeMS is less than or equal to the expected value. A few
 				// milliseconds will have elapsed toward the context deadline, and (remainingTimeout

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -328,7 +328,7 @@ func TestOperation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, 0)
+				got, err := tc.op.calculateMaxTimeMS(tc.ctx, tc.rtt90, 0, 0)
 
 				// Assert that the calculated maxTimeMS is less than or equal to the expected value. A few
 				// milliseconds will have elapsed toward the context deadline, and (remainingTimeout

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -51,6 +51,7 @@ func (e ConnectionError) Unwrap() error {
 	return e.Wrapped
 }
 
+// Timeout returns true if the ConnectionError was caused by a network timeout.
 func (e ConnectionError) Timeout() bool {
 	var nerr net.Error
 	return errors.As(e.Wrapped, &nerr) && nerr.Timeout()

--- a/x/mongo/driver/topology/errors.go
+++ b/x/mongo/driver/topology/errors.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"go.mongodb.org/mongo-driver/mongo/description"
@@ -48,6 +49,11 @@ func (e ConnectionError) Error() string {
 // Unwrap returns the underlying error.
 func (e ConnectionError) Unwrap() error {
 	return e.Wrapped
+}
+
+func (e ConnectionError) Timeout() bool {
+	var nerr net.Error
+	return errors.As(e.Wrapped, &nerr) && nerr.Timeout()
 }
 
 // ServerSelectionError represents a Server Selection error.

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -295,7 +295,7 @@ func applyErrors(t *testing.T, topo *Topology, errors []applicationError) {
 		var currError error
 		switch appErr.Type {
 		case "command":
-			currError = driver.ExtractErrorFromServerResponse(appErr.Response)
+			currError = driver.ExtractErrorFromServerResponse(appErr.Response, false)
 		case "network":
 			currError = driver.Error{
 				Labels:  []string{driver.NetworkError},

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -445,7 +445,7 @@ func (s *Server) MaxTimeAdjust() int64 {
 
 const (
 	maxTimeAdjustMin = 0
-	maxTimeAdjustMax = 300
+	maxTimeAdjustMax = 3000
 
 	defaultMaxTimeAdjustDown = 400
 	defaultMaxTimeAdjustUp   = 10

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -446,17 +446,14 @@ func (s *Server) MaxTimeAdjust() int64 {
 
 // AddTimeoutSample subtracts the maxTimeMS from the amount of time available
 // for the round trip (rtt), if a deadline error occurs.
-func (s *Server) AddTimeoutSample(err error, rtt time.Duration, maxTimeMS uint64) {
-	if !errors.Is(err, context.DeadlineExceeded) {
-		return
-	}
-
+func (s *Server) AddTimeoutSample(rtt time.Duration, maxTimeMS uint64) {
 	mtd := time.Duration(maxTimeMS) * time.Millisecond
 	if mtd > 0 {
 		s.timeoutSamples = append(s.timeoutSamples, rtt-mtd)
 	}
 }
 
+// MaxTimeoutSample returns the maximum timeout sample recorded.
 func (s *Server) MaxTimeoutSample() time.Duration {
 	count := 0
 	max := time.Duration(0)

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -464,12 +464,12 @@ func setMaxTimeRatio(maxTimeRatio *int64, err error) {
 
 	// If the error is a client-side timeout, increase by 40 (4%). If it's not,
 	// reduce by 1 (0.1%).
-	var derr driver.Error
-	isMaxTimeMSExpired := errors.As(err, &derr) && derr.Code == 50
-
-	var nerr net.Error
-	isClientTimeout := ((errors.As(err, &nerr) && nerr.Timeout()) || errors.Is(err, context.DeadlineExceeded)) && !isMaxTimeMSExpired
-	if isClientTimeout {
+	//
+	// TODO: Add a test to ensure that this always indicates a connection
+	// read/write timeout.
+	var cerr ConnectionError
+	isNetTimeout := errors.As(err, &cerr) && cerr.Timeout()
+	if isNetTimeout {
 		v += maxTimeRatioInc
 		// TODO: Special condition for server-side timeout?
 	} else {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -464,11 +464,14 @@ func setMaxTimeRatio(maxTimeRatio *int64, err error) {
 
 	// If the error is a client-side timeout, increase by 40 (4%). If it's not,
 	// reduce by 1 (0.1%).
+	var derr driver.Error
+	isMaxTimeMSExpired := errors.As(err, &derr) && derr.Code == 50
+
 	var nerr net.Error
-	isTimeout := (errors.As(err, &nerr) && nerr.Timeout()) || errors.Is(err, context.DeadlineExceeded)
-	if isTimeout {
+	isClientTimeout := ((errors.As(err, &nerr) && nerr.Timeout()) || errors.Is(err, context.DeadlineExceeded)) && !isMaxTimeMSExpired
+	if isClientTimeout {
 		v += maxTimeRatioInc
-		// TODO: Condition for server-side timeout?
+		// TODO: Special condition for server-side timeout?
 	} else {
 		v -= maxTimeRatioDec
 	}

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -88,6 +88,7 @@ type Server struct {
 
 	state          int64
 	operationCount int64
+	maxTimeRatio   int64
 
 	cfg     *serverConfig
 	address address.Address
@@ -428,10 +429,74 @@ func getWriteConcernErrorForProcessing(err error) (*driver.WriteConcernError, bo
 	return nil, false
 }
 
+var _ driver.MaxTimeAdjuster = (*Server)(nil)
+
+func (s *Server) MaxTimeAdjust() int64 {
+	v := atomic.LoadInt64(&s.maxTimeRatio)
+	if v < maxTimeRatioMin {
+		return maxTimeRatioMin
+	}
+	if v > maxTimeRatioMax {
+		return maxTimeRatioMax
+	}
+	return v
+}
+
+// TODO: Re-set range?
+const (
+	maxTimeRatioMin = 0
+	maxTimeRatioMax = 300
+	maxTimeRatioInc = 40
+	maxTimeRatioDec = 1
+)
+
+func setMaxTimeRatio(maxTimeRatio *int64, err error) {
+	v := atomic.LoadInt64(maxTimeRatio)
+
+	// Normalize the value before we modify it to make sure it starts in the
+	// expected range.
+	if v < maxTimeRatioMin {
+		v = maxTimeRatioMin
+	}
+	if v > maxTimeRatioMax {
+		v = maxTimeRatioMax
+	}
+
+	// If the error is a client-side timeout, increase by 40 (4%). If it's not,
+	// reduce by 1 (0.1%).
+	var nerr net.Error
+	isTimeout := (errors.As(err, &nerr) && nerr.Timeout()) || errors.Is(err, context.DeadlineExceeded)
+	if isTimeout {
+		v += maxTimeRatioInc
+		// TODO: Condition for server-side timeout?
+	} else {
+		v -= maxTimeRatioDec
+	}
+
+	// Normalize the updated value and then store it.
+	if v < maxTimeRatioMin {
+		v = maxTimeRatioMin
+	}
+	if v > maxTimeRatioMax {
+		v = maxTimeRatioMax
+	}
+	atomic.StoreInt64(maxTimeRatio, v)
+}
+
 // ProcessError handles SDAM error handling and implements driver.ErrorProcessor.
 func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessErrorResult {
+
 	// Ignore nil errors.
 	if err == nil {
+		// Fast path for maxTimeRatio.
+		//
+		// If there is no error, and maxTimeRatio is already 0 or below, do
+		// nothing. If maxTimeRatio is above 0, decrement by 1 (0.1%). Note that
+		// maxTimeRatio can change between these atomic operations, but the
+		// value is normalized when used and when updated by the slow path.
+		if atomic.LoadInt64(&s.maxTimeRatio) > 0 {
+			atomic.AddInt64(&s.maxTimeRatio, -1)
+		}
 		return driver.NoChange
 	}
 
@@ -449,6 +514,10 @@ func (s *Server) ProcessError(err error, conn driver.Connection) driver.ProcessE
 	// pool.ready() calls from concurrent server description updates.
 	s.processErrorLock.Lock()
 	defer s.processErrorLock.Unlock()
+
+	// Slow path for maxTimeRatio. The "processErrorLock" must be held while
+	// calling.
+	setMaxTimeRatio(&s.maxTimeRatio, err)
 
 	// Get the wire version and service ID from the connection description because they will never
 	// change for the lifetime of a connection and can possibly be different between connections to

--- a/x/mongo/driver/topology/server_options.go
+++ b/x/mongo/driver/topology/server_options.go
@@ -42,6 +42,9 @@ type serverConfig struct {
 	logger               *logger.Logger
 	poolMaxIdleTime      time.Duration
 	poolMaintainInterval time.Duration
+
+	maxTimeAdjustDown int64
+	maxTimeAdjustUp   int64
 }
 
 func newServerConfig(opts ...ServerOption) *serverConfig {
@@ -49,6 +52,8 @@ func newServerConfig(opts ...ServerOption) *serverConfig {
 		heartbeatInterval: 10 * time.Second,
 		heartbeatTimeout:  10 * time.Second,
 		registry:          defaultRegistry,
+		maxTimeAdjustDown: defaultMaxTimeAdjustDown,
+		maxTimeAdjustUp:   defaultMaxTimeAdjustUp,
 	}
 
 	for _, opt := range opts {
@@ -195,6 +200,18 @@ func WithServerAPI(fn func(serverAPI *driver.ServerAPIOptions) *driver.ServerAPI
 func WithServerLoadBalanced(fn func(bool) bool) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.loadBalanced = fn(cfg.loadBalanced)
+	}
+}
+
+func withMaxTimeAdjustDown(adjust int64) ServerOption {
+	return func(cfg *serverConfig) {
+		cfg.maxTimeAdjustDown = adjust
+	}
+}
+
+func withMaxTimeAdjustUp(adjust int64) ServerOption {
+	return func(cfg *serverConfig) {
+		cfg.maxTimeAdjustUp = adjust
 	}
 }
 

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -1303,7 +1303,3 @@ func newServerDescription(
 		LastError: lastError,
 	}
 }
-
-func TestUpdateMaxTimeOffset(t *testing.T) {
-	updateMaxTimeOffset(nil, nil)
-}

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -1303,3 +1303,7 @@ func newServerDescription(
 		LastError: lastError,
 	}
 }
+
+func TestUpdateMaxTimeOffset(t *testing.T) {
+	updateMaxTimeOffset(nil, nil)
+}

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -354,6 +354,13 @@ func NewConfig(co *options.ClientOptions, clock *session.ClusterClock) (*Config,
 		)
 	}
 
+	if co.MaxTimeAdjustDown != nil {
+		serverOpts = append(serverOpts, withMaxTimeAdjustDown(*co.MaxTimeAdjustDown))
+	}
+	if co.MaxTimeAdjustUp != nil {
+		serverOpts = append(serverOpts, withMaxTimeAdjustUp(*co.MaxTimeAdjustUp))
+	}
+
 	lgr, err := newLogger(co.LoggerOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
DO NOT MERGE!

## Summary

Experimental change to minimize connection churn during lots-of-timeout events caused by increased database latency.

Changes:
* Fix a bug that prevents `maxTimeMS` from being added to commands when a context with deadline is used on an operation, even if `timeoutMS` is set on the client.
  * Omit `maxTimeMS` from operations that create a cursor (`Find`, `Aggregate`) because the default behavior of `maxTimeMS` is to limit the lifetime of the cursor as well as the initial command, which may be surprising. `FindOne` operations still send `maxTimeMS`.
* Use minimum round-trip time instead of 90th percentile round-trip time to calculate `maxTimeMS`
* Add a feedback mechanism that reduces the `maxTimeMS` value when an operation encounters a client-side timeout error. The adjustment is made per-server, so different `mongod` or `mongos` nodes may get different `maxTimeMS` values.
  * The maximum reduction is `([remaining time] - [minimum RTT]) * 0.3` or 500ms, whichever is smaller.

Same changes as https://github.com/mongodb/mongo-go-driver/pull/1583, but based on the v1.14.0 release.

## Background & Motivation

The automatic `maxTimeMS` mechanism as described in the [CSOT spec](https://github.com/mongodb/specifications/blob/master/source/client-side-operations-timeout/client-side-operations-timeout.md#command-execution) currently does not sufficiently mitigate high connection churn under certain timeout scenarios. Additionally, there is a bug in the Go Driver that prevents automatic `maxTimeMS` values from being added to commands if the Context passed to an operation has a deadline.
