### PR TITLE
GODRIVER-3470 Correct BSON unmarshaling logic for null values (#1924) [master]

### DIFF
--- a/bson/default_value_decoders.go
+++ b/bson/default_value_decoders.go
@@ -1221,7 +1221,13 @@ func valueUnmarshalerDecodeValue(_ DecodeContext, vr ValueReader, val reflect.Va
 		return ValueDecoderError{Name: "ValueUnmarshalerDecodeValue", Types: []reflect.Type{tValueUnmarshaler}, Received: val}
 	}
 
-	if vr.Type() == TypeNull {
+	// If BSON value is null and the go value is a pointer, then don't call
+	// UnmarshalBSONValue. Even if the Go pointer is already initialized (i.e.,
+	// non-nil), encountering null in BSON will result in the pointer being
+	// directly set to nil here. Since the pointer is being replaced with nil,
+	// there is no opportunity (or reason) for the custom UnmarshalBSONValue logic
+	// to be called.
+	if vr.Type() == TypeNull && val.Kind() == reflect.Ptr {
 		val.Set(reflect.Zero(val.Type()))
 
 		return vr.ReadNull()

--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -36,7 +36,11 @@ type ValueUnmarshaler interface {
 }
 
 // Unmarshal parses the BSON-encoded data and stores the result in the value
-// pointed to by val. If val is nil or not a pointer, Unmarshal returns an error.
+// pointed to by val. If val is nil or not a pointer, Unmarshal returns an
+// error.
+//
+// When unmarshaling BSON, if the BSON value is null and the Go value is a
+// pointer, the pointer is set to nil without calling UnmarshalBSONValue.
 func Unmarshal(data []byte, val interface{}) error {
 	vr := newDocumentReader(bytes.NewReader(data))
 	if l, err := vr.peekLength(); err != nil {

--- a/bson/unmarshal_value_test.go
+++ b/bson/unmarshal_value_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
@@ -31,6 +32,26 @@ func TestUnmarshalValue(t *testing.T) {
 			assert.Equal(t, tc.val, gotValue.Elem().Interface(), "value mismatch; expected %s, got %s", tc.val, gotValue.Elem())
 		})
 	}
+}
+
+func TestInitializedPointerDataWithBSONNull(t *testing.T) {
+	// Set up the test case with initialized pointers.
+	tc := unmarshalBehaviorTestCase{
+		BSONValuePtrTracker: &unmarshalBSONValueCallTracker{},
+		BSONPtrTracker:      &unmarshalBSONCallTracker{},
+	}
+	// Create BSON data where the '*_ptr_tracker' fields are explicitly set to
+	// null.
+	bytes := docToBytes(D{
+		{Key: "bv_ptr_tracker", Value: nil},
+		{Key: "b_ptr_tracker", Value: nil},
+	})
+	// Unmarshal the BSON data into the test case struct. This should set the
+	// pointer fields to nil due to the BSON null value.
+	err := Unmarshal(bytes, &tc)
+	require.NoError(t, err)
+	assert.Nil(t, tc.BSONValuePtrTracker)
+	assert.Nil(t, tc.BSONPtrTracker)
 }
 
 // tests covering GODRIVER-2779

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -172,6 +172,50 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			want:  &valNonPtrStruct,
 			data:  docToBytes(valNonPtrStruct),
 		},
+		{
+			name:  "nil pointer and non-pointer type with BSON minkey",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				BSONValueTracker: unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONValuePtrTracker: &unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONTracker: unmarshalBSONCallTracker{
+					called: true,
+				},
+				BSONPtrTracker: nil,
+			},
+			data: docToBytes(D{
+				{Key: "bv_tracker", Value: MinKey{}},
+				{Key: "bv_ptr_tracker", Value: MinKey{}},
+				{Key: "b_tracker", Value: MinKey{}},
+				{Key: "b_ptr_tracker", Value: MinKey{}},
+			}),
+		},
+		{
+			name:  "nil pointer and non-pointer type with BSON maxkey",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				BSONValueTracker: unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONValuePtrTracker: &unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONTracker: unmarshalBSONCallTracker{
+					called: true,
+				},
+				BSONPtrTracker: nil,
+			},
+			data: docToBytes(D{
+				{Key: "bv_tracker", Value: MaxKey{}},
+				{Key: "bv_ptr_tracker", Value: MaxKey{}},
+				{Key: "b_tracker", Value: MaxKey{}},
+				{Key: "b_ptr_tracker", Value: MaxKey{}},
+			}),
+		},
 	}
 }
 
