### PR TITLE
Fix data race in 'discard connections' pool test. [v1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ test-race:
 
 .PHONY: test-short
 test-short:
-	go test $(BUILD_TAGS) -timeout 60s -short ./...
+	go test $(BUILD_TAGS) -timeout 60s -short -race ./...
 
 ### Local FaaS targets. ###
 .PHONY: build-faas-awslambda

--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -868,7 +868,7 @@ func TestPool(t *testing.T) {
 			go func() {
 				select {
 				case nc := <-ncs:
-					_, err = nc.Write([]byte{5, 0, 0, 0, 0})
+					_, err := nc.Write([]byte{5, 0, 0, 0, 0})
 					require.NoError(t, err, "Write error")
 				case <-time.After(100 * time.Millisecond):
 				}


### PR DESCRIPTION
Based on https://github.com/mongodb/mongo-go-driver/pull/1860

## Summary
* Don't share the `err` variable in the goroutine closure (pool_test.go line 893) to prevent a data race.
* Enable the race detector in the `test-short` Taskfile target.

## Background & Motivation

The race detector panics because of a data race in the "discards connections closed by the server side" connection pool test:
```
WARNING: DATA RACE
Read at 0x00c0005f4aa0 by goroutine 4142:
  go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.TestPool_checkOut.func10.3()
      /Users/matt.dale/work/mongo-go-driver/x/mongo/driver/topology/pool_test.go:897 +0x1b0

Previous write at 0x00c0005f4aa0 by goroutine 3796:
  go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.TestPool_checkOut.func10()
      /Users/matt.dale/work/mongo-go-driver/x/mongo/driver/topology/pool_test.go:907 +0x90c
...
```
