### PR TITLE
GODRIVER-3218 Skip Aggregation with  Crud Tests on 8.0+

### DIFF
--- a/testdata/crud/unified/aggregate-write-readPreference.json
+++ b/testdata/crud/unified/aggregate-write-readPreference.json
@@ -91,7 +91,8 @@
       "runOnRequirements": [
         {
           "minServerVersion": "5.0",
-          "serverless": "forbid"
+          "serverless": "forbid",
+          "maxServerVersion": "7.99"
         }
       ],
       "operations": [

--- a/testdata/crud/unified/aggregate-write-readPreference.yml
+++ b/testdata/crud/unified/aggregate-write-readPreference.yml
@@ -60,6 +60,8 @@ tests:
     runOnRequirements:
       - minServerVersion: "5.0"
         serverless: "forbid"
+        # GODRIVER-3218
+        maxServerVersion: "7.99"
     operations:
       - object: *collection0
         name: aggregate

--- a/testdata/crud/unified/db-aggregate-write-readPreference.json
+++ b/testdata/crud/unified/db-aggregate-write-readPreference.json
@@ -65,7 +65,8 @@
       "runOnRequirements": [
         {
           "minServerVersion": "5.0",
-          "serverless": "forbid"
+          "serverless": "forbid",
+          "maxServerVersion": "7.99"
         }
       ],
       "operations": [

--- a/testdata/crud/unified/db-aggregate-write-readPreference.yml
+++ b/testdata/crud/unified/db-aggregate-write-readPreference.yml
@@ -53,6 +53,8 @@ tests:
     runOnRequirements:
       - minServerVersion: "5.0"
         serverless: "forbid"
+        # GODRIVER-3218
+        maxServerVersion: "7.99"
     operations:
       - object: *database0
         name: aggregate


### PR DESCRIPTION
GODRIVER-3218 

## Summary

Limit the two tests to server versions less than 8.0 until upstream ticket is addressed.

