### PR TITLE
GODRIVER-3452 MergeClientOptions returns object when given nil arguments

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -1265,6 +1265,10 @@ func extractX509UsernameFromSubject(subject string) string {
 // precedence.
 func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 	if len(opts) == 1 {
+		if opts[0] == nil {
+			return Client()
+		}
+
 		return opts[0]
 	}
 

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -178,12 +178,12 @@ func TestClientOptions(t *testing.T) {
 
 		t.Run("MergeClientOptions single nil option", func(t *testing.T) {
 			got := MergeClientOptions(nil)
-			assert.NotNil(t, got)
+			assert.Equal(t, Client(), got)
 		})
 
 		t.Run("MergeClientOptions multiple nil options", func(t *testing.T) {
 			got := MergeClientOptions(nil, nil)
-			assert.NotNil(t, got)
+			assert.Equal(t, Client(), got)
 		})
 	})
 	t.Run("direct connection validation", func(t *testing.T) {

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -175,6 +175,16 @@ func TestClientOptions(t *testing.T) {
 				t.Errorf("Merged client options do not match. got %v; want %v", got.err.Error(), opt1.err.Error())
 			}
 		})
+
+		t.Run("MergeClientOptions single nil option", func(t *testing.T) {
+			got := MergeClientOptions(nil)
+			assert.NotNil(t, got)
+		})
+
+		t.Run("MergeClientOptions multiple nil options", func(t *testing.T) {
+			got := MergeClientOptions(nil, nil)
+			assert.NotNil(t, got)
+		})
 	})
 	t.Run("direct connection validation", func(t *testing.T) {
 		t.Run("multiple hosts", func(t *testing.T) {


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3452

## Summary

Currently MergeClientOptions returns `nil` when given a single `nil` argument. This is unexpected behavior, this function should always return an object to avoid a check where used.

## Background & Motivation

NA
