### PR TITLE
GODRIVER-3374 Add ReadCompressedCompressedMessage back to wiremessage API

### DIFF
--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -539,6 +539,17 @@ func ReadCompressedCompressorID(src []byte) (id CompressorID, rem []byte, ok boo
 	return CompressorID(src[0]), src[1:], true
 }
 
+// ReadCompressedCompressedMessage reads the compressed wiremessage to dst.
+//
+// Deprecated: This function is not required by the Go Driver and will not be
+// removed in the 2.0 release.
+func ReadCompressedCompressedMessage(src []byte, length int32) (msg []byte, rem []byte, ok bool) {
+	if len(src) < int(length) || length < 0 {
+		return nil, src, false
+	}
+	return src[:length], src[length:], true
+}
+
 // ReadKillCursorsZero reads the zero field from src.
 func ReadKillCursorsZero(src []byte) (zero int32, rem []byte, ok bool) {
 	return readi32(src)

--- a/x/mongo/driver/wiremessage/wiremessage.go
+++ b/x/mongo/driver/wiremessage/wiremessage.go
@@ -541,7 +541,7 @@ func ReadCompressedCompressorID(src []byte) (id CompressorID, rem []byte, ok boo
 
 // ReadCompressedCompressedMessage reads the compressed wiremessage to dst.
 //
-// Deprecated: This function is not required by the Go Driver and will not be
+// Deprecated: This function is not required by the Go Driver and will be
 // removed in the 2.0 release.
 func ReadCompressedCompressedMessage(src []byte, length int32) (msg []byte, rem []byte, ok bool) {
 	if len(src) < int(length) || length < 0 {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3374

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Support `ReadCompressedCompressedMessage` for the v1 lifetime.

## Background & Motivation

<!--- Rationale for the pull request. -->

Users may rely on this low-cost helper.
