### PR TITLE
GODRIVER-3434 Avoid initializing null data given custom decoder

### DIFF
--- a/bson/default_value_decoders.go
+++ b/bson/default_value_decoders.go
@@ -1166,6 +1166,12 @@ func valueUnmarshalerDecodeValue(_ DecodeContext, vr ValueReader, val reflect.Va
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
 
+	if vr.Type() == TypeNull {
+		val.Set(reflect.Zero(val.Type()))
+
+		return vr.ReadNull()
+	}
+
 	if val.Kind() == reflect.Ptr && val.IsNil() {
 		if !val.CanSet() {
 			return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -197,6 +197,25 @@ type unmarshalerNonPtrStruct struct {
 
 type myInt64 int64
 
+var _ ValueUnmarshaler = (*myInt64)(nil)
+
+func (mi *myInt64) UnmarshalBSONValue(t byte, b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	if Type(t) == TypeInt64 {
+		i, err := newValueReader(TypeInt64, bytes.NewReader(b)).ReadInt64()
+		if err != nil {
+			return err
+		}
+
+		*mi = myInt64(i)
+	}
+
+	return nil
+}
+
 func (mi *myInt64) UnmarshalBSON(b []byte) error {
 	if len(b) == 0 {
 		return nil


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3436

## Summary

<!--- A summary of the changes proposed by this pull request. -->

If the value reader is null, prevent `DefaultValueDecoders` from initializing a pointer to the zero value.

## Background & Motivation

The current behavior will lead to unexpected results:

```go
ill instantiate a pointer field decoded from null data if the user defines a UnmarshalBSONValue. For example:

package main

import (
	"fmt"

	"go.mongodb.org/mongo-driver/v2/bson"
	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
)

type DBInt64 int64

type Product struct {
	TotalForSell *DBInt64 `json:"total_for_sell" bson:"total_for_sell,omitempty"`
}

func (i *DBInt64) UnmarshalBSONValue(t bson.Type, value []byte) error {
	return nil
}

func main() {
	idx, doc := bsoncore.AppendDocumentStart(nil)
	doc = bsoncore.AppendNullElement(doc, "total_for_sell")

	doc, err := bsoncore.AppendDocumentEnd(doc, idx)
	if err != nil {
		panic(err)
	}

	bytes := bson.Raw(doc)

	got := Product{}
	if err := bson.Unmarshal(bytes, &got); err != nil {
		panic(err)
	}

	if got.TotalForSell != nil {
		fmt.Println("null value decoded as non-nil")
	}
}
```

Output:
```
❯ go run custom_type_with_pointer.go
null value decoded as non-nil
```