### PR TITLE
GODRIVER-3436 Avoid initializing null data given custom decoder

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1521,6 +1521,12 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
 
+	if vr.Type() == bsontype.Null {
+		val.Set(reflect.Zero(val.Type()))
+
+		return vr.ReadNull()
+	}
+
 	if val.Kind() == reflect.Ptr && val.IsNil() {
 		if !val.CanSet() {
 			return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -176,7 +176,7 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			data:  docToBytes(valNonPtrStruct),
 		},
 		{
-			name:  "do not initialize null-literal data for custom type and unmarshaler",
+			name:  "null-literal data for custom type and unmarshaler should not be initialize",
 			sType: reflect.TypeOf(unmarshalerPtrStruct{}),
 			want:  &unmarshalerPtrStruct{},
 			data:  docWithNullValueBytes("I"),

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 type unmarshalingTestCase struct {
@@ -174,6 +175,12 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			want:  &valNonPtrStruct,
 			data:  docToBytes(valNonPtrStruct),
 		},
+		{
+			name:  "meep",
+			sType: reflect.TypeOf(unmarshalerPtrStruct{}),
+			want:  &unmarshalerPtrStruct{},
+			data:  docWithNullValueBytes("I"),
+		},
 	}
 }
 
@@ -249,4 +256,15 @@ func (ms *myString) UnmarshalBSON(bytes []byte) error {
 	}
 	*ms = myString(s)
 	return nil
+}
+
+// create a byte slice that represents BSON with a variable key value that is
+// null, e.g. {<key>: null}.
+func docWithNullValueBytes(key string) []byte {
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendNullElement(doc, key)
+
+	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
+
+	return Raw(doc)
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -176,7 +176,7 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			data:  docToBytes(valNonPtrStruct),
 		},
 		{
-			name:  "meep",
+			name:  "do not initialize null-literal data for custom type and unmarshaler",
 			sType: reflect.TypeOf(unmarshalerPtrStruct{}),
 			want:  &unmarshalerPtrStruct{},
 			data:  docWithNullValueBytes("I"),


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3436

## Summary

<!--- A summary of the changes proposed by this pull request. -->

If the value reader is null, prevent `DefaultValueDecoders` from initializing a pointer to the zero value.

## Background & Motivation

The current behavior will lead to unexpected results:

```go
ill instantiate a pointer field decoded from null data if the user defines a UnmarshalBSONValue. For example:

package main

import (
	"fmt"

	"go.mongodb.org/mongo-driver/bson"
	"go.mongodb.org/mongo-driver/bson/bsontype"
	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
)

type DBInt64 int64

type Product struct {
	TotalForSell *DBInt64 `json:"total_for_sell" bson:"total_for_sell,omitempty"`
}

func (i *DBInt64) UnmarshalBSONValue(t bsontype.Type, value []byte) error {
	return nil
}

func main() {
	idx, doc := bsoncore.AppendDocumentStart(nil)
	doc = bsoncore.AppendNullElement(doc, "total_for_sell")

	doc, err := bsoncore.AppendDocumentEnd(doc, idx)
	if err != nil {
		panic(err)
	}

	bytes := bson.Raw(doc)

	got := Product{}
	if err := bson.Unmarshal(bytes, &got); err != nil {
		panic(err)
	}

	if got.TotalForSell != nil {
		fmt.Println("null value decoded as non-nil")
	}
}
```

Output:
```
❯ go run custom_type_with_pointer.go
null value decoded as non-nil
```