### PR TITLE
GODRIVER-3370 Add bypassEmptyTsReplacement option.

### DIFF
--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -39,6 +39,7 @@ type bulkWrite struct {
 	writeConcern             *writeconcern.WriteConcern
 	result                   BulkWriteResult
 	let                      interface{}
+	bypassEmptyTsReplacement *bool
 }
 
 func (bw *bulkWrite) execute(ctx context.Context) error {
@@ -206,6 +207,10 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 		retry = driver.RetryOncePerCommand
 	}
 	op = op.Retry(retry)
+
+	if bw.bypassEmptyTsReplacement != nil {
+		op.BypassEmptyTsReplacement(*bw.bypassEmptyTsReplacement)
+	}
 
 	err := op.Execute(ctx)
 
@@ -414,6 +419,10 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		retry = driver.RetryOncePerCommand
 	}
 	op = op.Retry(retry)
+
+	if bw.bypassEmptyTsReplacement != nil {
+		op.BypassEmptyTsReplacement(*bw.bypassEmptyTsReplacement)
+	}
 
 	err := op.Execute(ctx)
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -360,7 +360,7 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 		imOpts.SetComment(ioOpts.Comment)
 	}
 	if ioOpts.BypassEmptyTsReplacement != nil {
-		imOpts.SetBypassEmptyTsReplacement(*ioOpts.BypassEmptyTsReplacement)
+		imOpts.BypassEmptyTsReplacement = ioOpts.BypassEmptyTsReplacement
 	}
 	res, err := coll.insert(ctx, []interface{}{document}, imOpts)
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -234,6 +234,7 @@ func (coll *Collection) BulkWrite(ctx context.Context, models []WriteModel,
 		selector:                 selector,
 		writeConcern:             wc,
 		let:                      bwo.Let,
+		bypassEmptyTsReplacement: bwo.BypassEmptyTsReplacement,
 	}
 
 	err = op.execute(ctx)
@@ -307,6 +308,9 @@ func (coll *Collection) insert(ctx context.Context, documents []interface{},
 	if imo.Ordered != nil {
 		op = op.Ordered(*imo.Ordered)
 	}
+	if imo.BypassEmptyTsReplacement != nil {
+		op = op.BypassEmptyTsReplacement(*imo.BypassEmptyTsReplacement)
+	}
 	retry := driver.RetryNone
 	if coll.client.retryWrites {
 		retry = driver.RetryOncePerCommand
@@ -354,6 +358,9 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 	}
 	if ioOpts.Comment != nil {
 		imOpts.SetComment(ioOpts.Comment)
+	}
+	if ioOpts.BypassEmptyTsReplacement != nil {
+		imOpts.SetBypassEmptyTsReplacement(*ioOpts.BypassEmptyTsReplacement)
 	}
 	res, err := coll.insert(ctx, []interface{}{document}, imOpts)
 
@@ -609,6 +616,9 @@ func (coll *Collection) updateOrReplace(ctx context.Context, filter bsoncore.Doc
 		}
 		op = op.Comment(comment)
 	}
+	if uo.BypassEmptyTsReplacement != nil {
+		op.BypassEmptyTsReplacement(*uo.BypassEmptyTsReplacement)
+	}
 	retry := driver.RetryNone
 	// retryable writes are only enabled updateOne/replaceOne operations
 	if !multi && coll.client.retryWrites {
@@ -760,6 +770,7 @@ func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 		uOpts.Hint = opt.Hint
 		uOpts.Let = opt.Let
 		uOpts.Comment = opt.Comment
+		uOpts.BypassEmptyTsReplacement = opt.BypassEmptyTsReplacement
 		updateOptions = append(updateOptions, uOpts)
 	}
 
@@ -1659,6 +1670,9 @@ func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{
 		}
 		op = op.Let(let)
 	}
+	if fo.BypassEmptyTsReplacement != nil {
+		op = op.BypassEmptyTsReplacement(*fo.BypassEmptyTsReplacement)
+	}
 
 	return coll.findAndModify(ctx, op)
 }
@@ -1764,6 +1778,9 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 			return &SingleResult{err: err}
 		}
 		op = op.Let(let)
+	}
+	if fo.BypassEmptyTsReplacement != nil {
+		op = op.BypassEmptyTsReplacement(*fo.BypassEmptyTsReplacement)
 	}
 
 	return coll.findAndModify(ctx, op)

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -9,6 +9,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -1858,6 +1860,330 @@ func TestCollection(t *testing.T) {
 				})
 			}
 		})
