### PR TITLE
Remove unused function param to fix linter failure.

### DIFF
--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -658,7 +658,7 @@ func TestOperation(t *testing.T) {
 		op := Operation{
 			Database:   "foobar",
 			Deployment: d,
-			CommandFn: func(dst []byte, desc description.SelectedServer) ([]byte, error) {
+			CommandFn: func(dst []byte, _ description.SelectedServer) ([]byte, error) {
 				return dst, nil
 			},
 			Timeout: &dur,


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Remove unused function param to fix linter failure.

## Background & Motivation

<!--- Rationale for the pull request. -->
