### PR TITLE
GODRIVER-3314 Add PR Cherrypicker Task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -418,6 +418,14 @@ functions:
           export SCRIPT="$DRIVERS_TOOLS/.evergreen/github_app/assign-reviewer.sh"
           bash $SCRIPT -p $CONFIG -h ${github_commit} -o "mongodb" -n "mongo-go-driver"
 
+  "backport pr":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - ${DRIVERS}/.evergreen/github_app/backport-pr.sh mongodb mongo-go-driver ${github_commit}
+
   send-perf-data:
     - command: perf.send
       params:
@@ -908,6 +916,11 @@ tasks:
       - func: "add PR reviewer"  
       - func: "add PR labels"
       - func: "create-api-report"
+
+  - name: backport-pr
+    allowed_requesters: ["commit"]
+    commands:
+      - func: "backport pr"  
 
   - name: perf
     tags: ["performance"]
@@ -2485,6 +2498,13 @@ buildvariants:
       GO_DIST: "/opt/golang/go1.20"
     tasks:
       - name: ".compile-check"
+
+  - name: backport-pr
+    display_name: "Backport PR"
+    run_on:
+      - rhel8.7-large
+    tasks: 
+      - name: "backport-pr"
 
   - name: atlas-test
     tags: ["pullrequest"]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,6 +49,21 @@ pre-commit run --all-files
 
 ### Cherry-picking between branches
 
+#### Using the GitHub App
+
+Within a PR, you can make the comment:
+
+```
+drivers-pr-bot please backport to {target_branch}
+```
+
+The preferred workflow is to make the comment and then merge the PR.
+
+If you merge the PR and the "backport-pr" task runs before you make the comment, you can
+make the comment and then re-run the "backport-pr" task for that commit.
+
+#### Manually
+
 You must first install the `gh` cli (`brew install gh`), then set your GitHub username:
 
 ```bash


### PR DESCRIPTION
GODRIVER-3314

## Summary

Make it easier to backport PRs by making the magic GitHub comment: `drivers-pr-bot please backport to {target_branch}`.

## Background & Motivation

Less friction when backporting PRs to release branches.