### PR TITLE
Use a local Go 1.18 installation to check for minimum version support.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1380,6 +1380,10 @@ tasks:
       - command: subprocess.exec
         params:
           binary: bash
+          # Set the GO_VERSION to empty string to use the Go installation in the
+          # PATH.
+          env:
+            GO_VERSION: ""
           args: [*task-runner, build]
 
   - name: "atlas-test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1362,7 +1362,7 @@ tasks:
         vars:
           MONGO_GO_DRIVER_COMPRESSOR: "snappy"
 
-  # Build with the oldest supported version of Go.
+  # Build the compilecheck submodule with the oldest supported version of Go.
   - name: go1.18-build
     tags: ["compile-check"]
     commands:
@@ -1370,8 +1370,7 @@ tasks:
         params:
           binary: bash
           env:
-            GOROOT: /opt/golang/go1.18
-          add_to_path: [/opt/golang/go1.18/bin]
+            GO_VERSION: "1.18"
           args: [*task-runner, build-compile-check]
 
   # Build with the same Go version that we're using for tests.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,10 +18,13 @@ tasks:
   check-license: bash etc/check_license.sh
 
   build:
-    deps: [cross-compile, build-tests, build-compile-check, install-libmongocrypt]
+    deps: [install-libmongocrypt]
     cmds:
       - go build ./...
       - go build ${BUILD_TAGS} ./...
+      - task: build-tests
+      - task: build-compile-check
+      - task: cross-compile
 
   build-tests: go test -short ${BUILD_TAGS} -run ^$$ ./...
 

--- a/etc/compile_check.sh
+++ b/etc/compile_check.sh
@@ -2,31 +2,27 @@
 set -e # exit when any command fails
 set -x # show all commands being run
 
-GC=go
+GC=go$GO_VERSION
 COMPILE_CHECK_DIR="internal/cmd/compilecheck"
-# shellcheck disable=SC2034
-DEV_MIN_VERSION=1.19
-
-# version will flatten a version string of upto 4 components for inequality
-# comparison.
-function version {
-	echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
-}
 
 # compile_check will attempt to build the internal/test/compilecheck project
 # using the provided Go version. This is to simulate an end-to-end use case.
-# This check will only run on environments where the Go version is greater than
-# or equal to the given version.
 function compile_check {
 	# Change the directory to the compilecheck test directory.
-	cd ${COMPILE_CHECK_DIR}
+	pushd ${COMPILE_CHECK_DIR}
 
-	MACHINE_VERSION=`${GC} version | { read _ _ v _; echo ${v#go}; }`
+	# If a custom Go version is set using the GO_VERSION env var (e.g. "1.18"),
+	# add the GOPATH bin directory to PATH and then install that Go version.
+	if [ ! -z "$GO_VERSION" ]; then
+		PATH=$(go env GOPATH)/bin:$PATH
+		export PATH
 
-	# If the version is not 1.13, then run "go mod tidy"
-	if [ "$(version $MACHINE_VERSION)" -ge "$(version 1.15)" ]; then
-		go mod tidy
+		go install golang.org/dl/go$GO_VERSION@latest
+		${GC} download
 	fi
+
+	${GC} version
+	${GC} mod tidy
 
 	# Check simple build.
 	${GC} build ./...
@@ -35,7 +31,7 @@ function compile_check {
 	${GC} build -buildmode=plugin
 
 	# Check build with tags.
-	go build $BUILD_TAGS ./...
+	${GC} build $BUILD_TAGS ./...
 
 	# Check build with various architectures.
 	GOOS=linux GOARCH=386 ${GC} build ./...
@@ -50,7 +46,7 @@ function compile_check {
 	rm compilecheck.so
 
 	# Change the directory back to the working directory.
-	cd -
+	popd
 }
 
 compile_check

--- a/etc/compile_check.sh
+++ b/etc/compile_check.sh
@@ -2,7 +2,12 @@
 set -e # exit when any command fails
 set -x # show all commands being run
 
-GC=go$GO_VERSION
+# Default to Go 1.18 if GO_VERSION is not set.
+#
+# Use the "=" operator (instead of the more common ":-" operator) so that it
+# allows setting GO_VERSION="" to use the Go installation in the PATH, and it
+# sets the GO_VERSION variable if the default is used.
+GC=go${GO_VERSION="1.18"}
 COMPILE_CHECK_DIR="internal/cmd/compilecheck"
 
 # compile_check will attempt to build the internal/test/compilecheck project


### PR DESCRIPTION
## Summary

* Update `compile_check.sh` to use a "local" Go installation (i.e. `go install golang.org/dl/go[ver]@latest`) for checking the Go 1.18 build.
* Update the `build` Taskfile target to run all the build steps sequentially so the output is understandable.

## Background & Motivation

The `go1.18-build` task currently doesn't actually use Go 1.18 to build. The `add_to_path` instruction is ineffective because the Taskfile is configured to load environment variables from a `.env` file. Instead, we should use a "local" Go 1.18 installation so we don't have to worry about overriding PATH.