### PR TITLE
GODRIVER-2721 Fully support "errors.Is" and "errors.As".

### DIFF
--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -369,7 +369,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					assert.True(mt, strings.Contains(insertErr.Error(), "auth error"),
 						"expected InsertOne auth error, got %v", insertErr)
 					assert.True(mt, strings.Contains(encErr.Error(), "auth error"),
-						"expected Encrypt auth error, got %v", insertErr)
+						"expected Encrypt auth error, got %v", encErr)
 					return
 				}
 				assert.Nil(mt, insertErr, "InsertOne error: %v", insertErr)

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -369,7 +369,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 					assert.True(mt, strings.Contains(insertErr.Error(), "auth error"),
 						"expected InsertOne auth error, got %v", insertErr)
 					assert.True(mt, strings.Contains(encErr.Error(), "auth error"),
-						"expected Encrypt auth error, got %v", encErr)
+						"expected Encrypt auth error, got %v", insertErr)
 					return
 				}
 				assert.Nil(mt, insertErr, "InsertOne error: %v", insertErr)

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -339,8 +339,8 @@ AggregateExecuteLoop:
 			break AggregateExecuteLoop
 		}
 
-		switch tt := err.(type) {
-		case driver.Error:
+		var tt driver.Error
+		if errors.As(err, &tt) {
 			// If error is not retryable, do not retry.
 			if !tt.RetryableRead() {
 				break AggregateExecuteLoop
@@ -370,7 +370,7 @@ AggregateExecuteLoop:
 
 			// Reset deployment.
 			cs.aggregate.Deployment(cs.createOperationDeployment(server, conn))
-		default:
+		} else {
 			// Do not retry if error is not a driver error.
 			break AggregateExecuteLoop
 		}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1045,7 +1045,8 @@ func aggregate(a aggregateParams, opts ...options.Lister[options.AggregateOption
 
 	err = op.Execute(a.ctx)
 	if err != nil {
-		if wce, ok := err.(driver.WriteCommandError); ok && wce.WriteConcernError != nil {
+		var wce driver.WriteCommandError
+		if errors.As(err, &wce) && wce.WriteConcernError != nil {
 			return nil, *convertDriverWriteConcernError(wce.WriteConcernError)
 		}
 		return nil, replaceErrors(err)
@@ -2041,8 +2042,8 @@ func (coll *Collection) drop(ctx context.Context) error {
 	err = op.Execute(ctx)
 
 	// ignore namespace not found errors
-	driverErr, ok := err.(driver.Error)
-	if !ok || (ok && !driverErr.NamespaceNotFound()) {
+	var driverErr driver.Error
+	if !errors.As(err, &driverErr) || !driverErr.NamespaceNotFound() {
 		return replaceErrors(err)
 	}
 	return nil

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -343,8 +343,8 @@ func (db *Database) Drop(ctx context.Context) error {
 
 	err = op.Execute(ctx)
 
-	driverErr, ok := err.(driver.Error)
-	if err != nil && (!ok || !driverErr.NamespaceNotFound()) {
+	var driverErr driver.Error
+	if err != nil && (!errors.As(err, &driverErr) || !driverErr.NamespaceNotFound()) {
 		return replaceErrors(err)
 	}
 	return nil

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -64,7 +64,7 @@ func replaceErrors(err error) error {
 	if errors.Is(err, topology.ErrTopologyClosed) {
 		return ErrClientDisconnected
 	}
-	if de := new(driver.Error); errors.As(err, de) {
+	if de, ok := err.(driver.Error); ok {
 		return CommandError{
 			Code:    de.Code,
 			Message: de.Message,
@@ -74,7 +74,7 @@ func replaceErrors(err error) error {
 			Raw:     bson.Raw(de.Raw),
 		}
 	}
-	if qe := new(driver.QueryFailureError); errors.As(err, qe) {
+	if qe, ok := err.(driver.QueryFailureError); ok {
 		// qe.Message is "command failure"
 		ce := CommandError{
 			Name:    qe.Message,
@@ -93,7 +93,7 @@ func replaceErrors(err error) error {
 
 		return ce
 	}
-	if me := new(mongocrypt.Error); errors.As(err, me) {
+	if me, ok := err.(mongocrypt.Error); ok {
 		return MongocryptError{Code: me.Code, Message: me.Message}
 	}
 
@@ -101,7 +101,7 @@ func replaceErrors(err error) error {
 		return ErrNilValue
 	}
 
-	if marshalErr := new(codecutil.MarshalError); errors.As(err, marshalErr) {
+	if marshalErr, ok := err.(codecutil.MarshalError); ok {
 		return MarshalError{
 			Value: marshalErr.Value,
 			Err:   marshalErr.Err,

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -51,14 +51,6 @@ type IndexModel struct {
 	Options *options.IndexOptionsBuilder
 }
 
-func isNamespaceNotFoundError(err error) bool {
-	var de driver.Error
-	if errors.As(err, &de) {
-		return de.Code == 26
-	}
-	return false
-}
-
 // List executes a listIndexes command and returns a cursor over the indexes in the collection.
 //
 // The opts parameter can be used to specify options for this operation (see the options.ListIndexesOptions
@@ -121,7 +113,8 @@ func (iv IndexView) List(ctx context.Context, opts ...options.Lister[options.Lis
 	if err != nil {
 		// for namespaceNotFound errors, return an empty cursor and do not throw an error
 		closeImplicitSession(sess)
-		if isNamespaceNotFoundError(err) {
+		var de driver.Error
+		if errors.As(err, &de) && de.NamespaceNotFound() {
 			return newEmptyCursor(), nil
 		}
 

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -52,7 +52,8 @@ type IndexModel struct {
 }
 
 func isNamespaceNotFoundError(err error) bool {
-	if de, ok := err.(driver.Error); ok {
+	var de driver.Error
+	if errors.As(err, &de) {
 		return de.Code == 26
 	}
 	return false

--- a/mongo/search_index_view.go
+++ b/mongo/search_index_view.go
@@ -8,6 +8,7 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -229,7 +230,8 @@ func (siv SearchIndexView) DropOne(
 		Timeout(siv.coll.client.timeout).Authenticator(siv.coll.client.authenticator)
 
 	err = op.Execute(ctx)
-	if de, ok := err.(driver.Error); ok && de.NamespaceNotFound() {
+	var de driver.Error
+	if errors.As(err, &de) && de.NamespaceNotFound() {
 		return nil
 	}
 	return err

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -193,7 +193,8 @@ func (s *Session) WithTransaction(
 			default:
 			}
 
-			if cerr, ok := err.(CommandError); ok {
+			var cerr CommandError
+			if errors.As(err, &cerr) {
 				if cerr.HasErrorLabel(driver.UnknownTransactionCommitResult) && !cerr.IsMaxTimeMSExpiredError() {
 					continue
 				}

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -55,7 +55,8 @@ func TestConvenientTransactions(t *testing.T) {
 			{"killAllSessions", bson.A{}},
 		}).Err()
 		if err != nil {
-			if ce, ok := err.(CommandError); !ok || ce.Code != errorInterrupted {
+			var ce CommandError
+			if !errors.As(err, &ce) || ce.Code != errorInterrupted {
 				t.Fatalf("killAllSessions error: %v", err)
 			}
 		}
@@ -115,8 +116,8 @@ func TestConvenientTransactions(t *testing.T) {
 				return nil, CommandError{Name: "test Error", Labels: []string{driver.TransientTransactionError}}
 			})
 			assert.NotNil(t, err, "expected WithTransaction error, got nil")
-			cmdErr, ok := err.(CommandError)
-			assert.True(t, ok, "expected error type %T, got %T", CommandError{}, err)
+			var cmdErr CommandError
+			assert.True(t, errors.As(err, &cmdErr), "expected error type %T, got %T", cmdErr, err)
 			assert.True(t, cmdErr.HasErrorLabel(driver.TransientTransactionError),
 				"expected error with label %v, got %v", driver.TransientTransactionError, cmdErr)
 		})
@@ -148,8 +149,8 @@ func TestConvenientTransactions(t *testing.T) {
 				return nil, err
 			})
 			assert.NotNil(t, err, "expected WithTransaction error, got nil")
-			cmdErr, ok := err.(CommandError)
-			assert.True(t, ok, "expected error type %T, got %T", CommandError{}, err)
+			var cmdErr CommandError
+			assert.True(t, errors.As(err, &cmdErr), "expected error type %T, got %T", cmdErr, err)
 			assert.True(t, cmdErr.HasErrorLabel(driver.UnknownTransactionCommitResult),
 				"expected error with label %v, got %v", driver.UnknownTransactionCommitResult, cmdErr)
 		})
@@ -181,8 +182,8 @@ func TestConvenientTransactions(t *testing.T) {
 				return nil, err
 			})
 			assert.NotNil(t, err, "expected WithTransaction error, got nil")
-			cmdErr, ok := err.(CommandError)
-			assert.True(t, ok, "expected error type %T, got %T", CommandError{}, err)
+			var cmdErr CommandError
+			assert.True(t, errors.As(err, &cmdErr), "expected error type %T, got %T", cmdErr, err)
 			assert.True(t, cmdErr.HasErrorLabel(driver.TransientTransactionError),
 				"expected error with label %v, got %v", driver.TransientTransactionError, cmdErr)
 		})
@@ -392,7 +393,8 @@ func TestConvenientTransactions(t *testing.T) {
 				{"killAllSessions", bson.A{}},
 			}).Err()
 			if err != nil {
-				if ce, ok := err.(CommandError); !ok || ce.Code != errorInterrupted {
+				var ce CommandError
+				if !errors.As(err, &ce) || ce.Code != errorInterrupted {
 					t.Fatalf("killAllSessions error: %v", err)
 				}
 			}


### PR DESCRIPTION
GODRIVER-2721

## Summary
~~This PR draft is not meant to be merged.~~

This PR and #1984 replace error assertions (except those in `replaceErrors()` in "mongo\errors.go") with `errors.Is()` and `errors.As()`.

However, the error assertion checks the immediate error type. Instead, `errors.Is()`/`errors.As()` trace the error tree. ~~The difference changes the current error handling logic so they are not proper. Moreover, any further replacements in `replaceErrors()` will cause regression failures because of the logic change.~~ The difference changes the error handling logic so any further replacements in `replaceErrors()` will cause regression failures. `replaceErrors()` will be replaced in another PR.

~~In conclusion, we should not replace error assertions with `errors.Is()`/`errors.As()` in the current code base.~~

~~We can consider closing GODRIVER-2721 and GODRIVER-2975, or making GODRIVER-2721 an epic for tickets such as GODRIVER-1854 and GODRIVER-2704.~~

## Background & Motivation

<!--- Rationale for the pull request. -->
