### PR TITLE
GODRIVER-2693 Rename event constants to match event names

### DIFF
--- a/event/monitoring.go
+++ b/event/monitoring.go
@@ -75,10 +75,10 @@ const (
 
 // strings for pool command monitoring types
 const (
-	PoolCreated               = "ConnectionPoolCreated"
-	PoolReady                 = "ConnectionPoolReady"
-	PoolCleared               = "ConnectionPoolCleared"
-	PoolClosedEvent           = "ConnectionPoolClosed"
+	ConnectionPoolCreated     = "ConnectionPoolCreated"
+	ConnectionPoolReady       = "ConnectionPoolReady"
+	ConnectionPoolCleared     = "ConnectionPoolCleared"
+	ConnectionPoolClosed      = "ConnectionPoolClosed"
 	ConnectionCreated         = "ConnectionCreated"
 	ConnectionReady           = "ConnectionReady"
 	ConnectionClosed          = "ConnectionClosed"

--- a/internal/eventtest/eventtest.go
+++ b/internal/eventtest/eventtest.go
@@ -72,7 +72,7 @@ func (tpm *TestPoolMonitor) ClearEvents() {
 // recorded by the testPoolMonitor.
 func (tpm *TestPoolMonitor) IsPoolCleared() bool {
 	poolClearedEvents := tpm.Events(func(evt *event.PoolEvent) bool {
-		return evt.Type == event.PoolCleared
+		return evt.Type == event.ConnectionPoolCleared
 	})
 	return len(poolClearedEvents) > 0
 }

--- a/internal/integration/change_stream_test.go
+++ b/internal/integration/change_stream_test.go
@@ -589,7 +589,7 @@ func TestChangeStream_ReplicaSet(t *testing.T) {
 			assert.NotNil(mt, err, "expected Watch error, got nil")
 
 			clearedEvents := tpm.Events(func(evt *event.PoolEvent) bool {
-				return evt.Type == event.PoolCleared
+				return evt.Type == event.ConnectionPoolCleared
 			})
 			assert.Equal(mt, 2, len(clearedEvents), "expected two PoolCleared events, got %d", len(clearedEvents))
 		})

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -897,7 +897,7 @@ func TestClientStress(t *testing.T) {
 				defer func() {
 					created := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.ConnectionCreated }))
 					closed := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.ConnectionClosed }))
-					poolCleared := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.PoolCleared }))
+					poolCleared := len(tpm.Events(func(e *event.PoolEvent) bool { return e.Type == event.ConnectionPoolCleared }))
 					mt.Logf("Connections created: %d, connections closed: %d, pool clears: %d", created, closed, poolCleared)
 				}()
 

