### PR TITLE
GODRIVER-3256 Bump maxWireVersion for MongoDB 8.0

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -22,7 +22,7 @@ var (
 	MinSupportedMongoDBVersion = "3.6"
 
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(6, 21)
+	SupportedWireVersions = description.NewVersionRange(6, 25)
 )
 
 type fsm struct {


### PR DESCRIPTION
GODRIVER-3256 

## Summary

Bump the supported max wire version.

## Background & Motivation

Support for MongoDB 8.0.
