### PR TITLE
GODRIVER-3215 Fix default auth source for auth specified via ClientOptions [master]

### DIFF
--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"math"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -20,13 +19,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/integtest"
 	"go.mongodb.org/mongo-driver/v2/internal/mongoutil"
-	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/v2/tag"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/mongocrypt"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology"
@@ -518,77 +515,4 @@ func TestClient(t *testing.T) {
 		errmsg := `invalid value "-1s" for "Timeout": value must be positive`
 		assert.Equal(t, errmsg, err.Error(), "expected error %v, got %v", errmsg, err.Error())
 	})
-}
-
-// Test that convertOIDCArgs exhaustively copies all fields of a driver.OIDCArgs
-// into an options.OIDCArgs.
-func TestConvertOIDCArgs(t *testing.T) {
-	refreshToken := "test refresh token"
-
-	testCases := []struct {
-		desc string
-		args *driver.OIDCArgs
-	}{
-		{
-			desc: "populated args",
-			args: &driver.OIDCArgs{
-				Version: 9,
-				IDPInfo: &driver.IDPInfo{
-					Issuer:        "test issuer",
-					ClientID:      "test client ID",
-					RequestScopes: []string{"test scope 1", "test scope 2"},
-				},
-				RefreshToken: &refreshToken,
-			},
-		},
-		{
-			desc: "nil",
-			args: nil,
-		},
-		{
-			desc: "nil IDPInfo and RefreshToken",
-			args: &driver.OIDCArgs{
-				Version:      9,
-				IDPInfo:      nil,
-				RefreshToken: nil,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc // Capture range variable.
-
-		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
-
-			got := convertOIDCArgs(tc.args)
-
-			if tc.args == nil {
-				assert.Nil(t, got, "expected nil when input is nil")
-				return
-			}
-
-			require.Equal(t,
-				3,
-				reflect.ValueOf(*tc.args).NumField(),
-				"expected the driver.OIDCArgs struct to have exactly 3 fields")
-			require.Equal(t,
-				3,
-				reflect.ValueOf(*got).NumField(),
-				"expected the options.OIDCArgs struct to have exactly 3 fields")
-
-			assert.Equal(t,
-				tc.args.Version,
-				got.Version,
-				"expected Version field to be equal")
-			assert.EqualValues(t,
-				tc.args.IDPInfo,
-				got.IDPInfo,
-				"expected IDPInfo field to be convertible to equal values")
-			assert.Equal(t,
-				tc.args.RefreshToken,
-				got.RefreshToken,
-				"expected RefreshToken field to be equal")
-		})
-	}
 }

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -90,9 +90,9 @@ type ContextDialer interface {
 // The SERVICE_HOST and CANONICALIZE_HOST_NAME properties must not be used at the same time on Linux and Darwin
 // systems.
 //
-// AuthSource: the name of the database to use for authentication. This defaults to "$external" for MONGODB-X509,
-// GSSAPI, and PLAIN and "admin" for all other mechanisms. This can also be set through the "authSource" URI option
-// (e.g. "authSource=otherDb").
+// AuthSource: the name of the database to use for authentication. This defaults to "$external" for MONGODB-AWS,
+// MONGODB-OIDC, MONGODB-X509, GSSAPI, and PLAIN. It defaults to  "admin" for all other auth mechanisms. This can
+// also be set through the "authSource" URI option (e.g. "authSource=otherDb").
 //
 // Username: the username for authentication. This can also be set through the URI as a username:password pair before
 // the first @ character. For example, a URI for user "user", password "pwd", and host "localhost:27017" would be

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -22,9 +22,6 @@ import (
 
 const sourceExternal = "$external"
 
-// Config contains the configuration for an Authenticator.
-type Config = driver.AuthConfig
-
 // AuthenticatorFactory constructs an authenticator.
 type AuthenticatorFactory func(*Cred, *http.Client) (Authenticator, error)
 

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -20,6 +20,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 )
 
+const sourceExternal = "$external"
+
+// Config contains the configuration for an Authenticator.
+type Config = driver.AuthConfig
+
 // AuthenticatorFactory constructs an authenticator.
 type AuthenticatorFactory func(*Cred, *http.Client) (Authenticator, error)
 

--- a/x/mongo/driver/auth/gssapi.go
+++ b/x/mongo/driver/auth/gssapi.go
@@ -24,7 +24,7 @@ import (
 const GSSAPI = "GSSAPI"
 
 func newGSSAPIAuthenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
-	if cred.Source != "" && cred.Source != "$external" {
+	if cred.Source != "" && cred.Source != sourceExternal {
 		return nil, newAuthError("GSSAPI source must be empty or $external", nil)
 	}
 
@@ -57,7 +57,7 @@ func (a *GSSAPIAuthenticator) Auth(ctx context.Context, cfg *driver.AuthConfig) 
 	if err != nil {
 		return newAuthError("error creating gssapi", err)
 	}
-	return ConductSaslConversation(ctx, cfg, "$external", client)
+	return ConductSaslConversation(ctx, cfg, sourceExternal, client)
 }
 
 // Reauth reauthenticates the connection.

--- a/x/mongo/driver/auth/mongodbaws.go
+++ b/x/mongo/driver/auth/mongodbaws.go
@@ -21,17 +21,15 @@ import (
 const MongoDBAWS = "MONGODB-AWS"
 
 func newMongoDBAWSAuthenticator(cred *Cred, httpClient *http.Client) (Authenticator, error) {
-	if cred.Source != "" && cred.Source != "$external" {
+	if cred.Source != "" && cred.Source != sourceExternal {
 		return nil, newAuthError("MONGODB-AWS source must be empty or $external", nil)
 	}
 	if httpClient == nil {
 		return nil, errors.New("httpClient must not be nil")
 	}
 	return &MongoDBAWSAuthenticator{
-		source: cred.Source,
 		credentials: &credproviders.StaticProvider{
 			Value: credentials.Value{
-				ProviderName:    cred.Source,
 				AccessKeyID:     cred.Username,
 				SecretAccessKey: cred.Password,
 				SessionToken:    cred.Props["AWS_SESSION_TOKEN"],
@@ -43,7 +41,6 @@ func newMongoDBAWSAuthenticator(cred *Cred, httpClient *http.Client) (Authentica
 
 // MongoDBAWSAuthenticator uses AWS-IAM credentials over SASL to authenticate a connection.
 type MongoDBAWSAuthenticator struct {
-	source      string
 	credentials *credproviders.StaticProvider
 	httpClient  *http.Client
 }
@@ -56,7 +53,7 @@ func (a *MongoDBAWSAuthenticator) Auth(ctx context.Context, cfg *driver.AuthConf
 			credentials: providers.Cred,
 		},
 	}
-	err := ConductSaslConversation(ctx, cfg, a.source, adapter)
+	err := ConductSaslConversation(ctx, cfg, sourceExternal, adapter)
 	if err != nil {
 		return newAuthError("sasl conversation error", err)
 	}

--- a/x/mongo/driver/auth/mongodbcr.go
+++ b/x/mongo/driver/auth/mongodbcr.go
@@ -30,8 +30,12 @@ import (
 const MONGODBCR = "MONGODB-CR"
 
 func newMongoDBCRAuthenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
+	source := cred.Source
+	if source == "" {
+		source = "admin"
+	}
 	return &MongoDBCRAuthenticator{
-		DB:       cred.Source,
+		DB:       source,
 		Username: cred.Username,
 		Password: cred.Password,
 	}, nil

--- a/x/mongo/driver/auth/plain.go
+++ b/x/mongo/driver/auth/plain.go
@@ -17,6 +17,21 @@ import (
 const PLAIN = "PLAIN"
 
 func newPlainAuthenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
+	// TODO(GODRIVER-3317): The PLAIN specification says about auth source:
+	//
+	// "MUST be specified. Defaults to the database name if supplied on the
+	// connection string or $external."
+	//
+	// We should actually pass through the auth source, not always pass
+	// $external. If it's empty, we should default to $external.
+	//
+	// For example:
+	//
+	//  source := cred.Source
+	//  if source == "" {
+	//      source = "$external"
+	//  }
+	//
 	return &PlainAuthenticator{
 		Username: cred.Username,
 		Password: cred.Password,
@@ -31,7 +46,7 @@ type PlainAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *PlainAuthenticator) Auth(ctx context.Context, cfg *driver.AuthConfig) error {
-	return ConductSaslConversation(ctx, cfg, "$external", &plainSaslClient{
+	return ConductSaslConversation(ctx, cfg, sourceExternal, &plainSaslClient{
 		username: a.Username,
 		password: a.Password,
 	})

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"encoding/base64"
-
 	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"

--- a/x/mongo/driver/auth/plain_test.go
+++ b/x/mongo/driver/auth/plain_test.go
@@ -8,6 +8,7 @@ package auth_test
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 

--- a/x/mongo/driver/auth/scram.go
+++ b/x/mongo/driver/auth/scram.go
@@ -38,6 +38,10 @@ var (
 )
 
 func newScramSHA1Authenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
+	source := cred.Source
+	if source == "" {
+		source = "admin"
+	}
 	passdigest := mongoPasswordDigest(cred.Username, cred.Password)
 	client, err := scram.SHA1.NewClientUnprepped(cred.Username, passdigest, "")
 	if err != nil {
@@ -46,12 +50,16 @@ func newScramSHA1Authenticator(cred *Cred, _ *http.Client) (Authenticator, error
 	client.WithMinIterations(4096)
 	return &ScramAuthenticator{
 		mechanism: SCRAMSHA1,
-		source:    cred.Source,
+		source:    source,
 		client:    client,
 	}, nil
 }
 
 func newScramSHA256Authenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
+	source := cred.Source
+	if source == "" {
+		source = "admin"
+	}
 	passprep, err := stringprep.SASLprep.Prepare(cred.Password)
 	if err != nil {
 		return nil, newAuthError("error SASLprepping password", err)
@@ -63,7 +71,7 @@ func newScramSHA256Authenticator(cred *Cred, _ *http.Client) (Authenticator, err
 	client.WithMinIterations(4096)
 	return &ScramAuthenticator{
 		mechanism: SCRAMSHA256,
-		source:    cred.Source,
+		source:    source,
 		client:    client,
 	}, nil
 }

--- a/x/mongo/driver/auth/x509.go
+++ b/x/mongo/driver/auth/x509.go
@@ -19,6 +19,9 @@ import (
 const MongoDBX509 = "MONGODB-X509"
 
 func newMongoDBX509Authenticator(cred *Cred, _ *http.Client) (Authenticator, error) {
+	// TODO(GODRIVER-3309): Validate that cred.Source is either empty or
+	// "$external" to make validation uniform with other auth mechanisms that
+	// require Source to be "$external" (e.g. MONGODB-AWS, MONGODB-OIDC, etc).
 	return &MongoDBX509Authenticator{User: cred.Username}, nil
 }
 
@@ -66,7 +69,7 @@ func (a *MongoDBX509Authenticator) Auth(ctx context.Context, cfg *driver.AuthCon
 	requestDoc := createFirstX509Message()
 	authCmd := operation.
 		NewCommand(requestDoc).
-		Database("$external").
+		Database(sourceExternal).
 		Deployment(driver.SingleConnectionDeployment{cfg.Connection}).
 		ClusterClock(cfg.ClusterClock).
 		ServerAPI(cfg.ServerAPI)

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -291,7 +291,7 @@ func (u *ConnString) setDefaultAuthParams(dbName string) error {
 			u.AuthMechanismProperties["SERVICE_NAME"] = "mongodb"
 		}
 		fallthrough
-	case "mongodb-aws", "mongodb-x509":
+	case "mongodb-aws", "mongodb-x509", "mongodb-oidc":
 		if u.AuthSource == "" {
 			u.AuthSource = "$external"
 		} else if u.AuthSource != "$external" {
@@ -306,13 +306,6 @@ func (u *ConnString) setDefaultAuthParams(dbName string) error {
 			u.AuthSource = dbName
 			if u.AuthSource == "" {
 				u.AuthSource = "admin"
-			}
-		}
-	case "mongodb-oidc":
-		if u.AuthSource == "" {
-			u.AuthSource = dbName
-			if u.AuthSource == "" {
-				u.AuthSource = "$external"
 			}
 		}
 	case "":


### PR DESCRIPTION
[GODRIVER-3215](https://jira.mongodb.org/browse/GODRIVER-3215)

## Summary

* Move logic for creating an authenticator from `ClientOptions` to a new function `topology.NewAuthenticator`. Use it everywhere that needs to create an authenticator from `ClientOptions`.
  * Requires moving `convertOIDCArgs` into the `topology` package.
* Move the logic for setting the default auth source into each individual authenticator type.
  * The current logic for setting the default auth source appears to be in `topology.NewConfigWithAuthenticator`, but actually has no effect currently, so no default auth sources are being set.
* Update PLAIN authenticator to support auth sources other than "$external".
  * Using the database name from the connection string as the auth source is currently supported in [connstring](https://github.com/mongodb/mongo-go-driver/blob/8dc4e78d83525e19b22c8bbeec00c17f8af92881/x/mongo/driver/connstring/connstring.go#L283-L289), but is ignored by the PLAIN authenticator. Using database name from the connection string is also described in the [spec](https://github.com/mongodb/specifications/blob/master/source/auth/auth.md#mongocredential-properties-2).
* Correct MONGODB-OIDC connection string logic for setting auth source (it should be identical to MONGODB-AWS and MONGODB-X509).

## Background & Motivation

Currently, if auth mechanism "MONGODB-AWS" is set using `ClientOptions.SetAuth`, the default auth source is set to "admin" instead of "$external". The result is a confusing error message
> MONGODB-AWS source must be empty or $external

There was a further regression (that hasn't been released yet) caused by https://github.com/mongodb/mongo-go-driver/pull/1678, which effectively skips _all_ of the default auth source logic. Refactor the authenticator creation logic and the default auth source logic to make similar regressions more obvious.