### PR TITLE
GODRIVER-3358 Do not override authSource from TXT record

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -145,7 +145,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone --branch GODRIVER-3358 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -145,7 +145,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone --branch GODRIVER-3358 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec

--- a/x/mongo/driver/connstring/connstring.go
+++ b/x/mongo/driver/connstring/connstring.go
@@ -297,10 +297,6 @@ func (u *ConnString) setDefaultAuthParams(dbName string) error {
 		}
 		fallthrough
 	case "mongodb-aws", "mongodb-x509", "mongodb-oidc":
-		// dns.LookupTXT will get "authSource=admin" from Atlas hosts.
-		if u.AuthSource == "admin" {
-			u.AuthSource = "$external"
-		}
 		if u.AuthSource == "" {
 			u.AuthSource = "$external"
 		} else if u.AuthSource != "$external" {


### PR DESCRIPTION
GODRIVER-3358

## Summary

Defer to the TXT record unless overridden by the connection string.

## Background & Motivation

This is how the spec is written.  We updated the connection strings in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/502.
