### PR TITLE
GODRIVERS-3132 [master] Skip test until QE Range Protocol V2 is Implemented

### DIFF
--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -2462,9 +2462,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 
-	// Only test MongoDB Server 7.0+. MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.
-	// libmongocrypt is configured to use the QEv2 protocol.
-	mt.RunOpts("22. range explicit encryption", qeRunOpts, func(mt *mtest.T) {
+	// GODRIVER-3123.  When we implement this feature, lower the min server version to 8.0.1
+	qeRunOpts22 := qeRunOpts.MaxServerVersion("7.99.99")
+	mt.RunOpts("22. range explicit encryption", qeRunOpts22, func(mt *mtest.T) {
 		type testcase struct {
 			typeStr       string
 			field         string


### PR DESCRIPTION
GODRIVER-3123

## Summary

Skip prose test for Range Protocol until QE Range Protocol V2 is Implemented.

## Background & Motivation

The tests will fail until we implement the new feature.