### PR TITLE
GODRIVER-3252 Update `Database.ListCollectionSpecifications` and `IndexView.ListSpecifications` to return slice of values.

### DIFF
--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -298,7 +298,7 @@ func TestDatabase(t *testing.T) {
 				AppendInt32("size", 4096).
 				Build()
 
-			expectedSpec := &mongo.CollectionSpecification{
+			expectedSpec := mongo.CollectionSpecification{
 				Name:     cappedName,
 				Type:     "collection",
 				ReadOnly: false,
@@ -312,7 +312,7 @@ func TestDatabase(t *testing.T) {
 				keysDoc := bsoncore.NewDocumentBuilder().
 					AppendInt32("_id", 1).
 					Build()
-				expectedSpec.IDIndex = &mongo.IndexSpecification{
+				expectedSpec.IDIndex = mongo.IndexSpecification{
 					Name:         "_id_",
 					Namespace:    mt.DB.Name() + "." + cappedName,
 					KeysDocument: bson.Raw(keysDoc),

--- a/internal/integration/index_view_test.go
+++ b/internal/integration/index_view_test.go
@@ -493,7 +493,7 @@ func TestIndexView(t *testing.T) {
 			})
 			assert.Nil(mt, err, "CreateMany error: %v", err)
 
-			expectedSpecs := []*mongo.IndexSpecification{
+			expectedSpecs := []mongo.IndexSpecification{
 				{
 					Name:               "_id_",
 					Namespace:          mt.DB.Name() + "." + mt.Coll.Name(),
@@ -634,7 +634,7 @@ func TestIndexView(t *testing.T) {
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 			specs, err := clustered.Indexes().ListSpecifications(context.Background())
 			assert.Nil(mt, err, "ListSpecifications error: %v", err)
-			expectedSpecs := []*mongo.IndexSpecification{
+			expectedSpecs := []mongo.IndexSpecification{
 				{
 					Name:         "_id_",
 					Namespace:    mt.DB.Name() + "." + name,

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -367,7 +367,7 @@ func (db *Database) Drop(ctx context.Context) error {
 //
 // For more information about the command, see https://www.mongodb.com/docs/manual/reference/command/listCollections/.
 func (db *Database) ListCollectionSpecifications(ctx context.Context, filter interface{},
-	opts ...*options.ListCollectionsOptions) ([]*CollectionSpecification, error) {
+	opts ...*options.ListCollectionsOptions) ([]CollectionSpecification, error) {
 
 	cursor, err := db.ListCollections(ctx, filter, opts...)
 	if err != nil {
@@ -390,13 +390,13 @@ func (db *Database) ListCollectionSpecifications(ctx context.Context, filter int
 		return nil, err
 	}
 
-	specs := make([]*CollectionSpecification, len(resp))
+	specs := make([]CollectionSpecification, len(resp))
 	for idx, spec := range resp {
-		specs[idx] = &CollectionSpecification{
+		specs[idx] = CollectionSpecification{
 			Name:    spec.Name,
 			Type:    spec.Type,
 			Options: spec.Options,
-			IDIndex: newIndexSpecificationFromResponse(spec.IDIndex),
+			IDIndex: IndexSpecification(spec.IDIndex),
 		}
 
 		if spec.Info != nil {
@@ -406,7 +406,7 @@ func (db *Database) ListCollectionSpecifications(ctx context.Context, filter int
 
 		// Pre-4.4 servers report a namespace in their responses, so we only set Namespace manually if it was not in
 		// the response.
-		if specs[idx].IDIndex != nil && specs[idx].IDIndex.Namespace == "" {
+		if specs[idx].IDIndex.Namespace == "" {
 			specs[idx].IDIndex.Namespace = db.name + "." + specs[idx].Name
 		}
 	}

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -141,7 +141,7 @@ func (iv IndexView) List(ctx context.Context, opts ...*options.ListIndexesOption
 }
 
 // ListSpecifications executes a List command and returns a slice of returned IndexSpecifications
-func (iv IndexView) ListSpecifications(ctx context.Context, opts ...*options.ListIndexesOptions) ([]*IndexSpecification, error) {
+func (iv IndexView) ListSpecifications(ctx context.Context, opts ...*options.ListIndexesOptions) ([]IndexSpecification, error) {
 	cursor, err := iv.List(ctx, opts...)
 	if err != nil {
 		return nil, err
@@ -155,9 +155,9 @@ func (iv IndexView) ListSpecifications(ctx context.Context, opts ...*options.Lis
 
 	namespace := iv.coll.db.Name() + "." + iv.coll.Name()
 
-	specs := make([]*IndexSpecification, len(resp))
+	specs := make([]IndexSpecification, len(resp))
 	for idx, spec := range resp {
-		specs[idx] = newIndexSpecificationFromResponse(spec)
+		specs[idx] = IndexSpecification(spec)
 		specs[idx].Namespace = namespace
 	}
 

--- a/mongo/results.go
+++ b/mongo/results.go
@@ -139,19 +139,6 @@ type indexListSpecificationResponse struct {
 	Clustered          *bool    `bson:"clustered"`
 }
 
-func newIndexSpecificationFromResponse(resp indexListSpecificationResponse) *IndexSpecification {
-	return &IndexSpecification{
-		Name:               resp.Name,
-		Namespace:          resp.Namespace,
-		KeysDocument:       resp.KeysDocument,
-		Version:            resp.Version,
-		ExpireAfterSeconds: resp.ExpireAfterSeconds,
-		Sparse:             resp.Sparse,
-		Unique:             resp.Unique,
-		Clustered:          resp.Clustered,
-	}
-}
-
 // CollectionSpecification represents a collection in a database. This type is returned by the
 // Database.ListCollectionSpecifications function.
 type CollectionSpecification struct {
@@ -171,9 +158,8 @@ type CollectionSpecification struct {
 	// A document containing the options used to construct the collection.
 	Options bson.Raw
 
-	// An IndexSpecification instance with details about the collection's _id index. This will be nil if the NameOnly
-	// option is used and for MongoDB versions < 3.4.
-	IDIndex *IndexSpecification
+	// An IndexSpecification instance with details about the collection's _id index.
+	IDIndex IndexSpecification
 }
 
 // DistinctResult represents an array of BSON data returned from an operation.


### PR DESCRIPTION
GODRIVER-3252

## Summary
Update `Database.ListCollectionSpecifications` and `IndexView.ListSpecifications` to return a slice of values.

## Background & Motivation
The pointers confuse users because it’s unclear whether they can be nil.
