### PR TITLE
GODRIVER-3157 Skip Serverless Proxy test that requires failpoint on hello.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -560,6 +560,8 @@ functions:
         working_dir: src/go.mongodb.org/mongo-driver
         script: |
           ${PREPARE_SHELL}
+
+          IS_SERVERLESS_PROXY="${IS_SERVERLESS_PROXY}" \
           bash etc/run-serverless-test.sh
 
   run-atlas-data-lake-test:
@@ -2115,6 +2117,7 @@ axes:
         display_name: "Serverless Proxy"
         variables:
           VAULT_NAME: "serverless_next"
+          IS_SERVERLESS_PROXY: "true"
 
 task_groups:
   - name: serverless_task_group

--- a/etc/run-serverless-test.sh
+++ b/etc/run-serverless-test.sh
@@ -5,6 +5,7 @@ source ${DRIVERS_TOOLS}/.evergreen/serverless/secrets-export.sh
 AUTH="auth" \
     SSL="ssl" \
     MONGODB_URI="${SERVERLESS_URI}" \
+    IS_SERVERLESS_PROXY="${IS_SERVERLESS_PROXY}" \
     SERVERLESS="serverless" \
     MAKEFILE_TARGET=evg-test-serverless \
     sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh

--- a/testdata/load-balancers/sdam-error-handling.json
+++ b/testdata/load-balancers/sdam-error-handling.json
@@ -1,6 +1,6 @@
 {
   "description": "state change errors are correctly handled",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [
@@ -260,7 +260,7 @@
       ]
     },
     {
-      "description": "errors during the initial connection hello are ignore",
+      "description": "errors during the initial connection hello are ignored",
       "runOnRequirements": [
         {
           "minServerVersion": "4.9"

--- a/testdata/load-balancers/sdam-error-handling.yml
+++ b/testdata/load-balancers/sdam-error-handling.yml
@@ -1,6 +1,6 @@
 description: state change errors are correctly handled
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]
@@ -139,7 +139,7 @@ tests:
 
   # This test uses singleClient to ensure that connection attempts are routed
   # to the same mongos on which the failpoint is set.
-  - description: errors during the initial connection hello are ignore 
+  - description: errors during the initial connection hello are ignored
     runOnRequirements:
       # Server version 4.9+ is needed to set a fail point on the initial
       # connection handshake with the appName filter due to SERVER-49336.


### PR DESCRIPTION
[GODRIVER-3157](https://jira.mongodb.org/browse/GODRIVER-3157)

## Summary

Skip the ["errors during the initial connection hello are ignored"](https://github.com/mongodb/specifications/blob/57bb0f2af7a46872f5d0457bd34032f3bdc8ab15/source/load-balancers/tests/sdam-error-handling.yml#L142) test case when running against Serverless Proxy, which doesn't support failpoints on "hello".

Also sync the latest [sdam-error-handling](https://github.com/mongodb/specifications/commits/master/source/load-balancers/tests/sdam-error-handling.yml) load balancer tests at https://github.com/mongodb/specifications/commit/008d2f5aab41dabced03e0860bab614c0f15ded5 to get the corrected test description (since the skipping logic is based on test description, so would stop skipping the test if we synced that test later).

## Background & Motivation

Serverless Proxy responds to "hello" directly (i.e. does not forward it to the database layer) and does not support failpoints. This test will not work on Serverless Proxy because it depends on setting a failpoint on "hello".
