### PR TITLE
GODRIVER-3277 Rename DropWithKey to DropOneWithKey

### DIFF
--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -435,12 +435,12 @@ func (iv IndexView) DropOne(ctx context.Context, name string, opts ...*options.D
 	return iv.drop(ctx, name, opts...)
 }
 
-// DropWithKey drops a collection index by key using the dropIndexes operation. If the operation succeeds, this returns
+// DropOneWithKey drops a collection index by key using the dropIndexes operation. If the operation succeeds, this returns
 // a BSON document in the form {nIndexesWas: <int32>}. The "nIndexesWas" field in the response contains the number of
 // indexes that existed prior to the drop.
 //
 // This function is useful to drop an index using its key specification instead of its name.
-func (iv IndexView) DropWithKey(ctx context.Context, keySpecDocument interface{}, opts ...*options.DropIndexesOptions) (bson.Raw, error) {
+func (iv IndexView) DropOneWithKey(ctx context.Context, keySpecDocument interface{}, opts ...*options.DropIndexesOptions) (bson.Raw, error) {
 	doc, err := marshal(keySpecDocument, iv.coll.bsonOpts, iv.coll.registry)
 	if err != nil {
 		return nil, err

--- a/mongo/integration/index_view_test.go
+++ b/mongo/integration/index_view_test.go
@@ -674,7 +674,7 @@ func TestIndexView(t *testing.T) {
 				assert.NoError(mt, err)
 				assert.Equal(mt, len(test.models), len(indexNames), "expected %v index names, got %v", len(test.models), len(indexNames))
 
-				_, err = iv.DropWithKey(context.Background(), test.index)
+				_, err = iv.DropOneWithKey(context.Background(), test.index)
 				assert.Nil(mt, err, "DropOne error: %v", err)
 
 				cursor, err := iv.List(context.Background())


### PR DESCRIPTION
[GODRIVER-3277](https://jira.mongodb.org/browse/GODRIVER-3277)

## Summary

The solution for [GODRIVER-2701](https://jira.mongodb.org/browse/GODRIVER-2701) adds a new method to the IndexView API called DropWithKey. The [standard API](https://github.com/mongodb/specifications/blob/master/source/index-management/index-management.md#standard-api) for dropOne overloads the function signature to include a key option.

This PR renames DropWithKey to DropOneWithKey before releasing 1.17 to follow the spec as best as possible.