+	})
+}
+
+func TestBypassEmptyTsReplacement(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+
+	marshalValue := func(val interface{}) bson.RawValue {
+		t.Helper()
+
+		valType, data, err := bson.MarshalValue(val)
+		assert.Nil(t, err, "MarshalValue error: %v", err)
+		return bson.RawValue{
+			Type:  valType,
+			Value: data,
+		}
+	}
+
+	mt.Run("insert one", func(mt *mtest.T) {
+		doc := bson.D{{"x", 42}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.InsertOneOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.InsertOne().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.InsertOne().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				_, err := mt.Coll.InsertOne(context.Background(), doc, tc.opts)
+				require.NoError(mt, err, "InsertOne error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("insert many", func(mt *mtest.T) {
+		docs := []interface{}{
+			bson.D{{"x", 42}},
+			bson.D{{"y", "foo"}},
+		}
+
+		testCases := []struct {
+			name     string
+			opts     *options.InsertManyOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.InsertMany().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.InsertMany().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				_, err := mt.Coll.InsertMany(context.Background(), docs, tc.opts)
+				require.NoError(mt, err, "InsertMany error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("update one", func(mt *mtest.T) {
+		filter := bson.D{{"x", 42}}
+		update := bson.D{{"$inc", bson.D{{"x", 1}}}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.UpdateOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.Update().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.Update().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				_, err := mt.Coll.UpdateOne(context.Background(), filter, update, tc.opts)
+				require.NoError(mt, err, "UpdateOne error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("update many", func(mt *mtest.T) {
+		filter := bson.D{{"x", 42}}
+		update := bson.D{{"$inc", bson.D{{"x", 1}}}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.UpdateOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.Update().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.Update().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				_, err := mt.Coll.UpdateMany(context.Background(), filter, update, tc.opts)
+				require.NoError(mt, err, "UpdateMany error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("replace one", func(mt *mtest.T) {
+		filter := bson.D{{"x", 42}}
+		replacement := bson.D{{"y", "foo"}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.ReplaceOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.Replace().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.Replace().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				_, err := mt.Coll.ReplaceOne(context.Background(), filter, replacement, tc.opts)
+				require.NoError(mt, err, "ReplaceOne error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("find one and update", func(mt *mtest.T) {
+		filter := bson.D{{"x", 1}}
+		update := bson.D{{"$inc", bson.D{{"x", 1}}}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.FindOneAndUpdateOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.FindOneAndUpdate().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.FindOneAndUpdate().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				initCollection(mt, mt.Coll)
+				mt.ClearEvents()
+
+				_, err := mt.Coll.FindOneAndUpdate(context.Background(), filter, update, tc.opts).Raw()
+				require.NoError(mt, err, "FindOneAndUpdate error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("find one and replace", func(mt *mtest.T) {
+		filter := bson.D{{"x", 1}}
+		replacement := bson.D{{"y", "foo"}}
+
+		testCases := []struct {
+			name     string
+			opts     *options.FindOneAndReplaceOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				nil,
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.FindOneAndReplace().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.FindOneAndReplace().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, tc := range testCases {
+			mt.Run(tc.name, func(mt *mtest.T) {
+				initCollection(mt, mt.Coll)
+				mt.ClearEvents()
+
+				_, err := mt.Coll.FindOneAndReplace(context.Background(), filter, replacement, tc.opts).Raw()
+				require.NoError(mt, err, "FindOneAndReplace error: %v", err)
+				evt := mt.GetStartedEvent()
+				val := evt.Command.Lookup("bypassEmptyTsReplacement")
+				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+			})
+		}
+	})
+	mt.Run("bulk write", func(mt *mtest.T) {
+		models := []struct {
+			name  string
+			model mongo.WriteModel
+		}{
+			{
+				"insert one",
+				mongo.NewInsertOneModel().SetDocument(bson.D{{"_id", "id1"}}),
+			},
+			{
+				"update one",
+				mongo.NewUpdateOneModel().SetFilter(bson.D{{"_id", "id3"}}).SetUpdate(bson.D{{"$set", bson.D{{"_id", 3.14159}}}}),
+			},
+			{
+				"update many",
+				mongo.NewUpdateManyModel().SetFilter(bson.D{{"_id", "id3"}}).SetUpdate(bson.D{{"$set", bson.D{{"_id", 3.14159}}}}),
+			},
+			{
+				"replace one",
+				mongo.NewReplaceOneModel().SetFilter(bson.D{{"_id", "id3"}}).SetReplacement(bson.D{{"_id", 3.14159}}),
+			},
+		}
+
+		testCases := []struct {
+			name     string
+			opts     *options.BulkWriteOptions
+			expected bson.RawValue
+		}{
+			{
+				"empty",
+				options.BulkWrite(),
+				bson.RawValue{},
+			},
+			{
+				"false",
+				options.BulkWrite().SetBypassEmptyTsReplacement(false),
+				marshalValue(false),
+			},
+			{
+				"true",
+				options.BulkWrite().SetBypassEmptyTsReplacement(true),
+				marshalValue(true),
+			},
+		}
+		for _, m := range models {
+			for _, tc := range testCases {
+				mt.Run(fmt.Sprintf("%s %s", m.name, tc.name), func(mt *mtest.T) {
+					_, err := mt.Coll.BulkWrite(context.Background(), []mongo.WriteModel{m.model}, tc.opts)
+					require.NoError(mt, err, "BulkWrite error: %v", err)
+					evt := mt.GetStartedEvent()
+					val := evt.Command.Lookup("bypassEmptyTsReplacement")
+					require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				})
+			}
+		}
 	})
 }
 

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1864,7 +1864,7 @@ func TestCollection(t *testing.T) {
 }
 
 func TestBypassEmptyTsReplacement(t *testing.T) {
-	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false).MinServerVersion("5.0"))
 
 	marshalValue := func(val interface{}) bson.RawValue {
 		t.Helper()

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1877,6 +1877,10 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 		}
 	}
 
+	boolPtr := func(b bool) *bool {
+		return &b
+	}
+
 	mt.Run("insert one", func(mt *mtest.T) {
 		doc := bson.D{{"x", 42}}
 
@@ -1892,12 +1896,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.InsertOne().SetBypassEmptyTsReplacement(false),
+				&options.InsertOneOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.InsertOne().SetBypassEmptyTsReplacement(true),
+				&options.InsertOneOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -1929,12 +1933,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.InsertMany().SetBypassEmptyTsReplacement(false),
+				&options.InsertManyOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.InsertMany().SetBypassEmptyTsReplacement(true),
+				&options.InsertManyOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -1964,12 +1968,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.Update().SetBypassEmptyTsReplacement(false),
+				&options.UpdateOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.Update().SetBypassEmptyTsReplacement(true),
+				&options.UpdateOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -1999,12 +2003,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.Update().SetBypassEmptyTsReplacement(false),
+				&options.UpdateOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.Update().SetBypassEmptyTsReplacement(true),
+				&options.UpdateOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -2034,12 +2038,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.Replace().SetBypassEmptyTsReplacement(false),
+				&options.ReplaceOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.Replace().SetBypassEmptyTsReplacement(true),
+				&options.ReplaceOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -2069,12 +2073,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.FindOneAndUpdate().SetBypassEmptyTsReplacement(false),
+				&options.FindOneAndUpdateOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.FindOneAndUpdate().SetBypassEmptyTsReplacement(true),
+				&options.FindOneAndUpdateOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -2107,12 +2111,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.FindOneAndReplace().SetBypassEmptyTsReplacement(false),
+				&options.FindOneAndReplaceOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.FindOneAndReplace().SetBypassEmptyTsReplacement(true),
+				&options.FindOneAndReplaceOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}
@@ -2164,12 +2168,12 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 			},
 			{
 				"false",
-				options.BulkWrite().SetBypassEmptyTsReplacement(false),
+				&options.BulkWriteOptions{BypassEmptyTsReplacement: boolPtr(false)},
 				marshalValue(false),
 			},
 			{
 				"true",
-				options.BulkWrite().SetBypassEmptyTsReplacement(true),
+				&options.BulkWriteOptions{BypassEmptyTsReplacement: boolPtr(true)},
 				marshalValue(true),
 			},
 		}

--- a/mongo/integration/collection_test.go
+++ b/mongo/integration/collection_test.go
@@ -1870,7 +1870,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 		t.Helper()
 
 		valType, data, err := bson.MarshalValue(val)
-		assert.Nil(t, err, "MarshalValue error: %v", err)
+		require.Nil(t, err, "MarshalValue error: %v", err)
 		return bson.RawValue{
 			Type:  valType,
 			Value: data,
@@ -1911,7 +1911,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "InsertOne error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -1948,7 +1948,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "InsertMany error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -1983,7 +1983,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "UpdateOne error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -2018,7 +2018,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "UpdateMany error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -2053,7 +2053,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "ReplaceOne error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -2091,7 +2091,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "FindOneAndUpdate error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -2129,7 +2129,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 				require.NoError(mt, err, "FindOneAndReplace error: %v", err)
 				evt := mt.GetStartedEvent()
 				val := evt.Command.Lookup("bypassEmptyTsReplacement")
-				require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+				assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 			})
 		}
 	})
@@ -2184,7 +2184,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 					require.NoError(mt, err, "BulkWrite error: %v", err)
 					evt := mt.GetStartedEvent()
 					val := evt.Command.Lookup("bypassEmptyTsReplacement")
-					require.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
+					assert.Equal(mt, tc.expected, val, "expected bypassEmptyTsReplacement to be %s", tc.expected.String())
 				})
 			}
 		}

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -71,12 +71,6 @@ func (b *BulkWriteOptions) SetLet(let interface{}) *BulkWriteOptions {
 	return b
 }
 
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (b *BulkWriteOptions) SetBypassEmptyTsReplacement(bypassEmptyTsReplacement bool) *BulkWriteOptions {
-	b.BypassEmptyTsReplacement = &bypassEmptyTsReplacement
-	return b
-}
-
 // MergeBulkWriteOptions combines the given BulkWriteOptions instances into a single BulkWriteOptions in a last-one-wins
 // fashion.
 //

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -29,6 +29,12 @@ type BulkWriteOptions struct {
 	// parameter names to values. Values must be constant or closed expressions that do not reference document fields.
 	// Parameters can then be accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // BulkWrite creates a new *BulkWriteOptions instance.
@@ -65,6 +71,12 @@ func (b *BulkWriteOptions) SetLet(let interface{}) *BulkWriteOptions {
 	return b
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (b *BulkWriteOptions) SetBypassEmptyTsReplacement(bypassEmptyTsReplacement bool) *BulkWriteOptions {
+	b.BypassEmptyTsReplacement = &bypassEmptyTsReplacement
+	return b
+}
+
 // MergeBulkWriteOptions combines the given BulkWriteOptions instances into a single BulkWriteOptions in a last-one-wins
 // fashion.
 //
@@ -87,6 +99,9 @@ func MergeBulkWriteOptions(opts ...*BulkWriteOptions) *BulkWriteOptions {
 		}
 		if opt.Let != nil {
 			b.Let = opt.Let
+		}
+		if opt.BypassEmptyTsReplacement != nil {
+			b.BypassEmptyTsReplacement = opt.BypassEmptyTsReplacement
 		}
 	}
 

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -675,6 +675,12 @@ type FindOneAndReplaceOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // FindOneAndReplace creates a new FindOneAndReplaceOptions instance.
@@ -746,6 +752,12 @@ func (f *FindOneAndReplaceOptions) SetLet(let interface{}) *FindOneAndReplaceOpt
 	return f
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (f *FindOneAndReplaceOptions) SetBypassEmptyTsReplacement(b bool) *FindOneAndReplaceOptions {
+	f.BypassEmptyTsReplacement = &b
+	return f
+}
+
 // MergeFindOneAndReplaceOptions combines the given FindOneAndReplaceOptions instances into a single
 // FindOneAndReplaceOptions in a last-one-wins fashion.
 //
@@ -786,6 +798,9 @@ func MergeFindOneAndReplaceOptions(opts ...*FindOneAndReplaceOptions) *FindOneAn
 		}
 		if opt.Let != nil {
 			fo.Let = opt.Let
+		}
+		if opt.BypassEmptyTsReplacement != nil {
+			fo.BypassEmptyTsReplacement = opt.BypassEmptyTsReplacement
 		}
 	}
 
@@ -852,6 +867,12 @@ type FindOneAndUpdateOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // FindOneAndUpdate creates a new FindOneAndUpdateOptions instance.
@@ -929,6 +950,12 @@ func (f *FindOneAndUpdateOptions) SetLet(let interface{}) *FindOneAndUpdateOptio
 	return f
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (f *FindOneAndUpdateOptions) SetBypassEmptyTsReplacement(b bool) *FindOneAndUpdateOptions {
+	f.BypassEmptyTsReplacement = &b
+	return f
+}
+
 // MergeFindOneAndUpdateOptions combines the given FindOneAndUpdateOptions instances into a single
 // FindOneAndUpdateOptions in a last-one-wins fashion.
 //
@@ -972,6 +999,9 @@ func MergeFindOneAndUpdateOptions(opts ...*FindOneAndUpdateOptions) *FindOneAndU
 		}
 		if opt.Let != nil {
 			fo.Let = opt.Let
+		}
+		if opt.BypassEmptyTsReplacement != nil {
+			fo.BypassEmptyTsReplacement = opt.BypassEmptyTsReplacement
 		}
 	}
 

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -752,12 +752,6 @@ func (f *FindOneAndReplaceOptions) SetLet(let interface{}) *FindOneAndReplaceOpt
 	return f
 }
 
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (f *FindOneAndReplaceOptions) SetBypassEmptyTsReplacement(b bool) *FindOneAndReplaceOptions {
-	f.BypassEmptyTsReplacement = &b
-	return f
-}
-
 // MergeFindOneAndReplaceOptions combines the given FindOneAndReplaceOptions instances into a single
 // FindOneAndReplaceOptions in a last-one-wins fashion.
 //
