### PR TITLE
Update guide to reflect that bson string methods are cannonical

### DIFF
--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -844,7 +844,7 @@ The `bson/primitive` package has been merged into the `bson` package.
 
 Additionally, the `bson.D` has implemented the `json.Marshaler` and `json.Unmarshaler` interfaces, where it uses a key-value representation in "regular" (i.e. non-Extended) JSON.
 
-The `bson.D.String` and `bson.M.String` methods return a relaxed Extended JSON representation of the document.
+The `bson.D.String` and `bson.M.String` methods return an Extended JSON representation of the document.
 
 ```go
 // v2


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

<!--- A summary of the changes proposed by this pull request. -->

`bson.M` and `bson.D` `String()` methods using decode into canonical extended JSON for their String representation. However, the migration guide says "relaxed". 

## Background & Motivation

<!--- Rationale for the pull request. -->
