### PR TITLE
GODRIVER-3168 Retry KMS requests on transient errors.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -553,21 +553,6 @@ functions:
           KMS_MOCK_SERVERS_RUNNING: "true"
         args: [*task-runner, evg-test-kmip]
 
-  start-kms-failpoint-server:
-    - command: subprocess.exec
-      params:
-        working_dir: src/go.mongodb.org/mongo-driver
-        binary: bash
-        background: true
-        include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "DRIVERS_TOOLS"]
-        # This cannot use task because it will hang on Windows.
-        args: [etc/setup-encryption.sh]
-    - command: subprocess.exec
-      params:
-        binary: python3
-        background: true
-        args: ["-u", "${DRIVERS_TOOLS}/.evergreen/csfle/kms_failpoint_server.py", "--port", "9003"]
-
   run-retry-kms-requests:
     - command: subprocess.exec
       type: test
@@ -575,7 +560,8 @@ functions:
         binary: "bash"
         env: 
           GO_BUILD_TAGS: cse
-        include_expansions_in_env: [AUTH, SSL, MONGODB_URI, TOPOLOGY, MONGO_GO_DRIVER_COMPRESSOR]
+        include_expansions_in_env: [AUTH, SSL, MONGODB_URI, TOPOLOGY, 
+          MONGO_GO_DRIVER_COMPRESSOR]
         args: [*task-runner, setup-test]
     - command: subprocess.exec
       type: test
@@ -1473,7 +1459,7 @@ tasks:
           SSL: "nossl"
 
   - name: "test-kms-tls-invalid-cert"
-    tags: ["kms-tls"]
+    tags: ["kms-test"]
     commands:
       - func: bootstrap-mongo-orchestration
         vars:
@@ -1489,7 +1475,7 @@ tasks:
           SSL: "nossl"
 
   - name: "test-kms-tls-invalid-hostname"
-    tags: ["kms-tls"]
+    tags: ["kms-test"]
     commands:
       - func: bootstrap-mongo-orchestration
         vars:
@@ -1520,14 +1506,14 @@ tasks:
           SSL: "nossl"
 
   - name: "test-retry-kms-requests"
-    tags: ["retry-kms-requests"]
+    tags: ["kms-test"]
     commands:
       - func: bootstrap-mongo-orchestration
         vars:
           TOPOLOGY: "server"
           AUTH: "noauth"
           SSL: "nossl"
-      - func: start-kms-failpoint-server
+      - func: start-cse-servers
       - func: run-retry-kms-requests
 
   - name: "test-serverless"
@@ -2207,11 +2193,11 @@ buildvariants:
     tasks:
       - name: ".versioned-api"
 
-  - matrix_name: "kms-tls-test"
+  - matrix_name: "kms-test"
     matrix_spec: { version: ["7.0"], os-ssl-40: ["rhel87-64"] }
-    display_name: "KMS TLS ${os-ssl-40}"
+    display_name: "KMS TEST ${os-ssl-40}"
     tasks:
-      - name: ".kms-tls"
+      - name: ".kms-test"
 
   - matrix_name: "load-balancer-test"
     tags: ["pullrequest"]
@@ -2238,12 +2224,6 @@ buildvariants:
     display_name: "KMS KMIP ${os-ssl-40}"
     tasks:
       - name: ".kms-kmip"
-
-  - matrix_name: "retry-kms-requests-test"
-    matrix_spec: { version: ["7.0"], os-ssl-40: ["rhel87-64"] }
-    display_name: "Retry KMS Requests ${os-ssl-40}"
-    tasks:
-      - name: ".retry-kms-requests"
 
   - matrix_name: "fuzz-test"
     matrix_spec: { version: ["5.0"], os-ssl-40: ["rhel87-64"] }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -554,9 +554,6 @@ functions:
         args: [*task-runner, evg-test-kmip]
 
   start-kms-failpoint-server:
-    - command: ec2.assume_role
-      params:
-        role_arn: ${aws_test_secrets_role}
     - command: subprocess.exec
       params:
         working_dir: src/go.mongodb.org/mongo-driver