--- a/internal/integration/retryable_reads_prose_test.go
+++ b/internal/integration/retryable_reads_prose_test.go
@@ -80,7 +80,7 @@ func TestRetryableReadsProse(t *testing.T) {
 		events := tpm.Events(func(e *event.PoolEvent) bool {
 			connectionCheckedOut := e.Type == event.ConnectionCheckedOut
 			connectionCheckOutFailed := e.Type == event.ConnectionCheckOutFailed
-			poolCleared := e.Type == event.PoolCleared
+			poolCleared := e.Type == event.ConnectionPoolCleared
 			return connectionCheckedOut || connectionCheckOutFailed || poolCleared
 		})
 
@@ -89,7 +89,7 @@ func TestRetryableReadsProse(t *testing.T) {
 		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
 		assert.Equal(mt, event.ConnectionCheckedOut, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
-		assert.Equal(mt, event.PoolCleared, events[1].Type,
+		assert.Equal(mt, event.ConnectionPoolCleared, events[1].Type,
 			"expected ConnectionPoolCleared event, got %v", events[1].Type)
 		assert.Equal(mt, event.ConnectionCheckOutFailed, events[2].Type,
 			"expected ConnectionCheckedOutFailed event, got %v", events[2].Type)

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -192,7 +192,7 @@ func TestRetryableWritesProse(t *testing.T) {
 		events := tpm.Events(func(e *event.PoolEvent) bool {
 			connectionCheckedOut := e.Type == event.ConnectionCheckedOut
 			connectionCheckOutFailed := e.Type == event.ConnectionCheckOutFailed
-			poolCleared := e.Type == event.PoolCleared
+			poolCleared := e.Type == event.ConnectionPoolCleared
 			return connectionCheckedOut || connectionCheckOutFailed || poolCleared
 		})
 
@@ -201,7 +201,7 @@ func TestRetryableWritesProse(t *testing.T) {
 		assert.True(mt, len(events) >= 3, "expected at least 3 events, got %v", len(events))
 		assert.Equal(mt, event.ConnectionCheckedOut, events[0].Type,
 			"expected ConnectionCheckedOut event, got %v", events[0].Type)
-		assert.Equal(mt, event.PoolCleared, events[1].Type,
+		assert.Equal(mt, event.ConnectionPoolCleared, events[1].Type,
 			"expected ConnectionPoolCleared event, got %v", events[1].Type)
 		assert.Equal(mt, event.ConnectionCheckOutFailed, events[2].Type,
 			"expected ConnectionCheckedOutFailed event, got %v", events[2].Type)

--- a/internal/integration/unified/event.go
+++ b/internal/integration/unified/event.go
@@ -84,13 +84,13 @@ func monitoringEventTypeFromString(eventStr string) (monitoringEventType, bool) 
 
 func monitoringEventTypeFromPoolEvent(evt *event.PoolEvent) monitoringEventType {
 	switch evt.Type {
-	case event.PoolCreated:
+	case event.ConnectionPoolCreated:
 		return poolCreatedEvent
-	case event.PoolReady:
+	case event.ConnectionPoolReady:
 		return poolReadyEvent
-	case event.PoolCleared:
+	case event.ConnectionPoolCleared:
 		return poolClearedEvent
-	case event.PoolClosedEvent:
+	case event.ConnectionPoolClosed:
 		return poolClosedEvent
 	case event.ConnectionCreated:
 		return connectionCreatedEvent

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -352,7 +352,7 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.PoolClearedEvent != nil:
 			var actual *event.PoolEvent
-			if actual, pooled, err = getNextPoolEvent(pooled, event.PoolCleared); err != nil {
+			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionPoolCleared); err != nil {
 				return newEventVerificationError(idx, client, err.Error())
 			}
 			if expectServiceID := evt.PoolClearedEvent.HasServiceID; expectServiceID != nil {

--- a/internal/integration/unified_runner_events_helper_test.go
+++ b/internal/integration/unified_runner_events_helper_test.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	poolEventTypesMap = map[string]string{
-		"PoolClearedEvent": event.PoolCleared,
+		"PoolClearedEvent": event.ConnectionPoolCleared,
 	}
 	defaultCallbackTimeout = 10 * time.Second
 )

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -264,7 +264,7 @@ func newPool(config poolConfig, connOpts ...ConnectionOption) *pool {
 
 	if pool.monitor != nil {
 		pool.monitor.Event(&event.PoolEvent{
-			Type: event.PoolCreated,
+			Type: event.ConnectionPoolCreated,
 			PoolOptions: &event.MonitorPoolOptions{
 				MaxPoolSize: config.MaxPoolSize,
 				MinPoolSize: config.MinPoolSize,
@@ -307,7 +307,7 @@ func (p *pool) ready() error {
 	// "pool ready" event is always sent before maintain() starts creating connections.
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
-			Type:    event.PoolReady,
+			Type:    event.ConnectionPoolReady,
 			Address: p.address.String(),
 		})
 	}
@@ -418,7 +418,7 @@ func (p *pool) close(ctx context.Context) {
 
 	if p.monitor != nil {
 		p.monitor.Event(&event.PoolEvent{
-			Type:    event.PoolClosedEvent,
+			Type:    event.ConnectionPoolClosed,
 			Address: p.address.String(),
 		})
 	}
@@ -919,7 +919,7 @@ func (p *pool) clearImpl(err error, serviceID *bson.ObjectID, interruptAllConnec
 
 	if sendEvent && p.monitor != nil {
 		event := &event.PoolEvent{
-			Type:         event.PoolCleared,
+			Type:         event.ConnectionPoolCleared,
 			Address:      p.address.String(),
 			ServiceID:    serviceID,
 			Interruption: interruptAllConnections,


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-2693

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Rename Pool* event constants to match their string literal values.

## Background & Motivation

<!--- Rationale for the pull request. -->

https://github.com/mongodb/mongo-go-driver/pull/1456 missed renaming the Pool* event constants.
