### PR TITLE
GODRIVER-3339 Separate `Many` and `One` for `UpdateOptions` and `DeleteOptions`.

### DIFF
--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -627,6 +627,10 @@ for _, set := range options.Client().ApplyURI(uri).Opts {
 return clientOptionAdder{option: &opts}
 ```
 
+### DeleteManyOptions / DeleteOneOptions
+
+The `DeleteOptions` has been separated into `DeleteManyOptions` and `DeleteOneOptions` to configure the corresponding `DeleteMany` and `DeleteOne` operations.
+
 ### FindOneOptions
 
 The following types are not valid for a `findOne` operation and have been removed:
@@ -635,6 +639,10 @@ The following types are not valid for a `findOne` operation and have been remove
 - `CursorType`
 - `MaxAwaitTime`
 - `NoCursorTimeout`
+
+### UpdateManyOptions / UpdateOneOptions
+
+The `UpdateOptions` has been separated into `UpdateManyOptions` and `UpdateOneOptions` to configure the corresponding `UpdateMany` and `UpdateOne` operations.
 
 ### Merge\*Options
 

--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -296,7 +296,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.RunOpts("not found with options", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			opts := options.Delete().SetCollation(&options.Collation{Locale: "en_US"})
+			opts := options.DeleteOne().SetCollation(&options.Collation{Locale: "en_US"})
 			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
@@ -339,13 +339,13 @@ func TestCollection(t *testing.T) {
 			})
 			assert.Nil(mt, err, "CreateOne error: %v", err)
 
-			opts := options.Delete().SetHint(bson.M{"x": 1})
+			opts := options.DeleteOne().SetHint(bson.M{"x": 1})
 			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 1}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("multikey map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
-			opts := options.Delete().SetHint(bson.M{"x": 1, "y": 1})
+			opts := options.DeleteOne().SetHint(bson.M{"x": 1, "y": 1})
 			_, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
@@ -365,7 +365,7 @@ func TestCollection(t *testing.T) {
 		})
 		mt.RunOpts("not found with options", mtest.NewOptions().MinServerVersion("3.4"), func(mt *mtest.T) {
 			initCollection(mt, mt.Coll)
-			opts := options.Delete().SetCollation(&options.Collation{Locale: "en_US"})
+			opts := options.DeleteMany().SetCollation(&options.Collation{Locale: "en_US"})
 			res, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", bson.D{{"$lt", 1}}}}, opts)
 			assert.Nil(mt, err, "DeleteMany error: %v", err)
 			assert.Equal(mt, int64(0), res.DeletedCount, "expected DeletedCount 0, got %v", res.DeletedCount)
@@ -408,13 +408,13 @@ func TestCollection(t *testing.T) {
 			})
 			assert.Nil(mt, err, "index CreateOne error: %v", err)
 
-			opts := options.Delete().SetHint(bson.M{"x": 1})
+			opts := options.DeleteOne().SetHint(bson.M{"x": 1})
 			res, err := mt.Coll.DeleteOne(context.Background(), bson.D{{"x", 1}}, opts)
 			assert.Nil(mt, err, "DeleteOne error: %v", err)
 			assert.Equal(mt, int64(1), res.DeletedCount, "expected DeletedCount 1, got %v", res.DeletedCount)
 		})
 		mt.RunOpts("multikey map index", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
-			opts := options.Delete().SetHint(bson.M{"x": 1, "y": 1})
+			opts := options.DeleteMany().SetHint(bson.M{"x": 1, "y": 1})
 			_, err := mt.Coll.DeleteMany(context.Background(), bson.D{{"x", 0}}, opts)
 			assert.Equal(mt, mongo.ErrMapForOrderedArgument{"hint"}, err, "expected error %v, got %v", mongo.ErrMapForOrderedArgument{"hint"}, err)
 		})
@@ -451,7 +451,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", 0}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateOne(context.Background(), filter, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateOne(context.Background(), filter, update, options.UpdateOne().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateOne error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected matched count 0, got %v", res.ModifiedCount)
@@ -570,7 +570,7 @@ func TestCollection(t *testing.T) {
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
 			id := "blah"
-			res, err := mt.Coll.UpdateByID(context.Background(), id, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateByID(context.Background(), id, update, options.UpdateOne().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateByID error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)
@@ -633,7 +633,7 @@ func TestCollection(t *testing.T) {
 			filter := bson.D{{"x", bson.D{{"$lt", 1}}}}
 			update := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
-			res, err := mt.Coll.UpdateMany(context.Background(), filter, update, options.Update().SetUpsert(true))
+			res, err := mt.Coll.UpdateMany(context.Background(), filter, update, options.UpdateMany().SetUpsert(true))
 			assert.Nil(mt, err, "UpdateMany error: %v", err)
 			assert.Equal(mt, int64(0), res.MatchedCount, "expected matched count 0, got %v", res.MatchedCount)
 			assert.Equal(mt, int64(0), res.ModifiedCount, "expected modified count 0, got %v", res.ModifiedCount)

--- a/internal/integration/crud_helpers_test.go
+++ b/internal/integration/crud_helpers_test.go
@@ -801,7 +801,7 @@ func executeDeleteOne(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.D
 	mt.Helper()
 
 	filter := emptyDoc
-	opts := options.Delete()
+	opts := options.DeleteOne()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -837,7 +837,7 @@ func executeDeleteMany(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.
 	mt.Helper()
 
 	filter := emptyDoc
-	opts := options.Delete()
+	opts := options.DeleteMany()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -874,7 +874,7 @@ func executeUpdateOne(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.U
 
 	filter := emptyDoc
 	var update interface{} = emptyDoc
-	opts := options.Update()
+	opts := options.UpdateOne()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -902,7 +902,7 @@ func executeUpdateOne(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.U
 		}
 	}
 
-	updateArgs, err := mongoutil.NewOptions[options.UpdateOptions](opts)
+	updateArgs, err := mongoutil.NewOptions[options.UpdateOneOptions](opts)
 	require.NoError(mt, err, "failed to construct options from builder")
 
 	if updateArgs.Upsert == nil {
@@ -926,7 +926,7 @@ func executeUpdateMany(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.
 
 	filter := emptyDoc
 	var update interface{} = emptyDoc
-	opts := options.Update()
+	opts := options.UpdateMany()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -954,7 +954,7 @@ func executeUpdateMany(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.
 		}
 	}
 
-	updateArgs, err := mongoutil.NewOptions[options.UpdateOptions](opts)
+	updateArgs, err := mongoutil.NewOptions[options.UpdateManyOptions](opts)
 	require.NoError(mt, err, "failed to construct options from builder")
 
 	if updateArgs.Upsert == nil {

--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -296,7 +296,7 @@ func TestHintErrors(t *testing.T) {
 	mt.Run("UpdateMany", func(mt *mtest.T) {
 
 		_, got := mt.Coll.UpdateMany(context.Background(), bson.D{{"a", 1}}, bson.D{{"$inc", bson.D{{"a", 1}}}},
-			options.Update().SetHint("_id_"))
+			options.UpdateMany().SetHint("_id_"))
 		assert.NotNil(mt, got, "expected non-nil error, got nil")
 		assert.Equal(mt, got, expected, "expected: %v got: %v", expected, got)
 	})

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -1316,7 +1316,7 @@ func executeUpdateOne(ctx context.Context, operation *operation) (*operationResu
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateArguments[options.UpdateOneOptions](operation.Arguments)
+	updateArgs, err := createUpdateOneArguments(operation.Arguments)
 	if err != nil {
 		return nil, err
 	}
@@ -1335,7 +1335,7 @@ func executeUpdateMany(ctx context.Context, operation *operation) (*operationRes
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateArguments[options.UpdateManyOptions](operation.Arguments)
+	updateArgs, err := createUpdateManyArguments(operation.Arguments)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -1316,12 +1316,12 @@ func executeUpdateOne(ctx context.Context, operation *operation) (*operationResu
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateOneArguments(operation.Arguments)
+	updateArgs, updateOpts, err := createUpdateOneArguments(operation.Arguments)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := coll.UpdateOne(ctx, updateArgs.filter, updateArgs.update, updateArgs.opts)
+	res, err := coll.UpdateOne(ctx, updateArgs.filter, updateArgs.update, updateOpts)
 	raw, buildErr := buildUpdateResultDocument(res)
 	if buildErr != nil {
 		return nil, buildErr
@@ -1335,12 +1335,12 @@ func executeUpdateMany(ctx context.Context, operation *operation) (*operationRes
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateManyArguments(operation.Arguments)
+	updateArgs, updateOpts, err := createUpdateManyArguments(operation.Arguments)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := coll.UpdateMany(ctx, updateArgs.filter, updateArgs.update, updateArgs.opts)
+	res, err := coll.UpdateMany(ctx, updateArgs.filter, updateArgs.update, updateOpts)
 	raw, buildErr := buildUpdateResultDocument(res)
 	if buildErr != nil {
 		return nil, buildErr

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -403,7 +403,7 @@ func executeDeleteOne(ctx context.Context, operation *operation) (*operationResu
 	}
 
 	var filter bson.Raw
-	opts := options.Delete()
+	opts := options.DeleteOne()
 
 	elems, err := operation.Arguments.Elements()
 	if err != nil {
@@ -457,7 +457,7 @@ func executeDeleteMany(ctx context.Context, operation *operation) (*operationRes
 	}
 
 	var filter bson.Raw
-	opts := options.Delete()
+	opts := options.DeleteMany()
 
 	elems, err := operation.Arguments.Elements()
 	if err != nil {
@@ -1316,7 +1316,7 @@ func executeUpdateOne(ctx context.Context, operation *operation) (*operationResu
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateArguments(operation.Arguments)
+	updateArgs, err := createUpdateArguments[options.UpdateOneOptions](operation.Arguments)
 	if err != nil {
 		return nil, err
 	}
@@ -1335,7 +1335,7 @@ func executeUpdateMany(ctx context.Context, operation *operation) (*operationRes
 		return nil, err
 	}
 
-	updateArgs, err := createUpdateArguments(operation.Arguments)
+	updateArgs, err := createUpdateArguments[options.UpdateManyOptions](operation.Arguments)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -20,16 +20,14 @@ func newMissingArgumentError(arg string) error {
 	return fmt.Errorf("operation arguments document is missing required field %q", arg)
 }
 
-type updateManyArguments struct {
+type updateArguments struct {
 	filter bson.Raw
 	update interface{}
-	opts   *options.UpdateManyOptionsBuilder
 }
 
-func createUpdateManyArguments(args bson.Raw) (*updateManyArguments, error) {
-	ua := &updateManyArguments{
-		opts: options.UpdateMany(),
-	}
+func createUpdateManyArguments(args bson.Raw) (*updateArguments, *options.UpdateManyOptionsBuilder, error) {
+	ua := &updateArguments{}
+	opts := options.UpdateMany()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -38,61 +36,54 @@ func createUpdateManyArguments(args bson.Raw) (*updateManyArguments, error) {
 
 		switch key {
 		case "arrayFilters":
-			ua.opts.SetArrayFilters(
+			opts.SetArrayFilters(
 				bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			)
 		case "bypassDocumentValidation":
-			ua.opts.SetBypassDocumentValidation(val.Boolean())
+			opts.SetBypassDocumentValidation(val.Boolean())
 		case "collation":
 			collation, err := createCollation(val.Document())
 			if err != nil {
-				return nil, fmt.Errorf("error creating collation: %w", err)
+				return nil, nil, fmt.Errorf("error creating collation: %w", err)
 			}
-			ua.opts.SetCollation(collation)
+			opts.SetCollation(collation)
 		case "comment":
-			ua.opts.SetComment(val)
+			opts.SetComment(val)
 		case "filter":
 			ua.filter = val.Document()
 		case "hint":
 			hint, err := createHint(val)
 			if err != nil {
-				return nil, fmt.Errorf("error creating hint: %w", err)
+				return nil, nil, fmt.Errorf("error creating hint: %w", err)
 			}
-			ua.opts.SetHint(hint)
+			opts.SetHint(hint)
 		case "let":
-			ua.opts.SetLet(val.Document())
+			opts.SetLet(val.Document())
 		case "update":
 			var err error
 			ua.update, err = createUpdateValue(val)
 			if err != nil {
-				return nil, fmt.Errorf("error processing update value: %w", err)
+				return nil, nil, fmt.Errorf("error processing update value: %w", err)
 			}
 		case "upsert":
-			ua.opts.SetUpsert(val.Boolean())
+			opts.SetUpsert(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized update option %q", key)
+			return nil, nil, fmt.Errorf("unrecognized update option %q", key)
 		}
 	}
 	if ua.filter == nil {
-		return nil, newMissingArgumentError("filter")
+		return nil, nil, newMissingArgumentError("filter")
 	}
 	if ua.update == nil {
-		return nil, newMissingArgumentError("update")
+		return nil, nil, newMissingArgumentError("update")
 	}
 
-	return ua, nil
+	return ua, opts, nil
 }
 
-type updateOneArguments struct {
-	filter bson.Raw
-	update interface{}
-	opts   *options.UpdateOneOptionsBuilder
-}
-
-func createUpdateOneArguments(args bson.Raw) (*updateOneArguments, error) {
-	ua := &updateOneArguments{
-		opts: options.UpdateOne(),
-	}
+func createUpdateOneArguments(args bson.Raw) (*updateArguments, *options.UpdateOneOptionsBuilder, error) {
+	ua := &updateArguments{}
+	opts := options.UpdateOne()
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
@@ -101,49 +92,49 @@ func createUpdateOneArguments(args bson.Raw) (*updateOneArguments, error) {
 
 		switch key {
 		case "arrayFilters":
-			ua.opts.SetArrayFilters(
+			opts.SetArrayFilters(
 				bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			)
 		case "bypassDocumentValidation":
-			ua.opts.SetBypassDocumentValidation(val.Boolean())
+			opts.SetBypassDocumentValidation(val.Boolean())
 		case "collation":
 			collation, err := createCollation(val.Document())
 			if err != nil {
-				return nil, fmt.Errorf("error creating collation: %w", err)
+				return nil, nil, fmt.Errorf("error creating collation: %w", err)
 			}
-			ua.opts.SetCollation(collation)
+			opts.SetCollation(collation)
 		case "comment":
-			ua.opts.SetComment(val)
+			opts.SetComment(val)
 		case "filter":
 			ua.filter = val.Document()
 		case "hint":
 			hint, err := createHint(val)
 			if err != nil {
-				return nil, fmt.Errorf("error creating hint: %w", err)
+				return nil, nil, fmt.Errorf("error creating hint: %w", err)
 			}
-			ua.opts.SetHint(hint)
+			opts.SetHint(hint)
 		case "let":
-			ua.opts.SetLet(val.Document())
+			opts.SetLet(val.Document())
 		case "update":
 			var err error
 			ua.update, err = createUpdateValue(val)
 			if err != nil {
-				return nil, fmt.Errorf("error processing update value: %w", err)
+				return nil, nil, fmt.Errorf("error processing update value: %w", err)
 			}
 		case "upsert":
-			ua.opts.SetUpsert(val.Boolean())
+			opts.SetUpsert(val.Boolean())
 		default:
-			return nil, fmt.Errorf("unrecognized update option %q", key)
+			return nil, nil, fmt.Errorf("unrecognized update option %q", key)
 		}
 	}
 	if ua.filter == nil {
-		return nil, newMissingArgumentError("filter")
+		return nil, nil, newMissingArgumentError("filter")
 	}
 	if ua.update == nil {
-		return nil, newMissingArgumentError("update")
+		return nil, nil, newMissingArgumentError("update")
 	}
 
-	return ua, nil
+	return ua, opts, nil
 }
 
 type listCollectionsArguments struct {

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -8,6 +8,8 @@ package unified
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/internal/bsonutil"
@@ -20,38 +22,45 @@ func newMissingArgumentError(arg string) error {
 	return fmt.Errorf("operation arguments document is missing required field %q", arg)
 }
 
-type updateArguments struct {
+type updateArguments[Options options.UpdateManyOptions | options.UpdateOneOptions] struct {
 	filter bson.Raw
 	update interface{}
-	opts   *options.UpdateOptionsBuilder
+	opts   options.Lister[Options]
 }
 
-func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
-	ua := &updateArguments{
-		opts: options.Update(),
+func createUpdateArguments[Options options.UpdateManyOptions | options.UpdateOneOptions](
+	args bson.Raw,
+) (*updateArguments[Options], error) {
+	ua := &updateArguments[Options]{}
+	var builder reflect.Value
+	switch any((*Options)(nil)).(type) {
+	case *options.UpdateManyOptions:
+		builder = reflect.ValueOf(options.UpdateMany())
+	case *options.UpdateOneOptions:
+		builder = reflect.ValueOf(options.UpdateOne())
 	}
-	var err error
 
 	elems, _ := args.Elements()
 	for _, elem := range elems {
 		key := elem.Key()
 		val := elem.Value()
 
+		var arg reflect.Value
 		switch key {
 		case "arrayFilters":
-			ua.opts.SetArrayFilters(
+			arg = reflect.ValueOf(
 				bsonutil.RawToInterfaces(bsonutil.RawArrayToDocuments(val.Array())...),
 			)
 		case "bypassDocumentValidation":
-			ua.opts.SetBypassDocumentValidation(val.Boolean())
+			arg = reflect.ValueOf(val.Boolean())
 		case "collation":
 			collation, err := createCollation(val.Document())
 			if err != nil {
 				return nil, fmt.Errorf("error creating collation: %w", err)
 			}
-			ua.opts.SetCollation(collation)
+			arg = reflect.ValueOf(collation)
 		case "comment":
-			ua.opts.SetComment(val)
+			arg = reflect.ValueOf(val)
 		case "filter":
 			ua.filter = val.Document()
 		case "hint":
@@ -59,18 +68,28 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error creating hint: %w", err)
 			}
-			ua.opts.SetHint(hint)
+			arg = reflect.ValueOf(hint)
 		case "let":
-			ua.opts.SetLet(val.Document())
+			arg = reflect.ValueOf(val.Document())
 		case "update":
+			var err error
 			ua.update, err = createUpdateValue(val)
 			if err != nil {
 				return nil, fmt.Errorf("error processing update value: %w", err)
 			}
 		case "upsert":
-			ua.opts.SetUpsert(val.Boolean())
+			arg = reflect.ValueOf(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized update option %q", key)
+		}
+		if arg.IsValid() {
+			fn := builder.MethodByName(
+				fmt.Sprintf("Set%s%s", strings.ToUpper(string(key[0])), key[1:]),
+			)
+			if !fn.IsValid() {
+				return nil, fmt.Errorf("unrecognized update option %q", key)
+			}
+			fn.Call([]reflect.Value{arg})
 		}
 	}
 	if ua.filter == nil {
@@ -79,6 +98,7 @@ func createUpdateArguments(args bson.Raw) (*updateArguments, error) {
 	if ua.update == nil {
 		return nil, newMissingArgumentError("update")
 	}
+	ua.opts = builder.Interface().(options.Lister[Options])
 
 	return ua, nil
 }

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -336,44 +336,37 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 
 		switch converted := model.(type) {
 		case *ReplaceOneModel:
-			doc, err = createUpdateDoc(
-				converted.Filter,
-				converted.Replacement,
-				converted.Hint,
-				nil,
-				converted.Collation,
-				converted.Upsert,
-				false,
-				false,
-				bw.collection.bsonOpts,
-				bw.collection.registry)
+			doc, err = updateDoc{
+				filter:    converted.Filter,
+				update:    converted.Replacement,
+				hint:      converted.Hint,
+				collation: converted.Collation,
+				upsert:    converted.Upsert,
+			}.marshal(bw.collection.bsonOpts, bw.collection.registry)
 			hasHint = hasHint || (converted.Hint != nil)
 		case *UpdateOneModel:
-			doc, err = createUpdateDoc(
-				converted.Filter,
-				converted.Update,
-				converted.Hint,
-				converted.ArrayFilters,
-				converted.Collation,
-				converted.Upsert,
-				false,
-				true,
-				bw.collection.bsonOpts,
-				bw.collection.registry)
+			doc, err = updateDoc{
+				filter:         converted.Filter,
+				update:         converted.Update,
+				hint:           converted.Hint,
+				arrayFilters:   converted.ArrayFilters,
+				collation:      converted.Collation,
+				upsert:         converted.Upsert,
+				checkDollarKey: true,
+			}.marshal(bw.collection.bsonOpts, bw.collection.registry)
 			hasHint = hasHint || (converted.Hint != nil)
 			hasArrayFilters = hasArrayFilters || (converted.ArrayFilters != nil)
 		case *UpdateManyModel:
-			doc, err = createUpdateDoc(
-				converted.Filter,
-				converted.Update,
-				converted.Hint,
-				converted.ArrayFilters,
-				converted.Collation,
-				converted.Upsert,
-				true,
-				true,
-				bw.collection.bsonOpts,
-				bw.collection.registry)
+			doc, err = updateDoc{
+				filter:         converted.Filter,
+				update:         converted.Update,
+				hint:           converted.Hint,
+				arrayFilters:   converted.ArrayFilters,
+				collation:      converted.Collation,
+				upsert:         converted.Upsert,
+				multi:          true,
+				checkDollarKey: true,
+			}.marshal(bw.collection.bsonOpts, bw.collection.registry)
 			hasHint = hasHint || (converted.Hint != nil)
 			hasArrayFilters = hasArrayFilters || (converted.ArrayFilters != nil)
 		}
@@ -423,19 +416,20 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 	return op.Result(), err
 }
 
-func createUpdateDoc(
-	filter interface{},
-	update interface{},
-	hint interface{},
-	arrayFilters []interface{},
-	collation *options.Collation,
-	upsert *bool,
-	multi bool,
-	checkDollarKey bool,
-	bsonOpts *options.BSONOptions,
-	registry *bson.Registry,
-) (bsoncore.Document, error) {
-	f, err := marshal(filter, bsonOpts, registry)
+type updateDoc struct {
+	filter         interface{}
+	update         interface{}
+	hint           interface{}
+	sort           interface{}
+	arrayFilters   []interface{}
+	collation      *options.Collation
+	upsert         *bool
+	multi          bool
+	checkDollarKey bool
+}
+
+func (doc updateDoc) marshal(bsonOpts *options.BSONOptions, registry *bson.Registry) (bsoncore.Document, error) {
+	f, err := marshal(doc.filter, bsonOpts, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -443,39 +437,49 @@ func createUpdateDoc(
 	uidx, updateDoc := bsoncore.AppendDocumentStart(nil)
 	updateDoc = bsoncore.AppendDocumentElement(updateDoc, "q", f)
 
-	u, err := marshalUpdateValue(update, bsonOpts, registry, checkDollarKey)
+	u, err := marshalUpdateValue(doc.update, bsonOpts, registry, doc.checkDollarKey)
 	if err != nil {
 		return nil, err
 	}
 
 	updateDoc = bsoncore.AppendValueElement(updateDoc, "u", u)
 
-	if multi {
-		updateDoc = bsoncore.AppendBooleanElement(updateDoc, "multi", multi)
+	if doc.multi {
+		updateDoc = bsoncore.AppendBooleanElement(updateDoc, "multi", doc.multi)
+	}
+	if doc.sort != nil {
+		if isUnorderedMap(doc.sort) {
+			return nil, ErrMapForOrderedArgument{"sort"}
+		}
+		s, err := marshal(doc.sort, bsonOpts, registry)
+		if err != nil {
+			return nil, err
+		}
+		updateDoc = bsoncore.AppendDocumentElement(updateDoc, "sort", s)
 	}
 
-	if arrayFilters != nil {
+	if doc.arrayFilters != nil {
 		reg := registry
-		arr, err := marshalValue(arrayFilters, bsonOpts, reg)
+		arr, err := marshalValue(doc.arrayFilters, bsonOpts, reg)
 		if err != nil {
 			return nil, err
 		}
 		updateDoc = bsoncore.AppendArrayElement(updateDoc, "arrayFilters", arr.Data)
 	}
 
-	if collation != nil {
-		updateDoc = bsoncore.AppendDocumentElement(updateDoc, "collation", bsoncore.Document(toDocument(collation)))
+	if doc.collation != nil {
+		updateDoc = bsoncore.AppendDocumentElement(updateDoc, "collation", bsoncore.Document(toDocument(doc.collation)))
 	}
 
-	if upsert != nil {
-		updateDoc = bsoncore.AppendBooleanElement(updateDoc, "upsert", *upsert)
+	if doc.upsert != nil {
+		updateDoc = bsoncore.AppendBooleanElement(updateDoc, "upsert", *doc.upsert)
 	}
 
-	if hint != nil {
-		if isUnorderedMap(hint) {
+	if doc.hint != nil {
+		if isUnorderedMap(doc.hint) {
 			return nil, ErrMapForOrderedArgument{"hint"}
 		}
-		hintVal, err := marshalValue(hint, bsonOpts, registry)
+		hintVal, err := marshalValue(doc.hint, bsonOpts, registry)
 		if err != nil {
 			return nil, err
 		}

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -420,7 +420,6 @@ type updateDoc struct {
 	filter         interface{}
 	update         interface{}
 	hint           interface{}
-	sort           interface{}
 	arrayFilters   []interface{}
 	collation      *options.Collation
 	upsert         *bool
@@ -446,16 +445,6 @@ func (doc updateDoc) marshal(bsonOpts *options.BSONOptions, registry *bson.Regis
 
 	if doc.multi {
 		updateDoc = bsoncore.AppendBooleanElement(updateDoc, "multi", doc.multi)
-	}
-	if doc.sort != nil {
-		if isUnorderedMap(doc.sort) {
-			return nil, ErrMapForOrderedArgument{"sort"}
-		}
-		s, err := marshal(doc.sort, bsonOpts, registry)
-		if err != nil {
-			return nil, err
-		}
-		updateDoc = bsoncore.AppendDocumentElement(updateDoc, "sort", s)
 	}
 
 	if doc.arrayFilters != nil {

--- a/mongo/crud_examples_test.go
+++ b/mongo/crud_examples_test.go
@@ -283,7 +283,7 @@ func ExampleCollection_DeleteMany() {
 	// Delete all documents in which the "name" field is "Bob" or "bob".
 	// Specify the Collation option to provide a collation that will ignore case
 	// for string comparisons.
-	opts := options.Delete().SetCollation(&options.Collation{
+	opts := options.DeleteMany().SetCollation(&options.Collation{
 		Locale:    "en_US",
 		Strength:  1,
 		CaseLevel: false,
@@ -301,7 +301,7 @@ func ExampleCollection_DeleteOne() {
 	// Delete at most one document in which the "name" field is "Bob" or "bob".
 	// Specify the SetCollation option to provide a collation that will ignore
 	// case for string comparisons.
-	opts := options.Delete().SetCollation(&options.Collation{
+	opts := options.DeleteOne().SetCollation(&options.Collation{
 		Locale:    "en_US",
 		Strength:  1,
 		CaseLevel: false,
@@ -568,7 +568,7 @@ func ExampleCollection_UpdateOne() {
 	// "newemail@example.com".
 	// Specify the Upsert option to insert a new document if a document matching
 	// the filter isn't found.
-	opts := options.Update().SetUpsert(true)
+	opts := options.UpdateOne().SetUpsert(true)
 	filter := bson.D{{"_id", id}}
 	update := bson.D{{"$set", bson.D{{"email", "newemail@example.com"}}}}
 

--- a/mongo/options/deleteoptions.go
+++ b/mongo/options/deleteoptions.go
@@ -6,9 +6,9 @@
 
 package options
 
-// DeleteOptions represents arguments that can be used to configure DeleteOne
-// and DeleteMany operations.
-type DeleteOptions struct {
+// DeleteOneOptions represents arguments that can be used to configure DeleteOne
+// operations.
+type DeleteOneOptions struct {
 	// Specifies a collation to use for string comparisons during the operation. This option is only valid for MongoDB
 	// versions >= 3.4. For previous server versions, the driver will return an error if this option is used. The
 	// default value is nil, which means the default collation of the collection will be used.
@@ -33,26 +33,26 @@ type DeleteOptions struct {
 	Let interface{}
 }
 
-// DeleteOptionsBuilder contains options to configure delete operations. Each
+// DeleteOneOptionsBuilder contains options to configure DeleteOne operations. Each
 // option can be set through setter functions. See documentation for each setter
 // function for an explanation of the option.
-type DeleteOptionsBuilder struct {
-	Opts []func(*DeleteOptions) error
+type DeleteOneOptionsBuilder struct {
+	Opts []func(*DeleteOneOptions) error
 }
 
-// Delete creates a new DeleteOptions instance.
-func Delete() *DeleteOptionsBuilder {
-	return &DeleteOptionsBuilder{}
+// DeleteOne creates a new DeleteOneOptions instance.
+func DeleteOne() *DeleteOneOptionsBuilder {
+	return &DeleteOneOptionsBuilder{}
 }
 
-// List returns a list of DeleteOptions setter functions.
-func (do *DeleteOptionsBuilder) List() []func(*DeleteOptions) error {
+// List returns a list of DeleteOneOptions setter functions.
+func (do *DeleteOneOptionsBuilder) List() []func(*DeleteOneOptions) error {
 	return do.Opts
 }
 
 // SetCollation sets the value for the Collation field.
-func (do *DeleteOptionsBuilder) SetCollation(c *Collation) *DeleteOptionsBuilder {
-	do.Opts = append(do.Opts, func(opts *DeleteOptions) error {
+func (do *DeleteOneOptionsBuilder) SetCollation(c *Collation) *DeleteOneOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
 		opts.Collation = c
 
 		return nil
@@ -62,8 +62,8 @@ func (do *DeleteOptionsBuilder) SetCollation(c *Collation) *DeleteOptionsBuilder
 }
 
 // SetComment sets the value for the Comment field.
-func (do *DeleteOptionsBuilder) SetComment(comment interface{}) *DeleteOptionsBuilder {
-	do.Opts = append(do.Opts, func(opts *DeleteOptions) error {
+func (do *DeleteOneOptionsBuilder) SetComment(comment interface{}) *DeleteOneOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
 		opts.Comment = comment
 
 		return nil
@@ -73,8 +73,8 @@ func (do *DeleteOptionsBuilder) SetComment(comment interface{}) *DeleteOptionsBu
 }
 
 // SetHint sets the value for the Hint field.
-func (do *DeleteOptionsBuilder) SetHint(hint interface{}) *DeleteOptionsBuilder {
-	do.Opts = append(do.Opts, func(opts *DeleteOptions) error {
+func (do *DeleteOneOptionsBuilder) SetHint(hint interface{}) *DeleteOneOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
 		opts.Hint = hint
 
 		return nil
@@ -84,8 +84,96 @@ func (do *DeleteOptionsBuilder) SetHint(hint interface{}) *DeleteOptionsBuilder 
 }
 
 // SetLet sets the value for the Let field.
-func (do *DeleteOptionsBuilder) SetLet(let interface{}) *DeleteOptionsBuilder {
-	do.Opts = append(do.Opts, func(opts *DeleteOptions) error {
+func (do *DeleteOneOptionsBuilder) SetLet(let interface{}) *DeleteOneOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
+		opts.Let = let
+
+		return nil
+	})
+
+	return do
+}
+
+// DeleteManyOptions represents arguments that can be used to configure DeleteMany
+// operations.
+type DeleteManyOptions struct {
+	// Specifies a collation to use for string comparisons during the operation. This option is only valid for MongoDB
+	// versions >= 3.4. For previous server versions, the driver will return an error if this option is used. The
+	// default value is nil, which means the default collation of the collection will be used.
+	Collation *Collation
+
+	// A string or document that will be included in server logs, profiling logs, and currentOp queries to help trace
+	// the operation.  The default value is nil, which means that no comment will be included in the logs.
+	Comment interface{}
+
+	// The index to use for the operation. This should either be the index name as a string or the index specification
+	// as a document. This option is only valid for MongoDB versions >= 4.4. Server versions >= 3.4 will return an error
+	// if this option is specified. For server versions < 3.4, the driver will return a client-side error if this option
+	// is specified. The driver will return an error if this option is specified during an unacknowledged write
+	// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil,
+	// which means that no hint will be sent.
+	Hint interface{}
+
+	// Specifies parameters for the delete expression. This option is only valid for MongoDB versions >= 5.0. Older
+	// servers will report an error for using this option. This must be a document mapping parameter names to values.
+	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
+	// accessed as variables in an aggregate expression context (e.g. "$$var").
+	Let interface{}
+}
+
+// DeleteManyOptionsBuilder contains options to configure DeleteMany operations.
+// Each option can be set through setter functions. See documentation for each
+// setter function for an explanation of the option.
+type DeleteManyOptionsBuilder struct {
+	Opts []func(*DeleteManyOptions) error
+}
+
+// DeleteMany creates a new DeleteManyOptions instance.
+func DeleteMany() *DeleteManyOptionsBuilder {
+	return &DeleteManyOptionsBuilder{}
+}
+
+// List returns a list of DeleteOneOptions setter functions.
+func (do *DeleteManyOptionsBuilder) List() []func(*DeleteManyOptions) error {
+	return do.Opts
+}
+
+// SetCollation sets the value for the Collation field.
+func (do *DeleteManyOptionsBuilder) SetCollation(c *Collation) *DeleteManyOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
+		opts.Collation = c
+
+		return nil
+	})
+
+	return do
+}
+
+// SetComment sets the value for the Comment field.
+func (do *DeleteManyOptionsBuilder) SetComment(comment interface{}) *DeleteManyOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
+		opts.Comment = comment
+
+		return nil
+	})
+
+	return do
+}
+
+// SetHint sets the value for the Hint field.
+func (do *DeleteManyOptionsBuilder) SetHint(hint interface{}) *DeleteManyOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
+		opts.Hint = hint
+
+		return nil
+	})
+
+	return do
+}
+
+// SetLet sets the value for the Let field.
+func (do *DeleteManyOptionsBuilder) SetLet(let interface{}) *DeleteManyOptionsBuilder {
+	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
 		opts.Let = let
 
 		return nil

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -6,9 +6,9 @@
 
 package options
 
-// UpdateOptions represents arguments that can be used to configure UpdateOne and
-// UpdateMany operations.
-type UpdateOptions struct {
+// UpdateOneOptions represents arguments that can be used to configure UpdateOne
+// operations.
+type UpdateOneOptions struct {
 	// A set of filters specifying to which array elements an update should apply. This option is only valid for MongoDB
 	// versions >= 3.6. For previous server versions, the driver will return an error if this option is used. The
 	// default value is nil, which means the update will apply to all array elements.
@@ -48,26 +48,26 @@ type UpdateOptions struct {
 	Let interface{}
 }
 
-// UpdateOptionsBuilder contains options to configure update operations. Each
-// option can be set through setter functions. See documentation for each setter
-// function for an explanation of the option.
-type UpdateOptionsBuilder struct {
-	Opts []func(*UpdateOptions) error
+// UpdateOneOptionsBuilder contains options to configure UpdateOne operations.
+// Each option can be set through setter functions. See documentation for each
+// setter function for an explanation of the option.
+type UpdateOneOptionsBuilder struct {
+	Opts []func(*UpdateOneOptions) error
 }
 
-// Update creates a new UpdateOptions instance.
-func Update() *UpdateOptionsBuilder {
-	return &UpdateOptionsBuilder{}
+// UpdateOne creates a new UpdateOneOptions instance.
+func UpdateOne() *UpdateOneOptionsBuilder {
+	return &UpdateOneOptionsBuilder{}
 }
 
-// List returns a list of UpdateOptions setter functions.
-func (uo *UpdateOptionsBuilder) List() []func(*UpdateOptions) error {
+// List returns a list of UpdateOneOptions setter functions.
+func (uo *UpdateOneOptionsBuilder) List() []func(*UpdateOneOptions) error {
 	return uo.Opts
 }
 
 // SetArrayFilters sets the value for the ArrayFilters field.
-func (uo *UpdateOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.ArrayFilters = af
 
 		return nil
@@ -77,8 +77,8 @@ func (uo *UpdateOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateOptions
 }
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field.
-func (uo *UpdateOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.BypassDocumentValidation = &b
 
 		return nil
@@ -88,8 +88,8 @@ func (uo *UpdateOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateOptio
 }
 
 // SetCollation sets the value for the Collation field.
-func (uo *UpdateOptionsBuilder) SetCollation(c *Collation) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetCollation(c *Collation) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Collation = c
 
 		return nil
@@ -99,8 +99,8 @@ func (uo *UpdateOptionsBuilder) SetCollation(c *Collation) *UpdateOptionsBuilder
 }
 
 // SetComment sets the value for the Comment field.
-func (uo *UpdateOptionsBuilder) SetComment(comment interface{}) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetComment(comment interface{}) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Comment = comment
 
 		return nil
@@ -110,8 +110,8 @@ func (uo *UpdateOptionsBuilder) SetComment(comment interface{}) *UpdateOptionsBu
 }
 
 // SetHint sets the value for the Hint field.
-func (uo *UpdateOptionsBuilder) SetHint(h interface{}) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetHint(h interface{}) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Hint = h
 
 		return nil
@@ -121,8 +121,8 @@ func (uo *UpdateOptionsBuilder) SetHint(h interface{}) *UpdateOptionsBuilder {
 }
 
 // SetUpsert sets the value for the Upsert field.
-func (uo *UpdateOptionsBuilder) SetUpsert(b bool) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetUpsert(b bool) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Upsert = &b
 
 		return nil
@@ -132,8 +132,144 @@ func (uo *UpdateOptionsBuilder) SetUpsert(b bool) *UpdateOptionsBuilder {
 }
 
 // SetLet sets the value for the Let field.
-func (uo *UpdateOptionsBuilder) SetLet(l interface{}) *UpdateOptionsBuilder {
-	uo.Opts = append(uo.Opts, func(opts *UpdateOptions) error {
+func (uo *UpdateOneOptionsBuilder) SetLet(l interface{}) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
+		opts.Let = l
+
+		return nil
+	})
+
+	return uo
+}
+
+// UpdateManyOptions represents arguments that can be used to configure UpdateMany
+// operations.
+type UpdateManyOptions struct {
+	// A set of filters specifying to which array elements an update should apply. This option is only valid for MongoDB
+	// versions >= 3.6. For previous server versions, the driver will return an error if this option is used. The
+	// default value is nil, which means the update will apply to all array elements.
+	ArrayFilters []interface{}
+
+	// If true, writes executed as part of the operation will opt out of document-level validation on the server. This
+	// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
+	// false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
+	// validation.
+	BypassDocumentValidation *bool
+
+	// Specifies a collation to use for string comparisons during the operation. This option is only valid for MongoDB
+	// versions >= 3.4. For previous server versions, the driver will return an error if this option is used. The
+	// default value is nil, which means the default collation of the collection will be used.
+	Collation *Collation
+
+	// A string or document that will be included in server logs, profiling logs, and currentOp queries to help trace
+	// the operation.  The default value is nil, which means that no comment will be included in the logs.
+	Comment interface{}
+
+	// The index to use for the operation. This should either be the index name as a string or the index specification
+	// as a document. This option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will return an error
+	// if this option is specified. For server versions < 3.4, the driver will return a client-side error if this option
+	// is specified. The driver will return an error if this option is specified during an unacknowledged write
+	// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil,
+	// which means that no hint will be sent.
+	Hint interface{}
+
+	// If true, a new document will be inserted if the filter does not match any documents in the collection. The
+	// default value is false.
+	Upsert *bool
+
+	// Specifies parameters for the update expression. This option is only valid for MongoDB versions >= 5.0. Older
+	// servers will report an error for using this option. This must be a document mapping parameter names to values.
+	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
+	// accessed as variables in an aggregate expression context (e.g. "$$var").
+	Let interface{}
+}
+
+// UpdateManyOptionsBuilder contains options to configure UpdateMany operations.
+// Each option can be set through setter functions. See documentation for each
+// setter function for an explanation of the option.
+type UpdateManyOptionsBuilder struct {
+	Opts []func(*UpdateManyOptions) error
+}
+
+// UpdateMany creates a new UpdateManyOptions instance.
+func UpdateMany() *UpdateManyOptionsBuilder {
+	return &UpdateManyOptionsBuilder{}
+}
+
+// List returns a list of UpdateManyOptions setter functions.
+func (uo *UpdateManyOptionsBuilder) List() []func(*UpdateManyOptions) error {
+	return uo.Opts
+}
+
+// SetArrayFilters sets the value for the ArrayFilters field.
+func (uo *UpdateManyOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.ArrayFilters = af
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetBypassDocumentValidation sets the value for the BypassDocumentValidation field.
+func (uo *UpdateManyOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.BypassDocumentValidation = &b
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetCollation sets the value for the Collation field.
+func (uo *UpdateManyOptionsBuilder) SetCollation(c *Collation) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.Collation = c
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetComment sets the value for the Comment field.
+func (uo *UpdateManyOptionsBuilder) SetComment(comment interface{}) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.Comment = comment
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetHint sets the value for the Hint field.
+func (uo *UpdateManyOptionsBuilder) SetHint(h interface{}) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.Hint = h
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetUpsert sets the value for the Upsert field.
+func (uo *UpdateManyOptionsBuilder) SetUpsert(b bool) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.Upsert = &b
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetLet sets the value for the Let field.
+func (uo *UpdateManyOptionsBuilder) SetLet(l interface{}) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
 		opts.Let = l
 
 		return nil


### PR DESCRIPTION
GODRIVER-3339

## Summary
- Separate the “UpdateOptions” struct into “UpdateManyOptions” and “UpdateOneOptions”.
- Separate the “DeleteOptions” struct into “DeleteManyOptions” and “DeleteOneOptions”.

## Background & Motivation
For [DRIVERS-2822](https://jira.mongodb.org/browse/DRIVERS-2822), `sort` only applies to `UpdateOne`. The server throws an error if a `sort` exists in `UpdateMany`. Therefore, this PR proposes separating the options for `UpdateOne` and `UpdateMany`.
Although there is no immediate requirement yet, the “DeleteOptions” struct is also considered to be divided for future changes as it is shared by both “DeleteOne” and “DeleteMany” now.
