### PR TITLE
GODRIVER-2993 SDAM unit test sharded/too_new needs to defined wireVersions for host b

### DIFF
--- a/testdata/server-discovery-and-monitoring/rs/too_old.json
+++ b/testdata/server-discovery-and-monitoring/rs/too_old.json
@@ -30,7 +30,9 @@
             "hosts": [
               "a:27017",
               "b:27017"
-            ]
+            ],
+            "minWireVersion": 999,
+            "maxWireVersion": 1000
           }
         ]
       ],

--- a/testdata/server-discovery-and-monitoring/rs/too_old.yml
+++ b/testdata/server-discovery-and-monitoring/rs/too_old.yml
@@ -18,7 +18,9 @@ phases: [
                     isWritablePrimary: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
                 }]
         ],
         outcome: {

--- a/testdata/server-discovery-and-monitoring/sharded/too_new.json
+++ b/testdata/server-discovery-and-monitoring/sharded/too_new.json
@@ -21,7 +21,9 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
-            "msg": "isdbgrid"
+            "msg": "isdbgrid",
+            "minWireVersion": 7,
+            "maxWireVersion": 900
           }
         ]
       ],

--- a/testdata/server-discovery-and-monitoring/sharded/too_new.yml
+++ b/testdata/server-discovery-and-monitoring/sharded/too_new.yml
@@ -15,7 +15,9 @@ phases: [
                     ok: 1,
                     helloOk: true,
                     isWritablePrimary: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 7,
+                    maxWireVersion: 900
                 }]
         ],
         outcome: {


### PR DESCRIPTION
[GODRIVER-2993](https://jira.mongodb.org/browse/GODRIVER-2993)