@@ -947,12 +941,6 @@ func (f *FindOneAndUpdateOptions) SetHint(hint interface{}) *FindOneAndUpdateOpt
 // SetLet sets the value for the Let field.
 func (f *FindOneAndUpdateOptions) SetLet(let interface{}) *FindOneAndUpdateOptions {
 	f.Let = let
-	return f
-}
-
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (f *FindOneAndUpdateOptions) SetBypassEmptyTsReplacement(b bool) *FindOneAndUpdateOptions {
-	f.BypassEmptyTsReplacement = &b
 	return f
 }
 

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -42,12 +42,6 @@ func (ioo *InsertOneOptions) SetComment(comment interface{}) *InsertOneOptions {
 	return ioo
 }
 
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (ioo *InsertOneOptions) SetBypassEmptyTsReplacement(b bool) *InsertOneOptions {
-	ioo.BypassEmptyTsReplacement = &b
-	return ioo
-}
-
 // MergeInsertOneOptions combines the given InsertOneOptions instances into a single InsertOneOptions in a last-one-wins
 // fashion.
 //
@@ -117,12 +111,6 @@ func (imo *InsertManyOptions) SetComment(comment interface{}) *InsertManyOptions
 // SetOrdered sets the value for the Ordered field.
 func (imo *InsertManyOptions) SetOrdered(b bool) *InsertManyOptions {
 	imo.Ordered = &b
-	return imo
-}
-
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (imo *InsertManyOptions) SetBypassEmptyTsReplacement(b bool) *InsertManyOptions {
-	imo.BypassEmptyTsReplacement = &b
 	return imo
 }
 

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -17,6 +17,12 @@ type InsertOneOptions struct {
 	// A string or document that will be included in server logs, profiling logs, and currentOp queries to help trace
 	// the operation.  The default value is nil, which means that no comment will be included in the logs.
 	Comment interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // InsertOne creates a new InsertOneOptions instance.
@@ -33,6 +39,12 @@ func (ioo *InsertOneOptions) SetBypassDocumentValidation(b bool) *InsertOneOptio
 // SetComment sets the value for the Comment field.
 func (ioo *InsertOneOptions) SetComment(comment interface{}) *InsertOneOptions {
 	ioo.Comment = comment
+	return ioo
+}
+
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (ioo *InsertOneOptions) SetBypassEmptyTsReplacement(b bool) *InsertOneOptions {
+	ioo.BypassEmptyTsReplacement = &b
 	return ioo
 }
 
@@ -53,6 +65,9 @@ func MergeInsertOneOptions(opts ...*InsertOneOptions) *InsertOneOptions {
 		if ioo.Comment != nil {
 			ioOpts.Comment = ioo.Comment
 		}
+		if ioo.BypassEmptyTsReplacement != nil {
+			ioOpts.BypassEmptyTsReplacement = ioo.BypassEmptyTsReplacement
+		}
 	}
 
 	return ioOpts
@@ -72,6 +87,12 @@ type InsertManyOptions struct {
 
 	// If true, no writes will be executed after one fails. The default value is true.
 	Ordered *bool
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // InsertMany creates a new InsertManyOptions instance.
@@ -99,6 +120,12 @@ func (imo *InsertManyOptions) SetOrdered(b bool) *InsertManyOptions {
 	return imo
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (imo *InsertManyOptions) SetBypassEmptyTsReplacement(b bool) *InsertManyOptions {
+	imo.BypassEmptyTsReplacement = &b
+	return imo
+}
+
 // MergeInsertManyOptions combines the given InsertManyOptions instances into a single InsertManyOptions in a last one
 // wins fashion.
 //
@@ -118,6 +145,9 @@ func MergeInsertManyOptions(opts ...*InsertManyOptions) *InsertManyOptions {
 		}
 		if imo.Ordered != nil {
 			imOpts.Ordered = imo.Ordered
+		}
+		if imo.BypassEmptyTsReplacement != nil {
+			imOpts.BypassEmptyTsReplacement = imo.BypassEmptyTsReplacement
 		}
 	}
 

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -40,6 +40,12 @@ type ReplaceOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // Replace creates a new ReplaceOptions instance.
@@ -83,6 +89,12 @@ func (ro *ReplaceOptions) SetLet(l interface{}) *ReplaceOptions {
 	return ro
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (ro *ReplaceOptions) SetBypassEmptyTsReplacement(b bool) *ReplaceOptions {
+	ro.BypassEmptyTsReplacement = &b
+	return ro
+}
+
 // MergeReplaceOptions combines the given ReplaceOptions instances into a single ReplaceOptions in a last-one-wins
 // fashion.
 //
@@ -111,6 +123,9 @@ func MergeReplaceOptions(opts ...*ReplaceOptions) *ReplaceOptions {
 		}
 		if ro.Let != nil {
 			rOpts.Let = ro.Let
+		}
+		if ro.BypassEmptyTsReplacement != nil {
+			rOpts.BypassEmptyTsReplacement = ro.BypassEmptyTsReplacement
 		}
 	}
 

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -89,12 +89,6 @@ func (ro *ReplaceOptions) SetLet(l interface{}) *ReplaceOptions {
 	return ro
 }
 
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (ro *ReplaceOptions) SetBypassEmptyTsReplacement(b bool) *ReplaceOptions {
-	ro.BypassEmptyTsReplacement = &b
-	return ro
-}
-
 // MergeReplaceOptions combines the given ReplaceOptions instances into a single ReplaceOptions in a last-one-wins
 // fashion.
 //

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -100,12 +100,6 @@ func (uo *UpdateOptions) SetLet(l interface{}) *UpdateOptions {
 	return uo
 }
 
-// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
-func (uo *UpdateOptions) SetBypassEmptyTsReplacement(b bool) *UpdateOptions {
-	uo.BypassEmptyTsReplacement = &b
-	return uo
-}
-
 // MergeUpdateOptions combines the given UpdateOptions instances into a single UpdateOptions in a last-one-wins fashion.
 //
 // Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -45,6 +45,12 @@ type UpdateOptions struct {
 	// Values must be constant or closed expressions that do not reference document fields. Parameters can then be
 	// accessed as variables in an aggregate expression context (e.g. "$$var").
 	Let interface{}
+
+	// If true, the server accepts empty Timestamp as a literal rather than replacing it with the current time.
+	//
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	BypassEmptyTsReplacement *bool
 }
 
 // Update creates a new UpdateOptions instance.
@@ -94,6 +100,12 @@ func (uo *UpdateOptions) SetLet(l interface{}) *UpdateOptions {
 	return uo
 }
 
+// SetBypassEmptyTsReplacement sets the value for the BypassEmptyTsReplacement field.
+func (uo *UpdateOptions) SetBypassEmptyTsReplacement(b bool) *UpdateOptions {
+	uo.BypassEmptyTsReplacement = &b
+	return uo
+}
+
 // MergeUpdateOptions combines the given UpdateOptions instances into a single UpdateOptions in a last-one-wins fashion.
 //
 // Deprecated: Merging options structs will not be supported in Go Driver 2.0. Users should create a
@@ -124,6 +136,9 @@ func MergeUpdateOptions(opts ...*UpdateOptions) *UpdateOptions {
 		}
 		if uo.Let != nil {
 			uOpts.Let = uo.Let
+		}
+		if uo.BypassEmptyTsReplacement != nil {
+			uOpts.BypassEmptyTsReplacement = uo.BypassEmptyTsReplacement
 		}
 	}
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -52,6 +52,7 @@ type FindAndModify struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	timeout                  *time.Duration
+	bypassEmptyTsReplacement *bool
 
 	result FindAndModifyResult
 }
