### PR TITLE
GODRIVER-3032 Don't retry writes on pre-4.4 mongos

### DIFF
--- a/testdata/retryable-writes/unified/insertOne-serverErrors.json
+++ b/testdata/retryable-writes/unified/insertOne-serverErrors.json
@@ -378,6 +378,99 @@
       ]
     },
     {
+      "description": "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "InsertOne succeeds after connection failure",
       "operations": [
         {

--- a/testdata/retryable-writes/unified/insertOne-serverErrors.yml
+++ b/testdata/retryable-writes/unified/insertOne-serverErrors.yml
@@ -157,6 +157,44 @@ tests:
           # writeConcernError doesn't prevent the server from applying the write
           - { _id: 3, x: 33 }
 
+  - description: "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point only once since a RetryableWriteError label
+            # will not be added and the write will not be retried.
+            mode: { times: 1 }
+            data:
+              failCommands: [ "insert" ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsOmit: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          # writeConcernError doesn't prevent the server from applying the write
+          - { _id: 3, x: 33 }
   -
     description: 'InsertOne succeeds after connection failure'
     operations:

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -140,7 +140,7 @@ func (wce WriteCommandError) Error() string {
 }
 
 // Retryable returns true if the error is retryable
-func (wce WriteCommandError) Retryable(wireVersion *description.VersionRange) bool {
+func (wce WriteCommandError) Retryable(serverKind description.ServerKind, wireVersion *description.VersionRange) bool {
 	for _, label := range wce.Labels {
 		if label == RetryableWriteError {
 			return true
@@ -153,7 +153,8 @@ func (wce WriteCommandError) Retryable(wireVersion *description.VersionRange) bo
 	if wce.WriteConcernError == nil {
 		return false
 	}
-	return wce.WriteConcernError.Retryable()
+
+	return wce.WriteConcernError.Retryable(serverKind, wireVersion)
 }
 
 // HasErrorLabel returns true if the error contains the specified label.
@@ -186,7 +187,14 @@ func (wce WriteConcernError) Error() string {
 }
 
 // Retryable returns true if the error is retryable
-func (wce WriteConcernError) Retryable() bool {
+func (wce WriteConcernError) Retryable(serverKind description.ServerKind, wireVersion *description.VersionRange) bool {
+	if serverKind == description.ServerKindMongos && wireVersion.Max < 9 {
+		// For a pre-4.4 mongos response, we can trust that mongos will have already
+		// retried the operation if necessary. Drivers should not retry to avoid
+		// "excessive retrying".
+		return false
+	}
+
 	for _, code := range retryableCodes {
 		if wce.Code == int64(code) {
 			return true

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -153,7 +153,6 @@ func (wce WriteCommandError) Retryable(serverKind description.ServerKind, wireVe
 	if wce.WriteConcernError == nil {
 		return false
 	}
-
 	return wce.WriteConcernError.Retryable(serverKind, wireVersion)
 }
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -820,7 +820,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			}
 
 			connDesc := conn.Description()
-			retryableErr := tt.Retryable(connDesc.WireVersion)
+			retryableErr := tt.Retryable(connDesc.Kind, connDesc.WireVersion)
 			preRetryWriteLabelVersion := connDesc.WireVersion != nil && connDesc.WireVersion.Max < 9
 			inTransaction := op.Client != nil &&
 				!(op.Client.Committing || op.Client.Aborting) && op.Client.TransactionRunning()


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3032

## Summary

For a pre-4.4 mongos response, we can trust that mongos will have already retried the operation if necessary. Drivers should not retry to avoid "excessive retrying".

Under similar circumstances, the specifications now clarify that drivers should not consider codes within writeErrors from a mongod or mongos response. Notably, the Go Driver does not currently do this.

## Background & Motivation

<!--- Rationale for the pull request. -->

From the comments on the related drivers ticket:

> Pre and post 4.4 mongos will retry on retryable codes within the writeConcernError field (it chooses to retry based on the "effective status" from a command response - [4.2 code](https://github.com/mongodb/mongo/blob/54e29d8dcc/src/mongo/s/client/shard.cpp#L127-L128) and [current master](https://github.com/mongodb/mongo/blob/146311aeb40f9ac573277f4ef2c2342530755124/src/mongo/s/client/shard.cpp#L126-L127) - which will check the write concern status - [4.2](https://github.com/mongodb/mongo/blob/54e29d8dcc/src/mongo/s/client/shard.cpp#L64-L67) and [master](https://github.com/mongodb/mongo/blob/146311aeb40f9ac573277f4ef2c2342530755124/src/mongo/s/client/shard.cpp#L64-L67)). So in both cases drivers should not retry because mongos would only return a retryable write concern error if it exhausts its retry attempts. The only difference pre and post 4.4 with regard to write concern errors is that mongos will not retry on WriteConcernFailed in post 4.4 (as called out by the [retryable error label proposal](https://docs.google.com/document/d/1etljLCq1GLchti_7pVZta4JRaoCoc8OBnjVyYwj_slo/edit#heading=h.bfy81zxgct4z)), but I don't think that affects drivers behavior because [according to their retryable writes spec](https://github.com/mongodb/specifications/blob/77f3ea40e5da8c22651cdecca60502a2bcca212e/source/retryable-writes/retryable-writes.rst#determining-retryable-errors), that code isn't considered retryable.
