### PR TITLE
GODRIVER-3098 Drop support for MongoDB 3.6

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1722,10 +1722,6 @@ axes:
         display_name: "4.0"
         variables:
           VERSION: "4.0"
-      - id: "3.6"
-        display_name: "3.6"
-        variables:
-          VERSION: "3.6"
       - id: "rapid"
         display_name: "rapid"
         variables:
@@ -2176,19 +2172,6 @@ buildvariants:
       GO_DIST: "/opt/golang/go1.23"
     tasks:
       - name: ".goleak"
-
-  - matrix_name: "tests-rhel-36-with-zlib-support"
-    tags: ["pullrequest"]
-    matrix_spec: { version: ["3.6"], os-ssl-32: ["rhel87-64"] }
-    display_name: "${version} ${os-ssl-32}"
-    tasks:
-      - name: ".test !.enterprise-auth !.snappy !.zstd"
-
-  - matrix_name: "tests-windows-36-with-zlib-support"
-    matrix_spec: { version: ["3.6"], os-ssl-32: ["windows-64"] }
-    display_name: "${version} ${os-ssl-32}"
-    tasks:
-      - name: ".test !.enterprise-auth !.snappy !.zstd"
 
   - matrix_name: "tests-rhel-40-with-snappy-support"
     tags: ["pullrequest"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the following resources to learn more about upgrading from version 1.x to 2.
 
 - Go 1.18 or higher. We aim to support the latest versions of Go.
 - Go 1.23 or higher is required to run the driver test suite.
-- MongoDB 3.6 and higher.
+- MongoDB 4.0 and higher.
 
 ## Installation
 

--- a/internal/driverutil/description.go
+++ b/internal/driverutil/description.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	MinWireVersion = 6
+	MinWireVersion = 7
 	MaxWireVersion = 25
 )
 

--- a/internal/integration/index_view_test.go
+++ b/internal/integration/index_view_test.go
@@ -528,11 +528,6 @@ func TestIndexView(t *testing.T) {
 					Unique:             nil,
 				},
 			}
-			if mtest.CompareServerVersions(mtest.ServerVersion(), "3.4") < 0 {
-				for _, expectedSpec := range expectedSpecs {
-					expectedSpec.Version = 1
-				}
-			}
 
 			specs, err := mt.Coll.Indexes().ListSpecifications(context.Background())
 			assert.Nil(mt, err, "ListSpecifications error: %v", err)

--- a/mongo/bulk_write_models.go
+++ b/mongo/bulk_write_models.go
@@ -70,12 +70,13 @@ func (dom *DeleteOneModel) SetCollation(collation *options.Collation) *DeleteOne
 	return dom
 }
 
-// SetHint specifies the index to use for the operation. This should either be the index name as a string or the index
-// specification as a document. This option is only valid for MongoDB versions >= 4.4. Server versions >= 3.4 will
-// return an error if this option is specified. For server versions < 3.4, the driver will return a client-side error if
-// this option is specified. The driver will return an error if this option is specified during an unacknowledged write
-// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil, which
-// means that no hint will be sent.
+// SetHint specifies the index to use for the operation. This should either be
+// the index name as a string or the index specification as a document. This
+// option is only valid for MongoDB versions >= 4.4. Server versions < 4.4 will
+// return an error if this option is specified. The driver will return an error
+// if this option is specified during an unacknowledged write operation. The
+// driver will return an error if the hint parameter is a multi-key map. The
+// default value is nil, which means that no hint will be sent.
 func (dom *DeleteOneModel) SetHint(hint interface{}) *DeleteOneModel {
 	dom.Hint = hint
 	return dom
@@ -111,12 +112,13 @@ func (dmm *DeleteManyModel) SetCollation(collation *options.Collation) *DeleteMa
 	return dmm
 }
 
