### PR TITLE
GODRIVER-3307 Simplify MarshalValue and UnmarshalValue test case setup.

### DIFF
--- a/bson/unmarshal_value_test.go
+++ b/bson/unmarshal_value_test.go
@@ -19,24 +19,18 @@ import (
 func TestUnmarshalValue(t *testing.T) {
 	t.Parallel()
 
-	unmarshalValueTestCases := newMarshalValueTestCases(t)
+	for _, tc := range marshalValueTestCases {
+		tc := tc
 
-	t.Run("UnmarshalValue", func(t *testing.T) {
-		t.Parallel()
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		for _, tc := range unmarshalValueTestCases {
-			tc := tc
-
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-
-				gotValue := reflect.New(reflect.TypeOf(tc.val))
-				err := UnmarshalValue(tc.bsontype, tc.bytes, gotValue.Interface())
-				assert.Nil(t, err, "UnmarshalValueWithRegistry error: %v", err)
-				assert.Equal(t, tc.val, gotValue.Elem().Interface(), "value mismatch; expected %s, got %s", tc.val, gotValue.Elem())
-			})
-		}
-	})
+			gotValue := reflect.New(reflect.TypeOf(tc.val))
+			err := UnmarshalValue(tc.bsontype, tc.bytes, gotValue.Interface())
+			assert.Nil(t, err, "UnmarshalValueWithRegistry error: %v", err)
+			assert.Equal(t, tc.val, gotValue.Elem().Interface(), "value mismatch; expected %s, got %s", tc.val, gotValue.Elem())
+		})
+	}
 }
 
 // tests covering GODRIVER-2779


### PR DESCRIPTION
[GODRIVER-3307](https://jira.mongodb.org/browse/GODRIVER-3307)

## Summary

* Use keyed structs for all `MarshalValue` test cases to make them easier to read.
* Use only struct literals instead of functions to define the `MarshalValue` test cases.
* Don't use `Marshal` when testing `MarshalValue` to prevent bugs in `Marshal` from masking bugs in `MarshalValue`.
* Remove unnecessary subtest nesting in `TestMarshalValue`.

## Background & Motivation


