### PR TITLE
GODRIVER-3321 Fix CSE SetTLSConfig option.

### DIFF
--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1517,46 +1517,52 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace)
 
 		// make TLS opts containing client certificate and CA file
-		tlsConfig := make(map[string]*tls.Config)
 		clientAndCATlsMap := map[string]interface{}{
 			"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 			"tlsCAFile":             tlsCAFileKMIP,
 		}
-		certConfig, err := options.BuildTLSConfig(clientAndCATlsMap)
+		clientAndCATLSConfig, err := options.BuildTLSConfig(clientAndCATlsMap)
 		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
-		tlsConfig["aws"] = certConfig
-		tlsConfig["azure"] = certConfig
-		tlsConfig["gcp"] = certConfig
-		tlsConfig["kmip"] = certConfig
 
 		// create valid Client Encryption options and set valid TLS options
 		validClientEncryptionOptionsWithTLS := options.ClientEncryption().
 			SetKmsProviders(validKmsProviders).
 			SetKeyVaultNamespace(kvNamespace).
-			SetTLSConfig(tlsConfig)
+			SetTLSConfig(map[string]*tls.Config{
+				"aws":   clientAndCATLSConfig,
+				"azure": clientAndCATLSConfig,
+				"gcp":   clientAndCATLSConfig,
+				"kmip":  clientAndCATLSConfig,
+			})
 
 		// make TLS opts containing only CA file
-		caTlsMap := map[string]interface{}{
+		caTlSMap := map[string]interface{}{
 			"tlsCAFile": tlsCAFileKMIP,
 		}
-		certConfig, err = options.BuildTLSConfig(caTlsMap)
+		caTLSConfig, err := options.BuildTLSConfig(caTlSMap)
 		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
-		tlsConfig["aws"] = certConfig
-		tlsConfig["azure"] = certConfig
-		tlsConfig["gcp"] = certConfig
-		tlsConfig["kmip"] = certConfig
 
 		// create invalid Client Encryption options with expired credentials
 		expiredClientEncryptionOptions := options.ClientEncryption().
 			SetKmsProviders(expiredKmsProviders).
 			SetKeyVaultNamespace(kvNamespace).
-			SetTLSConfig(tlsConfig)
+			SetTLSConfig(map[string]*tls.Config{
+				"aws":   caTLSConfig,
+				"azure": caTLSConfig,
+				"gcp":   caTLSConfig,
+				"kmip":  caTLSConfig,
+			})
 
 		// create invalid Client Encryption options with invalid hostnames
 		invalidHostnameClientEncryptionOptions := options.ClientEncryption().
 			SetKmsProviders(invalidKmsProviders).
 			SetKeyVaultNamespace(kvNamespace).
-			SetTLSConfig(tlsConfig)
+			SetTLSConfig(map[string]*tls.Config{
+				"aws":   caTLSConfig,
+				"azure": caTLSConfig,
+				"gcp":   caTLSConfig,
+				"kmip":  caTLSConfig,
+			})
 
 		awsMasterKeyNoClientCert := map[string]interface{}{
 			"region":   "us-east-1",

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1517,11 +1517,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace)
 
 		// make TLS opts containing client certificate and CA file
-		clientAndCATlsMap := map[string]interface{}{
+		clientAndCATLSConfig, err := options.BuildTLSConfig(map[string]interface{}{
 			"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 			"tlsCAFile":             tlsCAFileKMIP,
-		}
-		clientAndCATLSConfig, err := options.BuildTLSConfig(clientAndCATlsMap)
+		})
 		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
 
 		// create valid Client Encryption options and set valid TLS options
@@ -1536,10 +1535,9 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			})
 
 		// make TLS opts containing only CA file
-		caTlSMap := map[string]interface{}{
+		caTLSConfig, err := options.BuildTLSConfig(map[string]interface{}{
 			"tlsCAFile": tlsCAFileKMIP,
-		}
-		caTLSConfig, err := options.BuildTLSConfig(caTlSMap)
+		})
 		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
 
 		// create invalid Client Encryption options with expired credentials

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1444,6 +1444,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		if os.Getenv("KMS_MOCK_SERVERS_RUNNING") == "" {
 			mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
 		}