@@ -578,15 +575,15 @@ functions:
         binary: "bash"
         env: 
           GO_BUILD_TAGS: cse
-        include_expansions_in_env: [AUTH, SSL, MONGODB_URI, TOPOLOGY, 
-          MONGO_GO_DRIVER_COMPRESSOR]
+        include_expansions_in_env: [AUTH, SSL, MONGODB_URI, TOPOLOGY, MONGO_GO_DRIVER_COMPRESSOR]
         args: [*task-runner, setup-test]
     - command: subprocess.exec
       type: test
       params:
         binary: "bash"
         env:
-          KMS_FAILPOINT_SERVERS_RUNNING: "true"
+          KMS_FAILPOINT_CA_FILE: "${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
+          KMS_FAILPOINT_SERVER_RUNNING: "true"
         args: [*task-runner, evg-test-retry-kms-requests]
 
   run-fuzz-tests:
@@ -1532,10 +1529,6 @@ tasks:
           SSL: "nossl"
       - func: start-kms-failpoint-server
       - func: run-retry-kms-requests
-        vars:
-          TOPOLOGY: "server"
-          AUTH: "noauth"
-          SSL: "nossl"
 
   - name: "test-serverless"
     tags: ["serverless"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -553,6 +553,42 @@ functions:
           KMS_MOCK_SERVERS_RUNNING: "true"
         args: [*task-runner, evg-test-kmip]
 
+  start-kms-failpoint-server:
+    - command: ec2.assume_role
+      params:
+        role_arn: ${aws_test_secrets_role}
+    - command: subprocess.exec
+      params:
+        working_dir: src/go.mongodb.org/mongo-driver
+        binary: bash
+        background: true
+        include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "DRIVERS_TOOLS"]
+        # This cannot use task because it will hang on Windows.
+        args: [etc/setup-encryption.sh]
+    - command: subprocess.exec
+      params:
+        binary: python3
+        background: true
+        args: ["-u", "${DRIVERS_TOOLS}/.evergreen/csfle/kms_failpoint_server.py", "--port", "9003"]
+
+  run-retry-kms-requests:
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: "bash"
+        env: 
+          GO_BUILD_TAGS: cse
+        include_expansions_in_env: [AUTH, SSL, MONGODB_URI, TOPOLOGY, 
+          MONGO_GO_DRIVER_COMPRESSOR]
+        args: [*task-runner, setup-test]
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: "bash"
+        env:
+          KMS_FAILPOINT_SERVERS_RUNNING: "true"
+        args: [*task-runner, evg-test-retry-kms-requests]
+
   run-fuzz-tests:
     - command: subprocess.exec
       type: test
@@ -1486,6 +1522,21 @@ tasks:
           AUTH: "noauth"
           SSL: "nossl"
 
