### PR TITLE
GODRIVER-963 canonical parameter is not respected in UnmarshalExtJSON

### DIFF
--- a/bson/extjson_parser.go
+++ b/bson/extjson_parser.go
@@ -61,10 +61,10 @@ type extJSONParser struct {
 	k  string
 	v  *extJSONValue
 
-	err       error
-	canonical bool
-	depth     int
-	maxDepth  int
+	err           error
+	canonicalOnly bool
+	depth         int
+	maxDepth      int
 
 	emptyObject bool
 	relaxedUUID bool
@@ -74,13 +74,13 @@ type extJSONParser struct {
 // parsing from the first character of the argued json input. It will not
 // perform any read-ahead and will therefore not report any errors about
 // malformed JSON at this point.
-func newExtJSONParser(r io.Reader, canonical bool) *extJSONParser {
+func newExtJSONParser(r io.Reader, canonicalOnly bool) *extJSONParser {
 	return &extJSONParser{
-		js:        &jsonScanner{r: r},
-		s:         jpsStartState,
-		m:         []jsonParseMode{},
-		canonical: canonical,
-		maxDepth:  maxNestingDepth,
+		js:            &jsonScanner{r: r},
+		s:             jpsStartState,
+		m:             []jsonParseMode{},
+		canonicalOnly: canonicalOnly,
+		maxDepth:      maxNestingDepth,
 	}
 }
 
@@ -413,12 +413,12 @@ func (ejp *extJSONParser) readValue(t Type) (*extJSONValue, error) {
 				}
 				v = &extJSONValue{t: TypeEmbeddedDocument, v: &extJSONObject{keys: keys, values: vals}}
 			case jpsSawValue:
-				if ejp.canonical {
+				if ejp.canonicalOnly {
 					return nil, invalidJSONError("{")
 				}
 				v = ejp.v
 			default:
-				if ejp.canonical {
+				if ejp.canonicalOnly {
 					return nil, invalidJSONErrorForType("object", t)
 				}
 				return nil, invalidJSONErrorForType("ISO-8601 Internet Date/Time Format as described in RFC-3339", t)

--- a/bson/extjson_reader.go
+++ b/bson/extjson_reader.go
@@ -27,19 +27,19 @@ type extJSONValueReader struct {
 }
 
 // NewExtJSONValueReader creates a new ValueReader from a given io.Reader
-// It will interpret the JSON of r as canonical or relaxed according to the
-// given canonical flag
-func NewExtJSONValueReader(r io.Reader, canonical bool) (ValueReader, error) {
-	return newExtJSONValueReader(r, canonical)
+// It will interpret the JSON of r as canonical only, or allow both
+// canonical and relaxed according to the given canonicalOnly flag
+func NewExtJSONValueReader(r io.Reader, canonicalOnly bool) (ValueReader, error) {
+	return newExtJSONValueReader(r, canonicalOnly)
 }
 
-func newExtJSONValueReader(r io.Reader, canonical bool) (*extJSONValueReader, error) {
+func newExtJSONValueReader(r io.Reader, canonicalOnly bool) (*extJSONValueReader, error) {
 	ejvr := new(extJSONValueReader)
-	return ejvr.reset(r, canonical)
+	return ejvr.reset(r, canonicalOnly)
 }
 
-func (ejvr *extJSONValueReader) reset(r io.Reader, canonical bool) (*extJSONValueReader, error) {
-	p := newExtJSONParser(r, canonical)
+func (ejvr *extJSONValueReader) reset(r io.Reader, canonicalOnly bool) (*extJSONValueReader, error) {
+	p := newExtJSONParser(r, canonicalOnly)
 	typ, err := p.peekType()
 
 	if err != nil {

--- a/bson/extjson_reader.go
+++ b/bson/extjson_reader.go
@@ -26,9 +26,9 @@ type extJSONValueReader struct {
 	frame int
 }
 
-// NewExtJSONValueReader creates a new ValueReader from a given io.Reader
-// It will interpret the JSON of r as canonical only, or allow both
-// canonical and relaxed according to the given canonicalOnly flag
+// NewExtJSONValueReader returns a ValueReader that reads Extended JSON values
+// from r. If canonicalOnly is true, reading values from the ValueReader returns
+// an error if the Extended JSON was not marshaled in canonical mode.
 func NewExtJSONValueReader(r io.Reader, canonicalOnly bool) (ValueReader, error) {
 	return newExtJSONValueReader(r, canonicalOnly)
 }

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -58,8 +58,8 @@ func UnmarshalValue(t Type, data []byte, val interface{}) error {
 // UnmarshalExtJSON parses the extended JSON-encoded data and stores the result
 // in the value pointed to by val. If val is nil or not a pointer, UnmarshalExtJSON
 // returns an error.
-func UnmarshalExtJSON(data []byte, canonical bool, val interface{}) error {
-	ejvr, err := NewExtJSONValueReader(bytes.NewReader(data), canonical)
+func UnmarshalExtJSON(data []byte, canonicalOnly bool, val interface{}) error {
+	ejvr, err := NewExtJSONValueReader(bytes.NewReader(data), canonicalOnly)
 	if err != nil {
 		return err
 	}

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -58,6 +58,12 @@ func UnmarshalValue(t Type, data []byte, val interface{}) error {
 // UnmarshalExtJSON parses the extended JSON-encoded data and stores the result
 // in the value pointed to by val. If val is nil or not a pointer, UnmarshalExtJSON
 // returns an error.
+//
+// If canonicalOnly is true, UnmarshalExtJSON returns an error if the Extended
+// JSON was not marshaled in canonical mode.
+//
+// For more information about Extended JSON, see
+// https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
 func UnmarshalExtJSON(data []byte, canonicalOnly bool, val interface{}) error {
 	ejvr, err := NewExtJSONValueReader(bytes.NewReader(data), canonicalOnly)
 	if err != nil {


### PR DESCRIPTION
[GODRIVER-963](https://jira.mongodb.org/browse/GODRIVER-963)

## Summary

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation

"The canonical parameter in UnmarshalExtJSON not forcing strictly canonical or non-canonical unmarshaling, but instead disabling unmarshaling non-canonical format when canonical=true. If canonical=false in UnmarshalExtJSON, it will unmarshal canonical or "relaxed" extended JSON."

Followed Matt's comment to rename canonical to canonicalOnly and update the documentation to describe the above behavior.