### PR TITLE
GODRIVER-3373 Prevent panic if http.DefaultTransport is not an *http.Transport

### DIFF
--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -11,8 +11,20 @@ import (
 )
 
 // DefaultHTTPClient is the default HTTP client used across the driver.
-var DefaultHTTPClient = &http.Client{
-	Transport: http.DefaultTransport.(*http.Transport).Clone(),
+var DefaultHTTPClient *http.Client
+
+func init() {
+	var transport http.RoundTripper
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = dt.Clone()
+	} else {
+		// We can not assume that the DefaultTransport is an *http.Transport
+		transport = http.DefaultTransport
+	}
+
+	DefaultHTTPClient = &http.Client{
+		Transport: transport,
+	}
 }
 
 // CloseIdleHTTPConnections closes any connections which were previously


### PR DESCRIPTION
GODRIVER-3373

## Summary

It is not safe to assume that `http.DefaultTransport` is always an `*http.Transport`. This patch prevents a panic that previously occured when the type assertion failed.

## Background & Motivation

I am using https://github.com/motemen/go-loghttp to log http requests. This package replaces http.DefaultTransport with a *loghttp.Transport.  It can therefore currently not be used together with mongo-go-driver.

### Related Issues:
- Discussion in loghttp package: https://github.com/motemen/go-loghttp/issues/3
- Fix for the same problem in google api client: https://github.com/googleapis/google-cloud-go/pull/10162