@@ -213,6 +214,9 @@ func (fam *FindAndModify) command(dst []byte, desc description.SelectedServer) (
 	}
 	if fam.let != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "let", fam.let)
+	}
+	if fam.bypassEmptyTsReplacement != nil {
+		dst = bsoncore.AppendBooleanElement(dst, "bypassEmptyTsReplacement", *fam.bypassEmptyTsReplacement)
 	}
 
 	return dst, nil
@@ -487,5 +491,15 @@ func (fam *FindAndModify) Authenticator(authenticator driver.Authenticator) *Fin
 	}
 
 	fam.authenticator = authenticator
+	return fam
+}
+
+// BypassEmptyTsReplacement sets the bypassEmptyTsReplacement to use for this operation.
+func (fam *FindAndModify) BypassEmptyTsReplacement(bypassEmptyTsReplacement bool) *FindAndModify {
+	if fam == nil {
+		fam = new(FindAndModify)
+	}
+
+	fam.bypassEmptyTsReplacement = &bypassEmptyTsReplacement
 	return fam
 }

--- a/x/mongo/driver/operation/insert.go
+++ b/x/mongo/driver/operation/insert.go
@@ -43,6 +43,7 @@ type Insert struct {
 	result                   InsertResult
 	serverAPI                *driver.ServerAPIOptions
 	timeout                  *time.Duration
+	bypassEmptyTsReplacement *bool
 	logger                   *logger.Logger
 }
 
