### PR TITLE
GODRIVER-3366 Ensure snappy tests are run in CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2184,7 +2184,7 @@ task_groups:
 
   - name: testazurekms_task_group
     setup_group_can_fail_task: true
-    teardown_group_can_fail_task: true
+    teardown_task_can_fail_task: true
     setup_group_timeout_secs: 1800 # 30 minutes
     setup_group:
       - func: fetch-source
@@ -2446,20 +2446,20 @@ buildvariants:
     tasks:
       - name: ".test !.enterprise-auth !.snappy !.zstd"
 
-  - matrix_name: "tests-rhel-40-with-zlib-support"
+  - matrix_name: "tests-rhel-40-with-snappy-support"
     tags: ["pullrequest"]
     matrix_spec: { version: ["4.0"], os-ssl-40: ["rhel87-64"] }
     display_name: "${version} ${os-ssl-40}"
     tasks:
-      - name: ".test !.enterprise-auth !.snappy !.zstd"
+      - name: ".test !.enterprise-auth !.zlib !.zstd"
 
-  - matrix_name: "tests-windows-40-with-zlib-support"
+  - matrix_name: "tests-windows-40-with-snappy-support"
     matrix_spec: { version: ["4.0"], os-ssl-40: ["windows-64"] }
     display_name: "${version} ${os-ssl-40}"
     tasks:
-      - name: ".test !.enterprise-auth !.snappy !.zstd"
+      - name: ".test !.enterprise-auth !.zlib !.zstd"
 
-  - matrix_name: "tests-rhel-42-plus-zlib-zstd-support"
+  - matrix_name: "tests-rhel-44-plus-zlib-zstd-support"
     tags: ["pullrequest"]
     matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0", "7.0", "8.0"], os-ssl-40: ["rhel87-64"] }
     display_name: "${version} ${os-ssl-40}"


### PR DESCRIPTION
GODRIVER-3366 

## Summary

Ensure snappy tests are run in CI.

## Background & Motivation

These tests were accidentally excluded at some point.
