### PR TITLE
GODRIVER-3331 Fix default authSource for SRV connections [master]

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1715,7 +1715,7 @@ tasks:
   - name: "testgcpkms-task"
     commands:
     - command: shell.exec
-      type: setup
+      type: test
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
@@ -1796,7 +1796,7 @@ tasks:
   - name: "testazurekms-task"
     commands:
     - command: shell.exec
-      type: setup
+      type: test
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
@@ -1862,6 +1862,7 @@ tasks:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
           duration_seconds: 3600
       - command: shell.exec
+        type: test
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           shell: bash
@@ -1884,6 +1885,7 @@ tasks:
   - name: "oidc-auth-test-azure"
     commands:
     - command: shell.exec
+      type: test
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         shell: bash
@@ -1909,6 +1911,7 @@ tasks:
   - name: "oidc-auth-test-gcp"
     commands:
     - command: shell.exec
+      type: test
       params:
         working_dir: src/go.mongodb.org/mongo-driver
         shell: bash
@@ -2604,7 +2607,7 @@ buildvariants:
   - name: testoidc-variant
     display_name: "OIDC"
     run_on:
-      - ubuntu2204-large
+      - ubuntu2204-small
     expansions:
       GO_DIST: "/opt/golang/go1.22"
     tasks:

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -1306,7 +1306,7 @@ func TestSetURIopts(t *testing.T) {
 					"TOKEN_RESOURCE": "mongodb://test-cluster"}},
 				HTTPClient: httputil.DefaultHTTPClient,
 			},
-			wantErrs: nil
+			wantErrs: nil,
 		},
 		{
 			name: "comma in key:value pair causes error",

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -1285,7 +1285,7 @@ func TestSetURIopts(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
-			name: "tmp",
+			name: "oidc azure",
 			uri:  "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster,ENVIRONMENT:azureManagedIdentities",
 			wantopts: &ClientOptions{
 				Hosts: []string{"example.com"},
@@ -1295,6 +1295,18 @@ func TestSetURIopts(t *testing.T) {
 				HTTPClient: httputil.DefaultHTTPClient,
 			},
 			wantErrs: nil,
+		},
+		{
+			name: "oidc gcp",
+			uri:  "mongodb://test.mongodb.net/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:mongodb://test-cluster",
+			wantopts: &ClientOptions{
+				Hosts: []string{"test.mongodb.net"},
+				Auth: &Credential{AuthMechanism: "MONGODB-OIDC", AuthSource: "$external", AuthMechanismProperties: map[string]string{
+					"ENVIRONMENT":    "gcp",
+					"TOKEN_RESOURCE": "mongodb://test-cluster"}},
+				HTTPClient: httputil.DefaultHTTPClient,
+			},
+			wantErrs: nil
 		},
 		{
 			name: "comma in key:value pair causes error",

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -292,6 +292,10 @@ func (u *ConnString) setDefaultAuthParams(dbName string) error {
 		}
 		fallthrough
 	case "mongodb-aws", "mongodb-x509", "mongodb-oidc":
+		// dns.LookupTXT will get "authSource=admin" from Atlas hosts.
+		if u.AuthSource == "admin" {
+			u.AuthSource = "$external"
+		}
 		if u.AuthSource == "" {
 			u.AuthSource = "$external"
 		} else if u.AuthSource != "$external" {

--- a/x/mongo/driver/connstring/connstring_test.go
+++ b/x/mongo/driver/connstring/connstring_test.go
@@ -90,6 +90,28 @@ func TestAuthSource(t *testing.T) {
 			}
 		})
 	}
+
+	tests = []struct {
+		s        string
+		expected string
+		err      bool
+	}{
+		{s: "authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:mongodb://test-cluster", expected: "$external"},
+	}
+
+	for _, test := range tests {
+		s := fmt.Sprintf("mongodb://test.mongodb.net/?authMechanism=MONGODB-OIDC&/%s", test.s)
+		t.Run(s, func(t *testing.T) {
+			cs, err := connstring.ParseAndValidate(s)
+			if test.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, cs.AuthSource)
+			}
+		})
+	}
+
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
[GODRIVER-3331](https://jira.mongodb.org/browse/GODRIVER-3331)

## Summary

Override the default auth source from `admin` to `$external` where appropriate.

## Background & Motivation

SRV connections from Atlas contain a record of `authSource=admin`, which we need to override for the auth mechanisms that require `$external` as the auth source.