### PR TITLE
GODRIVER-3120 Add list of possible OS errors to case 11

### DIFF
--- a/mongo/integration/client_side_encryption_prose_test.go
+++ b/mongo/integration/client_side_encryption_prose_test.go
@@ -1628,8 +1628,16 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				_, err := cpt.clientEnc.CreateDataKey(context.Background(), tc.name, dkOpts)
 
 				assert.NotNil(mt, err, "expected error, got nil")
-				assert.True(mt, strings.Contains(err.Error(), "certificate signed by unknown authority"),
-					"expected error '%s' to contain '%s'", err.Error(), "certificate signed by unknown authority")
+
+				possibleErrors := []string{
+					"x509: certificate signed by unknown authority",                   // Windows
+					"x509: “valid.testing.golang.invalid” certificate is not trusted", // MacOS
+					"x509: certificate is not authorized to sign other certificates",  // All others
+				}
+
+				assert.True(t, containsSubstring(possibleErrors, err.Error()),
+					"expected possibleErrors=%v to contain %v, but it didn't",
+					possibleErrors, err.Error())
 
 				// call CreateDataKey with CEO & TLS with each provider and corresponding master key
 				cpt = setup(mt, nil, defaultKvClientOptions, validClientEncryptionOptionsWithTLS)


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3120

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Add list of possible OS dependent errors that can occur when an unknown authority signs a certificate, see [here](https://cs.opensource.google/go/go/+/master:src/crypto/x509/platform_test.go;l=170?q=certificate%20signed%20by%20unknown%20authority&ss=go%2Fgo) for more details.


## Background & Motivation

<!--- Rationale for the pull request. -->

Example failure:

```
 [2024/02/02 06:42:59.770] === RUN   TestClientSideEncryptionProse/11._kms_tls_options_tests/kmip
 [2024/02/02 06:42:59.770]     client_side_encryption_prose_test.go:1631:
 [2024/02/02 06:42:59.770]         	Error Trace:	/data/mci/a715128daf36f39e041d22b141c0582a/src/go.mongodb.org/mongo-driver/mongo/integration/client_side_encryption_prose_test.go:1631
 [2024/02/02 06:42:59.770]         	            				/data/mci/a715128daf36f39e041d22b141c0582a/src/go.mongodb.org/mongo-driver/mongo/integration/mongotest.go:267
 [2024/02/02 06:42:59.770]         	Error:      	Should be true
 [2024/02/02 06:42:59.770]         	Test:       	TestClientSideEncryptionProse/11._kms_tls_options_tests/kmip
 [2024/02/02 06:42:59.770]         	Messages:   	expected error 'tls: failed to verify certificate: x509: certificate is not authorized to sign other certificates' to contain 'certificate signed by unknown authority'
 [2024/02/02 06:42:59.770] --- FAIL: TestClientSideEncryptionProse (0.14s)
 ```
