### PR TITLE
GODRIVER-3470 Correct BSON unmarshaling logic for null values (#1924)

### DIFF
--- a/bson/unmarshal.go
+++ b/bson/unmarshal.go
@@ -41,6 +41,9 @@ type ValueUnmarshaler interface {
 // Unmarshal parses the BSON-encoded data and stores the result in the value
 // pointed to by val. If val is nil or not a pointer, Unmarshal returns
 // InvalidUnmarshalError.
+//
+// When unmarshaling BSON, if the BSON value is null and the Go value is a
+// pointer, the pointer is set to nil without calling UnmarshalBSONValue.
 func Unmarshal(data []byte, val interface{}) error {
 	return UnmarshalWithRegistry(DefaultRegistry, data, val)
 }

--- a/bson/unmarshal_value_test.go
+++ b/bson/unmarshal_value_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/internal/assert"
+	"go.mongodb.org/mongo-driver/internal/require"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -91,6 +92,29 @@ func TestUnmarshalValue(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestInitializedPointerDataWithBSONNull(t *testing.T) {
+	// Set up the test case with initialized pointers.
+	tc := unmarshalBehaviorTestCase{
+		BSONValuePtrTracker: &unmarshalBSONValueCallTracker{},
+		BSONPtrTracker:      &unmarshalBSONCallTracker{},
+	}
+
+	// Create BSON data where the '*_ptr_tracker' fields are explicitly set to
+	// null.
+	bytes := docToBytes(D{
+		{Key: "bv_ptr_tracker", Value: nil},
+		{Key: "b_ptr_tracker", Value: nil},
+	})
+
+	// Unmarshal the BSON data into the test case struct. This should set the
+	// pointer fields to nil due to the BSON null value.
+	err := Unmarshal(bytes, &tc)
+	require.NoError(t, err)
+
+	assert.Nil(t, tc.BSONValuePtrTracker)
+	assert.Nil(t, tc.BSONPtrTracker)
 }
 
 // tests covering GODRIVER-2779


### PR DESCRIPTION
Cherry-pick of 659342c5d8d8436dcfe7863026808d14505c225d to release/1.17