### PR TITLE
Remove 8.0 from windows waterfall build

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2425,7 +2425,7 @@ buildvariants:
       - name: ".test !.enterprise-auth !.snappy"
 
   - matrix_name: "tests-windows-42-plus-zlib-zstd-support"
-    matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0", "8.0"], os-ssl-40: ["windows-64-go-1-20"] }
+    matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0"], os-ssl-40: ["windows-64-go-1-20"] }
     display_name: "${version} ${os-ssl-40}"
     tasks:
       - name: ".test !.enterprise-auth !.snappy"


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Remove 8.0 from the merge / waterfall build.

## Background & Motivation

<!--- Rationale for the pull request. -->

It is unnecessary to define 8.0 in both the waterfall and pullrequest build, it results in 8.0 being run twice in the waterfall:

<img width="194" alt="Screenshot 2024-07-02 at 10 41 31 PM" src="https://github.com/mongodb/mongo-go-driver/assets/24281431/3178c4b5-9036-4a8f-a4df-b902ce843bf8">

Example: https://spruce.mongodb.com/version/mongo_go_driver_v1_ad124427ab0ffabd0f7367dcd540feb6e171df4f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
