### PR TITLE
GODRIVER-2529 Remove repeat test from client_encryption_test.go

### DIFF
--- a/mongo/client_encryption_test.go
+++ b/mongo/client_encryption_test.go
@@ -32,7 +32,6 @@ func TestClientEncryption_ErrClientDisconnected(t *testing.T) {
 	t.Run("CreateEncryptedCollection", func(t *testing.T) {
 		t.Parallel()
 		_, _, err := ce.CreateEncryptedCollection(context.Background(), nil, "", options.CreateCollection(), "", nil)
-		assert.Equal(t, ErrClientDisconnected, err, "expected error %v, got %v", ErrClientDisconnected, err)
 		assert.ErrorIs(t, err, ErrClientDisconnected)
 	})
 	t.Run("AddKeyAltName", func(t *testing.T) {


### PR DESCRIPTION
Remove repeat line from client_encryption_test.go that was left from GODRIVER-2529

## Summary

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation

<!--- Rationale for the pull request. -->
