### PR TITLE
GODRIVER-2866 Update method signatures of `bson.ValueMarshaler`/`bson.ValueUnmarshaler` to only use basic types.

### DIFF
--- a/bson/default_value_decoders.go
+++ b/bson/default_value_decoders.go
@@ -1280,7 +1280,7 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 		// NB: this error should be unreachable due to the above checks
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
-	return m.UnmarshalBSONValue(t, src)
+	return m.UnmarshalBSONValue(byte(t), src)
 }
 
 // UnmarshalerDecodeValue is the ValueDecoderFunc for Unmarshaler implementations.

--- a/bson/default_value_encoders.go
+++ b/bson/default_value_encoders.go
@@ -569,7 +569,7 @@ func (dve DefaultValueEncoders) ValueMarshalerEncodeValue(_ EncodeContext, vw Va
 	if err != nil {
 		return err
 	}
-	return copyValueFromBytes(vw, t, data)
+	return copyValueFromBytes(vw, Type(t), data)
 }
 
 // MarshalerEncodeValue is the ValueEncoderFunc for Marshaler implementations.

--- a/bson/default_value_encoders_test.go
+++ b/bson/default_value_encoders_test.go
@@ -1857,8 +1857,8 @@ type testValueMarshalPtr struct {
 	err error
 }
 
-func (tvm *testValueMarshalPtr) MarshalBSONValue() (Type, []byte, error) {
-	return tvm.t, tvm.buf, tvm.err
+func (tvm *testValueMarshalPtr) MarshalBSONValue() (byte, []byte, error) {
+	return byte(tvm.t), tvm.buf, tvm.err
 }
 
 type testMarshalPtr struct {

--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -34,7 +34,7 @@ type Marshaler interface {
 // create custom BSON marshaling behavior for an entire BSON document, implement
 // the Marshaler interface instead.
 type ValueMarshaler interface {
-	MarshalBSONValue() (Type, []byte, error)
+	MarshalBSONValue() (byte, []byte, error)
 }
 
 // Pool of buffers for marshalling BSON.

--- a/bson/marshal.go
+++ b/bson/marshal.go
@@ -34,7 +34,7 @@ type Marshaler interface {
 // create custom BSON marshaling behavior for an entire BSON document, implement
 // the Marshaler interface instead.
 type ValueMarshaler interface {
-	MarshalBSONValue() (byte, []byte, error)
+	MarshalBSONValue() (typ byte, data []byte, err error)
 }
 
 // Pool of buffers for marshalling BSON.

--- a/bson/marshal_value_cases_test.go
+++ b/bson/marshal_value_cases_test.go
@@ -37,13 +37,13 @@ type marshalValueMarshaler struct {
 
 var _ ValueMarshaler = marshalValueMarshaler{}
 
-func (mvi marshalValueMarshaler) MarshalBSONValue() (Type, []byte, error) {
-	return TypeInt32, bsoncore.AppendInt32(nil, int32(mvi.Foo)), nil
+func (mvi marshalValueMarshaler) MarshalBSONValue() (byte, []byte, error) {
+	return byte(TypeInt32), bsoncore.AppendInt32(nil, int32(mvi.Foo)), nil
 }
 
 var _ ValueUnmarshaler = &marshalValueMarshaler{}
 
-func (mvi *marshalValueMarshaler) UnmarshalBSONValue(_ Type, b []byte) error {
+func (mvi *marshalValueMarshaler) UnmarshalBSONValue(_ byte, b []byte) error {
 	v, _, _ := bsoncore.ReadInt32(b)
 	mvi.Foo = int(v)
 	return nil

--- a/bson/primitive_codecs_test.go
+++ b/bson/primitive_codecs_test.go
@@ -1066,8 +1066,8 @@ type testValueMarshaler struct {
 	err error
 }
 
-func (tvm testValueMarshaler) MarshalBSONValue() (Type, []byte, error) {
-	return tvm.t, tvm.buf, tvm.err
+func (tvm testValueMarshaler) MarshalBSONValue() (byte, []byte, error) {
+	return byte(tvm.t), tvm.buf, tvm.err
 }
 
 type testValueUnmarshaler struct {
@@ -1076,8 +1076,8 @@ type testValueUnmarshaler struct {
 	err error
 }
 
-func (tvu *testValueUnmarshaler) UnmarshalBSONValue(t Type, val []byte) error {
-	tvu.t, tvu.val = t, val
+func (tvu *testValueUnmarshaler) UnmarshalBSONValue(t byte, val []byte) error {
+	tvu.t, tvu.val = Type(t), val
 	return tvu.err
 }
 func (tvu testValueUnmarshaler) Equal(tvu2 testValueUnmarshaler) bool {

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -31,7 +31,7 @@ type Unmarshaler interface {
 // document. To create custom BSON unmarshaling behavior for an entire BSON
 // document, implement the Unmarshaler interface instead.
 type ValueUnmarshaler interface {
-	UnmarshalBSONValue(Type, []byte) error
+	UnmarshalBSONValue(byte, []byte) error
 }
 
 // Unmarshal parses the BSON-encoded data and stores the result in the value

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -31,7 +31,7 @@ type Unmarshaler interface {
 // document. To create custom BSON unmarshaling behavior for an entire BSON
 // document, implement the Unmarshaler interface instead.
 type ValueUnmarshaler interface {
-	UnmarshalBSONValue(byte, []byte) error
+	UnmarshalBSONValue(typ byte, data []byte) error
 }
 
 // Unmarshal parses the BSON-encoded data and stores the result in the value

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -229,8 +229,8 @@ func marshalAggregatePipeline(
 		if err != nil {
 			return nil, false, err
 		}
-		if btype != bson.TypeArray {
-			return nil, false, fmt.Errorf("ValueMarshaler returned a %v, but was expecting %v", btype, bson.TypeArray)
+		if typ := bson.Type(btype); typ != bson.TypeArray {
+			return nil, false, fmt.Errorf("ValueMarshaler returned a %v, but was expecting %v", typ, bson.TypeArray)
 		}
 
 		var hasOutputStage bool

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -616,6 +616,6 @@ type bvMarsh struct {
 	err  error
 }
 
-func (b bvMarsh) MarshalBSONValue() (bson.Type, []byte, error) {
-	return b.t, b.data, b.err
+func (b bvMarsh) MarshalBSONValue() (byte, []byte, error) {
+	return byte(b.t), b.data, b.err
 }


### PR DESCRIPTION
GODRIVER-2866

## Summary
Update method signatures of `bson.ValueMarshaler`/`bson.ValueUnmarshaler` to only use basic types.