+  - name: "test-retry-kms-requests"
+    tags: ["retry-kms-requests"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+      - func: start-kms-failpoint-server
+      - func: run-retry-kms-requests
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "noauth"
+          SSL: "nossl"
+
   - name: "test-serverless"
     tags: ["serverless"]
     commands:
@@ -2194,6 +2245,12 @@ buildvariants:
     display_name: "KMS KMIP ${os-ssl-40}"
     tasks:
       - name: ".kms-kmip"
+
+  - matrix_name: "retry-kms-requests-test"
+    matrix_spec: { version: ["7.0"], os-ssl-40: ["rhel87-64"] }
+    display_name: "Retry KMS Requests ${os-ssl-40}"
+    tasks:
+      - name: ".retry-kms-requests"
 
   - matrix_name: "fuzz-test"
     matrix_spec: { version: ["5.0"], os-ssl-40: ["rhel87-64"] }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,6 +141,9 @@ tasks:
   evg-test-kms:
     - go test -exec "env PKG_CONFIG_PATH=${PKG_CONFIG_PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" ${BUILD_TAGS} -v -timeout {{.TEST_TIMEOUT}}s ./internal/integration -run TestClientSideEncryptionProse/kms_tls_tests >> test.suite
 
+  evg-test-retry-kms-requests:
+    - go test -exec "env PKG_CONFIG_PATH=${PKG_CONFIG_PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" ${BUILD_TAGS} -v -timeout {{.TEST_TIMEOUT}}s ./internal/integration -run TestClientSideEncryptionProse/kms_retry_tests >> test.suite
+
   evg-test-load-balancers:
     # Load balancer should be tested with all unified tests as well as tests in the following
     # components: retryable reads, retryable writes, change streams, initial DNS seedlist discovery.

--- a/etc/install-libmongocrypt.sh
+++ b/etc/install-libmongocrypt.sh
@@ -3,7 +3,7 @@
 # This script installs libmongocrypt into an "install" directory.
 set -eux
 
-LIBMONGOCRYPT_TAG="1.11.0"
+LIBMONGOCRYPT_TAG="1.12.0"
 
 # Install libmongocrypt based on OS.
 if [ "Windows_NT" = "${OS:-}" ]; then

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -2990,17 +2990,14 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		mt.Parallel()
 
-		var tlsCfg *tls.Config
-		if tlsCAFile := os.Getenv("KMS_FAILPOINT_CA_FILE"); tlsCAFile == "" {
-			require.Fail(mt, "failed to load CA file")
-		} else {
-			var err error
-			clientAndCATlsMap := map[string]interface{}{
-				"tlsCAFile": tlsCAFile,
-			}
-			tlsCfg, err = options.BuildTLSConfig(clientAndCATlsMap)
-			require.Nil(mt, err, "BuildTLSConfig error: %v", err)
+		tlsCAFile := os.Getenv("KMS_FAILPOINT_CA_FILE")
+		require.NotEmpty(mt, tlsCAFile, "failed to load CA file")
+
+		clientAndCATlsMap := map[string]interface{}{
+			"tlsCAFile": tlsCAFile,
 		}
+		tlsCfg, err := options.BuildTLSConfig(clientAndCATlsMap)
+		require.NoError(mt, err, "BuildTLSConfig error: %v", err)
 
 		setFailPoint := func(failure string, count int) error {
 			url := fmt.Sprintf("https://localhost:9003/set_failpoint/%s", failure)

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -2991,7 +2991,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		mt.Parallel()
 
 		tlsCAFile := os.Getenv("KMS_FAILPOINT_CA_FILE")
-		require.NotEmpty(mt, tlsCAFile, "failed to load CA file")
+		require.NotEqual(mt, tlsCAFile, "", "failed to load CA file")
 
 		clientAndCATlsMap := map[string]interface{}{
 			"tlsCAFile": tlsCAFile,

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -3096,7 +3096,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 						SetKeyID(keyID).
 						SetAlgorithm("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")
 					_, err = clientEncryption.Encrypt(context.Background(), testVal, eo)
-					assert.NoError(mt, err, "error in Encrypt: %v", err)
+					require.NoError(mt, err, "error in Encrypt: %v", err)
 				})
 			}
 		}

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -3111,7 +3111,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 				ceo := options.ClientEncryption().
 					SetKeyVaultNamespace(kvNamespace).
-					SetKmsProviders(fullKmsProvidersMap).
+					SetKmsProviders(kmsProviders).
 					SetTLSConfig(map[string]*tls.Config{dataKey.provider: tlsCfg})
 				clientEncryption, err := mongo.NewClientEncryption(keyVaultClient, ceo)
 				require.NoError(mt, err, "error on NewClientEncryption: %v", err)
@@ -3121,8 +3121,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 				dkOpts := options.DataKey().SetMasterKey(dataKey.masterKey)
 				_, err = clientEncryption.CreateDataKey(context.Background(), dataKey.provider, dkOpts)
