### PR TITLE
Bump lint go version to 1.22.8

### DIFF
--- a/etc/golangci-lint.sh
+++ b/etc/golangci-lint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+GO_VERSION=1.22.8
+GOLANGCI_LINT_VERSION=1.60.1
+
 # Unset the cross-compiler overrides while downloading binaries.
 GOOS_ORIG=${GOOS:-}
 export GOOS=
@@ -8,11 +11,11 @@ GOARCH_ORIG=${GOARCH:-}
 export GOARCH=
 
 # Keep this in sync with go version used in static-analysis Evergreen build variant.
-go install golang.org/dl/go1.22.7@latest
-go1.22.7 download
-PATH="$(go1.22.7 env GOROOT)/bin:$PATH"
+go install golang.org/dl/go$GO_VERSION@latest
+go$GO_VERSION download
+PATH="$(go$GO_VERSION env GOROOT)/bin:$PATH"
 export PATH
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCI_LINT_VERSION
 
 export GOOS=$GOOS_ORIG
 export GOARCH=$GOARCH_ORIG


### PR DESCRIPTION
lint version not aligned with https://github.com/mongodb/mongo-go-driver/commit/9d4146089f65d51ee93db037945250ab14383e32