### PR TITLE
GODRIVER-3256 [master] Bump maxWireVersion for MongoDB 8.0

### DIFF
--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -23,7 +23,7 @@ var (
 	MinSupportedMongoDBVersion = "3.6"
 
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = driverutil.NewVersionRange(6, 21)
+	SupportedWireVersions = description.NewVersionRange(6, 25)
 )
 
 type fsm struct {

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -23,7 +23,7 @@ var (
 	MinSupportedMongoDBVersion = "3.6"
 
 	// SupportedWireVersions is the range of wire versions supported by the driver.
-	SupportedWireVersions = description.NewVersionRange(6, 25)
+	SupportedWireVersions = driverutil.NewVersionRange(6, 25)
 )
 
 type fsm struct {


### PR DESCRIPTION
Cherry-pick of #1695 from v1 to master