### PR TITLE
GODRIVER-3161 Resync the fle2v2-Range-* tests and skip prose test 22

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -2457,9 +2457,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 
-	// Only test MongoDB Server 7.0+. MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.
-	// libmongocrypt is configured to use the QEv2 protocol.
-	mt.RunOpts("22. range explicit encryption", qeRunOpts, func(mt *mtest.T) {
+	qeRunOpts22 := qeRunOpts.MinServerVersion("8.0")
+	mt.RunOpts("22. range explicit encryption", qeRunOpts22, func(mt *mtest.T) {
 		type testcase struct {
 			typeStr       string
 			field         string

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Date-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.yml
@@ -8,6 +8,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Double-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Int-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Delete.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Update.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-Long-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-WrongType.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-WrongType.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Range-WrongType.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Range-WrongType.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3161

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Resync the "fle2v2-Range-*" tests and skip prose test "22. Range Explicit Encryption for server 8.0+" to avoid the test failures.

## Background & Motivation

<!--- Rationale for the pull request. -->

Drivers that previously implemented the "rangePreview" naming will be broken until they support the "range" name.

