### PR TITLE
Remove GCP from supplied callback example

### DIFF
--- a/mongo/client_examples_test.go
+++ b/mongo/client_examples_test.go
@@ -583,16 +583,11 @@ func ExampleConnect_oIDC() {
 			}, nil
 		}
 		uri := os.Getenv("MONGODB_URI")
-		props := map[string]string{
-			"ENVIRONMENT":    "gcp",
-			"TOKEN_RESOURCE": "<audience>",
-		}
 		opts := options.Client().ApplyURI(uri)
 		opts.SetAuth(
 			options.Credential{
-				AuthMechanism:           "MONGODB-OIDC",
-				AuthMechanismProperties: props,
-				OIDCMachineCallback:     eksCallback,
+				AuthMechanism:       "MONGODB-OIDC",
+				OIDCMachineCallback: eksCallback,
 			},
 		)
 		c, err := mongo.Connect(context.TODO(), opts)


### PR DESCRIPTION


## Summary

Fix the example for OIDC custom callback to not use the gcp env

