### PR TITLE
GODRIVER-1639 Add RawArray to bson lib

### DIFF
--- a/bson/raw_array.go
+++ b/bson/raw_array.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2024-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bson
 
 import (

--- a/bson/raw_array.go
+++ b/bson/raw_array.go
@@ -1,0 +1,67 @@
+package bson
+
+import (
+	"io"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// RawArray is a raw bytes representation of a BSON array.
+type RawArray []byte
+
+// ReadArray reads a BSON array from the io.Reader and returns it as a
+// bson.RawArray.
+func ReadArray(r io.Reader) (RawArray, error) {
+	doc, err := bsoncore.NewArrayFromReader(r)
+
+	return RawArray(doc), err
+}
+
+// Index searches for and retrieves the value at the given index. This method
+// will panic if the array is invalid or if the index is out of bounds.
+func (a RawArray) Index(index uint) RawValue {
+	return convertFromCoreValue(bsoncore.Array(a).Index(index))
+}
+
+// IndexErr searches for and retrieves the value at the given index.
+func (a RawArray) IndexErr(index uint) (RawValue, error) {
+	elem, err := bsoncore.Array(a).IndexErr(index)
+
+	return convertFromCoreValue(elem), err
+}
+
+// DebugString outputs a human readable version of Array. It will attempt to
+// stringify the valid components of the array even if the entire array is not
+// valid.
+func (a RawArray) DebugString() string {
+	return bsoncore.Array(a).DebugString()
+}
+
+// String outputs an ExtendedJSON version of Array. If the Array is not valid,
+// this method returns an empty string.
+func (a RawArray) String() string {
+	return bsoncore.Array(a).String()
+}
+
+// Values returns this array as a slice of values. The returned slice will
+// contain valid values. If the array is not valid, the values up to the invalid
+// point will be returned along with an error.
+func (a RawArray) Values() ([]RawValue, error) {
+	vals, err := bsoncore.Array(a).Values()
+	if err != nil {
+		return nil, err
+	}
+
+	rvals := make([]RawValue, 0, len(vals))
+	for _, val := range vals {
+		rvals = append(rvals, convertFromCoreValue(val))
+	}
+
+	return rvals, err
+}
+
+// Validate validates the array and ensures the elements contained within are
+// valid.
+func (a RawArray) Validate() error {
+	return bsoncore.Array(a).Validate()
+}

--- a/bson/raw_array_test.go
+++ b/bson/raw_array_test.go
@@ -1,0 +1,469 @@
+package bson
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+func TestReadArray(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		ioReader io.Reader
+		arr      RawArray
+		err      error
+	}{
+		{
+			"nil reader",
+			nil,
+			nil,
+			ErrNilReader,
+		},
+		{
+			"premature end of reader",
+			bytes.NewBuffer([]byte{}),
+			nil,
+			io.EOF,
+		},
+		{
+			"empty Array",
+			bytes.NewBuffer([]byte{5, 0, 0, 0, 0}),
+			[]byte{5, 0, 0, 0, 0},
+			nil,
+		},
+		{
+			"non-empty Array",
+			bytes.NewBuffer([]byte{
+				'\x1B', '\x00', '\x00', '\x00',
+				'\x02',
+				'0', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x72', '\x00',
+				'\x02',
+				'1', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x7a', '\x00',
+				'\x00',
+			}),
+			[]byte{
+				'\x1B', '\x00', '\x00', '\x00',
+				'\x02',
+				'0', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x72', '\x00',
+				'\x02',
+				'1', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x7a', '\x00',
+				'\x00',
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			arr, err := ReadArray(tc.ioReader)
+			if !compareErrors(err, tc.err) {
+				t.Errorf("errors do not match. got %v; want %v", err, tc.err)
+			}
+			if !bytes.Equal(tc.arr, arr) {
+				t.Errorf("Arrays differ. got %v; want %v", tc.arr, arr)
+			}
+		})
+	}
+}
+
+func TestArray_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TooShort", func(t *testing.T) {
+		t.Parallel()
+
+		want := bsoncore.NewInsufficientBytesError(nil, nil)
+		got := RawArray{'\x00', '\x00'}.Validate()
+		if !compareErrors(got, want) {
+			t.Errorf("Did not get expected error. got %v; want %v", got, want)
+		}
+	})
+
+	t.Run("InvalidLength", func(t *testing.T) {
+		t.Parallel()
+
+		want := bsoncore.NewArrayLengthError(200, 5)
+		r := make(RawArray, 5)
+		binary.LittleEndian.PutUint32(r[0:4], 200)
+		got := r.Validate()
+		if !compareErrors(got, want) {
+			t.Errorf("Did not get expected error. got %v; want %v", got, want)
+		}
+	})
+
+	t.Run("Invalid Element", func(t *testing.T) {
+		t.Parallel()
+
+		want := bsoncore.NewInsufficientBytesError(nil, nil)
+		r := make(RawArray, 7)
+		binary.LittleEndian.PutUint32(r[0:4], 7)
+		r[4], r[5], r[6] = 0x02, 'f', 0x00
+		got := r.Validate()
+		if !compareErrors(got, want) {
+			t.Errorf("Did not get expected error. got %v; want %v", got, want)
+		}
+	})
+
+	t.Run("Missing Null Terminator", func(t *testing.T) {
+		t.Parallel()
+
+		want := bsoncore.ErrMissingNull
+		r := make(RawArray, 6)
+		binary.LittleEndian.PutUint32(r[0:4], 6)
+		r[4], r[5] = 0x0A, '0'
+		got := r.Validate()
+		if !compareErrors(got, want) {
+			t.Errorf("Did not get expected error. got %v; want %v", got, want)
+		}
+	})
+
+	testCases := []struct {
+		name string
+		r    RawArray
+		want error
+	}{
+		{"array null", RawArray{'\x08', '\x00', '\x00', '\x00', '\x0A', '0', '\x00', '\x00'}, nil},
+		{"array",
+			RawArray{
+				'\x1B', '\x00', '\x00', '\x00',
+				'\x02',
+				'0', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x72', '\x00',
+				'\x02',
+				'1', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x7a', '\x00',
+				'\x00',
+			},
+			nil,
+		},
+		{"subarray",
+			RawArray{
+				'\x13', '\x00', '\x00', '\x00',
+				'\x04',
+				'0', '\x00',
+				'\x0B', '\x00', '\x00', '\x00', '\x0A', '0', '\x00',
+				'\x0A', '1', '\x00', '\x00', '\x00',
+			},
+			nil,
+		},
+		{"invalid key order",
+			RawArray{
+				'\x0B', '\x00', '\x00', '\x00', '\x0A', '2', '\x00',
+				'\x0A', '0', '\x00', '\x00', '\x00',
+			},
+			errors.New(`array key "2" is out of order or invalid`),
+		},
+		{"invalid key type",
+			RawArray{
+				'\x0B', '\x00', '\x00', '\x00', '\x0A', 'p', '\x00',
+				'\x0A', 'q', '\x00', '\x00', '\x00',
+			},
+			errors.New(`array key "p" is out of order or invalid`),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture the range variable
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.r.Validate()
+			if !compareErrors(got, tc.want) {
+				t.Errorf("Returned error does not match. got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestArray_Index(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Out of bounds", func(t *testing.T) {
+		t.Parallel()
+
+		rdr := RawArray{0xe, 0x0, 0x0, 0x0, 0xa, '0', 0x0, 0xa, '1', 0x0, 0xa, 0x7a, 0x0, 0x0}
+		_, err := rdr.IndexErr(3)
+		if !errors.Is(err, bsoncore.ErrOutOfBounds) {
+			t.Errorf("Out of bounds should be returned when accessing element beyond end of Array. got %v; want %v", err,
+				bsoncore.ErrOutOfBounds)
+		}
+	})
+
+	t.Run("Validation Error", func(t *testing.T) {
+		t.Parallel()
+
+		rdr := RawArray{0x07, 0x00, 0x00, 0x00, 0x00}
+		_, got := rdr.IndexErr(1)
+		want := bsoncore.NewInsufficientBytesError(nil, nil)
+		if !compareErrors(got, want) {
+			t.Errorf("Did not receive expected error. got %v; want %v", got, want)
+		}
+	})
+
+	testArray := RawArray{
+		'\x26', '\x00', '\x00', '\x00',
+		'\x02',
+		'0', '\x00',
+		'\x04', '\x00', '\x00', '\x00',
+		'\x62', '\x61', '\x72', '\x00',
+		'\x02',
+		'1', '\x00',
+		'\x04', '\x00', '\x00', '\x00',
+		'\x62', '\x61', '\x7a', '\x00',
+		'\x02',
+		'2', '\x00',
+		'\x04', '\x00', '\x00', '\x00',
+		'\x71', '\x75', '\x78', '\x00',
+		'\x00',
+	}
+	testCases := []struct {
+		name  string
+		index uint
+		want  RawValue
+	}{
+		{"first",
+			0,
+			RawValue{
+				Type:  TypeString,
+				Value: []byte{0x04, 0x00, 0x00, 0x00, 0x62, 0x61, 0x72, 0x00},
+			},
+		},
+		{"second",
+			1,
+			RawValue{
+				Type:  TypeString,
+				Value: []byte{0x04, 0x00, 0x00, 0x00, 0x62, 0x61, 0x7a, 0x00},
+			},
+		},
+		{"third",
+			2,
+			RawValue{
+				Type:  TypeString,
+				Value: []byte{0x04, 0x00, 0x00, 0x00, 0x71, 0x75, 0x78, 0x00},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture the range variable
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("IndexErr", func(t *testing.T) {
+				t.Parallel()
+
+				got, err := testArray.IndexErr(tc.index)
+				if err != nil {
+					t.Errorf("Unexpected error from IndexErr: %s", err)
+				}
+				if diff := cmp.Diff(got, tc.want); diff != "" {
+					t.Errorf("Arrays differ: (-got +want)\n%s", diff)
+				}
+			})
+
+			t.Run("Index", func(t *testing.T) {
+				t.Parallel()
+
+				defer func() {
+					if err := recover(); err != nil {
+						t.Errorf("Unexpected error: %v", err)
+					}
+				}()
+				got := testArray.Index(tc.index)
+				if diff := cmp.Diff(got, tc.want); diff != "" {
+					t.Errorf("Arrays differ: (-got +want)\n%s", diff)
+				}
+			})
+		})
+	}
+}
+
+func TestRawArray_Stringt(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		arr              RawArray
+		arrayString      string
+		arrayDebugString string
+	}{
+		{
+			"array",
+			RawArray{
+				'\x1B', '\x00', '\x00', '\x00',
+				'\x02',
+				'0', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x72', '\x00',
+				'\x02',
+				'1', '\x00',
+				'\x04', '\x00', '\x00', '\x00',
+				'\x62', '\x61', '\x7a', '\x00',
+				'\x00',
+			},
+			`["bar","baz"]`,
+			`Array(27)["bar","baz"]`,
+		},
+		{
+			"subarray",
+			RawArray{
+				'\x13', '\x00', '\x00', '\x00',
+				'\x04',
+				'0', '\x00',
+				'\x0B', '\x00', '\x00', '\x00',
+				'\x0A', '0', '\x00',
+				'\x0A', '1', '\x00',
+				'\x00', '\x00',
+			},
+			`[[null,null]]`,
+			`Array(19)[Array(11)[null,null]]`,
+		},
+		{
+			"malformed--length too small",
+			RawArray{
+				'\x04', '\x00', '\x00', '\x00',
+				'\x00',
+			},
+			``,
+			`Array(4)[]`,
+		},
+		{
+			"malformed--length too large",
+			RawArray{
+				'\x13', '\x00', '\x00', '\x00',
+				'\x00',
+			},
+			``,
+			`Array(19)[<malformed (15)>]`,
+		},
+		{
+			"malformed--missing null byte",
+			RawArray{
+				'\x06', '\x00', '\x00', '\x00',
+				'\x02', '0',
+			},
+			``,
+			`Array(6)[<malformed (2)>]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture the range variable
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			arrayString := tc.arr.String()
+			if arrayString != tc.arrayString {
+				t.Errorf("array strings do not match. got %q; want %q",
+					arrayString, tc.arrayString)
+			}
+
+			arrayDebugString := tc.arr.DebugString()
+			if arrayDebugString != tc.arrayDebugString {
+				t.Errorf("array debug strings do not match. got %q; want %q",
+					arrayDebugString, tc.arrayDebugString)
+			}
+		})
+	}
+}
+
+func TestRawArray_Values(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		arr  RawArray
+		want []RawValue
+	}{
+		{
+			name: "empty",
+			arr:  []byte{0x05, 0x00, 0x00, 0x00, 0x00},
+			want: []RawValue{},
+		},
+		{
+			name: "null document",
+			arr:  []byte{0x07, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00}, // [{}]
+			want: []RawValue{
+				{
+					Type:  TypeNull,
+					Value: []byte{},
+				},
+			},
+		},
+		{
+			name: "same",
+			arr: []byte{0x13, 0x00, 0x00, 0x00, 0x10, 0x30, 0x00, 0x01, 0x00, 0x00,
+				0x00, 0x10, 0x31, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00}, // [int32(1), int32(2)]
+			want: []RawValue{
+				{ // int32(1)
+					Type:  TypeInt32,
+					Value: []byte{0x01, 0x00, 0x00, 0x00},
+				},
+				{ // int32(2)
+					Type:  TypeInt32,
+					Value: []byte{0x02, 0x00, 0x00, 0x00},
+				},
+			},
+		},
+		{
+			name: "mixed",
+			arr: []byte{0x17, 0x00, 0x00, 0x00, 0x10, 0x30, 0x00, 0x01, 0x00, 0x00,
+				0x00, 0x02, 0x31, 0x00, 0x04, 0x00, 0x00, 0x00, 0x66, 0x6F, 0x6F, 0x00, 0x00}, // [int32(1), "foo"]
+			want: []RawValue{
+				{ // int32(1)
+					Type:  TypeInt32,
+					Value: []byte{0x01, 0x00, 0x00, 0x00},
+				},
+				{ // "foo"
+					Type:  TypeString,
+					Value: []byte{0x04, 0x00, 0x00, 0x00, 0x66, 0x6F, 0x6F, 0x00},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range testCases {
+		tcase := tcase
+
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := tcase.arr.Values()
+			fmt.Println("values: ", values)
+			require.NoError(t, err, "failed to turn array into values")
+			require.Len(t, values, len(tcase.want), "got len does not match want")
+
+			for idx, want := range tcase.want {
+				fmt.Println(want.Value, values[idx].Value)
+				assert.True(t, want.Equal(values[idx]), "want: %v, got: %v", want, values[idx])
+			}
+		})
+	}
+}

--- a/bson/raw_array_test.go
+++ b/bson/raw_array_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) MongoDB, Inc. 2024-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 package bson
 
 import (

--- a/bson/raw_value.go
+++ b/bson/raw_value.go
@@ -158,13 +158,14 @@ func (rv RawValue) DocumentOK() (Raw, bool) {
 
 // Array returns the BSON array the Value represents as an Array. It panics if the
 // value is a BSON type other than array.
-func (rv RawValue) Array() Raw { return Raw(convertToCoreValue(rv).Array()) }
+func (rv RawValue) Array() RawArray { return RawArray(convertToCoreValue(rv).Array()) }
 
 // ArrayOK is the same as Array, except it returns a boolean instead
 // of panicking.
-func (rv RawValue) ArrayOK() (Raw, bool) {
+func (rv RawValue) ArrayOK() (RawArray, bool) {
 	doc, ok := convertToCoreValue(rv).ArrayOK()
-	return Raw(doc), ok
+
+	return RawArray(doc), ok
 }
 
 // Binary returns the BSON binary value the Value represents. It panics if the value is a BSON type

--- a/internal/bsonutil/bsonutil.go
+++ b/internal/bsonutil/bsonutil.go
@@ -37,9 +37,9 @@ func StringSliceFromRawValue(name string, val bson.RawValue) ([]string, error) {
 	return strs, nil
 }
 
-// RawToDocuments converts a bson.Raw that is internally an array of documents to []bson.Raw.
-func RawToDocuments(doc bson.Raw) []bson.Raw {
-	values, err := doc.Values()
+// RawArrayToDocuments converts an array of documents to []bson.Raw.
+func RawArrayToDocuments(arr bson.RawArray) []bson.Raw {
+	values, err := arr.Values()
 	if err != nil {
 		panic(fmt.Sprintf("error converting BSON document to values: %v", err))
 	}

--- a/internal/integration/change_stream_test.go
+++ b/internal/integration/change_stream_test.go
@@ -71,7 +71,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		assert.NotNil(mt, started, "expected started event for aggregate, got nil")
 
 		// pipeline is array of documents. first value of first element in array is the first stage document
-		firstStage := started.Command.Lookup("pipeline").Array().Index(0).Value().Document()
+		firstStage := started.Command.Lookup("pipeline").Array().Index(0).Document()
 		elems, _ := firstStage.Elements()
 		assert.Equal(mt, 1, len(elems), "expected first stage document to have 1 element, got %v", len(elems))
 		firstKey := elems[0].Key()
@@ -282,7 +282,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 		assert.Equal(mt, "aggregate", aggEvent.CommandName, "expected command name 'aggregate', got '%v'", aggEvent.CommandName)
 
 		// check for startAtOperationTime in pipeline
-		csStage := aggEvent.Command.Lookup("pipeline").Array().Index(0).Value().Document() // $changeStream stage
+		csStage := aggEvent.Command.Lookup("pipeline").Array().Index(0).Document() // $changeStream stage
 		_, err = csStage.Lookup("$changeStream").Document().LookupErr("startAtOperationTime")
 		assert.Nil(mt, err, "startAtOperationTime not included in aggregate command")
 	})

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -194,7 +194,7 @@ func TestClient(t *testing.T) {
 				assert.Nil(mt, err, "connectionStatus error: %v", err)
 				users, err := rdr.LookupErr("authInfo", "authenticatedUsers")
 				assert.Nil(mt, err, "authenticatedUsers not found in response")
-				elems, err := users.Array().Elements()
+				elems, err := bson.Raw(users.Array()).Elements()
 				assert.Nil(mt, err, "error getting users elements: %v", err)
 
 				for _, userElem := range elems {

--- a/internal/integration/cmd_monitoring_helpers_test.go
+++ b/internal/integration/cmd_monitoring_helpers_test.go
@@ -92,7 +92,7 @@ func compareValues(mt *mtest.T, key string, expected, actual bson.RawValue) erro
 	case bson.TypeArray:
 		e := expected.Array()
 		a := actual.Array()
-		return compareDocsHelper(mt, e, a, key)
+		return compareDocsHelper(mt, bson.Raw(e), bson.Raw(a), key)
 	}
 
 	if expected.Type != actual.Type {
@@ -429,7 +429,7 @@ func compareSucceededEvent(mt *mtest.T, expectation *expectation) error {
 
 		switch key {
 		case "writeErrors":
-			if err = compareWriteErrors(mt, val.Array(), actualVal.Array()); err != nil {
+			if err = compareWriteErrors(mt, bson.Raw(val.Array()), bson.Raw(actualVal.Array())); err != nil {
 				return newMatchError(mt, expected.Reply, evt.Reply, "%s", err)
 			}
 		default:

--- a/internal/integration/crud_helpers_test.go
+++ b/internal/integration/crud_helpers_test.go
@@ -171,7 +171,7 @@ func executeAggregate(mt *mtest.T, agg aggregator, sess mongo.Session, args bson
 
 		switch key {
 		case "pipeline":
-			pipeline = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			pipeline = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "batchSize":
 			opts.SetBatchSize(val.Int32())
 		case "collation":
@@ -209,7 +209,7 @@ func executeWatch(mt *mtest.T, w watcher, sess mongo.Session, args bson.Raw) (*m
 
 		switch key {
 		case "pipeline":
-			pipeline = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			pipeline = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		default:
 			mt.Fatalf("unrecognized watch option: %v", key)
 		}
@@ -312,7 +312,7 @@ func executeInsertMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.I
 
 		switch key {
 		case "documents":
-			docs = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			docs = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "options":
 			// Some of the older tests use this to set the "ordered" option
 			optsDoc := val.Document()
@@ -699,7 +699,7 @@ func executeFindOneAndUpdate(mt *mtest.T, sess mongo.Session, args bson.Raw) *mo
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			})
 		case "sort":
 			opts = opts.SetSort(val.Document())
@@ -881,7 +881,7 @@ func executeUpdateOne(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.Up
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			})
 		case "upsert":
 			opts = opts.SetUpsert(val.Boolean())
@@ -929,7 +929,7 @@ func executeUpdateMany(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.U
 			update = createUpdate(mt, val)
 		case "arrayFilters":
 			opts = opts.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			})
 		case "upsert":
 			opts = opts.SetUpsert(val.Boolean())
@@ -1055,7 +1055,7 @@ func executeWithTransaction(mt *mtest.T, sess mongo.Session, args bson.Raw) erro
 func executeBulkWrite(mt *mtest.T, sess mongo.Session, args bson.Raw) (*mongo.BulkWriteResult, error) {
 	mt.Helper()
 
-	models := createBulkWriteModels(mt, args.Lookup("requests").Array())
+	models := createBulkWriteModels(mt, bson.Raw(args.Lookup("requests").Array()))
 	opts := options.BulkWrite()
 
 	rawOpts, err := args.LookupErr("options")
@@ -1115,7 +1115,7 @@ func createBulkWriteModel(mt *mtest.T, rawModel bson.Raw) mongo.WriteModel {
 		}
 		if arrayFilters, err := args.LookupErr("arrayFilters"); err == nil {
 			uom.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(arrayFilters.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(arrayFilters.Array())...),
 			})
 		}
 		if hintVal, err := args.LookupErr("hint"); err == nil {
@@ -1138,7 +1138,7 @@ func createBulkWriteModel(mt *mtest.T, rawModel bson.Raw) mongo.WriteModel {
 		}
 		if arrayFilters, err := args.LookupErr("arrayFilters"); err == nil {
 			umm.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(arrayFilters.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(arrayFilters.Array())...),
 			})
 		}
 		if hintVal, err := args.LookupErr("hint"); err == nil {

--- a/internal/integration/unified/bulkwrite_helpers.go
+++ b/internal/integration/unified/bulkwrite_helpers.go
@@ -15,12 +15,20 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// This file provides helper functions to convert BSON documents to WriteModel instances.
+// This file provides helper functions to convert BSON documents to WriteModel
+// instances.
 
-// createBulkWriteModels converts a bson.Raw that is internally an array to a slice of WriteModel. Each value in the
-// array must be a document in the form { requestType: { optionKey1: optionValue1, ... } }. For example, the document
-// { insertOne: { document: { x: 1 } } } would be translated to an InsertOneModel to insert the document { x: 1 }.
-func createBulkWriteModels(rawModels bson.Raw) ([]mongo.WriteModel, error) {
+// createBulkWriteModels converts an bson raw array to a slice of WriteModel.
+// Each value in the array must be a document in the form
+//
+//	{ requestType: { optionKey1: optionValue1, ... } }.
+//
+// For example, the document
+//
+//	{ insertOne: { document: { x: 1 } } }
+//
+// would be translated to an InsertOneModel to insert the document { x: 1 }.
+func createBulkWriteModels(rawModels bson.RawArray) ([]mongo.WriteModel, error) {
 	vals, _ := rawModels.Values()
 	models := make([]mongo.WriteModel, 0, len(vals))
 
@@ -74,7 +82,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				uom.SetArrayFilters(options.ArrayFilters{
-					Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+					Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())
@@ -123,7 +131,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 			switch key {
 			case "arrayFilters":
 				umm.SetArrayFilters(options.ArrayFilters{
-					Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+					Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 				})
 			case "collation":
 				collation, err := createCollation(val.Document())

--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -81,7 +81,7 @@ func executeCreateChangeStream(ctx context.Context, operation *operation) (*oper
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			pipeline = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "resumeAfter":
 			opts.SetResumeAfter(val.Document())
 		case "showExpandedEvents":

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -73,7 +73,7 @@ func executeAggregate(ctx context.Context, operation *operation) (*operationResu
 		case "maxAwaitTimeMS":
 			opts.SetMaxAwaitTime(time.Duration(val.Int32()) * time.Millisecond)
 		case "pipeline":
-			pipeline = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			pipeline = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "let":
 			opts.SetLet(val.Document())
 		default:
@@ -912,7 +912,7 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 		switch key {
 		case "arrayFilters":
 			opts.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			})
 		case "bypassDocumentValidation":
 			opts.SetBypassDocumentValidation(val.Boolean())
@@ -999,7 +999,7 @@ func executeInsertMany(ctx context.Context, operation *operation) (*operationRes
 		case "comment":
 			opts.SetComment(val)
 		case "documents":
-			documents = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			documents = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "ordered":
 			opts.SetOrdered(val.Boolean())
 		default:

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -41,7 +41,7 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 		switch key {
 		case "arrayFilters":
 			ua.opts.SetArrayFilters(options.ArrayFilters{
-				Filters: bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...),
+				Filters: bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			})
 		case "bypassDocumentValidation":
 			ua.opts.SetBypassDocumentValidation(val.Boolean())

--- a/internal/integration/unified/database_operation_execution.go
+++ b/internal/integration/unified/database_operation_execution.go
@@ -43,7 +43,7 @@ func executeCreateView(ctx context.Context, operation *operation) (*operationRes
 		case "collection":
 			collName = val.StringValue()
 		case "pipeline":
-			pipeline = bsonutil.RawToInterfaces(bsonutil.RawToDocuments(val.Array())...)
+			pipeline = bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...)
 		case "viewOn":
 			viewOn = val.StringValue()
 		default:

--- a/mongo/bson_helpers_test.go
+++ b/mongo/bson_helpers_test.go
@@ -61,7 +61,7 @@ func compareBsonValues(t *testing.T, key string, expected, actual bson.RawValue)
 	case bson.TypeEmbeddedDocument:
 		compareDocuments(t, expected.Document(), actual.Document())
 	case bson.TypeArray:
-		compareDocuments(t, expected.Array(), actual.Array())
+		compareDocuments(t, bson.Raw(expected.Array()), bson.Raw(actual.Array()))
 	default:
 		assert.Equal(t, expected.Value, actual.Value,
 			"value mismatch for key %v; expected %v, got %v", key, expected.Value, actual.Value)


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-1639

## Summary

<!--- A summary of the changes proposed by this pull request. -->
Copy the unstable bsoncore Array methods to the stable bson library, in the style of `bson.Raw`.

## Background & Motivation

<!--- Rationale for the pull request. -->
Make the lookup logic less awkward for arrays in the stable lib. Consider the following example:

```
{
    a: [{x: 1}, {y: 2},
}
```

Currently the lookup would be `doc.Lookup("a", "1", "y")`, now a user could use 

```
doc.Lookup("a").Array()[1].Document()["y"]`
```
