### PR TITLE
GODRIVER-3498 Revert skip to non-lb-connection-establishment.

### DIFF
--- a/testdata/load-balancers/non-lb-connection-establishment.json
+++ b/testdata/load-balancers/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",

--- a/testdata/load-balancers/non-lb-connection-establishment.yml
+++ b/testdata/load-balancers/non-lb-connection-establishment.yml
@@ -42,11 +42,6 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
-    runOnRequirements:
-      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
-        topologies: [ single ]
-      - topologies: [ sharded ]
-
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
[GODRIVER-3498](https://jira.mongodb.org/browse/GODRIVER-3498)

## Summary

Sync non-lb-connection-establishment test to https://github.com/mongodb/specifications/commit/f04df7d667e20fa7f9ae067e6951662c68da85b6

## Background & Motivation

Test failure resolved by [SERVER-101078](https://jira.mongodb.org/browse/SERVER-101078).