+		if tlsCAFileKMIP == "" || tlsClientCertificateKeyFileKMIP == "" {
+			mt.Fatal("Env vars CSFLE_TLS_CA_FILE and CSFLE_TLS_CLIENT_CERT_FILE must be set")
+		}
+
 		validKmsProviders := map[string]map[string]interface{}{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
@@ -1514,18 +1518,16 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		// make TLS opts containing client certificate and CA file
 		tlsConfig := make(map[string]*tls.Config)
-		if tlsCAFileKMIP != "" && tlsClientCertificateKeyFileKMIP != "" {
-			clientAndCATlsMap := map[string]interface{}{
-				"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
-				"tlsCAFile":             tlsCAFileKMIP,
-			}
-			certConfig, err := options.BuildTLSConfig(clientAndCATlsMap)
-			assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
-			tlsConfig["aws"] = certConfig
-			tlsConfig["azure"] = certConfig
-			tlsConfig["gcp"] = certConfig
-			tlsConfig["kmip"] = certConfig
+		clientAndCATlsMap := map[string]interface{}{
+			"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
+			"tlsCAFile":             tlsCAFileKMIP,
 		}
+		certConfig, err := options.BuildTLSConfig(clientAndCATlsMap)
+		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
+		tlsConfig["aws"] = certConfig
+		tlsConfig["azure"] = certConfig
+		tlsConfig["gcp"] = certConfig
+		tlsConfig["kmip"] = certConfig
 
 		// create valid Client Encryption options and set valid TLS options
 		validClientEncryptionOptionsWithTLS := options.ClientEncryption().
@@ -1533,18 +1535,16 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace).
 			SetTLSConfig(tlsConfig)
 
-		// make TLS opts containing only CA file
-		if tlsCAFileKMIP != "" {
-			caTlsMap := map[string]interface{}{
-				"tlsCAFile": tlsCAFileKMIP,
-			}
-			certConfig, err := options.BuildTLSConfig(caTlsMap)
-			assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
-			tlsConfig["aws"] = certConfig
-			tlsConfig["azure"] = certConfig
-			tlsConfig["gcp"] = certConfig
-			tlsConfig["kmip"] = certConfig
+			// make TLS opts containing only CA file
+		caTlsMap := map[string]interface{}{
+			"tlsCAFile": tlsCAFileKMIP,
 		}
+		certConfig, err = options.BuildTLSConfig(caTlsMap)
+		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
+		tlsConfig["aws"] = certConfig
+		tlsConfig["azure"] = certConfig
+		tlsConfig["gcp"] = certConfig
+		tlsConfig["kmip"] = certConfig
 
 		// create invalid Client Encryption options with expired credentials
 		expiredClientEncryptionOptions := options.ClientEncryption().
@@ -1622,7 +1622,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 				possibleErrors := []string{
 					"x509: certificate signed by unknown authority",                   // Windows
-					"x509: “valid.testing.golang.invalid” certificate is not trusted", // MacOS
+					"x509: “valid.testing.golang.invalid” certificate is not trusted", // macOS
+					"x509: “server” certificate is not standards compliant",           // macOS
 					"x509: certificate is not authorized to sign other certificates",  // All others
 				}
 

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1535,7 +1535,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace).
 			SetTLSConfig(tlsConfig)
 
-			// make TLS opts containing only CA file
+		// make TLS opts containing only CA file
 		caTlsMap := map[string]interface{}{
 			"tlsCAFile": tlsCAFileKMIP,
 		}

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -185,15 +185,17 @@ func (a *AutoEncryptionOptionsBuilder) SetExtraOptions(extraOpts map[string]inte
 //
 // This should only be used to set custom TLS configurations. By default, the connection will use an empty tls.Config{} with MinVersion set to tls.VersionTLS12.
 func (a *AutoEncryptionOptionsBuilder) SetTLSConfig(tlsOpts map[string]*tls.Config) *AutoEncryptionOptionsBuilder {
-	a.Opts = append(a.Opts, func(args *AutoEncryptionOptions) error {
-		tlsConfigs := make(map[string]*tls.Config)
-		for provider, config := range tlsOpts {
-			// use TLS min version 1.2 to enforce more secure hash algorithms and advanced cipher suites
-			if config.MinVersion == 0 {
-				config.MinVersion = tls.VersionTLS12
-			}
-			tlsConfigs[provider] = config
+	tlsConfigs := make(map[string]*tls.Config)
+	for provider, config := range tlsOpts {
+		// Use TLS min version 1.2 to enforce more secure hash algorithms and
+		// advanced cipher suites.
+		if config.MinVersion == 0 {
+			config.MinVersion = tls.VersionTLS12
 		}
+		tlsConfigs[provider] = config
+	}
+
+	a.Opts = append(a.Opts, func(args *AutoEncryptionOptions) error {
 		args.TLSConfig = tlsConfigs
 
 		return nil

--- a/mongo/options/autoencryptionoptions.go
+++ b/mongo/options/autoencryptionoptions.go
@@ -184,19 +184,9 @@ func (a *AutoEncryptionOptionsBuilder) SetExtraOptions(extraOpts map[string]inte
 // to the KMS provider.
 //
 // This should only be used to set custom TLS configurations. By default, the connection will use an empty tls.Config{} with MinVersion set to tls.VersionTLS12.
-func (a *AutoEncryptionOptionsBuilder) SetTLSConfig(tlsOpts map[string]*tls.Config) *AutoEncryptionOptionsBuilder {
-	tlsConfigs := make(map[string]*tls.Config)
-	for provider, config := range tlsOpts {
-		// Use TLS min version 1.2 to enforce more secure hash algorithms and
-		// advanced cipher suites.
-		if config.MinVersion == 0 {
-			config.MinVersion = tls.VersionTLS12
-		}
-		tlsConfigs[provider] = config
-	}
-
+func (a *AutoEncryptionOptionsBuilder) SetTLSConfig(cfg map[string]*tls.Config) *AutoEncryptionOptionsBuilder {
 	a.Opts = append(a.Opts, func(args *AutoEncryptionOptions) error {
-		args.TLSConfig = tlsConfigs
+		args.TLSConfig = cfg
 
 		return nil
 	})

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -71,18 +71,22 @@ func (c *ClientEncryptionOptionsBuilder) SetKmsProviders(providers map[string]ma
 //
 // This should only be used to set custom TLS configurations. By default, the connection will use an empty tls.Config{} with MinVersion set to tls.VersionTLS12.
 func (c *ClientEncryptionOptionsBuilder) SetTLSConfig(tlsOpts map[string]*tls.Config) *ClientEncryptionOptionsBuilder {
-	c.Opts = append(c.Opts, func(opts *ClientEncryptionOptions) error {
-		tlsConfigs := make(map[string]*tls.Config)
-		for provider, config := range tlsOpts {
-			// use TLS min version 1.2 to enforce more secure hash algorithms and advanced cipher suites
-			if config.MinVersion == 0 {
-				config.MinVersion = tls.VersionTLS12
-			}
-			tlsConfigs[provider] = config
+	tlsConfigs := make(map[string]*tls.Config)
+	for provider, config := range tlsOpts {
+		// Use TLS min version 1.2 to enforce more secure hash algorithms and
+		// advanced cipher suites.
+		if config.MinVersion == 0 {
+			config.MinVersion = tls.VersionTLS12
 		}
+		tlsConfigs[provider] = config
+	}
+
+	c.Opts = append(c.Opts, func(opts *ClientEncryptionOptions) error {
 		opts.TLSConfig = tlsConfigs
+
 		return nil
 	})
+
 	return c
 }
 

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -70,19 +70,9 @@ func (c *ClientEncryptionOptionsBuilder) SetKmsProviders(providers map[string]ma
 // to the KMS provider.
 //
 // This should only be used to set custom TLS configurations. By default, the connection will use an empty tls.Config{} with MinVersion set to tls.VersionTLS12.
-func (c *ClientEncryptionOptionsBuilder) SetTLSConfig(tlsOpts map[string]*tls.Config) *ClientEncryptionOptionsBuilder {
-	tlsConfigs := make(map[string]*tls.Config)
-	for provider, config := range tlsOpts {
-		// Use TLS min version 1.2 to enforce more secure hash algorithms and
-		// advanced cipher suites.
-		if config.MinVersion == 0 {
-			config.MinVersion = tls.VersionTLS12
-		}
-		tlsConfigs[provider] = config
-	}
-
+func (c *ClientEncryptionOptionsBuilder) SetTLSConfig(cfg map[string]*tls.Config) *ClientEncryptionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *ClientEncryptionOptions) error {
-		opts.TLSConfig = tlsConfigs
+		opts.TLSConfig = cfg
 
 		return nil
 	})


### PR DESCRIPTION
[GODRIVER-3321](https://jira.mongodb.org/browse/GODRIVER-3321)

## Summary

Immediately make a copy of the TLS config map in `ClientEncryptionOptionsBuilder.SetTLSConfig` and `AutoEncryptionOptionsBuilder.SetTLSConfig` to prevent the map values from changing before the option function is called.

## Background & Motivation

Currently, if you modify the TLS config map passed to `ClientEncryptionOptionsBuilder.SetTLSConfig` or `AutoEncryptionOptionsBuilder.SetTLSConfig` before passing the options to `NewClientEncryption`, the TLS config map passed to `NewClientEncryption` will unexpectedly change. That's because the option function is a closure over the original map. Instead, we should make a copy of the map in the setter body and pass that copy into the option function.