### PR TITLE
GODRIVER-2486 add tests for equals terminated keys with no values

### DIFF
--- a/testdata/connection-string/valid-options.json
+++ b/testdata/connection-string/valid-options.json
@@ -20,6 +20,29 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
+    },
+    {
+      "description": "Equals terminated keys with no value are parsed without error",
+      "uri": "mongodb://alice:secret@example.com/admin?readPreferenceTags=",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": {
+        "readPreferenceTags": [
+          {}
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
[GODRIVER-2486](https://jira.mongodb.org/browse/GODRIVER-2486)

# Summary
Adds a test to ensure that keys terminated with equals sign (no value) are parsed without error.

# Background & Motivation
Tests conformity to current spec. Good to have, unless we're rethinking the implementation and planning to disallow this.