### PR TITLE
GODRIVER-3182 Update go dist version for backport task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2386,7 +2386,7 @@ buildvariants:
     run_on:
       - rhel8.7-small
     expansions:
-      GO_DIST: "/opt/golang/go1.20"
+      GO_DIST: "/opt/golang/go1.22"
     tasks: 
       - name: "backport-pr"
 


### PR DESCRIPTION
GODRIVER-3182

## Summary

Update go dist version for backport task

## Background & Motivation

Task requires Go 1.22+.