@@ -130,6 +131,9 @@ func (i *Insert) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	}
 	if i.ordered != nil {
 		dst = bsoncore.AppendBooleanElement(dst, "ordered", *i.ordered)
+	}
+	if i.bypassEmptyTsReplacement != nil {
+		dst = bsoncore.AppendBooleanElement(dst, "bypassEmptyTsReplacement", *i.bypassEmptyTsReplacement)
 	}
 	return dst, nil
 }
@@ -315,5 +319,15 @@ func (i *Insert) Authenticator(authenticator driver.Authenticator) *Insert {
 	}
 
 	i.authenticator = authenticator
+	return i
+}
+
+// BypassEmptyTsReplacement sets the bypassEmptyTsReplacement to use for this operation.
+func (i *Insert) BypassEmptyTsReplacement(bypassEmptyTsReplacement bool) *Insert {
+	if i == nil {
+		i = new(Insert)
+	}
+
+	i.bypassEmptyTsReplacement = &bypassEmptyTsReplacement
 	return i
 }

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -47,6 +47,7 @@ type Update struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	timeout                  *time.Duration
+	bypassEmptyTsReplacement *bool
 	logger                   *logger.Logger
 }
 
@@ -203,6 +204,9 @@ func (u *Update) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	}
 	if u.let != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "let", u.let)
+	}
+	if u.bypassEmptyTsReplacement != nil {
+		dst = bsoncore.AppendBooleanElement(dst, "bypassEmptyTsReplacement", *u.bypassEmptyTsReplacement)
 	}
 
 	return dst, nil
@@ -424,5 +428,15 @@ func (u *Update) Authenticator(authenticator driver.Authenticator) *Update {
 	}
 
 	u.authenticator = authenticator
+	return u
+}
+
+// BypassEmptyTsReplacement sets the bypassEmptyTsReplacement to use for this operation.
+func (u *Update) BypassEmptyTsReplacement(bypassEmptyTsReplacement bool) *Update {
+	if u == nil {
+		u = new(Update)
+	}
+
+	u.bypassEmptyTsReplacement = &bypassEmptyTsReplacement
 	return u
 }


### PR DESCRIPTION
GODRIVER-3370

## Summary
Add `bypassEmptyTsReplacement` option to:
- insertOne
- insertMany
- updateOne
- updateMany
- replaceOne
- findOneAndUpdate
- findOneAndReplace
- collection.bulkWrite

## Background & Motivation
Correlated server ticket: SERVER-88750
