### PR TITLE
GODRIVER-3187 Add SBOM lite file

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -1,48 +1,8 @@
 {
   "metadata": {
     "timestamp": "2024-06-04T11:44:11.689753+00:00",
-    "tools": [
-      {
-        "externalReferences": [
-          {
-            "type": "build-system",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
-          },
-          {
-            "type": "distribution",
-            "url": "https://pypi.org/project/cyclonedx-python-lib/"
-          },
-          {
-            "type": "documentation",
-            "url": "https://cyclonedx-python-library.readthedocs.io/"
-          },
-          {
-            "type": "issue-tracker",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
-          },
-          {
-            "type": "license",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
-          },
-          {
-            "type": "release-notes",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
-          },
-          {
-            "type": "vcs",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
-          },
-          {
-            "type": "website",
-            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
-          }
-        ],
-        "name": "cyclonedx-python-lib",
-        "vendor": "CycloneDX",
-        "version": "6.4.4"
-      }
-    ]
   },
+  "components": [],
   "serialNumber": "urn:uuid:6687021d-b80d-46ed-acc9-031a17e582a3",
   "version": 1,
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "timestamp": "2024-06-04T11:44:11.689753+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "6.4.4"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:6687021d-b80d-46ed-acc9-031a17e582a3",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/sbom.json
+++ b/sbom.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "timestamp": "2024-06-04T11:44:11.689753+00:00",
+    "timestamp": "2024-06-04T11:44:11.689753+00:00"
   },
   "components": [],
   "serialNumber": "urn:uuid:6687021d-b80d-46ed-acc9-031a17e582a3",


### PR DESCRIPTION
GODRIVER-3187

## Summary

Add SBOM-lite file to track bundled third party dependencies (there are none).

## Background & Motivation

Part of SSDLC conformance.
