### PR TITLE
Add GitHub Actions workflow for merge ups

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -1,0 +1,37 @@
+name: Merge up
+
+on:
+  push:
+    branches:
+      - release/*.*
+      - v*
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-up:
+    environment: release
+    name: Create merge up pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Make sure to include fetch-depth 0 so all branches are fetched, not
+          # just the current one
+          fetch-depth: 0
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: alcaeus/automatic-merge-up-action@main
+        with:
+          ref: ${{ github.ref_name }}
+          branchNamePattern: 'release/<major>.<minor>'
+          devBranchNamePattern: 'v<major>'
+          fallbackBranch: 'master'
+          enableAutoMerge: true


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to automatically merge changes up into newer branches. This changes the workflow in this repository: instead of merging all pull requests into the default branch and cherry-picking into older branches, pull request must now target the lowest branch they affect. Currently, this means that bug fixes would go into `release/1.17`, and new features go into `v2`.

Once a commit is pushed to a matching branch, the automation becomes active. The following details this process, assuming we pushed into the `release/v1.17` branch.

The first step is determining the branch to merge into. The action will consider these branch names in order:
- `release/1.18` (next minor branch matching `branchNamePattern`)
- `v1` (next minor branch matching `devBranchNamePattern`)
- `release/2.0` (next major branch matching `branchNamePattern`)
- `v2` (next major branch matching `devBranchNamePattern`)
- `master` (`fallbackBranch`)

In this case, the automation would select the `v1` branch, as `release/1.18` does not exist. Next, the automation branches off from `release/1.18` to create a temporary branch and creates a pull request targeting `v1`. This intermediate branch allows us to push additional commits to resolve conflicts, fix CI, and do other changes without affecting `release/1.17`. Once the PR is ready, it can be merged **using a merge commit**. This step is important to mark `v1` as containing all commits of `release/1.17`.
The process then repeats as a new commit has been pushed to `v1`. Since that is a dev branch, the automation only considers the following branches:
- `release/2.0` (next major branch matching `branchNamePattern`)
- `v2` (next major branch matching `devBranchNamePattern`)
- `master` (`fallbackBranch`)

For an example of such a merge-up pull request, please see [this PR](https://github.com/mongodb/mongo-php-library/pull/1599). Note that PHP still uses a dedicated bot user. Here, I've instead used the `release` environment to give the workflow access to the release app credentials, using that as PR author. We can switch this to use a different GitHub App if we want to have a separate account creating the merge-up PRs.

There are a few things to note:
* I've enabled merge commits in the repository settings
* I've enabled auto-merge in the repository settings
* The automation enables auto-merge, meaning that PRs are merged automatically once necessary approvals are given and required checks pass. This always uses a merge commit, avoiding errors
* The first merge-up PR into each branch will likely require manual intervention due to previous cherry-picks. In this case, we'll ignore changes by first resetting to the target branch, then merging the source branch using `--strategy=ours` - this has the effect of merging the branches as merged without changing any files.