### PR TITLE
GODRIVER-3023 Remove unused error from Clone function signature

### DIFF
--- a/internal/integration/mtest/mongotest.go
+++ b/internal/integration/mtest/mongotest.go
@@ -602,9 +602,7 @@ func (t *T) CloneDatabase(opts *options.DatabaseOptions) {
 
 // CloneCollection modifies the default collection for this test to match the given options.
 func (t *T) CloneCollection(opts *options.CollectionOptions) {
-	var err error
-	t.Coll, err = t.Coll.Clone(opts)
-	assert.Nil(t, err, "error cloning collection: %v", err)
+	t.Coll = t.Coll.Clone(opts)
 }
 
 func sanitizeCollectionName(db string, coll string) string {

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -162,7 +162,7 @@ func (coll *Collection) copy() *Collection {
 // Clone creates a copy of the Collection configured with the given CollectionOptions.
 // The specified options are merged with the existing options on the collection, with the specified options taking
 // precedence.
-func (coll *Collection) Clone(opts ...*options.CollectionOptions) (*Collection, error) {
+func (coll *Collection) Clone(opts ...*options.CollectionOptions) *Collection {
 	copyColl := coll.copy()
 	optsColl := mergeCollectionOptions(opts...)
 
@@ -187,7 +187,7 @@ func (coll *Collection) Clone(opts ...*options.CollectionOptions) (*Collection, 
 		description.LatencySelector(copyColl.client.localThreshold),
 	})
 
-	return copyColl, nil
+	return copyColl
 }
 
 // Name returns the name of the collection.
@@ -2169,7 +2169,7 @@ func (coll *Collection) Indexes() IndexView {
 
 // SearchIndexes returns a SearchIndexView instance that can be used to perform operations on the search indexes for the collection.
 func (coll *Collection) SearchIndexes() SearchIndexView {
-	c, _ := coll.Clone() // Clone() always return a nil error.
+	c := coll.Clone() // Clone() always return a nil error.
 	c.readConcern = nil
 	c.writeConcern = nil
 	return SearchIndexView{

--- a/mongo/gridfs_bucket.go
+++ b/mongo/gridfs_bucket.go
@@ -538,14 +538,11 @@ func createNumericalIndexIfNotExists(ctx context.Context, iv IndexView, model In
 // create indexes on the files and chunks collection if needed
 func (b *GridFSBucket) createIndexes(ctx context.Context) error {
 	// must use primary read pref mode to check if files coll empty
-	cloned, err := b.filesColl.Clone(options.Collection().SetReadPreference(readpref.Primary()))
-	if err != nil {
-		return err
-	}
+	cloned := b.filesColl.Clone(options.Collection().SetReadPreference(readpref.Primary()))
 
 	docRes := cloned.FindOne(ctx, bson.D{}, options.FindOne().SetProjection(bson.D{{"_id", 1}}))
 
-	_, err = docRes.Raw()
+	_, err := docRes.Raw()
 	if !errors.Is(err, ErrNoDocuments) {
 		// nil, or error that occurred during the FindOne operation
 		return err


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3023

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Remove unused error from the `collection.Clone` function signature

## Background & Motivation

<!--- Rationale for the pull request. -->
