### PR TITLE
GODRIVER-3249 [master] Handle all possible OIDC configuration errors

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -508,34 +508,6 @@ func setURIOpts(uri string, opts *ClientOptions) error {
 		opts.Timeout = &connString.Timeout
 	}
 
-	// OIDC Validation
-	if opts.Auth != nil && opts.Auth.AuthMechanism == auth.MongoDBOIDC {
-		if opts.Auth.Password != "" {
-			return fmt.Errorf("password must not be set for the %s auth mechanism", auth.MongoDBOIDC)
-		}
-		if opts.Auth.OIDCMachineCallback != nil && opts.Auth.OIDCHumanCallback != nil {
-			return fmt.Errorf("cannot set both OIDCMachineCallback and OIDCHumanCallback, only one may be specified")
-		}
-		if env, ok := opts.Auth.AuthMechanismProperties[auth.EnvironmentProp]; ok {
-			switch env {
-			case auth.GCPEnvironmentValue, auth.AzureEnvironmentValue:
-				if opts.Auth.OIDCMachineCallback != nil {
-					return fmt.Errorf("OIDCMachineCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
-				}
-				if opts.Auth.OIDCHumanCallback != nil {
-					return fmt.Errorf("OIDCHumanCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
-				}
-				if opts.Auth.AuthMechanismProperties[auth.ResourceProp] == "" {
-					return fmt.Errorf("%q must be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
-				}
-			default:
-				if opts.Auth.AuthMechanismProperties[auth.ResourceProp] != "" {
-					return fmt.Errorf("%q must not be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
-				}
-			}
-		}
-	}
-
 	return nil
 }
 
@@ -617,6 +589,34 @@ func (c *ClientOptionsBuilder) Validate() error {
 
 	if to := args.Timeout; to != nil && *to < 0 {
 		return fmt.Errorf(`invalid value %q for "Timeout": value must be positive`, *to)
+	}
+
+	// OIDC Validation
+	if args.Auth != nil && args.Auth.AuthMechanism == auth.MongoDBOIDC {
+		if args.Auth.Password != "" {
+			return fmt.Errorf("password must not be set for the %s auth mechanism", auth.MongoDBOIDC)
+		}
+		if args.Auth.OIDCMachineCallback != nil && args.Auth.OIDCHumanCallback != nil {
+			return fmt.Errorf("cannot set both OIDCMachineCallback and OIDCHumanCallback, only one may be specified")
+		}
+		if env, ok := args.Auth.AuthMechanismProperties[auth.EnvironmentProp]; ok {
+			switch env {
+			case auth.GCPEnvironmentValue, auth.AzureEnvironmentValue:
+				if args.Auth.OIDCMachineCallback != nil {
+					return fmt.Errorf("OIDCMachineCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
+				}
+				if args.Auth.OIDCHumanCallback != nil {
+					return fmt.Errorf("OIDCHumanCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
+				}
+				if args.Auth.AuthMechanismProperties[auth.ResourceProp] == "" {
+					return fmt.Errorf("%q must be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
+				}
+			default:
+				if args.Auth.AuthMechanismProperties[auth.ResourceProp] != "" {
+					return fmt.Errorf("%q must not be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -509,27 +509,27 @@ func setURIOpts(uri string, opts *ClientOptions) error {
 	}
 
 	// OIDC Validation
-	if c.Auth != nil && c.Auth.AuthMechanism == auth.MongoDBOIDC {
-		if c.Auth.Password != "" {
+	if opts.Auth != nil && opts.Auth.AuthMechanism == auth.MongoDBOIDC {
+		if opts.Auth.Password != "" {
 			return fmt.Errorf("password must not be set for the %s auth mechanism", auth.MongoDBOIDC)
 		}
-		if c.Auth.OIDCMachineCallback != nil && c.Auth.OIDCHumanCallback != nil {
+		if opts.Auth.OIDCMachineCallback != nil && opts.Auth.OIDCHumanCallback != nil {
 			return fmt.Errorf("cannot set both OIDCMachineCallback and OIDCHumanCallback, only one may be specified")
 		}
-		if env, ok := c.Auth.AuthMechanismProperties[auth.EnvironmentProp]; ok {
+		if env, ok := opts.Auth.AuthMechanismProperties[auth.EnvironmentProp]; ok {
 			switch env {
 			case auth.GCPEnvironmentValue, auth.AzureEnvironmentValue:
-				if c.Auth.OIDCMachineCallback != nil {
+				if opts.Auth.OIDCMachineCallback != nil {
 					return fmt.Errorf("OIDCMachineCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
 				}
-				if c.Auth.OIDCHumanCallback != nil {
+				if opts.Auth.OIDCHumanCallback != nil {
 					return fmt.Errorf("OIDCHumanCallback cannot be specified with the %s %q", env, auth.EnvironmentProp)
 				}
-				if c.Auth.AuthMechanismProperties[auth.ResourceProp] == "" {
+				if opts.Auth.AuthMechanismProperties[auth.ResourceProp] == "" {
 					return fmt.Errorf("%q must be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
 				}
 			default:
-				if c.Auth.AuthMechanismProperties[auth.ResourceProp] != "" {
+				if opts.Auth.AuthMechanismProperties[auth.ResourceProp] != "" {
 					return fmt.Errorf("%q must not be set for the %s %q", auth.ResourceProp, env, auth.EnvironmentProp)
 				}
 			}

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -388,7 +388,7 @@ func TestClientOptions(t *testing.T) {
 
 		testCases := []struct {
 			name string
-			opts *ClientOptions
+			opts *ClientOptionsBuilder
 			err  error
 		}{
 			{
@@ -473,7 +473,7 @@ func TestClientOptions(t *testing.T) {
 
 		testCases := []struct {
 			name string
-			opts *ClientOptions
+			opts *ClientOptionsBuilder
 			err  error
 		}{
 			{

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -379,6 +379,176 @@ func TestClientOptions(t *testing.T) {
 			})
 		}
 	})
+	t.Run("OIDC auth configuration validation", func(t *testing.T) {
+		t.Parallel()
+
+		emptyCb := func(_ context.Context, _ *OIDCArgs) (*OIDCCredential, error) {
+			return nil, nil
+		}
+
+		testCases := []struct {
+			name string
+			opts *ClientOptions
+			err  error
+		}{
+			{
+				name: "password must not be set",
+				opts: Client().SetAuth(Credential{AuthMechanism: "MONGODB-OIDC", Password: "password"}),
+				err:  fmt.Errorf("password must not be set for the MONGODB-OIDC auth mechanism"),
+			},
+			{
+				name: "cannot set both OIDCMachineCallback and OIDCHumanCallback simultaneously",
+				opts: Client().SetAuth(Credential{AuthMechanism: "MONGODB-OIDC",
+					OIDCMachineCallback: emptyCb, OIDCHumanCallback: emptyCb}),
+				err: fmt.Errorf("cannot set both OIDCMachineCallback and OIDCHumanCallback, only one may be specified"),
+			},
+			{
+				name: "cannot set OIDCMachineCallback in GCP Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					OIDCMachineCallback:     emptyCb,
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "gcp"},
+				}),
+				err: fmt.Errorf(`OIDCMachineCallback cannot be specified with the gcp "ENVIRONMENT"`),
+			},
+			{
+				name: "cannot set OIDCMachineCallback in AZURE Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					OIDCMachineCallback:     emptyCb,
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "azure"},
+				}),
+				err: fmt.Errorf(`OIDCMachineCallback cannot be specified with the azure "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must be set in GCP Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "gcp"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must be set for the gcp "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must be set in AZURE Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "azure"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must be set for the azure "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must not be set in TEST Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "test", "TOKEN_RESOURCE": "stuff"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must not be set for the test "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must not be set in any other Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "random env!", "TOKEN_RESOURCE": "stuff"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must not be set for the random env! "ENVIRONMENT"`),
+			},
+		}
+		for _, tc := range testCases {
+			tc := tc // Capture range variable.
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				err := tc.opts.Validate()
+				assert.Equal(t, tc.err, err, "want error %v, got error %v", tc.err, err)
+			})
+		}
+	})
+	t.Run("OIDC auth configuration validation", func(t *testing.T) {
+		t.Parallel()
+
+		emptyCb := func(_ context.Context, _ *OIDCArgs) (*OIDCCredential, error) {
+			return nil, nil
+		}
+
+		testCases := []struct {
+			name string
+			opts *ClientOptions
+			err  error
+		}{
+			{
+				name: "password must not be set",
+				opts: Client().SetAuth(Credential{AuthMechanism: "MONGODB-OIDC", Password: "password"}),
+				err:  fmt.Errorf("password must not be set for the MONGODB-OIDC auth mechanism"),
+			},
+			{
+				name: "cannot set both OIDCMachineCallback and OIDCHumanCallback simultaneously",
+				opts: Client().SetAuth(Credential{AuthMechanism: "MONGODB-OIDC",
+					OIDCMachineCallback: emptyCb, OIDCHumanCallback: emptyCb}),
+				err: fmt.Errorf("cannot set both OIDCMachineCallback and OIDCHumanCallback, only one may be specified"),
+			},
+			{
+				name: "cannot set OIDCMachineCallback in GCP Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					OIDCMachineCallback:     emptyCb,
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "gcp"},
+				}),
+				err: fmt.Errorf(`OIDCMachineCallback cannot be specified with the gcp "ENVIRONMENT"`),
+			},
+			{
+				name: "cannot set OIDCMachineCallback in AZURE Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					OIDCMachineCallback:     emptyCb,
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "azure"},
+				}),
+				err: fmt.Errorf(`OIDCMachineCallback cannot be specified with the azure "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must be set in GCP Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "gcp"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must be set for the gcp "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must be set in AZURE Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "azure"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must be set for the azure "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must not be set in TEST Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "test", "TOKEN_RESOURCE": "stuff"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must not be set for the test "ENVIRONMENT"`),
+			},
+			{
+				name: "TOKEN_RESOURCE must not be set in any other Environment",
+				opts: Client().SetAuth(Credential{
+					AuthMechanism:           "MONGODB-OIDC",
+					AuthMechanismProperties: map[string]string{"ENVIRONMENT": "random env!", "TOKEN_RESOURCE": "stuff"},
+				}),
+				err: fmt.Errorf(`"TOKEN_RESOURCE" must not be set for the random env! "ENVIRONMENT"`),
+			},
+		}
+		for _, tc := range testCases {
+			tc := tc // Capture range variable.
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				err := tc.opts.Validate()
+				assert.Equal(t, tc.err, err, "want error %v, got error %v", tc.err, err)
+			})
+		}
+	})
 }
 
 func createCertPool(t *testing.T, paths ...string) *x509.CertPool {

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/internal/randutil"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/auth"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/dns"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/wiremessage"
 )
@@ -250,6 +251,16 @@ func (u *ConnString) Validate() error {
 		}
 		if u.LoadBalanced {
 			return ErrSRVMaxHostsWithLoadBalanced
+		}
+	}
+
+	// Check for OIDC auth mechanism properties that cannot be set in the ConnString.
+	if u.AuthMechanism == auth.MongoDBOIDC {
+		if _, ok := u.AuthMechanismProperties[auth.AllowedHostsProp]; ok {
+			return fmt.Errorf(
+				"ALLOWED_HOSTS cannot be specified in the URI connection string for the %q auth mechanism, it must be specified through the ClientOptions directly",
+				auth.MongoDBOIDC,
+			)
 		}
 	}
 


### PR DESCRIPTION
GODRIVER-3249
## Summary

Add configuration errors for all malformed configuration for the OIDC authentication mechanism. Some of these are redundant with errors thrown by the OIDC code itself, but these should occur before that point. I think double checking is fine.

## Background & Motivation

OIDC epic
