### PR TITLE
GODRIVER-2567 CSFLE/QE Naming

### DIFF
--- a/internal/integration/crud_helpers_test.go
+++ b/internal/integration/crud_helpers_test.go
@@ -93,7 +93,7 @@ func isExpectedKillAllSessionsError(err error) bool {
 }
 
 // kill all open sessions on the server. This function uses mt.GlobalClient() because killAllSessions is not allowed
-// for clients configured with specific options (e.g. client side encryption).
+// for clients configured with specific options (e.g. in-use encryption).
 func killSessions(mt *mtest.T) {
 	mt.Helper()
 

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -74,7 +74,7 @@ type Client struct {
 	httpClient     *http.Client
 	logger         *logger.Logger
 
-	// client-side encryption fields
+	// in-use encryption fields
 	keyVaultClientFLE  *Client
 	keyVaultCollFLE    *Collection
 	mongocryptdFLE     *mongocryptdClient

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -596,7 +596,7 @@ func (db *Database) CreateCollection(ctx context.Context, name string, opts ...o
 		return fmt.Errorf("failed to construct options from builder: %w", err)
 	}
 
-	// Follow Client-Side Encryption specification to check for encryptedFields.
+	// Follow In-Use Encryption specification to check for encryptedFields.
 	// Check for encryptedFields from create options.
 	ef := args.EncryptedFields
 	// Check for encryptedFields from the client EncryptedFieldsMap.

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -102,16 +102,16 @@
 // using a different DNS server (8.8.8.8 is the common default), and, if that's not possible, avoiding the "mongodb+srv"
 // scheme.
 //
-// # Client Side Encryption
+// # Client-Side Field Level Encryption
 //
-// Client-side encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
+// Client-side field level encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
 // feature requires specifying the "cse" build tag during compilation:
 //
 //	go build -tags cse
 //
 // Note: Auto encryption is an enterprise- and Atlas-only feature.
 //
-// The libmongocrypt C library is required when using client-side encryption. Specific versions of libmongocrypt
+// The libmongocrypt C library is required when using client-side field level encryption. Specific versions of libmongocrypt
 // are required for different versions of the Go Driver:
 //
 // - Go Driver v1.2.0 requires libmongocrypt v1.0.0 or higher

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -108,9 +108,8 @@
 //
 // The Queryable Encryption and CSFLE features share much of the same API with some exceptions.
 //
-// - The supported algorithms documented in autoencryptionoptions.go do not apply to both features.
-// - SetEncryptedFieldsMap only applies to Queryable Encryption.
-// - SetSchemaMap only applies to CSFLE.
+// - AutoEncryptionOptions.SetEncryptedFieldsMap only applies to Queryable Encryption.
+// - AutoEncryptionOptions.SetSchemaMap only applies to CSFLE.
 //
 // In-use encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
 // feature requires specifying the "cse" build tag during compilation:

--- a/mongo/doc.go
+++ b/mongo/doc.go
@@ -102,16 +102,24 @@
 // using a different DNS server (8.8.8.8 is the common default), and, if that's not possible, avoiding the "mongodb+srv"
 // scheme.
 //
-// # Client-Side Field Level Encryption
+// # In-Use Encryption
 //
-// Client-side field level encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
+// MongoDB provides two approaches to In-Use Encryption: Queryable Encryption (QE) and Client-Side Field Level Encryption (CSFLE).
+//
+// The Queryable Encryption and CSFLE features share much of the same API with some exceptions.
+//
+// - The supported algorithms documented in autoencryptionoptions.go do not apply to both features.
+// - SetEncryptedFieldsMap only applies to Queryable Encryption.
+// - SetSchemaMap only applies to CSFLE.
+//
+// In-use encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted. Using this
 // feature requires specifying the "cse" build tag during compilation:
 //
 //	go build -tags cse
 //
 // Note: Auto encryption is an enterprise- and Atlas-only feature.
 //
-// The libmongocrypt C library is required when using client-side field level encryption. Specific versions of libmongocrypt
+// The libmongocrypt C library is required when using in-use encryption. Specific versions of libmongocrypt
 // are required for different versions of the Go Driver:
 //
 // - Go Driver v1.2.0 requires libmongocrypt v1.0.0 or higher

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -192,7 +192,7 @@ func IsNetworkError(err error) bool {
 	return errorHasLabel(err, "NetworkError")
 }
 
-// MongocryptError represents an libmongocrypt error during client-side encryption.
+// MongocryptError represents an libmongocrypt error during in-use encryption.
 type MongocryptError struct {
 	Code    int32
 	Message string
@@ -203,7 +203,7 @@ func (m MongocryptError) Error() string {
 	return fmt.Sprintf("mongocrypt error %d: %v", m.Code, m.Message)
 }
 
-// EncryptionKeyVaultError represents an error while communicating with the key vault collection during client-side
+// EncryptionKeyVaultError represents an error while communicating with the key vault collection during in-use
 // encryption.
 type EncryptionKeyVaultError struct {
 	Wrapped error
@@ -219,7 +219,7 @@ func (ekve EncryptionKeyVaultError) Unwrap() error {
 	return ekve.Wrapped
 }
 
-// MongocryptdError represents an error while communicating with mongocryptd during client-side encryption.
+// MongocryptdError represents an error while communicating with mongocryptd during in-use encryption.
 type MongocryptdError struct {
 	Wrapped error
 }

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -23,7 +23,7 @@ import (
 // If automatic encryption fails on an operation, use a MongoClient configured with bypassAutoEncryption=true and use
 // ClientEncryption.encrypt() to manually encrypt values.
 //
-// Enabling Client Side Encryption reduces the maximum document and message size (using a maxBsonObjectSize of 2MiB and
+// Enabling In-Use Encryption reduces the maximum document and message size (using a maxBsonObjectSize of 2MiB and
 // maxMessageSizeBytes of 6MB) and may have a negative performance impact.
 type AutoEncryptionOptions struct {
 	KeyVaultClientOptions Lister[ClientOptions]
@@ -105,8 +105,8 @@ func (a *AutoEncryptionOptionsBuilder) SetKmsProviders(providers map[string]map[
 }
 
 // SetSchemaMap specifies a map from namespace to local schema document. Schemas supplied in the schemaMap only apply
-// to configuring automatic encryption for client side encryption. Other validation rules in the JSON schema will not
-// be enforced by the driver and will result in an error.
+// to configuring automatic encryption for Client-Side Field Level Encryption. Other validation rules in the JSON schema
+// will not be enforced by the driver and will result in an error.
 //
 // Supplying a schemaMap provides more security than relying on JSON Schemas obtained from the server. It protects
 // against a malicious server advertising a false JSON Schema, which could trick the client into sending unencrypted

--- a/testdata/client-side-encryption/README.rst
+++ b/testdata/client-side-encryption/README.rst
@@ -1,5 +1,5 @@
 ============================
-Client Side Encryption Tests
+In-Use Encryption Tests
 ============================
 
 .. contents::

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -60,7 +60,7 @@ var (
 )
 
 const (
-	// maximum BSON object size when client side encryption is enabled
+	// maximum BSON object size when in-use encryption is enabled
 	cryptMaxBsonObjectSize uint32 = 2097152
 	// minimum wire version necessary to use automatic encryption
 	cryptMinWireVersion int32 = 8
@@ -279,7 +279,7 @@ type Operation struct {
 	// no events will be reported.
 	CommandMonitor *event.CommandMonitor
 
-	// Crypt specifies a Crypt object to use for automatic client side encryption and decryption.
+	// Crypt specifies a Crypt object to use for automatic in-use encryption and decryption.
 	Crypt Crypt
 
 	// ServerAPI specifies options used to configure the API version sent to the server.
@@ -706,7 +706,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			targetBatchSize := desc.MaxDocumentSize
 			maxDocSize := desc.MaxDocumentSize
 			if op.shouldEncrypt() {
-				// For client-side encryption, we want the batch to be split at 2 MiB instead of 16MiB.
+				// For in-use encryption, we want the batch to be split at 2 MiB instead of 16MiB.
 				// If there's only one document in the batch, it can be up to 16MiB, so we set target batch size to
 				// 2MiB but max document size to 16MiB. This will allow the AdvanceBatch call to create a batch
 				// with a single large document.
@@ -1126,7 +1126,7 @@ func (op Operation) readWireMessage(ctx context.Context, conn *mnet.Connection) 
 		return res, err
 	}
 
-	// If there is no error, automatically attempt to decrypt all results if client side encryption is enabled.
+	// If there is no error, automatically attempt to decrypt all results if in-use encryption is enabled.
 	if op.Crypt != nil {
 		res, err = op.Crypt.Decrypt(ctx, res)
 	}


### PR DESCRIPTION
[GODRIVER-2567](https://jira.mongodb.org/browse/GODRIVER-2567)

## Summary

There is a distinct difference between Queryable Encryption and Client-Side Field Level Encryption made in the Server docs. Drivers must update their docs to reflect correct terminology as-needed.

Both features CSFLE and QE are nested under "In Use Encryption" rather than "Client Side Encryption".  Please verify and rename any documents to follow this convention.

## Background & Motivation

<!--- Rationale for the pull request. -->
