### PR TITLE
GODRIVER-3335 Use small evergreen variants for static checks and bot runs

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2337,7 +2337,7 @@ buildvariants:
     tags: ["pullrequest"]
     display_name: "Static Analysis"
     run_on:
-      - rhel8.7-large
+      - rhel8.7-small
     expansions:
       GO_DIST: "/opt/golang/go1.22"
     tasks:
@@ -2366,7 +2366,7 @@ buildvariants:
     tags: ["pullrequest"]
     display_name: "Compile Only Checks"
     run_on:
-      - rhel8.7-large
+      - rhel8.7-small
     expansions:
       GO_DIST: "/opt/golang/go1.22"
     tasks:


### PR DESCRIPTION
GODRIVER-3335

## Summary

Prefer to use the -small variants for all static checks and bot runs, to ensure they run quickly. The large variants tend to be in contention with the server evergreen tasks.
## Background & Motivation
