### PR TITLE
GODRIVER-3125 Allow to set search index type

### DIFF
--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -379,7 +379,7 @@ func TestSearchIndexProse(t *testing.T) {
 
 		indexName = "test-search-index-case7-vector"
 		definition = bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
-		opts = options.SearchIndexes().SetName(indexName).SetType("vector")
+		opts = options.SearchIndexes().SetName(indexName).SetType("vectorSearch")
 		index, err = view.CreateOne(ctx, mongo.SearchIndexModel{
 			Definition: definition,
 			Options:    opts,
@@ -422,6 +422,6 @@ func TestSearchIndexProse(t *testing.T) {
 			Definition: definition,
 			Options:    opts,
 		})
-		require.NoError(mt, err, "failed to create index")
+		assert.ErrorContains(mt, err, "Attribute mappings missing")
 	})
 }

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -425,7 +425,12 @@ func TestSearchIndexProse(t *testing.T) {
 		}
 	})
 
-	mt.Run("case 8: Driver requires explicit type to create a vector search index", func(mt *mtest.T) {
+	case8CollName, err := uuid.New()
+	assert.NoError(mt, err, "failed to create random collection name for case #8")
+
+	mt.RunOpts("case 8: Driver requires explicit type to create a vector search index",
+		mtest.NewOptions().CollectionName(case8CollName.String()),
+		func(mt *mtest.T) {
 		ctx := context.Background()
 
 		_, err := mt.Coll.InsertOne(ctx, bson.D{})

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -98,10 +98,14 @@ func TestSearchIndexProse(t *testing.T) {
 				Definition: definition,
 				Options:    options.SearchIndexes().SetName("test-search-index-2"),
 			},
+			{
+				Definition: definition,
+				Options:    options.SearchIndexes().SetName("test-vector-search-index-1"),
+			},
 		}
 		indexes, err := view.CreateMany(ctx, models)
 		require.NoError(mt, err, "failed to create index")
-		require.Equal(mt, len(indexes), 2, "expected 2 indexes")
+		require.Equal(mt, len(indexes), 3, "expected 3 indexes")
 		for _, model := range models {
 			require.Contains(mt, indexes, *model.Options.Name)
 		}
@@ -136,6 +140,10 @@ func TestSearchIndexProse(t *testing.T) {
 				require.NoError(mt, err, "failed to marshal definition")
 				actual := doc.Lookup("latestDefinition").Value
 				assert.Equal(mt, expected, actual, "unmatched definition")
+
+				expectedType := opts.Type
+				actualType := doc.Lookup("type").Value
+				assert.Equal(mt, expectedType, actualType, "unmatched type")
 			}(models[i].Options)
 		}
 		wg.Wait()

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -312,116 +312,100 @@ func TestSearchIndexProse(t *testing.T) {
 			assert.Equal(mt, expected, actual, "unmatched definition")
 		})
 
-	mt.RunOpts("case 7: Driver can successfully handle search index types when creating indexes",
-		func(mt *mtest.T) {
-			ctx := context.Background()
+	mt.Run("case 7: Driver can successfully handle search index types when creating indexes", func(mt *mtest.T) {
+		ctx := context.Background()
 
-			_, err := mt.Coll.InsertOne(ctx, bson.D{})
-			require.NoError(mt, err, "failed to insert")
+		_, err := mt.Coll.InsertOne(ctx, bson.D{})
+		require.NoError(mt, err, "failed to insert")
 
-			view := mt.Coll.SearchIndexes()
+		view := mt.Coll.SearchIndexes()
 
-			definition := bson.D{{"mappings", bson.D{{"dynamic", false}}}}
-			indexName := "test-search-index-case7-implicit"
-			opts := options.SearchIndexes().SetName(indexName)
-			index, err := view.CreateOne(ctx, mongo.SearchIndexModel{
-				Definition: definition,
-				Options:    opts,
-			})
-			require.NoError(mt, err, "failed to create index")
-			require.Equal(mt, indexName, index, "unmatched name")
-			var doc bson.Raw
-			for doc == nil {
-				cursor, err := view.List(ctx, opts)
-				require.NoError(mt, err, "failed to list")
-
-				if !cursor.Next(ctx) {
-					break
-				}
-				name := cursor.Current.Lookup("name").StringValue()
-				queryable := cursor.Current.Lookup("queryable").Boolean()
-				indexType := cursor.Current.Lookup("type").StringValue()
-				if name == indexName && queryable {
-					doc = cursor.Current
-				} else {
-					t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
-					time.Sleep(5 * time.Second)
-				}
-			}
-			require.NotNil(mt, doc, "got empty document")
-			expected, err := bson.Marshal(definition)
-			require.NoError(mt, err, "failed to marshal definition")
-			actual := doc.Lookup("latestDefinition").Value
-			assert.Equal(mt, expected, actual, "unmatched definition")
-			assert.Equal(mt, indexType, "search")
-
-			indexName = "test-search-index-case7-explicit"
-			opts = options.SearchIndexes().SetName(indexName).setType("search")
-			index, err := view.CreateOne(ctx, mongo.SearchIndexModel{
-				Definition: definition,
-				Options:    opts,
-			})
-			require.NoError(mt, err, "failed to create index")
-			require.Equal(mt, indexName, index, "unmatched name")
-			var doc bson.Raw
-			for doc == nil {
-				cursor, err := view.List(ctx, opts)
-				require.NoError(mt, err, "failed to list")
-
-				if !cursor.Next(ctx) {
-					break
-				}
-				name := cursor.Current.Lookup("name").StringValue()
-				queryable := cursor.Current.Lookup("queryable").Boolean()
-				indexType := cursor.Current.Lookup("type").StringValue()
-				if name == indexName && queryable {
-					doc = cursor.Current
-				} else {
-					t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
-					time.Sleep(5 * time.Second)
-				}
-			}
-			require.NotNil(mt, doc, "got empty document")
-			expected, err := bson.Marshal(definition)
-			require.NoError(mt, err, "failed to marshal definition")
-			actual := doc.Lookup("latestDefinition").Value
-			assert.Equal(mt, expected, actual, "unmatched definition")
-			assert.Equal(mt, indexType, "search")
-
-			indexName = "test-search-index-case7-vector"
-			definition = bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
-			opts = options.SearchIndexes().SetName(indexName).setType("vector")
-			index, err := view.CreateOne(ctx, mongo.SearchIndexModel{
-				Definition: definition,
-				Options:    opts,
-			})
-			require.NoError(mt, err, "failed to create index")
-			require.Equal(mt, indexName, index, "unmatched name")
-			var doc bson.Raw
-			for doc == nil {
-				cursor, err := view.List(ctx, opts)
-				require.NoError(mt, err, "failed to list")
-
-				if !cursor.Next(ctx) {
-					break
-				}
-				name := cursor.Current.Lookup("name").StringValue()
-				queryable := cursor.Current.Lookup("queryable").Boolean()
-				indexType := cursor.Current.Lookup("type").StringValue()
-				if name == indexName && queryable {
-					doc = cursor.Current
-				} else {
-					t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
-					time.Sleep(5 * time.Second)
-				}
-			}
-			require.NotNil(mt, doc, "got empty document")
-			expected, err := bson.Marshal(definition)
-			require.NoError(mt, err, "failed to marshal definition")
-			actual := doc.Lookup("latestDefinition").Value
-			assert.Equal(mt, expected, actual, "unmatched definition")
-			assert.Equal(mt, indexType, "vectorSearch")
+		definition := bson.D{{"mappings", bson.D{{"dynamic", false}}}}
+		indexName := "test-search-index-case7-implicit"
+		opts := options.SearchIndexes().SetName(indexName)
+		index, err := view.CreateOne(ctx, mongo.SearchIndexModel{
+			Definition: definition,
+			Options:    opts,
 		})
+		require.NoError(mt, err, "failed to create index")
+		require.Equal(mt, indexName, index, "unmatched name")
+		var doc bson.Raw
+		for doc == nil {
+			cursor, err := view.List(ctx, opts)
+			require.NoError(mt, err, "failed to list")
+
+			if !cursor.Next(ctx) {
+				break
+			}
+			name := cursor.Current.Lookup("name").StringValue()
+			queryable := cursor.Current.Lookup("queryable").Boolean()
+			indexType := cursor.Current.Lookup("type").StringValue()
+			if name == indexName && queryable {
+				doc = cursor.Current
+				assert.Equal(mt, indexType, "search")
+			} else {
+				t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
+				time.Sleep(5 * time.Second)
+			}
+		}
+
+		indexName = "test-search-index-case7-explicit"
+		opts = options.SearchIndexes().SetName(indexName).SetType("search")
+		index, err = view.CreateOne(ctx, mongo.SearchIndexModel{
+			Definition: definition,
+			Options:    opts,
+		})
+		require.NoError(mt, err, "failed to create index")
+		require.Equal(mt, indexName, index, "unmatched name")
+		doc = nil
+		for doc == nil {
+			cursor, err := view.List(ctx, opts)
+			require.NoError(mt, err, "failed to list")
+
+			if !cursor.Next(ctx) {
+				break
+			}
+			name := cursor.Current.Lookup("name").StringValue()
+			queryable := cursor.Current.Lookup("queryable").Boolean()
+			indexType := cursor.Current.Lookup("type").StringValue()
+			if name == indexName && queryable {
+				doc = cursor.Current
+				assert.Equal(mt, indexType, "search")
+			} else {
+				t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
+				time.Sleep(5 * time.Second)
+			}
+		}
+
+		indexName = "test-search-index-case7-vector"
+		definition = bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
+		opts = options.SearchIndexes().SetName(indexName).SetType("vector")
+		index, err = view.CreateOne(ctx, mongo.SearchIndexModel{
+			Definition: definition,
+			Options:    opts,
+		})
+		require.NoError(mt, err, "failed to create index")
+		require.Equal(mt, indexName, index, "unmatched name")
+		doc = nil
+		for doc == nil {
+			cursor, err := view.List(ctx, opts)
+			require.NoError(mt, err, "failed to list")
+
+			if !cursor.Next(ctx) {
+				break
+			}
+			name := cursor.Current.Lookup("name").StringValue()
+			queryable := cursor.Current.Lookup("queryable").Boolean()
+			indexType := cursor.Current.Lookup("type").StringValue()
+			if name == indexName && queryable {
+				doc = cursor.Current
+				assert.Equal(mt, indexType, "vectorSearch")
+			} else {
+				t.Logf("cursor: %s, sleep 5 seconds...", cursor.Current.String())
+				time.Sleep(5 * time.Second)
+			}
+		}
+	})
 
 	mt.Run("case 8: Driver requires explicit type to create a vector search index", func(mt *mtest.T) {
 		ctx := context.Background()
@@ -432,9 +416,9 @@ func TestSearchIndexProse(t *testing.T) {
 		view := mt.Coll.SearchIndexes()
 
 		indexName := "test-search-index-case7-vector"
-		definition = bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
+		definition := bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
 		opts := options.SearchIndexes().SetName(indexName)
-		index, err := view.CreateOne(ctx, mongo.SearchIndexModel{
+		_, err = view.CreateOne(ctx, mongo.SearchIndexModel{
 			Definition: definition,
 			Options:    opts,
 		})

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -312,7 +312,12 @@ func TestSearchIndexProse(t *testing.T) {
 			assert.Equal(mt, expected, actual, "unmatched definition")
 		})
 
-	mt.Run("case 7: Driver can successfully handle search index types when creating indexes", func(mt *mtest.T) {
+	case7CollName, err := uuid.New()
+	assert.NoError(mt, err, "failed to create random collection name for case #7")
+
+	mt.RunOpts("case 7: Driver can successfully handle search index types when creating indexes",
+		mtest.NewOptions().CollectionName(case7CollName.String()),
+		func(mt *mtest.T) {
 		ctx := context.Background()
 
 		_, err := mt.Coll.InsertOne(ctx, bson.D{})

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -383,12 +383,25 @@ func TestSearchIndexProse(t *testing.T) {
 		}
 
 		indexName = "test-search-index-case7-vector"
-		definition = bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
-		opts = options.SearchIndexes().SetName(indexName).SetType("vectorSearch")
-		index, err = view.CreateOne(ctx, mongo.SearchIndexModel{
-			Definition: definition,
-			Options:    opts,
-		})
+		    type vectorDefinitionField struct {
+		    	Type          string `bson:"type"`
+		    	Path          string `bson:"path"`
+		    	NumDimensions int    `bson:"numDimensions"`
+		    	Similarity    string `bson:"similarity"`
+		    }
+
+		    type vectorDefinition struct {
+		    	Fields []vectorDefinitionField `bson:"fields"`
+		    }
+
+		    indexName = "test-search-index-case7-vector"
+		    opts = options.SearchIndexes().SetName(indexName).SetType("vectorSearch")
+		    index, err = view.CreateOne(ctx, mongo.SearchIndexModel{
+		    	Definition: vectorDefinition{
+		    		Fields: []vectorDefinitionField{{"vector", "path", 1536, "euclidean"}},
+		    	},
+		    	Options: opts,
+		    })
 		require.NoError(mt, err, "failed to create index")
 		require.Equal(mt, indexName, index, "unmatched name")
 		doc = nil

--- a/mongo/integration/search_index_prose_test.go
+++ b/mongo/integration/search_index_prose_test.go
@@ -438,13 +438,25 @@ func TestSearchIndexProse(t *testing.T) {
 
 		view := mt.Coll.SearchIndexes()
 
-		indexName := "test-search-index-case7-vector"
-		definition := bson.D{{"fields", bson.A{bson.D{{"type", "vector"}, {"path", "plot_embedding"}, {"numDimensions", 1536}, {"similarity", "euclidean"}}}}}
-		opts := options.SearchIndexes().SetName(indexName)
-		_, err = view.CreateOne(ctx, mongo.SearchIndexModel{
-			Definition: definition,
-			Options:    opts,
-		})
+			type vectorDefinitionField struct {
+				Type          string `bson:"type"`
+				Path          string `bson:"path"`
+				NumDimensions int    `bson:"numDimensions"`
+				Similarity    string `bson:"similarity"`
+			}
+
+			type vectorDefinition struct {
+				Fields []vectorDefinitionField `bson:"fields"`
+			}
+
+			const indexName = "test-search-index-case7-vector"
+			opts := options.SearchIndexes().SetName(indexName)
+			_, err = view.CreateOne(ctx, mongo.SearchIndexModel{
+				Definition: vectorDefinition{
+					Fields: []vectorDefinitionField{{"vector", "plot_embedding", 1536, "euclidean"}},
+				},
+				Options: opts,
+			})
 		assert.ErrorContains(mt, err, "Attribute mappings missing")
 	})
 }

--- a/mongo/integration/unified/collection_operation_execution.go
+++ b/mongo/integration/unified/collection_operation_execution.go
@@ -326,6 +326,7 @@ func executeCreateSearchIndex(ctx context.Context, operation *operation) (*opera
 			var m struct {
 				Definition interface{}
 				Name       *string
+				Type       *string
 			}
 			err = bson.Unmarshal(val.Document(), &m)
 			if err != nil {
@@ -334,6 +335,7 @@ func executeCreateSearchIndex(ctx context.Context, operation *operation) (*opera
 			model.Definition = m.Definition
 			model.Options = options.SearchIndexes()
 			model.Options.Name = m.Name
+			model.Options.Type = m.Type
 		default:
 			return nil, fmt.Errorf("unrecognized createSearchIndex option %q", key)
 		}
@@ -369,6 +371,7 @@ func executeCreateSearchIndexes(ctx context.Context, operation *operation) (*ope
 				var m struct {
 					Definition interface{}
 					Name       *string
+					Type       *string
 				}
 				err = bson.Unmarshal(val.Value, &m)
 				if err != nil {
@@ -379,6 +382,7 @@ func executeCreateSearchIndexes(ctx context.Context, operation *operation) (*ope
 					Options:    options.SearchIndexes(),
 				}
 				model.Options.Name = m.Name
+				model.Options.Type = m.Type
 				models = append(models, model)
 			}
 		default:

--- a/mongo/options/searchindexoptions.go
+++ b/mongo/options/searchindexoptions.go
@@ -9,6 +9,7 @@ package options
 // SearchIndexesOptions represents options that can be used to configure a SearchIndexView.
 type SearchIndexesOptions struct {
 	Name *string
+	Type *string
 }
 
 // SearchIndexes creates a new SearchIndexesOptions instance.

--- a/mongo/options/searchindexoptions.go
+++ b/mongo/options/searchindexoptions.go
@@ -24,8 +24,8 @@ func (sio *SearchIndexesOptions) SetName(name string) *SearchIndexesOptions {
 }
 
 // SetType sets the value for the Type field.
-func (sio *SearchIndexesOptions) SetType(ty string) *SearchIndexesOptions {
-	sio.Type = &ty
+func (sio *SearchIndexesOptions) SetType(typ string) *SearchIndexesOptions {
+	sio.Type = &typ
 	return sio
 }
 

--- a/mongo/options/searchindexoptions.go
+++ b/mongo/options/searchindexoptions.go
@@ -23,6 +23,12 @@ func (sio *SearchIndexesOptions) SetName(name string) *SearchIndexesOptions {
 	return sio
 }
 
+// SetType sets the value for the Type field.
+func (sio *SearchIndexesOptions) SetType(ty string) *SearchIndexesOptions {
+	sio.Type = &ty
+	return sio
+}
+
 // CreateSearchIndexesOptions represents options that can be used to configure a SearchIndexView.CreateOne or
 // SearchIndexView.CreateMany operation.
 type CreateSearchIndexesOptions struct {

--- a/mongo/search_index_view.go
+++ b/mongo/search_index_view.go
@@ -108,6 +108,9 @@ func (siv SearchIndexView) CreateMany(
 		if model.Options != nil && model.Options.Name != nil {
 			indexes = bsoncore.AppendStringElement(indexes, "name", *model.Options.Name)
 		}
+		if model.Options != nil && model.Options.Type != nil {
+			indexes = bsoncore.AppendStringElement(indexes, "type", *model.Options.Type)
+		}
 		indexes = bsoncore.AppendDocumentElement(indexes, "definition", definition)
 
 		indexes, err = bsoncore.AppendDocumentEnd(indexes, iidx)

--- a/testdata/index-management/createSearchIndex.json
+++ b/testdata/index-management/createSearchIndex.json
@@ -50,54 +50,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +75,117 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/testdata/index-management/createSearchIndex.yml
+++ b/testdata/index-management/createSearchIndex.yml
@@ -26,7 +26,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments:
-          model: { definition: &definition { mappings: { dynamic: true } } }
+          model: { definition: &definition { mappings: { dynamic: true } } , type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -39,7 +39,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -47,7 +47,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments: 
-          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index' }
+          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index', type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -60,5 +60,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndex
+        object: *collection0
+        arguments:
+          model: { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] }
+            , name: 'test index', type: 'vectorSearch' }
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0

--- a/testdata/index-management/createSearchIndexes.json
+++ b/testdata/index-management/createSearchIndexes.json
@@ -83,56 +83,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +109,121 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/testdata/index-management/createSearchIndexes.yml
+++ b/testdata/index-management/createSearchIndexes.yml
@@ -48,7 +48,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments:
-          models: [ { definition: &definition { mappings: { dynamic: true } } } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -61,7 +61,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -69,7 +69,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments: 
-          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -82,5 +82,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndexes
+        object: *collection0
+        arguments:
+          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] },
+                                                name: 'test index' , type: 'vectorSearch' } ]
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0


### PR DESCRIPTION
GODRIVER-3125

## Summary

Add the ability to pick the search index type when creating a new search index.

## Background & Motivation

Drivers must support use of the type field when creating search indexes. Creating a vector search index requires specifying type=vectorSearch. 
