### PR TITLE
GODRIVER-3185 Set up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
GODRIVER-3185

## Summary

Set up dependabot config for gomod and GitHub Actions.

## Background & Motivation

Better security posture for the repository.