-				require.Error(mt, err)
-				mt.Logf("CreateDataKey error: %v", err)
+				require.ErrorContains(mt, err, "KMS request failed after 3 retries due to a network error")
 			})
 		}
 	})

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -9,9 +9,7 @@ package driver
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -399,7 +397,10 @@ func (c *crypt) decryptKey(kmsCtx *mongocrypt.KmsContext) error {
 
 		res := make([]byte, bytesNeeded)
 		bytesRead, err := conn.Read(res)
-		if err != nil && !errors.Is(err, io.EOF) {
+		if err != nil {
+			if kmsCtx.Fail() {
+				err = nil
+			}
 			return err
 		}
 

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -398,10 +398,7 @@ func (c *crypt) decryptKey(kmsCtx *mongocrypt.KmsContext) error {
 		res := make([]byte, bytesNeeded)
 		bytesRead, err := conn.Read(res)
 		if err != nil {
-			if kmsCtx.Fail() {
-				err = nil
-			}
-			return err
+			return kmsCtx.RequestError()
 		}
 
 		if err = kmsCtx.FeedResponse(res[:bytesRead]); err != nil {

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -53,6 +53,7 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	if wrapped == nil {
 		return nil, errors.New("could not create new mongocrypt object")
 	}
+	C.mongocrypt_setopt_retry_kms(wrapped, true)
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
 		httpClient = httputil.DefaultHTTPClient
@@ -85,7 +86,7 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 	}
 
 	if opts.BypassQueryAnalysis {
-		C.mongocrypt_setopt_bypass_query_analysis(wrapped)
+		C.mongocrypt_setopt_bypass_query_analysis(crypt.wrapped)
 	}
 
 	// If loading the crypt_shared library isn't disabled, set the default library search path "$SYSTEM"

--- a/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
@@ -11,6 +11,7 @@ package mongocrypt
 
 // #include <mongocrypt.h>
 import "C"
+import "time"
 
 // KmsContext represents a mongocrypt_kms_ctx_t handle.
 type KmsContext struct {
@@ -41,6 +42,8 @@ func (kc *KmsContext) KMSProvider() string {
 
 // Message returns the message to send to the KMS.
 func (kc *KmsContext) Message() ([]byte, error) {
+	time.Sleep(time.Duration(C.mongocrypt_kms_ctx_usleep(kc.wrapped)) * time.Microsecond)
+
 	msgBinary := newBinary()
 	defer msgBinary.close()
 
@@ -73,4 +76,9 @@ func (kc *KmsContext) createErrorFromStatus() error {
 	defer C.mongocrypt_status_destroy(status)
 	C.mongocrypt_kms_ctx_status(kc.wrapped, status)
 	return errorFromStatus(status)
+}
+
+// Fail returns a boolean indicating whether the failed request may be retried.
+func (kc *KmsContext) Fail() bool {
+	return bool(C.mongocrypt_kms_ctx_fail(kc.wrapped))
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
@@ -78,7 +78,10 @@ func (kc *KmsContext) createErrorFromStatus() error {
 	return errorFromStatus(status)
 }
 
-// Fail returns a boolean indicating whether the failed request may be retried.
-func (kc *KmsContext) Fail() bool {
-	return bool(C.mongocrypt_kms_ctx_fail(kc.wrapped))
+// RequestError returns the source of the network error for KMS requests.
+func (kc *KmsContext) RequestError() error {
+	if bool(C.mongocrypt_kms_ctx_fail(kc.wrapped)) {
+		return nil
+	}
+	return kc.createErrorFromStatus()
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
@@ -37,3 +37,8 @@ func (kc *KmsContext) BytesNeeded() int32 {
 func (kc *KmsContext) FeedResponse([]byte) error {
 	panic(cseNotSupportedMsg)
 }
+
+// Fail returns a boolean indicating whether the failed request may be retried.
+func (kc *KmsContext) Fail() bool {
+	panic(cseNotSupportedMsg)
+}

--- a/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
@@ -38,7 +38,7 @@ func (kc *KmsContext) FeedResponse([]byte) error {
 	panic(cseNotSupportedMsg)
 }
 
-// Fail returns a boolean indicating whether the failed request may be retried.
-func (kc *KmsContext) Fail() bool {
+// RequestError returns the source of the network error for KMS requests.
+func (kc *KmsContext) RequestError() error {
 	panic(cseNotSupportedMsg)
 }


### PR DESCRIPTION
GODRIVER-3168

## Summary
Retry KMS requests on transient errors.

## Background & Motivation
Changes described here: https://github.com/mongodb/libmongocrypt/blob/master/integrating.md#state-mongocrypt_ctx_need_kms
New tests: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#24-kms-retry-tests
