### PR TITLE
GODRIVER-2975 Fully support "errors.Is" and "errors.As" in BSON APIs.

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -9,6 +9,7 @@ package bson
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -456,13 +457,14 @@ func TestD_UnmarshalJSON(t *testing.T) {
 				want := json.Unmarshal([]byte(tc.test), &a)
 				var b D
 				got := json.Unmarshal([]byte(tc.test), &b)
-				switch w := want.(type) {
-				case *json.UnmarshalTypeError:
+				w := new(json.UnmarshalTypeError)
+				if errors.As(want, &w) {
 					w.Type = reflect.TypeOf(b)
 					require.IsType(t, want, got)
-					g := got.(*json.UnmarshalTypeError)
+					g := new(json.UnmarshalTypeError)
+					assert.True(t, errors.As(got, &g))
 					assert.Equal(t, w, g)
-				default:
+				} else {
 					assert.Equal(t, want, got)
 				}
 			})

--- a/bson/registry_test.go
+++ b/bson/registry_test.go
@@ -369,7 +369,8 @@ func TestRegistry(t *testing.T) {
 						t.Parallel()
 
 						wanterr := tc.wanterr
-						if ene, ok := tc.wanterr.(errNoEncoder); ok {
+						var ene errNoEncoder
+						if errors.As(tc.wanterr, &ene) {
 							wanterr = errNoDecoder(ene)
 						}
 


### PR DESCRIPTION
GODRIVER-2975

## Summary
~~This PR draft is not meant to be merged. Read the [comments of #1969](https://github.com/mongodb/mongo-go-driver/pull/1969#issue-2892046587) for details.~~
This PR and #1969 replace error assertions (except those in replaceErrors() in "mongo\errors.go") with errors.Is() and errors.As().

## Background & Motivation

<!--- Rationale for the pull request. -->
