### PR TITLE
Use different credentials for merge-up PRs

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -13,15 +13,14 @@ permissions:
 
 jobs:
   merge-up:
-    environment: release
     name: Create merge up pull request
     runs-on: ubuntu-latest
 
     steps:
       - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ vars.PR_APP_ID }}
+          private_key: ${{ secrets.PR_APP_PRIVATE_KEY }}
           # Make sure to include fetch-depth 0 so all branches are fetched, not
           # just the current one
           fetch-depth: 0


### PR DESCRIPTION
This PR fixes the merge-up workflow introduced in #1962. The release bot does not have permission to create pull requests, but we can use the mongodb-drivers-pr-bot (which is more appropriate anyways) to create the pull requests.