### PR TITLE
GODRIVER-2821 Remove result check from Drop

### DIFF
--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -1582,7 +1582,7 @@ func TestCollection(t *testing.T) {
 			_, err := mt.Coll.Indexes().CreateOne(context.TODO(), indexModel)
 			assert.NoError(mt, err, "failed to create index")
 
-			_, err = mt.Coll.Indexes().DropOne(context.Background(), "username_1")
+			err = mt.Coll.Indexes().DropOne(context.Background(), "username_1")
 			assert.NoError(mt, err)
 		})
 	})


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2821

## Summary

<!--- A summary of the changes proposed by this pull request. -->
Remove check for result from Drop in the collection tests.

## Background & Motivation

<!--- Rationale for the pull request. -->
We removed the result type from DDL commands in [GODRIVER-961](https://jira.mongodb.org/browse/GODRIVER-961) and [GODRIVER-3220](https://jira.mongodb.org/browse/GODRIVER-3220).
