### PR TITLE
GODRIVER-3433 Restore SetOplogReplay.

### DIFF
--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -1165,6 +1165,7 @@ func TestCollection(t *testing.T) {
 				SetHint(indexName).
 				SetMax(bson.D{{"x", int32(5)}}).
 				SetMin(bson.D{{"x", int32(0)}}).
+				SetOplogReplay(false).
 				SetProjection(bson.D{{"x", int32(1)}}).
 				SetReturnKey(false).
 				SetShowRecordID(false).
@@ -1186,6 +1187,7 @@ func TestCollection(t *testing.T) {
 				AppendString("hint", indexName).
 				StartDocument("max").AppendInt32("x", 5).FinishDocument().
 				StartDocument("min").AppendInt32("x", 0).FinishDocument().
+				AppendBoolean("oplogReplay", false).
 				StartDocument("projection").AppendInt32("x", 1).FinishDocument().
 				AppendBoolean("returnKey", false).
 				AppendBoolean("showRecordId", false).

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -1471,6 +1471,8 @@ func createFindCursor(ctx context.Context, operation *operation) (*cursorResult,
 			opts.SetMin(val.Document())
 		case "noCursorTimeout":
 			opts.SetNoCursorTimeout(val.Boolean())
+		case "oplogReplay":
+			opts.SetOplogReplay(val.Boolean())
 		case "projection":
 			opts.SetProjection(val.Document())
 		case "returnKey":

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1465,6 +1465,9 @@ func (coll *Collection) find(
 	if args.NoCursorTimeout != nil {
 		op.NoCursorTimeout(*args.NoCursorTimeout)
 	}
+	if args.OplogReplay != nil {
+		op.OplogReplay(*args.OplogReplay)
+	}
 	if args.Projection != nil {
 		proj, err := marshal(args.Projection, coll.bsonOpts, coll.registry)
 		if err != nil {
@@ -1518,6 +1521,7 @@ func newFindArgsFromFindOneArgs(args *options.FindOneOptions) *options.FindOptio
 		v.Hint = args.Hint
 		v.Max = args.Max
 		v.Min = args.Min
+		v.OplogReplay = args.OplogReplay
 		v.Projection = args.Projection
 		v.ReturnKey = args.ReturnKey
 		v.ShowRecordID = args.ShowRecordID

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -22,6 +22,7 @@ type FindOptions struct {
 	Max                 interface{}
 	MaxAwaitTime        *time.Duration
 	Min                 interface{}
+	OplogReplay         *bool
 	Projection          interface{}
 	ReturnKey           *bool
 	ShowRecordID        *bool
@@ -200,6 +201,19 @@ func (f *FindOptionsBuilder) SetNoCursorTimeout(b bool) *FindOptionsBuilder {
 	return f
 }
 
+// SetOplogReplay sets the value for the OplogReplay field. OplogReplay is for internal
+// replication use only and should not be set.
+//
+// Deprecated: This option has been deprecated in MongoDB version 4.4 and will be ignored by
+// the server if it is set.
+func (f *FindOptionsBuilder) SetOplogReplay(b bool) *FindOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOptions) error {
+		opts.OplogReplay = &b
+		return nil
+	})
+	return f
+}
+
 // SetProjection sets the value for the Projection field. Projection is a document describing
 // which fields will be included in the documents returned by the Find operation. The
 // default value is nil, which means all fields will be included.
@@ -265,6 +279,7 @@ type FindOneOptions struct {
 	Hint                interface{}
 	Max                 interface{}
 	Min                 interface{}
+	OplogReplay         *bool
 	Projection          interface{}
 	ReturnKey           *bool
 	ShowRecordID        *bool
@@ -349,6 +364,19 @@ func (f *FindOneOptionsBuilder) SetMax(max interface{}) *FindOneOptionsBuilder {
 func (f *FindOneOptionsBuilder) SetMin(min interface{}) *FindOneOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneOptions) error {
 		opts.Min = min
+		return nil
+	})
+	return f
+}
+
+// SetOplogReplay sets the value for the OplogReplay field. OplogReplay is for internal
+// replication use only and should not be set.
+//
+// Deprecated: This option has been deprecated in MongoDB version 4.4 and will be ignored by
+// the server if it is set.
+func (f *FindOneOptionsBuilder) SetOplogReplay(b bool) *FindOneOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOneOptions) error {
+		opts.OplogReplay = &b
 		return nil
 	})
 	return f


### PR DESCRIPTION
GODRIVER-3433

## Summary
Restore the `SetOplogReplay`, which is still needed for 4.4 support.

## Background & Motivation
Removed in PR #1398
