### PR TITLE
GODRIVER-3470 Correct BSON unmarshaling logic for null values

### DIFF
--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1521,7 +1521,13 @@ func (dvd DefaultValueDecoders) ValueUnmarshalerDecodeValue(_ DecodeContext, vr 
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
 
-	if vr.Type() == bsontype.Null {
+	// If BSON value is null and the go value is a pointer, then don't call
+	// UnmarshalBSONValue. Even if the Go pointer is already initialized (i.e.,
+	// non-nil), encountering null in BSON will result in the pointer being
+	// directly set to nil here. Since the pointer is being replaced with nil,
+	// there is no opportunity (or reason) for the custom UnmarshalBSONValue logic
+	// to be called.
+	if vr.Type() == bsontype.Null && val.Kind() == reflect.Ptr {
 		val.Set(reflect.Zero(val.Type()))
 
 		return vr.ReadNull()

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1570,11 +1570,11 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonr
 	}
 
 	// If BSON value is null and the go value is a pointer, then don't call
-	// UnmarshalBSONValue. Even if the Go pointer is already initialized (i.e.,
+	// UnmarshalBSON. Even if the Go pointer is already initialized (i.e.,
 	// non-nil), encountering null in BSON will result in the pointer being
 	// directly set to nil here. Since the pointer is being replaced with nil,
-	// there is no opportunity (or reason) for the custom UnmarshalBSONValue logic
-	// to be called.
+	// there is no opportunity (or reason) for the custom UnmarshalBSON logic to
+	// be called.
 	if val.Kind() == reflect.Ptr && vr.Type() == bsontype.Null {
 		val.Set(reflect.Zero(val.Type()))
 

--- a/bson/bsoncodec/default_value_decoders.go
+++ b/bson/bsoncodec/default_value_decoders.go
@@ -1569,6 +1569,18 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonr
 		return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
 	}
 
+	// If BSON value is null and the go value is a pointer, then don't call
+	// UnmarshalBSONValue. Even if the Go pointer is already initialized (i.e.,
+	// non-nil), encountering null in BSON will result in the pointer being
+	// directly set to nil here. Since the pointer is being replaced with nil,
+	// there is no opportunity (or reason) for the custom UnmarshalBSONValue logic
+	// to be called.
+	if val.Kind() == reflect.Ptr && vr.Type() == bsontype.Null {
+		val.Set(reflect.Zero(val.Type()))
+
+		return vr.ReadNull()
+	}
+
 	if val.Kind() == reflect.Ptr && val.IsNil() {
 		if !val.CanSet() {
 			return ValueDecoderError{Name: "UnmarshalerDecodeValue", Types: []reflect.Type{tUnmarshaler}, Received: val}
@@ -1579,18 +1591,6 @@ func (dvd DefaultValueDecoders) UnmarshalerDecodeValue(_ DecodeContext, vr bsonr
 	_, src, err := bsonrw.Copier{}.CopyValueToBytes(vr)
 	if err != nil {
 		return err
-	}
-
-	// If the target Go value is a pointer and the BSON field value is empty, set the value to the
-	// zero value of the pointer (nil) and don't call UnmarshalBSON. UnmarshalBSON has no way to
-	// change the pointer value from within the function (only the value at the pointer address),
-	// so it can't set the pointer to "nil" itself. Since the most common Go value for an empty BSON
-	// field value is "nil", we set "nil" here and don't call UnmarshalBSON. This behavior matches
-	// the behavior of the Go "encoding/json" unmarshaler when the target Go value is a pointer and
-	// the JSON field value is "null".
-	if val.Kind() == reflect.Ptr && len(src) == 0 {
-		val.Set(reflect.Zero(val.Type()))
-		return nil
 	}
 
 	if !val.Type().Implements(tUnmarshaler) {

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -41,6 +41,9 @@ type ValueUnmarshaler interface {
 // Unmarshal parses the BSON-encoded data and stores the result in the value
 // pointed to by val. If val is nil or not a pointer, Unmarshal returns
 // InvalidUnmarshalError.
+//
+// When unmarshaling BSON, if the BSON value is null and the Go value is a
+// pointer, the pointer is set to nil without calling UnmarshalBSONValue.
 func Unmarshal(data []byte, val interface{}) error {
 	return UnmarshalWithRegistry(DefaultRegistry, data, val)
 }

--- a/bson/unmarshal_value_test.go
+++ b/bson/unmarshal_value_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -91,6 +92,29 @@ func TestUnmarshalValue(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestInitializedPointerDataWithBSONNull(t *testing.T) {
+	// Set up the test case with initialized pointers.
+	tc := unmarshalBehaviorTestCase{
+		BSONValuePtrTracker: &unmarshalBSONValueCallTracker{},
+		BSONPtrTracker:      &unmarshalBSONCallTracker{},
+	}
+
+	// Create BSON data where the '*_ptr_tracker' fields are explicitly set to
+	// null.
+	bytes := docToBytes(D{
+		{Key: "bv_ptr_tracker", Value: nil},
+		{Key: "b_ptr_tracker", Value: nil},
+	})
+
+	// Unmarshal the BSON data into the test case struct. This should set the
+	// pointer fields to nil due to the BSON null value.
+	err := Unmarshal(bytes, &tc)
+	require.NoError(t, err)
+
+	assert.Nil(t, tc.BSONValuePtrTracker)
+	assert.Nil(t, tc.BSONPtrTracker)
 }
 
 // tests covering GODRIVER-2779

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -114,6 +114,17 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			},
 			data: docToBytes(D{{"fooBar", int32(10)}}),
 		},
+		{
+			name:  "nil pointer and non-pointer type with literal null BSON",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				Tracker: unmarshalCallTracker{
+					unmarshalCalled: true,
+				},
+				PtrTracker: nil,
+			},
+			data: docToBytes(D{{Key: "tracker", Value: nil}, {Key: "ptr_tracker", Value: nil}}),
+		},
 		// GODRIVER-2252
 		// Test that a struct of pointer types with UnmarshalBSON functions defined marshal and
 		// unmarshal to the same Go values when the pointer values are "nil".
@@ -267,5 +278,20 @@ func (ms *myString) UnmarshalBSON(bytes []byte) error {
 		return err
 	}
 	*ms = myString(s)
+	return nil
+}
+
+type unmarshalCallTracker struct {
+	unmarshalCalled bool
+}
+
+type unmarshalBehaviorTestCase struct {
+	Tracker    unmarshalCallTracker  `bson:"tracker"`
+	PtrTracker *unmarshalCallTracker `bson:"ptr_tracker"`
+}
+
+func (ms *unmarshalCallTracker) UnmarshalBSONValue(bsontype.Type, []byte) error {
+	ms.unmarshalCalled = true
+
 	return nil
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -8,9 +8,12 @@ package bson
 
 import (
 	"reflect"
+	"testing"
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
 )
 
 type unmarshalingTestCase struct {
@@ -294,4 +297,21 @@ func (ms *unmarshalCallTracker) UnmarshalBSONValue(bsontype.Type, []byte) error 
 	ms.unmarshalCalled = true
 
 	return nil
+}
+
+func TestInitializedPointerDataWithBSONNull(t *testing.T) {
+	// Set up the test case with an initialized pointer.
+	tc := unmarshalBehaviorTestCase{
+		PtrTracker: &unmarshalCallTracker{},
+	}
+
+	// Create BSON data where the 'ptr_tracker' field is explicitly set to null.
+	bytes := docToBytes(D{{Key: "ptr_tracker", Value: nil}})
+
+	// Unmarshal the BSON data into the test case struct.
+	// This should set PtrTracker to nil due to the BSON null value.
+	err := Unmarshal(bytes, &tc)
+	require.NoError(t, err)
+
+	assert.Nil(t, tc.PtrTracker)
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type unmarshalingTestCase struct {
@@ -193,6 +194,50 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			sType: reflect.TypeOf(unmarshalerNonPtrStruct{}),
 			want:  &valNonPtrStruct,
 			data:  docToBytes(valNonPtrStruct),
+		},
+		{
+			name:  "nil pointer and non-pointer type with BSON minkey",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				BSONValueTracker: unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONValuePtrTracker: &unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONTracker: unmarshalBSONCallTracker{
+					called: true,
+				},
+				BSONPtrTracker: nil,
+			},
+			data: docToBytes(D{
+				{Key: "bv_tracker", Value: primitive.MinKey{}},
+				{Key: "bv_ptr_tracker", Value: primitive.MinKey{}},
+				{Key: "b_tracker", Value: primitive.MinKey{}},
+				{Key: "b_ptr_tracker", Value: primitive.MinKey{}},
+			}),
+		},
+		{
+			name:  "nil pointer and non-pointer type with BSON maxkey",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				BSONValueTracker: unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONValuePtrTracker: &unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONTracker: unmarshalBSONCallTracker{
+					called: true,
+				},
+				BSONPtrTracker: nil,
+			},
+			data: docToBytes(D{
+				{Key: "bv_tracker", Value: primitive.MaxKey{}},
+				{Key: "bv_ptr_tracker", Value: primitive.MaxKey{}},
+				{Key: "b_tracker", Value: primitive.MaxKey{}},
+				{Key: "b_ptr_tracker", Value: primitive.MaxKey{}},
+			}),
 		},
 	}
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3470

## Summary

Ensure UnmarshalBSONValue is bypassed and the Go pointer is set to nil ONLY when the Go type is a pointer and the BSON value is null.

## Background & Motivation

PR #1903 introduced logic where UnmarshalBSONValue() is not called for bson.TypeNull, which breaks applications that rely on this behavior for initializing fields.