@@ -265,5 +309,40 @@ func (ms *myString) UnmarshalBSON(b []byte) error {
 		return err
 	}
 	*ms = myString(s)
+	return nil
+}
+
+// unmarshalBSONValueCallTracker is a test struct that tracks whether the
+// UnmarshalBSONValue method has been called.
+type unmarshalBSONValueCallTracker struct {
+	called bool // called is set to true when UnmarshalBSONValue is invoked.
+}
+
+var _ ValueUnmarshaler = &unmarshalBSONValueCallTracker{}
+
+// unmarshalBSONCallTracker is a test struct that tracks whether the
+// UnmarshalBSON method has been called.
+type unmarshalBSONCallTracker struct {
+	called bool // called is set to true when UnmarshalBSON is invoked.
+}
+
+// Ensure unmarshalBSONCallTracker implements the Unmarshaler interface.
+var _ Unmarshaler = &unmarshalBSONCallTracker{}
+
+// unmarshalBehaviorTestCase holds instances of call trackers for testing BSON
+// unmarshaling behavior.
+type unmarshalBehaviorTestCase struct {
+	BSONValueTracker    unmarshalBSONValueCallTracker  `bson:"bv_tracker"`     // BSON value unmarshaling by value.
+	BSONValuePtrTracker *unmarshalBSONValueCallTracker `bson:"bv_ptr_tracker"` // BSON value unmarshaling by pointer.
+	BSONTracker         unmarshalBSONCallTracker       `bson:"b_tracker"`      // BSON unmarshaling by value.
+	BSONPtrTracker      *unmarshalBSONCallTracker      `bson:"b_ptr_tracker"`  // BSON unmarshaling by pointer.
+}
+
+func (tracker *unmarshalBSONValueCallTracker) UnmarshalBSONValue(byte, []byte) error {
+	tracker.called = true
+	return nil
+}
+func (tracker *unmarshalBSONCallTracker) UnmarshalBSON([]byte) error {
+	tracker.called = true
 	return nil
 }

--- a/bson/unmarshaling_cases_test.go
+++ b/bson/unmarshaling_cases_test.go
@@ -173,6 +173,26 @@ func unmarshalingTestCases() []unmarshalingTestCase {
 			data:  docToBytes(valNonPtrStruct),
 		},
 		{
+			name:  "nil pointer and non-pointer type with literal null BSON",
+			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
+			want: &unmarshalBehaviorTestCase{
+				BSONValueTracker: unmarshalBSONValueCallTracker{
+					called: true,
+				},
+				BSONValuePtrTracker: nil,
+				BSONTracker: unmarshalBSONCallTracker{
+					called: true,
+				},
+				BSONPtrTracker: nil,
+			},
+			data: docToBytes(D{
+				{Key: "bv_tracker", Value: nil},
+				{Key: "bv_ptr_tracker", Value: nil},
+				{Key: "b_tracker", Value: nil},
+				{Key: "b_ptr_tracker", Value: nil},
+			}),
+		},
+		{
 			name:  "nil pointer and non-pointer type with BSON minkey",
 			sType: reflect.TypeOf(unmarshalBehaviorTestCase{}),
 			want: &unmarshalBehaviorTestCase{
@@ -342,6 +362,7 @@ func (tracker *unmarshalBSONValueCallTracker) UnmarshalBSONValue(byte, []byte) e
 	tracker.called = true
 	return nil
 }
+
 func (tracker *unmarshalBSONCallTracker) UnmarshalBSON([]byte) error {
 	tracker.called = true
 	return nil


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-go-driver/commit/659342c5d8d8436dcfe7863026808d14505c225d to master