### PR TITLE
GODRIVER-3107 Fix leaking rttMonitor.runHellos() routine.

### DIFF
--- a/x/mongo/driver/topology/rtt_monitor.go
+++ b/x/mongo/driver/topology/rtt_monitor.go
@@ -56,7 +56,6 @@ type rttMonitor struct {
 	cfg      *rttConfig
 	ctx      context.Context
 	cancelFn context.CancelFunc
-	started  bool
 }
 
 var _ driver.RTTMonitor = &rttMonitor{}
@@ -83,7 +82,6 @@ func (r *rttMonitor) connect() {
 	r.connMu.Lock()
 	defer r.connMu.Unlock()
 
-	r.started = true
 	r.closeWg.Add(1)
 
 	go func() {
@@ -96,10 +94,6 @@ func (r *rttMonitor) connect() {
 func (r *rttMonitor) disconnect() {
 	r.connMu.Lock()
 	defer r.connMu.Unlock()
-
-	if !r.started {
-		return
-	}
 
 	r.cancelFn()
 

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -125,7 +125,7 @@ type Server struct {
 
 	processErrorLock sync.Mutex
 	rttMonitor       *rttMonitor
-	monitorOnce      *sync.Once
+	monitorOnce      sync.Once
 }
 
 // updateTopologyCallback is a callback used to create a server that should be called when the parent Topology instance
@@ -169,8 +169,6 @@ func NewServer(addr address.Address, topologyID primitive.ObjectID, opts ...Serv
 		subscribers:     make(map[uint64]chan description.Server),
 		globalCtx:       globalCtx,
 		globalCtxCancel: globalCtxCancel,
-
-		monitorOnce: new(sync.Once),
 	}
 	s.desc.Store(description.NewDefaultServer(addr))
 	rttCfg := &rttConfig{


### PR DESCRIPTION
GODRIVER-3107

## Summary
Fix the leaky `rttMonitor.runHellos()` routine when a disconnect occurs before a connection takes place.

## Background & Motivation
There is a chance that `rttMonitor.disconnect()` is called before `rttMonitor.connect()` as [described](https://github.com/mongodb/mongo-go-driver/pull/1376/files#r1375049503) in PR #1376. In that case, the [condition](https://github.com/mongodb/mongo-go-driver/blob/d41a7cc214e8ed6c229d0a80245023300296ef4c/x/mongo/driver/topology/rtt_monitor.go#L100-L102) in `disconnect()` triggers a shortcut return which makes the `runHellos()` routine impossible to be [closed](https://github.com/mongodb/mongo-go-driver/blob/d41a7cc214e8ed6c229d0a80245023300296ef4c/x/mongo/driver/topology/rtt_monitor.go#L164).
