### PR TITLE
GODRIVER-3225 Ensure usage of newer http2 package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )
+
+replace golang.org/x/net/http2 => golang.org/x/net/http2 v0.23.0 // GODRIVER-3225


### PR DESCRIPTION
GODRIVER-3225

## Summary

Ensure usage of newer http2 package

## Background & Motivation

Address https://www.cve.org/CVERecord?id=CVE-2023-45288.