-// SetHint specifies the index to use for the operation. This should either be the index name as a string or the index
-// specification as a document. This option is only valid for MongoDB versions >= 4.4. Server versions >= 3.4 will
-// return an error if this option is specified. For server versions < 3.4, the driver will return a client-side error if
-// this option is specified. The driver will return an error if this option is specified during an unacknowledged write
-// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil, which
-// means that no hint will be sent.
+// SetHint specifies the index to use for the operation. This should either be
+// the index name as a string or the index specification as a document. This
+// option is only valid for MongoDB versions >= 4.4. Server versions < 4.4 will
+// return an error if this option is specified. The driver will return an error
+// if this option is specified during an unacknowledged write operation. The
+// driver will return an error if the hint parameter is a multi-key map. The
+// default value is nil, which means that no hint will be sent.
 func (dmm *DeleteManyModel) SetHint(hint interface{}) *DeleteManyModel {
 	dmm.Hint = hint
 	return dmm
@@ -141,12 +143,13 @@ func NewReplaceOneModel() *ReplaceOneModel {
 	return &ReplaceOneModel{}
 }
 
-// SetHint specifies the index to use for the operation. This should either be the index name as a string or the index
-// specification as a document. This option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will
-// return an error if this option is specified. For server versions < 3.4, the driver will return a client-side error if
-// this option is specified. The driver will return an error if this option is specified during an unacknowledged write
-// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil, which
-// means that no hint will be sent.
+// SetHint specifies the index to use for the operation. This should either be
+// the index name as a string or the index specification as a document. This
+// option is only valid for MongoDB versions >= 4.2. Server versions < 4.2 will
+// return an error if this option is specified. The driver will return an error
+// if this option is specified during an unacknowledged write operation. The
+// driver will return an error if the hint parameter is a multi-key map. The
+// default value is nil, which means that no hint will be sent.
 func (rom *ReplaceOneModel) SetHint(hint interface{}) *ReplaceOneModel {
 	rom.Hint = hint
 	return rom
@@ -211,12 +214,13 @@ func NewUpdateOneModel() *UpdateOneModel {
 	return &UpdateOneModel{}
 }
 
-// SetHint specifies the index to use for the operation. This should either be the index name as a string or the index
-// specification as a document. This option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will
-// return an error if this option is specified. For server versions < 3.4, the driver will return a client-side error if
-// this option is specified. The driver will return an error if this option is specified during an unacknowledged write
-// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil, which
-// means that no hint will be sent.
+// SetHint specifies the index to use for the operation. This should either be
+// the index name as a string or the index specification as a document. This
+// option is only valid for MongoDB versions >= 4.2. Server versions < 4.2 will
+// return an error if this option is specified. The driver will return an error
+// if this option is specified during an unacknowledged write operation. The
+// driver will return an error if the hint parameter is a multi-key map. The
+// default value is nil, which means that no hint will be sent.
 func (uom *UpdateOneModel) SetHint(hint interface{}) *UpdateOneModel {
 	uom.Hint = hint
 	return uom
@@ -287,12 +291,13 @@ func NewUpdateManyModel() *UpdateManyModel {
 	return &UpdateManyModel{}
 }
 
-// SetHint specifies the index to use for the operation. This should either be the index name as a string or the index
-// specification as a document. This option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will
-// return an error if this option is specified. For server versions < 3.4, the driver will return a client-side error if
-// this option is specified. The driver will return an error if this option is specified during an unacknowledged write
-// operation. The driver will return an error if the hint parameter is a multi-key map. The default value is nil, which
-// means that no hint will be sent.
+// SetHint specifies the index to use for the operation. This should either be
+// the index name as a string or the index specification as a document. This
+// option is only valid for MongoDB versions >= 4.2. Server versions < 4.2 will
+// return an error if this option is specified. The driver will return an error
+// if this option is specified during an unacknowledged write operation. The
+// driver will return an error if the hint parameter is a multi-key map. The
+// default value is nil, which means that no hint will be sent.
 func (umm *UpdateManyModel) SetHint(hint interface{}) *UpdateManyModel {
 	umm.Hint = hint
 	return umm

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -118,8 +118,7 @@ func (db *Database) Collection(name string, opts ...options.Lister[options.Colle
 	return newCollection(db, name, opts...)
 }
 
-// Aggregate executes an aggregate command the database. This requires MongoDB version >= 3.6 and driver version >=
-// 1.1.0.
+// Aggregate executes an aggregate command the database.
 //
 // The pipeline parameter must be a slice of documents, each representing an aggregation stage. The pipeline
 // cannot be nil but can be empty. The stage documents must all be non-nil. For a pipeline of bson.D documents, the

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -70,8 +70,7 @@ func (ao *AggregateOptionsBuilder) SetBatchSize(i int32) *AggregateOptionsBuilde
 }
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true, writes
-// executed as part of the operation will opt out of document-level validation on the server. This
-// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value
+// executed as part of the operation will opt out of document-level validation on the server. The default value
 // is false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about
 // document validation.
 func (ao *AggregateOptionsBuilder) SetBypassDocumentValidation(b bool) *AggregateOptionsBuilder {
@@ -84,9 +83,8 @@ func (ao *AggregateOptionsBuilder) SetBypassDocumentValidation(b bool) *Aggregat
 	return ao
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For previous
-// server versions, the driver will return an error if this option is used. The default value is nil,
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
 // which means the default collation of the collection will be used.
 func (ao *AggregateOptionsBuilder) SetCollation(c *Collation) *AggregateOptionsBuilder {
 	ao.Opts = append(ao.Opts, func(opts *AggregateOptions) error {
@@ -99,8 +97,7 @@ func (ao *AggregateOptionsBuilder) SetCollation(c *Collation) *AggregateOptionsB
 }
 
 // SetMaxAwaitTime sets the value for the MaxAwaitTime field. Specifies maximum amount of time
-// that the server should wait for new documents to satisfy a tailable cursor query. This option is
-// only valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
+// that the server should wait for new documents to satisfy a tailable cursor query.
 func (ao *AggregateOptionsBuilder) SetMaxAwaitTime(d time.Duration) *AggregateOptionsBuilder {
 	ao.Opts = append(ao.Opts, func(opts *AggregateOptions) error {
 		opts.MaxAwaitTime = &d

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -66,8 +66,7 @@ func (b *BulkWriteOptionsBuilder) SetOrdered(ordered bool) *BulkWriteOptionsBuil
 }
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true, writes
-// executed as part of the operation will opt out of document-level validation on the server. This option
-// is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The default value is
+// executed as part of the operation will opt out of document-level validation on the server. The default value is
 // false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about document
 // validation.
 func (b *BulkWriteOptionsBuilder) SetBypassDocumentValidation(bypass bool) *BulkWriteOptionsBuilder {

--- a/mongo/options/changestreamoptions.go
+++ b/mongo/options/changestreamoptions.go
@@ -57,10 +57,9 @@ func (cso *ChangeStreamOptionsBuilder) SetBatchSize(i int32) *ChangeStreamOption
 	return cso
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string comparisons
-// during the operation. This option is only valid for MongoDB versions >= 3.4. For previous server versions,
-// the driver will return an error if this option is used. The default value is nil, which means the default
-// collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (cso *ChangeStreamOptionsBuilder) SetCollation(c Collation) *ChangeStreamOptionsBuilder {
 	cso.Opts = append(cso.Opts, func(opts *ChangeStreamOptions) error {
 		opts.Collation = &c

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -686,9 +686,9 @@ func (c *ClientOptions) SetAuth(auth Credential) *ClientOptions {
 
 // SetCompressors sets the compressors that can be used when communicating with a server. Valid values are:
 //
-// 1. "snappy" - requires server version >= 3.4
+// 1. "snappy"
 //
-// 2. "zlib" - requires server version >= 3.6
+// 2. "zlib"
 //
 // 3. "zstd" - requires server version >= 4.2, and driver version >= 1.2.0 with cgo support enabled or driver
 // version >= 1.3.0 without cgo.
@@ -920,9 +920,8 @@ func (c *ClientOptions) SetReplicaSet(s string) *ClientOptions {
 // DeleteManyModel instances to be considered retryable. Unacknowledged writes will not be retried, even if this option
 // is set to true.
 //
-// This option requires server version >= 3.6 and a replica set or sharded cluster and will be ignored for any other
-// cluster type. This can also be set through the "retryWrites" URI option (e.g. "retryWrites=true"). The default is
-// true.
+// This option only works on a replica set or sharded cluster and will be ignored for any other cluster type.
+// This can also be set through the "retryWrites" URI option (e.g. "retryWrites=true"). The default is true.
 func (c *ClientOptions) SetRetryWrites(b bool) *ClientOptions {
 	c.RetryWrites = &b
 
@@ -936,7 +935,7 @@ func (c *ClientOptions) SetRetryWrites(b bool) *ClientOptions {
 // EstimatedDocumentCount, Watch (for Client, Database, and Collection), ListCollections, and ListDatabases. Note that
 // operations run through RunCommand are not retried.
 //
-// This option requires server version >= 3.6 and driver version >= 1.1.0. The default is true.
+// The default is true.
 func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 	c.RetryReads = &b
 

--- a/mongo/options/countoptions.go
+++ b/mongo/options/countoptions.go
@@ -35,10 +35,9 @@ func (co *CountOptionsBuilder) List() []func(*CountOptions) error {
 	return co.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string comparisons
-// during the operation. This option is only valid for MongoDB versions >= 3.4. For previous server versions,
-// the driver will return an error if this option is used. The default value is nil, which means the default
-// collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (co *CountOptionsBuilder) SetCollation(c *Collation) *CountOptionsBuilder {
 	co.Opts = append(co.Opts, func(opts *CountOptions) error {
 		opts.Collation = c

--- a/mongo/options/createcollectionoptions.go
+++ b/mongo/options/createcollectionoptions.go
@@ -193,9 +193,8 @@ func (c *CreateCollectionOptionsBuilder) SetCapped(capped bool) *CreateCollectio
 	return c
 }
 
-// SetCollation sets the value for the Collation field. Specifies the default collation for the new
-// collection. This option is only valid for MongoDB versions >= 3.4. For previous server versions,
-// the driver will return an error if this option is used. The default value is nil.
+// SetCollation sets the value for the Collation field. Specifies the default
+// collation for the new collection. The default value is nil.
 func (c *CreateCollectionOptionsBuilder) SetCollation(collation *Collation) *CreateCollectionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateCollectionOptions) error {
 		opts.Collation = collation
@@ -222,9 +221,9 @@ func (c *CreateCollectionOptionsBuilder) SetChangeStreamPreAndPostImages(csppi i
 	return c
 }
 
-// SetDefaultIndexOptions sets the value for the DefaultIndexOptions field. Specifies a default
-// configuration for indexes on the collection. This option is only valid for MongoDB versions
-// >= 3.4. The default value is nil, meaning indexes will be configured using server defaults.
+// SetDefaultIndexOptions sets the value for the DefaultIndexOptions field.
+// Specifies a default configuration for indexes on the collection. The default
+// value is nil, meaning indexes will be configured using server defaults.
 func (c *CreateCollectionOptionsBuilder) SetDefaultIndexOptions(iopts *DefaultIndexOptionsBuilder) *CreateCollectionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateCollectionOptions) error {
 		opts.DefaultIndexOptions = iopts
@@ -278,7 +277,7 @@ func (c *CreateCollectionOptionsBuilder) SetStorageEngine(storageEngine interfac
 // SetValidationAction sets the value for the ValidationAction field. Specifies what should happen if a
 // document being inserted does not pass validation. Valid values are "error" and "warn". See
 // https://www.mongodb.com/docs/manual/core/schema-validation/#accept-or-reject-invalid-documents for more
-// information. This option is only valid for MongoDB versions >= 3.2. The default value is "error".
+// information. The default value is "error".
 func (c *CreateCollectionOptionsBuilder) SetValidationAction(action string) *CreateCollectionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateCollectionOptions) error {
 		opts.ValidationAction = &action
@@ -292,7 +291,7 @@ func (c *CreateCollectionOptionsBuilder) SetValidationAction(action string) *Cre
 // SetValidationLevel sets the value for the ValidationLevel field. Specifies how strictly the server applies
 // validation rules to existing documents in the collection during update operations. Valid values are "off",
 // "strict", and "moderate". See https://www.mongodb.com/docs/manual/core/schema-validation/#existing-documents
-// for more information. This option is only valid for MongoDB versions >= 3.2. The default value is "strict".
+// for more information. The default value is "strict".
 func (c *CreateCollectionOptionsBuilder) SetValidationLevel(level string) *CreateCollectionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateCollectionOptions) error {
 		opts.ValidationLevel = &level
@@ -305,8 +304,7 @@ func (c *CreateCollectionOptionsBuilder) SetValidationLevel(level string) *Creat
 
 // SetValidator sets the value for the Validator field. Sets a document specifying validation rules for the
 // collection. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more information about
-// schema validation. This option is only valid for MongoDB versions >= 3.2. The default value is nil,
-// meaning no validator will be used for the collection.
+// schema validation. The default value is nil, meaning no validator will be used for the collection.
 func (c *CreateCollectionOptionsBuilder) SetValidator(validator interface{}) *CreateCollectionOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateCollectionOptions) error {
 		opts.Validator = validator
@@ -402,9 +400,8 @@ func (c *CreateViewOptionsBuilder) List() []func(*CreateViewOptions) error {
 	return c.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies the default collation for the new
-// collection. This option is only valid for MongoDB versions >= 3.4. For previous server versions,
-// the driver will return an error if this option is used. The default value is nil.
+// SetCollation sets the value for the Collation field. Specifies the default
+// collation for the new collection. The default value is nil.
 func (c *CreateViewOptionsBuilder) SetCollation(collation *Collation) *CreateViewOptionsBuilder {
 	c.Opts = append(c.Opts, func(opts *CreateViewOptions) error {
 		opts.Collation = collation

--- a/mongo/options/deleteoptions.go
+++ b/mongo/options/deleteoptions.go
@@ -34,11 +34,9 @@ func (do *DeleteOneOptionsBuilder) List() []func(*DeleteOneOptions) error {
 	return do.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for
-// string comparisons during the operation. This option is only valid for MongoDB
-// versions >= 3.4. For previous server versions, the driver will return an error if this
-// option is used. The default value is nil, which means the default collation of the
-// collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (do *DeleteOneOptionsBuilder) SetCollation(c *Collation) *DeleteOneOptionsBuilder {
 	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
 		opts.Collation = c
@@ -62,13 +60,14 @@ func (do *DeleteOneOptionsBuilder) SetComment(comment interface{}) *DeleteOneOpt
 	return do
 }
 
-// SetHint sets the value for the Hint field. Specifies the index to use for the operation. This
-// should either be the index name as a string or the index specification as a document. This option
-// is only valid for MongoDB versions >= 4.4. Server versions >= 3.4 will return an error if this
-// option is specified. For server versions < 3.4, the driver will return a client-side error if this
-// option is specified. The driver will return an error if this option is specified during an
-// unacknowledged write operation. The driver will return an error if the hint parameter is a
-// multi-key map. The default value is nil, which means that no hint will be sent.
+// SetHint sets the value for the Hint field. Specifies the index to use for the
+// operation. This should either be the index name as a string or the index
+// specification as a document. This option is only valid for MongoDB versions
+// >= 4.4. Server versions < 4.4 will return an error if this option is
+// specified. The driver will return an error if this option is specified during
+// an unacknowledged write operation. The driver will return an error if the
+// hint parameter is a multi-key map. The default value is nil, which means that
+// no hint will be sent.
 func (do *DeleteOneOptionsBuilder) SetHint(hint interface{}) *DeleteOneOptionsBuilder {
 	do.Opts = append(do.Opts, func(opts *DeleteOneOptions) error {
 		opts.Hint = hint
@@ -122,10 +121,9 @@ func (do *DeleteManyOptionsBuilder) List() []func(*DeleteManyOptions) error {
 	return do.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4.
-// For previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (do *DeleteManyOptionsBuilder) SetCollation(c *Collation) *DeleteManyOptionsBuilder {
 	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
 		opts.Collation = c
@@ -149,14 +147,14 @@ func (do *DeleteManyOptionsBuilder) SetComment(comment interface{}) *DeleteManyO
 	return do
 }
 
-// SetHint sets the value for the Hint field. Specifies the index to use for the operation.
-// This should either be the index name as a string or the index specification as a document.
-// This option is only valid for MongoDB versions >= 4.4. Server versions >= 3.4 will return an
-// error if this option is specified. For server versions < 3.4, the driver will return a
-// client-side error if this option is specified. The driver will return an error if this option
-// is specified during an unacknowledged write operation. The driver will return an error if the
-// hint parameter is a multi-key map. The default value is nil, which means that no hint will
-// be sent.
+// SetHint sets the value for the Hint field. Specifies the index to use for the
+// operation. This should either be the index name as a string or the index
+// specification as a document. This option is only valid for MongoDB versions
+// >= 4.4. Server versions < 4.4 will return an error if this option is
+// specified. The driver will return an error if this option is specified during
+// an unacknowledged write operation. The driver will return an error if the
+// hint parameter is a multi-key map. The default value is nil, which means that
+// no hint will be sent.
 func (do *DeleteManyOptionsBuilder) SetHint(hint interface{}) *DeleteManyOptionsBuilder {
 	do.Opts = append(do.Opts, func(opts *DeleteManyOptions) error {
 		opts.Hint = hint

--- a/mongo/options/distinctoptions.go
+++ b/mongo/options/distinctoptions.go
@@ -33,11 +33,9 @@ func (do *DistinctOptionsBuilder) List() []func(*DistinctOptions) error {
 	return do.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use
-// for string comparisons during the operation. This option is only valid for MongoDB
-// versions >= 3.4. For previous server versions, the driver will return an error if
-// this option is used. The default value is nil, which means the default collation
-// of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (do *DistinctOptionsBuilder) SetCollation(c *Collation) *DistinctOptionsBuilder {
 	do.Opts = append(do.Opts, func(opts *DistinctOptions) error {
 		opts.Collation = c

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -52,11 +52,11 @@ func (f *FindOptionsBuilder) List() []func(*FindOptions) error {
 	return f.Opts
 }
 
-// SetAllowDiskUse sets the value for the AllowDiskUse field. AllowDiskUse specifies whether the
-// server can write temporary data to disk while executing the Find operation. This option is only
-// valid for MongoDB versions >= 4.4. Server versions >= 3.2 will report an error if this option
-// is specified. For server versions < 3.2, the driver will return a client-side error if this
-// option is specified. The default value is false.
+// SetAllowDiskUse sets the value for the AllowDiskUse field. AllowDiskUse
+// specifies whether the server can write temporary data to disk while executing
+// the Find operation. This option is only valid for MongoDB versions >= 4.4.
+// Server versions < 4.4 will return an error if this option is specified. The
+// default value is false.
 func (f *FindOptionsBuilder) SetAllowDiskUse(b bool) *FindOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOptions) error {
 		opts.AllowDiskUse = &b
@@ -86,10 +86,10 @@ func (f *FindOptionsBuilder) SetBatchSize(i int32) *FindOptionsBuilder {
 	return f
 }
 
-// SetCollation sets the value for the Collation field. Collation specifies a collation to use for
-// string comparisons during the operation. This option is only valid for MongoDB versions >= 3.4.
-// For previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Collation specifies a
+// collation to use for string comparisons during the operation. The default
+// value is nil, which means the default collation of the collection will be
+// used.
 func (f *FindOptionsBuilder) SetCollation(collation *Collation) *FindOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOptions) error {
 		opts.Collation = collation
@@ -167,11 +167,11 @@ func (f *FindOptionsBuilder) SetMax(max interface{}) *FindOptionsBuilder {
 	return f
 }
 
-// SetMaxAwaitTime sets the value for the MaxAwaitTime field. MaxAwaitTime is the maximum amount of
-// time that the server should wait for new documents to satisfy a tailable cursor query. This
-// option is only valid for tailable await cursors (see the CursorType option for more information)
-// and MongoDB versions >= 3.2. For other cursor types or previous server versions, this option
-// is ignored.
+// SetMaxAwaitTime sets the value for the MaxAwaitTime field. MaxAwaitTime is
+// the maximum amount of time that the server should wait for new documents to
+// satisfy a tailable cursor query. This option is only valid for tailable await
+// cursors (see the CursorType option for more information). For other cursor
+// types, this option is ignored.
 func (f *FindOptionsBuilder) SetMaxAwaitTime(d time.Duration) *FindOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOptions) error {
 		opts.MaxAwaitTime = &d
@@ -314,10 +314,9 @@ func (f *FindOneOptionsBuilder) SetAllowPartialResults(b bool) *FindOneOptionsBu
 	return f
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For
-// previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (f *FindOneOptionsBuilder) SetCollation(collation *Collation) *FindOneOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneOptions) error {
 		opts.Collation = collation
@@ -471,8 +470,7 @@ func (f *FindOneAndReplaceOptionsBuilder) List() []func(*FindOneAndReplaceOption
 }
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true, writes
-// executed as part of the operation will opt out of document-level validation on the server. This
-// option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions. The
+// executed as part of the operation will opt out of document-level validation on the server. The
 // default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for more
 // information about document validation.
 func (f *FindOneAndReplaceOptionsBuilder) SetBypassDocumentValidation(b bool) *FindOneAndReplaceOptionsBuilder {
@@ -485,10 +483,9 @@ func (f *FindOneAndReplaceOptionsBuilder) SetBypassDocumentValidation(b bool) *F
 	return f
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4.
-// For previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (f *FindOneAndReplaceOptionsBuilder) SetCollation(collation *Collation) *FindOneAndReplaceOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneAndReplaceOptions) error {
 		opts.Collation = collation
@@ -633,11 +630,10 @@ func (f *FindOneAndUpdateOptionsBuilder) List() []func(*FindOneAndUpdateOptions)
 	return f.Opts
 }
 
-// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a set of filters
-// specifying to which array elements an update should apply. This option is only valid for
-// MongoDB versions >= 3.6. For previous server versions, the driver will return an error if
-// this option is used. The default value is nil, which means the update will apply to all
-// array elements.
+// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a
+// set of filters specifying to which array elements an update should apply. The
+// default value is nil, which means the update will apply to all array
+// elements.
 func (f *FindOneAndUpdateOptionsBuilder) SetArrayFilters(filters []interface{}) *FindOneAndUpdateOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneAndUpdateOptions) error {
 		opts.ArrayFilters = filters
@@ -650,7 +646,6 @@ func (f *FindOneAndUpdateOptionsBuilder) SetArrayFilters(filters []interface{}) 
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the server.
-// This option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
 // The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/
 // for more information about document validation.
 func (f *FindOneAndUpdateOptionsBuilder) SetBypassDocumentValidation(b bool) *FindOneAndUpdateOptionsBuilder {
@@ -663,10 +658,9 @@ func (f *FindOneAndUpdateOptionsBuilder) SetBypassDocumentValidation(b bool) *Fi
 	return f
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For
-// previous server versions, the driver will return an error if this option is used. The default
-// value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (f *FindOneAndUpdateOptionsBuilder) SetCollation(collation *Collation) *FindOneAndUpdateOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneAndUpdateOptions) error {
 		opts.Collation = collation
@@ -807,10 +801,9 @@ func (f *FindOneAndDeleteOptionsBuilder) List() []func(*FindOneAndDeleteOptions)
 	return f.Opts
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4.
-// For previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (f *FindOneAndDeleteOptionsBuilder) SetCollation(collation *Collation) *FindOneAndDeleteOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneAndDeleteOptions) error {
 		opts.Collation = collation

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -262,8 +262,7 @@ func (i *IndexOptionsBuilder) SetSparse(sparse bool) *IndexOptionsBuilder {
 // SetStorageEngine sets the value for the StorageEngine field. Specifies the
 // storage engine to use for the index. The value must be a document in the form
 // {<storage engine name>: <options>}. The default value is nil, which means that
-// the default storage engine will be used. This option is only applicable for
-// MongoDB versions >= 3.0 and is ignored for previous server versions.
+// the default storage engine will be used.
 func (i *IndexOptionsBuilder) SetStorageEngine(engine interface{}) *IndexOptionsBuilder {
 	i.Opts = append(i.Opts, func(opts *IndexOptions) error {
 		opts.StorageEngine = engine
@@ -424,8 +423,7 @@ func (i *IndexOptionsBuilder) SetBucketSize(bucketSize int32) *IndexOptionsBuild
 }
 
 // SetPartialFilterExpression sets the value for the PartialFilterExpression field. Sets
-// a document that defines which collection documents the index should reference. This
-// option is only valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
+// a document that defines which collection documents the index should reference.
 func (i *IndexOptionsBuilder) SetPartialFilterExpression(expression interface{}) *IndexOptionsBuilder {
 	i.Opts = append(i.Opts, func(opts *IndexOptions) error {
 		opts.PartialFilterExpression = expression
@@ -437,8 +435,7 @@ func (i *IndexOptionsBuilder) SetPartialFilterExpression(expression interface{})
 }
 
 // SetCollation sets the value for the Collation field. Specifies the collation to use for
-// string comparisons for the index. This option is only valid for MongoDB versions >= 3.4.
-// For previous server versions, the driver will return an error if this option is used.
+// string comparisons for the index.
 func (i *IndexOptionsBuilder) SetCollation(collation *Collation) *IndexOptionsBuilder {
 	i.Opts = append(i.Opts, func(opts *IndexOptions) error {
 		opts.Collation = collation

--- a/mongo/options/insertoptions.go
+++ b/mongo/options/insertoptions.go
@@ -33,8 +33,7 @@ func (ioo *InsertOneOptionsBuilder) List() []func(*InsertOneOptions) error {
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the
-// server. This option is valid for MongoDB versions >= 3.2 and is ignored for previous server
-// versions. The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/
+// server. The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/
 // for more information about document validation.
 func (ioo *InsertOneOptionsBuilder) SetBypassDocumentValidation(b bool) *InsertOneOptionsBuilder {
 	ioo.Opts = append(ioo.Opts, func(opts *InsertOneOptions) error {
@@ -86,8 +85,7 @@ func (imo *InsertManyOptionsBuilder) List() []func(*InsertManyOptions) error {
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the
-// server. This option is valid for MongoDB versions >= 3.2 and is ignored for previous server
-// versions. The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/
+// server. The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/
 // for more information about document validation.
 func (imo *InsertManyOptionsBuilder) SetBypassDocumentValidation(b bool) *InsertManyOptionsBuilder {
 	imo.Opts = append(imo.Opts, func(opts *InsertManyOptions) error {

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -39,7 +39,6 @@ func (ro *ReplaceOptionsBuilder) List() []func(*ReplaceOptions) error {
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the server.
-// This option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
 // The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for
 // more information about document validation.
 func (ro *ReplaceOptionsBuilder) SetBypassDocumentValidation(b bool) *ReplaceOptionsBuilder {
@@ -52,10 +51,9 @@ func (ro *ReplaceOptionsBuilder) SetBypassDocumentValidation(b bool) *ReplaceOpt
 	return ro
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For
-// previous server versions, the driver will return an error if this option is used. The
-// default value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (ro *ReplaceOptionsBuilder) SetCollation(c *Collation) *ReplaceOptionsBuilder {
 	ro.Opts = append(ro.Opts, func(opts *ReplaceOptions) error {
 		opts.Collation = c
@@ -79,14 +77,14 @@ func (ro *ReplaceOptionsBuilder) SetComment(comment interface{}) *ReplaceOptions
 	return ro
 }
 
-// SetHint sets the value for the Hint field. Specifies the index to use for the operation.
-// This should either be the index name as a string or the index specification as a document.
-// This option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will return
-// an error if this option is specified. For server versions < 3.4, the driver will return a
-// client-side error if this option is specified. The driver will return an error if this option
-// is specified during an unacknowledged write operation. The driver will return an error if
-// the hint parameter is a multi-key map. The default value is nil, which means that no hint
-// will be sent.
+// SetHint sets the value for the Hint field. Specifies the index to use for the
+// operation. This should either be the index name as a string or the index
+// specification as a document. This option is only valid for MongoDB versions
+// >= 4.2. Server versions < 4.2 will return an error if this option is
+// specified. The driver will return an error if this option is specified during
+// an unacknowledged write operation. The driver will return an error if the
+// hint parameter is a multi-key map. The default value is nil, which means that
+// no hint will be sent.
 func (ro *ReplaceOptionsBuilder) SetHint(h interface{}) *ReplaceOptionsBuilder {
 	ro.Opts = append(ro.Opts, func(opts *ReplaceOptions) error {
 		opts.Hint = h

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -38,10 +38,10 @@ func (uo *UpdateOneOptionsBuilder) List() []func(*UpdateOneOptions) error {
 	return uo.Opts
 }
 
-// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a set of filters
-// specifying to which array elements an update should apply. This option is only valid for MongoDB
-// versions >= 3.6. For previous server versions, the driver will return an error if this option is
-// used. The default value is nil, which means the update will apply to all array elements.
+// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a
+// set of filters specifying to which array elements an update should apply. The
+// default value is nil, which means the update will apply to all array
+// elements.
 func (uo *UpdateOneOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateOneOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.ArrayFilters = af
@@ -54,7 +54,6 @@ func (uo *UpdateOneOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateOneO
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the server.
-// This option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
 // The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for
 // more information about document validation.
 func (uo *UpdateOneOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateOneOptionsBuilder {
@@ -67,10 +66,9 @@ func (uo *UpdateOneOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateOn
 	return uo
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For
-// previous server versions, the driver will return an error if this option is used. The default
-// value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (uo *UpdateOneOptionsBuilder) SetCollation(c *Collation) *UpdateOneOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Collation = c
@@ -94,13 +92,14 @@ func (uo *UpdateOneOptionsBuilder) SetComment(comment interface{}) *UpdateOneOpt
 	return uo
 }
 
-// SetHint sets the value for the Hint field. Specifies the index to use for the operation. This
-// should either be the index name as a string or the index specification as a document. This
-// option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will return an error
-// if this option is specified. For server versions < 3.4, the driver will return a client-side
-// error if this option is specified. The driver will return an error if this option is specified
-// during an unacknowledged write operation. The driver will return an error if the hint parameter
-// is a multi-key map. The default value is nil, which means that no hint will be sent.
+// SetHint sets the value for the Hint field. Specifies the index to use for the
+// operation. This should either be the index name as a string or the index
+// specification as a document. This option is only valid for MongoDB versions
+// >= 4.2. Server versions < 4.2 will return an error if this option is
+// specified. The driver will return an error if this option is specified during
+// an unacknowledged write operation. The driver will return an error if the
+// hint parameter is a multi-key map. The default value is nil, which means that
+// no hint will be sent.
 func (uo *UpdateOneOptionsBuilder) SetHint(h interface{}) *UpdateOneOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
 		opts.Hint = h
@@ -184,10 +183,10 @@ func (uo *UpdateManyOptionsBuilder) List() []func(*UpdateManyOptions) error {
 	return uo.Opts
 }
 
-// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a set of filters
-// specifying to which array elements an update should apply. This option is only valid for MongoDB
-// versions >= 3.6. For previous server versions, the driver will return an error if this option is
-// used. The default value is nil, which means the update will apply to all array elements.
+// SetArrayFilters sets the value for the ArrayFilters field. ArrayFilters is a
+// set of filters specifying to which array elements an update should apply. The
+// default value is nil, which means the update will apply to all array
+// elements.
 func (uo *UpdateManyOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateManyOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
 		opts.ArrayFilters = af
@@ -200,7 +199,6 @@ func (uo *UpdateManyOptionsBuilder) SetArrayFilters(af []interface{}) *UpdateMan
 
 // SetBypassDocumentValidation sets the value for the BypassDocumentValidation field. If true,
 // writes executed as part of the operation will opt out of document-level validation on the server.
-// This option is valid for MongoDB versions >= 3.2 and is ignored for previous server versions.
 // The default value is false. See https://www.mongodb.com/docs/manual/core/schema-validation/ for
 // more information about document validation.
 func (uo *UpdateManyOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateManyOptionsBuilder {
@@ -213,10 +211,9 @@ func (uo *UpdateManyOptionsBuilder) SetBypassDocumentValidation(b bool) *UpdateM
 	return uo
 }
 
-// SetCollation sets the value for the Collation field. Specifies a collation to use for string
-// comparisons during the operation. This option is only valid for MongoDB versions >= 3.4. For
-// previous server versions, the driver will return an error if this option is used. The default
-// value is nil, which means the default collation of the collection will be used.
+// SetCollation sets the value for the Collation field. Specifies a collation to
+// use for string comparisons during the operation. The default value is nil,
+// which means the default collation of the collection will be used.
 func (uo *UpdateManyOptionsBuilder) SetCollation(c *Collation) *UpdateManyOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
 		opts.Collation = c
@@ -240,13 +237,14 @@ func (uo *UpdateManyOptionsBuilder) SetComment(comment interface{}) *UpdateManyO
 	return uo
 }
 
-// SetHint sets the value for the Hint field. Specifies the index to use for the operation. This
-// should either be the index name as a string or the index specification as a document. This
-// option is only valid for MongoDB versions >= 4.2. Server versions >= 3.4 will return an error
-// if this option is specified. For server versions < 3.4, the driver will return a client-side
-// error if this option is specified. The driver will return an error if this option is specified
-// during an unacknowledged write operation. The driver will return an error if the hint parameter
-// is a multi-key map. The default value is nil, which means that no hint will be sent.
+// SetHint sets the value for the Hint field. Specifies the index to use for the
+// operation. This should either be the index name as a string or the index
+// specification as a document. This option is only valid for MongoDB versions
+// >= 4.2. Server versions < 4.2 will return an error if this option is
+// specified. The driver will return an error if this option is specified during
+// an unacknowledged write operation. The driver will return an error if the
+// hint parameter is a multi-key map. The default value is nil, which means that
+// no hint will be sent.
 func (uo *UpdateManyOptionsBuilder) SetHint(h interface{}) *UpdateManyOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
 		opts.Hint = h

--- a/mongo/results.go
+++ b/mongo/results.go
@@ -220,11 +220,10 @@ type CollectionSpecification struct {
 	// The type of the collection. This will either be "collection" or "view".
 	Type string
 
-	// Whether or not the collection is readOnly. This will be false for MongoDB versions < 3.4.
+	// Whether or not the collection is readOnly.
 	ReadOnly bool
 
-	// The collection UUID. This field will be nil for MongoDB versions < 3.6. For versions 3.6 and higher, this will
-	// be a bson.Binary with Subtype 4.
+	// The collection UUID as a bson.Binary with subtype 4.
 	UUID *bson.Binary
 
 	// A document containing the options used to construct the collection.

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -198,7 +198,7 @@ func (a *Aggregate) BypassDocumentValidation(bypassDocumentValidation bool) *Agg
 	return a
 }
 
-// Collation specifies a collation. This option is only valid for server versions 3.4 and above.
+// Collation specifies a collation.
 func (a *Aggregate) Collation(collation bsoncore.Document) *Aggregate {
 	if a == nil {
 		a = new(Aggregate)

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -151,7 +151,7 @@ func (c *Create) Capped(capped bool) *Create {
 	return c
 }
 
-// Collation specifies a collation. This option is only valid for server versions 3.4 and above.
+// Collation specifies a collation.
 func (c *Create) Collation(collation bsoncore.Document) *Create {
 	if c == nil {
 		c = new(Create)

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -277,8 +277,7 @@ func (d *Delete) Retry(retry driver.RetryMode) *Delete {
 }
 
 // Hint is a flag to indicate that the update document contains a hint. Hint is only supported by
-// servers >= 4.4. Older servers >= 3.4 will report an error for using the hint option. For servers <
-// 3.4, the driver will return an error if the hint option is used.
+// servers >= 4.4. Older servers will report an error for using the hint option.
 func (d *Delete) Hint(hint bool) *Delete {
 	if d == nil {
 		d = new(Delete)

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -207,8 +207,7 @@ func (u *Update) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	return dst, nil
 }
 
-// BypassDocumentValidation allows the operation to opt-out of document level validation. Valid
-// for server versions >= 3.2. For servers < 3.2, this setting is ignored.
+// BypassDocumentValidation allows the operation to opt-out of document level validation.
 func (u *Update) BypassDocumentValidation(bypassDocumentValidation bool) *Update {
 	if u == nil {
 		u = new(Update)
@@ -219,8 +218,7 @@ func (u *Update) BypassDocumentValidation(bypassDocumentValidation bool) *Update
 }
 
 // Hint is a flag to indicate that the update document contains a hint. Hint is only supported by
-// servers >= 4.2. Older servers >= 3.4 will report an error for using the hint option. For servers <
-// 3.4, the driver will return an error if the hint option is used.
+// servers >= 4.2. Older servers will report an error for using the hint option.
 func (u *Update) Hint(hint bool) *Update {
 	if u == nil {
 		u = new(Update)
@@ -230,8 +228,7 @@ func (u *Update) Hint(hint bool) *Update {
 	return u
 }
 
-// ArrayFilters is a flag to indicate that the update document contains an arrayFilters field. This option is only
-// supported on server versions 3.6 and higher. For servers < 3.6, the driver will return an error.
+// ArrayFilters is a flag to indicate that the update document contains an arrayFilters field.
 func (u *Update) ArrayFilters(arrayFilters bool) *Update {
 	if u == nil {
 		u = new(Update)

--- a/x/mongo/driver/topology/fsm.go
+++ b/x/mongo/driver/topology/fsm.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// MinSupportedMongoDBVersion is the version string for the lowest MongoDB version supported by the driver.
-	MinSupportedMongoDBVersion = "3.6"
+	MinSupportedMongoDBVersion = "4.0"
 
 	// SupportedWireVersions is the range of wire versions supported by the driver.
 	SupportedWireVersions = driverutil.NewVersionRange(driverutil.MinWireVersion, driverutil.MaxWireVersion)

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -114,7 +114,7 @@ func TestServerSelection(t *testing.T) {
 		}
 		want := fmt.Errorf(
 			"server at %s reports wire version %d, but this version of the Go driver requires "+
-				"at least 6 (MongoDB 3.6)",
+				"at least 7 (MongoDB 4.0)",
 			desc.Servers[0].Addr.String(),
 			desc.Servers[0].WireVersion.Max,
 		)


### PR DESCRIPTION
[GODRIVER-3098](https://jira.mongodb.org/browse/GODRIVER-3098)

## Summary

Drop support for MongoDB 3.6. The minimum supported MongoDB version is now 4.0.

## Background & Motivation

MongoDB 3.6 reached end-of-life in 2021.

Part of a stack of changes that must be reviewed in order:
1. https://github.com/mongodb/mongo-go-driver/pull/1985
2. https://github.com/mongodb/mongo-go-driver/pull/1986
3. https://github.com/mongodb/mongo-go-driver/pull/1988 (this PR)
