### PR TITLE
GODRIVER-3298 Handle joined errors correctly in WithTransaction.

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -166,25 +166,10 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// unwrap returns the inner error if err implements Unwrap(), otherwise it returns nil.
-func unwrap(err error) error {
-	u, ok := err.(interface {
-		Unwrap() error
-	})
-	if !ok {
-		return nil
-	}
-	return u.Unwrap()
-}
-
 // errorHasLabel returns true if err contains the specified label
 func errorHasLabel(err error, label string) bool {
-	for ; err != nil; err = unwrap(err) {
-		if le, ok := err.(LabeledError); ok && le.HasErrorLabel(label) {
-			return true
-		}
-	}
-	return false
+	var le LabeledError
+	return errors.As(err, &le) && le.HasErrorLabel(label)
 }
 
 // IsNetworkError returns true if err is a network error

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -107,20 +107,23 @@ func (s *Session) EndSession(ctx context.Context) {
 // parameter already has a Session attached to it, it will be replaced by this
 // session. The fn callback may be run multiple times during WithTransaction due
 // to retry attempts, so it must be idempotent.
-// If a command inside the callback fn fails, it may cause the transaction on the
-// server to be aborted. This situation is normally handled transparently by the
-// driver. However, if the application does not return that error from the fn,
-// the driver will not be able to determine whether the transaction was aborted or
-// not. The driver will then retry the block indefinitely.
-// To avoid this situation, the application MUST NOT silently handle errors within
-// the callback fn. If the application needs to handle errors within the block,
-// it MUST return them after doing so.
-// Non-retryable operation errors or any operation errors that occur after the timeout
-// expires will be returned without retrying. If the callback fails, the driver will call
-// AbortTransaction. Because this method must succeed to ensure that server-side
-// resources are properly cleaned up, context deadlines and cancellations will
-// not be respected during this call. For a usage example, see the
-// Client.StartSession method documentation.
+//
+// If a command inside the callback fn fails, it may cause the transaction on
+// the server to be aborted. This situation is normally handled transparently by
+// the driver. However, if the application does not return that error from the
+// fn, the driver will not be able to determine whether the transaction was
+// aborted or not. The driver will then retry the block indefinitely.
+//
+// To avoid this situation, the application MUST NOT silently handle errors
+// within the callback fn. If the application needs to handle errors within the
+// block, it MUST return them after doing so.
+//
+// Non-retryable operation errors or any operation errors that occur after the
+// timeout expires will be returned without retrying. If the callback fails, the
+// driver will call AbortTransaction. Because this method must succeed to ensure
+// that server-side resources are properly cleaned up, context deadlines and
+// cancellations will not be respected during this call. For a usage example,
+// see the Client.StartSession method documentation.
 func (s *Session) WithTransaction(
 	ctx context.Context,
 	fn func(ctx context.Context) (interface{}, error),


### PR DESCRIPTION
[GODRIVER-3298](https://jira.mongodb.org/browse/GODRIVER-3298)

## Summary

* Use `errors.As` to check for retryability of errors returned from the `WithTransaction` callback.

## Background & Motivation

Currently `WithTransaction` uses custom error unwrapping logic to check if an error returned by the callback should be retried. That unwrapping logic was not updated when support for join-able errors was added to the Go stdlib. Instead of maintaining custom error unwrapping logic, use `errors.As` to make sure the code continues to support future stdlib updates.
