### PR TITLE
GODRIVER-3195 Sync updated QE Range tests

### DIFF
--- a/testdata/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }

--- a/testdata/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.yml
@@ -37,3 +37,25 @@ tests:
           collection: "encryptedCollection"
         result:
           errorContains: "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
+      # Assert no collections were created.
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &esc_collection_name "enxcol_.encryptedCollection.esc"
+      # ecc collection is no longer created for QEv2
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecc_collection_name "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecoc_collection_name "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: encryptedCollection

--- a/testdata/client-side-encryption/legacy/fle2v2-CreateCollection.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-CreateCollection.json
@@ -157,9 +157,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -342,9 +339,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -850,9 +844,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1047,9 +1038,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1366,9 +1354,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1634,9 +1619,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",

--- a/testdata/client-side-encryption/legacy/fle2v2-CreateCollection.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-CreateCollection.yml
@@ -100,10 +100,6 @@ tests:
             command:
               create: *encrypted_collection_name
               encryptedFields: &encrypted_fields_expectation {
-                # Expect state collections are not included in the encryptedFields sent to the server.
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                     {
                         "path": "firstName",

--- a/testdata/client-side-encryption/legacy/fle2v2-MissingKey.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-MissingKey.json
@@ -54,7 +54,7 @@
   "key_vault_data": [],
   "tests": [
     {
-      "description": "FLE2 encrypt fails with mising key",
+      "description": "FLE2 encrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -85,7 +85,7 @@
       ]
     },
     {
-      "description": "FLE2 decrypt fails with mising key",
+      "description": "FLE2 decrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {

--- a/testdata/client-side-encryption/legacy/fle2v2-MissingKey.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-MissingKey.yml
@@ -19,7 +19,7 @@ data: [
 encrypted_fields: {'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
 key_vault_data: []
 tests:
-  - description: "FLE2 encrypt fails with mising key"
+  - description: "FLE2 encrypt fails with missing key"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
@@ -30,7 +30,7 @@ tests:
           document: { _id: 1, encryptedIndexed: "123" }
         result:
           errorContains: "not all keys requested were satisfied"
-  - description: "FLE2 decrypt fails with mising key"
+  - description: "FLE2 decrypt fails with missing key"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:

--- a/testdata/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
+++ b/testdata/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "default",

--- a/testdata/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
+++ b/testdata/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,6 +3,7 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
GODRIVER-3195

## Summary

Sync to updated QE 2 tests to fix failures on serverless tests.


Passing build: https://spruce.mongodb.com/version/66d8b1a11a39fb00071290fd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC