### PR TITLE
Add UnsafeAllowSeperateMaxTimeMSWithCSOT

### DIFF
--- a/internal/ptrutil/ptr.go
+++ b/internal/ptrutil/ptr.go
@@ -1,0 +1,12 @@
+// Copyright (C) MongoDB, Inc. 2024-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package ptrutil
+
+// Ptr will return the memory location of the given value.
+func Ptr[T any](val T) *T {
+	return &val
+}

--- a/mongo/integration/csot_test.go
+++ b/mongo/integration/csot_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/internal/assert"
 	"go.mongodb.org/mongo-driver/internal/eventtest"
+	"go.mongodb.org/mongo-driver/internal/ptrutil"
 	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
@@ -279,6 +280,9 @@ func TestCSOT_maxTimeMS(t *testing.T) {
 
 		evt := getStartedEvent(mt, command)
 		maxTimeVal := evt.Command.Lookup("maxTimeMS")
+		if len(maxTimeVal.Value) == 0 {
+			return -1
+		}
 
 		require.Greater(mt,
 			len(maxTimeVal.Value),
@@ -591,7 +595,180 @@ func TestCSOT_maxTimeMS(t *testing.T) {
 			maxTimeMS,
 			"expected maxTimeMS to be equal to the MaxTime value")
 	})
+
+	mt.Run("UnsafeAllowSeperateMaxTimeMSWithCSOT", func(mt *mtest.T) {
+		ops := []struct {
+			name        string
+			commandName string
+			fn          func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) error
+			cursorOp    bool
+		}{
+			{
+				name:        "FindOne",
+				commandName: "find",
+				fn: func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) error {
+					opts := options.FindOne()
+					if maxTime != nil {
+						opts.SetMaxTime(*maxTime)
+					}
+					res := coll.FindOne(ctx, bson.D{}, opts)
+					return res.Err()
+				},
+				cursorOp: false,
+			},
+			{
+				name:        "Find",
+				commandName: "find",
+				fn: func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) error {
+					opts := options.Find()
+					if maxTime != nil {
+						opts.SetMaxTime(*maxTime)
+					}
+					_, err := coll.Find(ctx, bson.D{}, opts)
+					return err
+				},
+				cursorOp: true,
+			},
+			{
+				name:        "FindOneAndUpdate",
+				commandName: "findAndModify",
+				fn: func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) error {
+					opts := options.FindOneAndUpdate()
+					if maxTime != nil {
+						opts.SetMaxTime(*maxTime)
+					}
+					res := coll.FindOneAndUpdate(ctx, bson.D{}, bson.M{"$set": bson.M{"key": "value"}}, opts)
+					return res.Err()
+				},
+				cursorOp: false,
+			},
+			{
+				name:        "Aggregate",
+				commandName: "aggregate",
+				fn: func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) error {
+					opts := options.Aggregate()
+					if maxTime != nil {
+						opts.SetMaxTime(*maxTime)
+					}
+					_, err := coll.Aggregate(ctx, bson.D{}, opts)
+					return err
+				},
+				cursorOp: true,
+			},
+		}
+
+		for _, op := range ops {
+			mt.Run(op.name, func(mt *mtest.T) {
+				testCases := []struct {
+					name       string
+					ctxTimeout *time.Duration
+					maxTime    *time.Duration
+					wantMS     int
+					wantDelta  float64
+				}{
+					{
+						name:       "CSOT with context deadline with maxTime",
+						ctxTimeout: ptrutil.Ptr(10 * time.Second),
+						maxTime:    ptrutil.Ptr(5 * time.Second),
+						wantMS:     5_000,
+						wantDelta:  0,
+					},
+					{
+						name:       "CSOT with context deadline without maxTime",
+						ctxTimeout: ptrutil.Ptr(10 * time.Second),
+						maxTime:    nil,
+						wantMS:     10_000,
+						wantDelta:  500,
+					},
+					{
+						name:       "CSOT without context deadline with maxTime",
+						ctxTimeout: nil,
+						maxTime:    ptrutil.Ptr(5 * time.Second),
+						wantMS:     5_000,
+						wantDelta:  0,
+					},
+					{
+						name:       "CSOT without context deadline with maxTime",
+						ctxTimeout: nil,
+						maxTime:    nil,
+						wantMS:     15_000,
+						wantDelta:  500,
+					},
+				}
+
+				for _, tc := range testCases {
+					mt.Run(tc.name, func(mt *mtest.T) {
+						driver.UnsafeAllowSeperateMaxTimeMSWithCSOT = true
+						defer func() { driver.UnsafeAllowSeperateMaxTimeMSWithCSOT = false }()
+
+						// Enable CSOT
+						mt.ResetClient(options.Client().SetTimeout(15 * time.Second))
+
+						var hasDeadline bool
+						ctx := context.Background()
+						if tc.ctxTimeout != nil {
+							var cancel context.CancelFunc
+
+							ctx, cancel = context.WithTimeout(ctx, *tc.ctxTimeout)
+							defer cancel()
+
+							hasDeadline = true
+						}
+
+						// Insert some documents so the collection isn't empty.
+						insertTwoDocuments(mt)
+
+						err := op.fn(ctx, mt.Coll, tc.maxTime)
+						require.NoError(mt, err)
+
+						// Assert that maxTimeMS is set and that it's equal to the MaxTime
+						// value.
+						maxTimeMS := getMaxTimeMS(mt, op.commandName)
+						if op.cursorOp && tc.maxTime == nil && hasDeadline {
+							assert.Equal(mt, int64(-1), maxTimeMS)
+						} else {
+							assert.InDelta(mt,
+								tc.wantMS,
+								maxTimeMS,
+								tc.wantDelta,
+								"expected maxTimeMS to be equal to the MaxTime value")
+						}
+					})
+				}
+			})
+		}
+	})
+
 }
