### PR TITLE
GODRIVER-3448 Limit GOMAXPROCS for fuzz tests

### DIFF
--- a/etc/run-fuzz.sh
+++ b/etc/run-fuzz.sh
@@ -35,7 +35,7 @@ do
 			done
 		fi
 
-		go test ${PARENTDIR} -run=${FUNC} -fuzz=${FUNC} -fuzztime=${FUZZTIME} || true
+		GOMAXPROCS=2 go test ${PARENTDIR} -run=${FUNC} -fuzz=${FUNC} -fuzztime=${FUZZTIME} || true
 
 		# Check if any new corpus files were generated for the fuzzer. If there are new corpus files, move them
 		# to $PROJECT_DIRECTORY/fuzz/$FUNC/* so they can be tarred up and uploaded to S3.


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3448

## Summary

<!--- A summary of the changes proposed by this pull request. -->
From a similar issue described in the Go project (https://github.com/golang/go/issues/65434):

> This limits the throughput and resource consumption of the fuzz workers in the tests, which also reduces the likelihood of running out of address space in the fuzz coordinator during the test.


Limiting the number of CPU cores means fewer OS threads are available to execute the workers deployed by Go fuzzing.