### PR TITLE
Remove debugging Println from collection.find

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1227,7 +1227,6 @@ func (coll *Collection) find(
 
 	f, err := marshal(filter, coll.bsonOpts, coll.registry)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Remove debugging Println from `collection.find` accidentally added in https://github.com/mongodb/mongo-go-driver/pull/1678.

## Background & Motivation
