### PR TITLE
GODRIVER-3326 Add `ObjectIDAsHexString` to `BSONOptions`.

### DIFF
--- a/internal/codecutil/encoding.go
+++ b/internal/codecutil/encoding.go
@@ -33,7 +33,7 @@ func (e MarshalError) Error() string {
 }
 
 // EncoderFn is used to functionally construct an encoder for marshaling values.
-type EncoderFn func(io.Writer) (*bson.Encoder, error)
+type EncoderFn func(io.Writer) *bson.Encoder
 
 // MarshalValue will attempt to encode the value with the encoder returned by
 // the encoder function.
@@ -49,14 +49,11 @@ func MarshalValue(val interface{}, encFn EncoderFn) (bsoncore.Value, error) {
 
 	buf := new(bytes.Buffer)
 
-	enc, err := encFn(buf)
-	if err != nil {
-		return bsoncore.Value{}, err
-	}
+	enc := encFn(buf)
 
 	// Encode the value in a single-element document with an empty key. Use
 	// bsoncore to extract the first element and return the BSON value.
-	err = enc.Encode(bson.D{{Key: "", Value: val}})
+	err := enc.Encode(bson.D{{Key: "", Value: val}})
 	if err != nil {
 		return bsoncore.Value{}, MarshalError{Value: val, Err: err}
 	}

--- a/internal/codecutil/encoding_test.go
+++ b/internal/codecutil/encoding_test.go
@@ -17,11 +17,9 @@ import (
 func testEncFn(t *testing.T) EncoderFn {
 	t.Helper()
 
-	return func(w io.Writer) (*bson.Encoder, error) {
+	return func(w io.Writer) *bson.Encoder {
 		rw := bson.NewDocumentWriter(w)
-		enc := bson.NewEncoder(rw)
-
-		return enc, nil
+		return bson.NewEncoder(rw)
 	}
 }
 

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -54,6 +54,12 @@ func (e *negateCodec) DecodeValue(_ bson.DecodeContext, vr bson.ValueReader, val
 	return nil
 }
 
+type intKey int
+
+func (i intKey) MarshalKey() (string, error) {
+	return fmt.Sprintf("key_%d", i), nil
+}
+
 var _ options.ContextDialer = &slowConnDialer{}
 
 // A slowConnDialer dials connections that delay network round trips by the given delay duration.
@@ -724,6 +730,20 @@ func TestClient_BSONOptions(t *testing.T) {
 		C string `json:"y" bson:"3"`
 	}
 
+	type omitemptyTest struct {
+		X jsonTagsTest `bson:"x,omitempty"`
+	}
+
+	type truncatingDoublesTest struct {
+		X int
+	}
+
+	type timeZoneTest struct {
+		X time.Time
+	}
+
+	timestamp, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+07:00")
+
 	testCases := []struct {
 		name       string
 		bsonOpts   *options.BSONOptions
@@ -767,6 +787,88 @@ func TestClient_BSONOptions(t *testing.T) {
 				Build()),
 		},
 		{
+			name: "NilMapAsEmpty",
+			bsonOpts: &options.BSONOptions{
+				NilMapAsEmpty: true,
+			},
+			doc:        bson.D{{Key: "x", Value: map[string]string(nil)}},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{{Key: "x", Value: bson.D{}}},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendDocument("x", bsoncore.NewDocumentBuilder().Build()).
+				Build()),
+		},
+		{
+			name: "NilSliceAsEmpty",
+			bsonOpts: &options.BSONOptions{
+				NilSliceAsEmpty: true,
+			},
+			doc:        bson.D{{Key: "x", Value: []int(nil)}},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{{Key: "x", Value: bson.A{}}},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendArray("x", bsoncore.NewDocumentBuilder().Build()).
+				Build()),
+		},
+		{
+			name: "NilByteSliceAsEmpty",
+			bsonOpts: &options.BSONOptions{
+				NilByteSliceAsEmpty: true,
+			},
+			doc:        bson.D{{Key: "x", Value: []byte(nil)}},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{{Key: "x", Value: bson.Binary{Data: []byte{}}}},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendBinary("x", 0, nil).
+				Build()),
+		},
+		{
+			name: "OmitZeroStruct",
+			bsonOpts: &options.BSONOptions{
+				OmitZeroStruct: true,
+			},
+			doc:        omitemptyTest{},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{},
+			wantRaw:    bson.Raw(bsoncore.NewDocumentBuilder().Build()),
+		},
+		{
+			name: "StringifyMapKeysWithFmt",
+			bsonOpts: &options.BSONOptions{
+				StringifyMapKeysWithFmt: true,
+			},
+			doc:        map[intKey]string{intKey(42): "foo"},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{{"42", "foo"}},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendString("42", "foo").
+				Build()),
+		},
+		{
+			name: "AllowTruncatingDoubles",
+			bsonOpts: &options.BSONOptions{
+				AllowTruncatingDoubles: true,
+			},
+			doc:        bson.D{{Key: "x", Value: 3.14}},
+			decodeInto: func() interface{} { return &truncatingDoublesTest{} },
+			want:       &truncatingDoublesTest{3},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendDouble("x", 3.14).
+				Build()),
+		},
+		{
+			name: "BinaryAsSlice",
+			bsonOpts: &options.BSONOptions{
+				BinaryAsSlice: true,
+			},
+			doc:        bson.D{{Key: "x", Value: []byte{42}}},
+			decodeInto: func() interface{} { return &bson.D{} },
+			want:       &bson.D{{Key: "x", Value: []byte{42}}},
+			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
+				AppendBinary("x", 0, []byte{42}).
+				Build()),
+		},
+		{
 			name: "DefaultDocumentM",
 			bsonOpts: &options.BSONOptions{
 				DefaultDocumentM: true,
@@ -774,6 +876,50 @@ func TestClient_BSONOptions(t *testing.T) {
 			doc:        bson.D{{Key: "doc", Value: bson.D{{Key: "a", Value: int64(1)}}}},
 			decodeInto: func() interface{} { return &bson.D{} },
 			want:       &bson.D{{Key: "doc", Value: bson.M{"a": int64(1)}}},
+		},
+		{
+			name: "UseLocalTimeZone",
+			bsonOpts: &options.BSONOptions{
+				UseLocalTimeZone: true,
+			},
+			doc:        bson.D{{Key: "x", Value: timestamp}},
+			decodeInto: func() interface{} { return &timeZoneTest{} },
+			want:       &timeZoneTest{timestamp.In(time.Local)},
+		},
+		{
+			name: "ZeroMaps",
+			bsonOpts: &options.BSONOptions{
+				ZeroMaps: true,
+			},
+			doc: bson.D{{"a", "apple"}, {"b", "banana"}},
+			decodeInto: func() interface{} {
+				return &map[string]string{
+					"b": "berry",
+					"c": "carrot",
+				}
+			},
+			want: &map[string]string{
+				"a": "apple",
+				"b": "banana",
+			},
+		},
+		{
+			name: "ZeroStructs",
+			bsonOpts: &options.BSONOptions{
+				ZeroStructs: true,
+			},
+			doc: bson.D{{"a", "apple"}, {"x", "broccoli"}},
+			decodeInto: func() interface{} {
+				return &jsonTagsTest{
+					B: "banana",
+					C: "carrot",
+				}
+			},
+			want: &jsonTagsTest{
+				A: "apple",
+				B: "broccoli",
+				C: "",
+			},
 		},
 	}
 
@@ -809,6 +955,35 @@ func TestClient_BSONOptions(t *testing.T) {
 	}
 
 	opts := mtest.NewOptions().ClientOptions(
+		options.Client().SetBSONOptions(&options.BSONOptions{
+			ObjectIDAsHexString: true,
+		}))
+	mt.RunOpts("ObjectIDAsHexString", opts, func(mt *mtest.T) {
+		res, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 42}})
+		require.NoError(mt, err, "InsertOne error")
+
+		sr := mt.Coll.FindOne(
+			context.Background(),
+			bson.D{{Key: "_id", Value: res.InsertedID}},
+		)
+
+		type data struct {
+			ID string `bson:"_id"`
+			X  int    `bson:"x"`
+		}
+		var got data
+
+		err = sr.Decode(&got)
+		require.NoError(mt, err, "Decode error")
+
+		want := data{
+			ID: res.InsertedID.(bson.ObjectID).Hex(),
+			X:  42,
+		}
+		assert.Equal(mt, want, got, "expected and actual decoded result are different")
+	})
+
+	opts = mtest.NewOptions().ClientOptions(
 		options.Client().SetBSONOptions(&options.BSONOptions{
 			ErrorOnInlineDuplicates: true,
 		}))

