### PR TITLE
GODRIVER-3229 Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -eux {0}
+
+jobs:
+  release:
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: ${{ vars.AWS_REGION_NAME }}
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+      - name: Get current version
+        run: |
+          export VERSION=$(cat version/version.go | grep "var Driver" | awk -F'"' '{print $2}')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - uses: mongodb-labs/drivers-github-tools/tag-version@v2
+        with:
+          version: ${{ env.VERSION }}
+      - uses: mongodb-labs/drivers-github-tools/sbom@v2
+        with:
+          silk_asset_group: mongodb-go-driver-cloud-1.12.0
+      - name: Draft GitHub Release
+        run: |
+          gh release create ${VERSION} --draft --verify-tag --title ${VERSION} --notes ""
+          gh release upload ${VERSION} $RELEASE_ASSETS/*.*


### PR DESCRIPTION
GODRIVER-3229

## Summary

Add workflow to create a signed tag and draft release with attached SBOM file.

## Background & Motivation

SSDLC Compliance.  Example run: https://github.com/blink1073/mongo-go-driver/actions/runs/9508933321

<img width="399" alt="image" src="https://github.com/mongodb/mongo-go-driver/assets/2096628/3ab16e7a-35e5-450c-8fd3-c6615076c1cf">

