### PR TITLE
GODRIVER-3301 Fix Atlas Data Lake Startup Failure

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -232,8 +232,9 @@ functions:
         shell: "bash"
         script: |
           ${PREPARE_SHELL}
-
+          set -x
           cd $DRIVERS_TOOLS/.evergreen/atlas_data_lake
+          cat $HOME/.docker/config.json
           DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash pull-mongohouse-image.sh
     - command: shell.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -234,7 +234,6 @@ functions:
           ${PREPARE_SHELL}
           set -x
           cd $DRIVERS_TOOLS/.evergreen/atlas_data_lake
-          cat $HOME/.docker/config.json
           DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash pull-mongohouse-image.sh
     - command: shell.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -227,22 +227,16 @@ functions:
         display_name: "test_suite.tgz"
 
   bootstrap-mongohoused:
-    - command: shell.exec
+    - command: subprocess.exec
       params:
-        shell: "bash"
-        script: |
-          ${PREPARE_SHELL}
-          set -x
-          cd $DRIVERS_TOOLS/.evergreen/atlas_data_lake
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash pull-mongohouse-image.sh
-    - command: shell.exec
+        binary: "bash"
+        args: 
+          - ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+    - command: subprocess.exec
       params:
-        shell: "bash"
-        script: |
-          ${PREPARE_SHELL}
-
-          cd $DRIVERS_TOOLS/.evergreen/atlas_data_lake
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash run-mongohouse-image.sh
+        binary: "bash"
+        args: 
+          - ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-image.sh
 
   bootstrap-mongo-orchestration:
     - command: shell.exec


### PR DESCRIPTION
[GODRIVER-3301](https://jira.mongodb.org/browse/GODRIVER-3301)

## Summary

Fix Atlas Data Lake Startup Failure by avoiding changing the environment before logging in to docker.