### PR TITLE
Bump golangci-lint for 1.23 compatibility [v1]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,6 @@ repos:
       exclude: ^(vendor)
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.60.1
   hooks:
   - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ fmt:
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 
 # Lint with various GOOS and GOARCH targets to catch static analysis failures that may only affect
 # specific operating systems or architectures. For example, staticcheck will only check for 64-bit

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -861,7 +861,7 @@ func newLogger(opts *options.LoggerOptions) (*logger.Logger, error) {
 
 	// If there are no component-level options and the environment does not
 	// contain component variables, then do nothing.
-	if (opts.ComponentLevels == nil || len(opts.ComponentLevels) == 0) &&
+	if (len(opts.ComponentLevels) == 0) &&
 		!logger.EnvHasComponentVariables() {
 
 		return nil, nil

--- a/mongo/integration/unified/event_verification.go
+++ b/mongo/integration/unified/event_verification.go
@@ -316,16 +316,16 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		switch {
 		case evt.ConnectionCreatedEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionCreated); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionReadyEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionReady); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionClosedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.ConnectionClosed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 
 			if expectedReason := evt.ConnectionClosedEvent.Reason; expectedReason != nil {
@@ -335,12 +335,12 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.ConnectionCheckedOutEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.GetSucceeded); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.ConnectionCheckOutFailedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.GetFailed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 
 			if expectedReason := evt.ConnectionCheckOutFailedEvent.Reason; expectedReason != nil {
@@ -350,12 +350,12 @@ func verifyCMAPEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.ConnectionCheckedInEvent != nil:
 			if _, pooled, err = getNextPoolEvent(pooled, event.ConnectionReturned); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 		case evt.PoolClearedEvent != nil:
 			var actual *event.PoolEvent
 			if actual, pooled, err = getNextPoolEvent(pooled, event.PoolCleared); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next pool event: %v", err.Error())
 			}
 			if expectServiceID := evt.PoolClearedEvent.HasServiceID; expectServiceID != nil {
 				if err := verifyServiceID(*expectServiceID, actual.ServiceID); err != nil {
@@ -515,7 +515,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerDescriptionChangedEvent != nil:
 			var got *event.ServerDescriptionChangedEvent
 			if got, changed, err = getNextServerDescriptionChangedEvent(changed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server description changed event: %v", err.Error())
 			}
 
 			prevDesc := evt.ServerDescriptionChangedEvent.NewDescription
@@ -546,7 +546,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatStartedEvent != nil:
 			var got *event.ServerHeartbeatStartedEvent
 			if got, started, err = getNextServerHeartbeatStartedEvent(started); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat started event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatStartedEvent.Awaited; want != nil && *want != got.Awaited {
@@ -555,7 +555,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatSucceededEvent != nil:
 			var got *event.ServerHeartbeatSucceededEvent
 			if got, succeeded, err = getNextServerHeartbeatSucceededEvent(succeeded); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat succeeded event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatSucceededEvent.Awaited; want != nil && *want != got.Awaited {
@@ -564,7 +564,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 		case evt.ServerHeartbeatFailedEvent != nil:
 			var got *event.ServerHeartbeatFailedEvent
 			if got, failed, err = getNextServerHeartbeatFailedEvent(failed); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next server heartbeat failed event: %v", err.Error())
 			}
 
 			if want := evt.ServerHeartbeatFailedEvent.Awaited; want != nil && *want != got.Awaited {
@@ -572,7 +572,7 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 			}
 		case evt.TopologyDescriptionChangedEvent != nil:
 			if _, tchanged, err = getNextTopologyDescriptionChangedEvent(tchanged); err != nil {
-				return newEventVerificationError(idx, client, err.Error())
+				return newEventVerificationError(idx, client, "failed to get next description changed event: %v", err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Upgrade `golangci-lint` go v1.60.1.
Cherry-pick of #1823.

## Background & Motivation

`golangci-lint@v1.59.1` panics when run with Go 1.22 and Go 1.23 in some cases.
