### PR TITLE
GODRIVER-3357 Bump golangci-lint for 1.23 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       exclude: ^(vendor)
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.60.1
   hooks:
   - id: golangci-lint
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -194,4 +194,4 @@ tasks:
   install-golangci-lint:
     internal: true
     cmds:
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1

--- a/bson/raw_array_test.go
+++ b/bson/raw_array_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"testing"
 
@@ -462,12 +461,10 @@ func TestRawArray_Values(t *testing.T) {
 			t.Parallel()
 
 			values, err := tcase.arr.Values()
-			fmt.Println("values: ", values)
 			require.NoError(t, err, "failed to turn array into values")
 			require.Len(t, values, len(tcase.want), "got len does not match want")
 
 			for idx, want := range tcase.want {
-				fmt.Println(want.Value, values[idx].Value)
 				assert.True(t, want.Equal(values[idx]), "want: %v, got: %v", want, values[idx])
 			}
 		})

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -302,6 +302,7 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 	return nil
 }
 
+//nolint:govet
 func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) error {
 	pooled := client.poolEvents()
 	if len(expectedEvents.CMAPEvents) == 0 && len(pooled) != 0 {
@@ -491,6 +492,7 @@ func getNextTopologyDescriptionChangedEvent(
 	return events[0], events[:1], nil
 }
 
+//nolint:govet
 func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) error {
 	var (
 		changed   = client.serverDescriptionChanged

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -544,7 +544,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatStartedEvent != nil:
 			var got *event.ServerHeartbeatStartedEvent
 			if got, started, err = getNextServerHeartbeatStartedEvent(started); err != nil {
-				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat started event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatStartedEvent.Awaited; want != nil && *want != got.Awaited {
@@ -553,7 +553,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatSucceededEvent != nil:
 			var got *event.ServerHeartbeatSucceededEvent
 			if got, succeeded, err = getNextServerHeartbeatSucceededEvent(succeeded); err != nil {
-				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat succeeded event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatSucceededEvent.Awaited; want != nil && *want != got.Awaited {
@@ -562,7 +562,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatFailedEvent != nil:
 			var got *event.ServerHeartbeatFailedEvent
 			if got, failed, err = getNextServerHeartbeatFailedEvent(failed); err != nil {
-				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat failed event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatFailedEvent.Awaited; want != nil && *want != got.Awaited {

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -302,7 +302,6 @@ func verifyCommandEvents(ctx context.Context, client *clientEntity, expectedEven
 	return nil
 }
 
-//nolint:govet
 func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) error {
 	pooled := client.poolEvents()
 	if len(expectedEvents.CMAPEvents) == 0 && len(pooled) != 0 {
@@ -315,16 +314,16 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		switch {
 		case evt.ConnectionCreatedEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCreated); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionReadyEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionReady); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionClosedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionClosed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 
 			if expectedReason := evt.ConnectionClosedEvent.Reason; expectedReason != nil {
@@ -334,12 +333,12 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.ConnectionCheckedOutEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckedOut); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionCheckOutFailedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckOutFailed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 
 			if expectedReason := evt.ConnectionCheckOutFailedEvent.Reason; expectedReason != nil {
@@ -349,12 +348,12 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.ConnectionCheckedInEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCheckedIn); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.PoolClearedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionPoolCleared); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 			if expectServiceID := evt.PoolClearedEvent.HasServiceID; expectServiceID != nil {
 				if err := verifyServiceID(*expectServiceID, actual.ServiceID); err != nil {
@@ -492,7 +491,6 @@ func getNextTopologyDescriptionChangedEvent(
 	return events[0], events[:1], nil
 }
 
-//nolint:govet
 func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) error {
 	var (
 		changed   = client.serverDescriptionChanged
@@ -515,7 +513,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerDescriptionChangedEvent != nil:
 			var got *event.ServerDescriptionChangedEvent
 			if got, changed, err = getNextServerDescriptionChangedEvent(changed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server description changed event: %v", err.Error())
 			}
 
 			prevDesc := evt.ServerDescriptionChangedEvent.NewDescription
@@ -546,7 +544,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatStartedEvent != nil:
 			var got *event.ServerHeartbeatStartedEvent
 			if got, started, err = getNextServerHeartbeatStartedEvent(started); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatStartedEvent.Awaited; want != nil && *want != got.Awaited {
@@ -555,7 +553,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatSucceededEvent != nil:
 			var got *event.ServerHeartbeatSucceededEvent
 			if got, succeeded, err = getNextServerHeartbeatSucceededEvent(succeeded); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatSucceededEvent.Awaited; want != nil && *want != got.Awaited {
@@ -564,7 +562,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatFailedEvent != nil:
 			var got *event.ServerHeartbeatFailedEvent
 			if got, failed, err = getNextServerHeartbeatFailedEvent(failed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatFailedEvent.Awaited; want != nil && *want != got.Awaited {
@@ -572,7 +570,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.TopologyDescriptionChangedEvent != nil:
 			if _, tchanged, err = getNextTopologyDescriptionChangedEvent(tchanged); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next description changed event: %v", err.Error())
 			}
 		}
 	}

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -921,9 +921,7 @@ func newLogger(opts options.Lister[options.LoggerOptions]) (*logger.Logger, erro
 
 	// If there are no component-level options and the environment does not
 	// contain component variables, then do nothing.
-	if (args.ComponentLevels == nil || len(args.ComponentLevels) == 0) &&
-		!logger.EnvHasComponentVariables() {
-
+	if len(args.ComponentLevels) == 0 && !logger.EnvHasComponentVariables() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

<!--- A summary of the changes proposed by this pull request. -->

`golangci-lint` versions < 1.60.1 are not 1.23 compatible. See issue #[4662](https://github.com/golangci/golangci-lint/issues/4662) for more information.

## Background & Motivation

<!--- Rationale for the pull request. -->

Devs should not be limited to the 1.22 minimum test version.
