### PR TITLE
Run `go mod tidy` before vendoring in compilecheck.

### DIFF
--- a/etc/compile_check.sh
+++ b/etc/compile_check.sh
@@ -20,18 +20,17 @@ function compile_check {
 	# Change the directory to the compilecheck test directory.
 	cd ${COMPILE_CHECK_DIR}
 
+	# If the Go version is 1.15 or greater, then run "go mod tidy".
+	MACHINE_VERSION=`${GC} version | { read _ _ v _; echo ${v#go}; }`
+	if [ $(version $MACHINE_VERSION) -ge $(version 1.15) ]; then
+		go mod tidy
+	fi
+
 	# Test vendoring
 	go mod vendor
 	${GC} build -mod=vendor
 
 	rm -rf vendor
-
-	MACHINE_VERSION=`${GC} version | { read _ _ v _; echo ${v#go}; }`
-
-	# If the version is not 1.13, then run "go mod tidy"
-	if [ $(version $MACHINE_VERSION) -ge $(version 1.15) ]; then
-		go mod tidy
-	fi
 
 	# Check simple build.
 	${GC} build ./...


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Run `go mod tidy` before `go mod vendor` in the compile check script.

## Background & Motivation

Github Dependabot PRs that update dependencies (e.g. https://github.com/mongodb/mongo-go-driver/pull/1619) fail the build check while running `etc/compile_check.sh` because of error:
```
+ GC=go
+ COMPILE_CHECK_DIR=internal/test/compilecheck
+ DEV_MIN_VERSION=1.19
+ compile_check
+ cd internal/test/compilecheck
+ go mod vendor
go: updates to go.mod needed; to update it:
        go mod tidy
```
That is caused by running `go mod vendor` after changing some dependency version in the `go.mongodb.org/mongo-driver` module. We already run `go mod tidy` later in the script, but need to run it earlier to avoid the above error.