### PR TITLE
GODRIVER-3216 Run go mod tidy before lambda test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1947,6 +1947,9 @@ tasks:
           include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           script: |
             ${PREPARE_SHELL}
+            pushd $TEST_LAMBDA_DIRECTORY/mongodb
+            go mod tidy
+            popd
             ./.evergreen/run-deployed-lambda-aws-tests.sh
 
   - name: "test-search-index"


### PR DESCRIPTION
GODRIVER-3216

## Summary

Run `go mod tidy` in the lambda test directory before running the test.

## Background & Motivation

Keep the test in sync with the top level go mod files.