--- a/mongo/cursor.go
+++ b/mongo/cursor.go
@@ -250,6 +250,9 @@ func getDecoder(
 		if opts.DefaultDocumentM {
 			dec.DefaultDocumentM()
 		}
+		if opts.ObjectIDAsHexString {
+			dec.ObjectIDAsHexString()
+		}
 		if opts.UseJSONStructTags {
 			dec.UseJSONStructTags()
 		}

--- a/mongo/cursor_test.go
+++ b/mongo/cursor_test.go
@@ -266,6 +266,8 @@ func TestNewCursorFromDocuments(t *testing.T) {
 }
 
 func TestGetDecoder(t *testing.T) {
+	t.Parallel()
+
 	decT := reflect.TypeOf((*bson.Decoder)(nil))
 	ctxT := reflect.TypeOf(bson.DecodeContext{})
 	for i := 0; i < decT.NumMethod(); i++ {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -60,7 +60,7 @@ func getEncoder(
 	w io.Writer,
 	opts *options.BSONOptions,
 	reg *bson.Registry,
-) (*bson.Encoder, error) {
+) *bson.Encoder {
 	vw := bson.NewDocumentWriter(w)
 	enc := bson.NewEncoder(vw)
 
@@ -95,13 +95,13 @@ func getEncoder(
 		enc.SetRegistry(reg)
 	}
 
-	return enc, nil
+	return enc
 }
 
 // newEncoderFn will return a function for constructing an encoder based on the
 // provided codec options.
 func newEncoderFn(opts *options.BSONOptions, registry *bson.Registry) codecutil.EncoderFn {
-	return func(w io.Writer) (*bson.Encoder, error) {
+	return func(w io.Writer) *bson.Encoder {
 		return getEncoder(w, opts, registry)
 	}
 }
@@ -128,12 +128,8 @@ func marshal(
 	}
 
 	buf := new(bytes.Buffer)
-	enc, err := getEncoder(buf, bsonOpts, registry)
-	if err != nil {
-		return nil, fmt.Errorf("error configuring BSON encoder: %w", err)
-	}
-
-	err = enc.Encode(val)
+	enc := getEncoder(buf, bsonOpts, registry)
+	err := enc.Encode(val)
 	if err != nil {
 		return nil, MarshalError{Value: val, Err: err}
 	}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -610,6 +610,8 @@ func TestMarshalValue(t *testing.T) {
 }
 
 func TestGetEncoder(t *testing.T) {
+	t.Parallel()
+
 	encT := reflect.TypeOf((*bson.Encoder)(nil))
 	ctxT := reflect.TypeOf(bson.EncodeContext{})
 	for i := 0; i < encT.NumMethod(); i++ {

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -205,6 +205,10 @@ type BSONOptions struct {
 	// "interface{}" or "map[string]interface{}".
 	DefaultDocumentM bool
 
+	// ObjectIDAsHexString causes the Decoder to decode object IDs to their hex
+	// representation.
+	ObjectIDAsHexString bool
+
 	// UseLocalTimeZone causes the driver to unmarshal time.Time values in the
 	// local timezone instead of the UTC timezone.
 	UseLocalTimeZone bool

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -163,7 +163,7 @@ type CursorOptions struct {
 	CommandMonitor        *event.CommandMonitor
 	Crypt                 Crypt
 	ServerAPI             *ServerAPIOptions
-	MarshalValueEncoderFn func(io.Writer) (*bson.Encoder, error)
+	MarshalValueEncoderFn func(io.Writer) *bson.Encoder
 
 	// MaxAwaitTime is only valid for tailable awaitData cursors. If this option
 	// is set, it will be used as the "maxTimeMS" field on getMore commands.


### PR DESCRIPTION
GODRIVER-3326

## Summary
- Add `ObjectIDAsHexString` to `BSONOptions` and enable it to set the `bson.Decoder`.
- Set up `TestGetDecoder` and `TestGetEncoder` to guarantee:
  - Each `bson.Decoder`/`bson.Encoder` config method has a corresponding field in `BSONOptions`.
  - `getDecoder()`/`getEncoder()` calls the corresponding `bson.Decoder`/`bson.Encoder` config methods according to `BSONOptions` fields.
- Remove the never-used error return from `EncoderFn`.

## Background & Motivation

<!--- Rationale for the pull request. -->