+
+// mt.Run("FindOne uses MaxTime when UnsafeAllowSeperateMaxTimeMSWithCSOT is set", func(mt *mtest.T) {
+//	driver.UnsafeAllowSeperateMaxTimeMSWithCSOT = true
+
+//	// Enable CSOT
+//	mt.ResetClient(options.Client().SetTimeout(0))
+
+//	// Insert some documents so the collection isn't empty.
+//	insertTwoDocuments(mt)
+
+//	// Set a 5-second MaxTime value.
+//	opts := options.FindOne().SetMaxTime(5 * time.Second)
+
+//	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+//	defer cancel()
+
+//	res := mt.Coll.FindOne(ctx, bson.D{}, opts)
+//	require.NoError(mt, res.Err(), "Find error")
+
+//	// Assert that maxTimeMS is set and that it's equal to the MaxTime
+//	// value.
+//	maxTimeMS := getMaxTimeMS(mt, "find")
+//	assert.Equal(mt,
+//		int64(5_000),
+//		maxTimeMS,
+//		"expected maxTimeMS to be equal to the MaxTime value")
+// })
+//
+// operation  func(ctx context.Context, coll *mongo.Collection, maxTime *time.Duration) errorb
 
 func TestCSOT_errors(t *testing.T) {
 	// Skip CSOT tests when SKIP_CSOT_TESTS=true. In Evergreen, we typically set

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -60,6 +60,22 @@ const (
 	readSnapshotMinWireVersion int32 = 13
 )
 
+// UnsafeAllowSeperateMaxTimeMSWithCSOT is a global flag that allows useres to
+// set maxTimeMS independently of the context deadline when CSOT is enabled
+// (client.Timeout >=0). If a user provides a context deadline it will be used
+// for all blocking client-side logic (e.g. socket timeouts, checking out
+// connections, etc).
+//
+// This switch is untested and experimental.
+//
+// ⚠️  **USE WITH CAUTION** ⚠️
+//
+// For CSOT, Go driver derives maxTimeMS from the context deadline to ensure
+// that the server-side timeout aligns with the client-side operation timeout.
+//
+// THIS OPTION MAY BE REMOVED AT ANY TIME.
+var UnsafeAllowSeperateMaxTimeMSWithCSOT bool
+
 // RetryablePoolError is a connection pool error that can be retried while executing an operation.
 type RetryablePoolError interface {
 	Retryable() bool
@@ -1593,6 +1609,8 @@ func (op Operation) addClusterTime(dst []byte, desc description.SelectedServer) 
 // operation's MaxTimeMS if set. If no MaxTimeMS is set on the operation, and context is
 // not a Timeout context, calculateMaxTimeMS returns 0.
 func (op Operation) calculateMaxTimeMS(ctx context.Context, mon RTTMonitor) (uint64, error) {
+	unsafelyOverrideCSOT := UnsafeAllowSeperateMaxTimeMSWithCSOT && op.MaxTime != nil
+
 	// If CSOT is enabled and we're not omitting the CSOT-calculated maxTimeMS
 	// value, then calculate maxTimeMS.
 	//
@@ -1603,7 +1621,7 @@ func (op Operation) calculateMaxTimeMS(ctx context.Context, mon RTTMonitor) (uin
 	// TODO(GODRIVER-2944): Remove or refactor this logic when we add the
 	// "timeoutMode" option, which will allow users to opt-in to the
 	// CSOT-calculated maxTimeMS values if that's the behavior they want.
-	if csot.IsTimeoutContext(ctx) && !op.OmitCSOTMaxTimeMS {
+	if csot.IsTimeoutContext(ctx) && !op.OmitCSOTMaxTimeMS && !unsafelyOverrideCSOT {
 		if deadline, ok := ctx.Deadline(); ok {
 			remainingTimeout := time.Until(deadline)
 			rtt90 := mon.P90()


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

<!--- A summary of the changes proposed by this pull request. -->
Add an experimental bool to enabled legacy timeout behavior while CSOT is enabled (client.Timeout. >=0). This would make context deadline only applicable to client-side blocking logic and specify MaxTime on the as a server-side timeout.

## Background & Motivation

<!--- Rationale for the pull request. -->
