### PR TITLE
Fix erroneous nil error return in FindOne.

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1551,7 +1551,7 @@ func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 
 	args, err := mongoutil.NewOptions(opts...)
 	if err != nil {
-		return nil
+		return &SingleResult{err: err}
 	}
 	cursor, err := coll.find(ctx, filter, false, newFindArgsFromFindOneArgs(args))
 	return &SingleResult{


### PR DESCRIPTION
## Summary

* Return a `SingleResult` with an error if building options fails in `FindOne`.

## Background & Motivation
