### PR TITLE
GODRIVER-3451 Add fuzz test for BSON MarshalValue/UnmarshalValue.

### DIFF
--- a/bson/decode_value_fuzz_test.go
+++ b/bson/decode_value_fuzz_test.go
@@ -27,6 +27,10 @@ func FuzzDecodeValue(f *testing.F) {
 		int64(0), math.MaxInt64, math.MinInt64,
 		// string, including empty and large string.
 		"", strings.Repeat("z", 10_000),
+		// map
+		map[string]any{"nested": []any{1, "two", map[string]any{"three": 3}}},
+		// array
+		[]any{1, 2, 3, "four"},
 	}
 
 	for _, v := range values {
@@ -48,6 +52,7 @@ func FuzzDecodeValue(f *testing.F) {
 		// to "nil". It's not clear if MarshalValue should support "nil", but
 		// for now we skip it.
 		if v == nil {
+			t.Logf("data unmarshaled to nil: %v", data)
 			return
 		}
 
@@ -56,7 +61,8 @@ func FuzzDecodeValue(f *testing.F) {
 			t.Fatalf("failed to marshal: %v", err)
 		}
 
-		if err := UnmarshalValue(typ, encoded, &v); err != nil {
+		var v2 any
+		if err := UnmarshalValue(typ, encoded, &v2); err != nil {
 			t.Fatalf("failed to unmarshal: %v", err)
 		}
 	})

--- a/bson/decode_value_fuzz_test.go
+++ b/bson/decode_value_fuzz_test.go
@@ -22,9 +22,9 @@ func FuzzDecodeValue(f *testing.F) {
 	// Also seed the fuzz corpus with special values that we want to test.
 	values := []any{
 		// int32, including max and min values.
-		int32(0), math.MaxInt32, math.MinInt32,
+		int32(0), int32(math.MaxInt32), int32(math.MinInt32),
 		// int64, including max and min values.
-		int64(0), math.MaxInt64, math.MinInt64,
+		int64(0), int64(math.MaxInt64), int64(math.MinInt64),
 		// string, including empty and large string.
 		"", strings.Repeat("z", 10_000),
 		// map

--- a/bson/decode_value_fuzz_test.go
+++ b/bson/decode_value_fuzz_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) MongoDB, Inc. 2025-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bson
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func FuzzDecodeValue(f *testing.F) {
+	// Seed the fuzz corpus with all BSON values from the MarshalValue test
+	// cases.
+	for _, tc := range marshalValueTestCases {
+		f.Add(byte(tc.bsontype), tc.bytes)
+	}
+
+	// Also seed the fuzz corpus with special values that we want to test.
+	values := []any{
+		// int32, including max and min values.
+		int32(0), math.MaxInt32, math.MinInt32,
+		// int64, including max and min values.
+		int64(0), math.MaxInt64, math.MinInt64,
+		// string, including empty and large string.
+		"", strings.Repeat("z", 10_000),
+	}
+
+	for _, v := range values {
+		typ, b, err := MarshalValue(v)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(byte(typ), b)
+	}
+
+	f.Fuzz(func(t *testing.T, bsonType byte, data []byte) {
+		var v any
+		if err := UnmarshalValue(Type(bsonType), data, &v); err != nil {
+			return
+		}
+
+		// There is no value encoder for Go "nil" (nil values handled
+		// differently by each type encoder), so skip anything that unmarshals
+		// to "nil". It's not clear if MarshalValue should support "nil", but
+		// for now we skip it.
+		if v == nil {
+			return
+		}
+
+		typ, encoded, err := MarshalValue(v)
+		if err != nil {
+			t.Fatalf("failed to marshal: %v", err)
+		}
+
+		if err := UnmarshalValue(typ, encoded, &v); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+	})
+}

--- a/bson/fuzz_test.go
+++ b/bson/fuzz_test.go
@@ -4,6 +4,11 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+// fuzz_test.go is used by the "oss-fuzz" integration. Use caution when
+// modifying this file because it may break that integration.
+//
+// See https://github.com/google/oss-fuzz/tree/master/projects/mongo-go-driver
+
 package bson
 
 import (
@@ -29,11 +34,11 @@ func FuzzDecode(f *testing.F) {
 
 			encoded, err := Marshal(i)
 			if err != nil {
-				t.Fatal("failed to marshal", err)
+				t.Fatalf("failed to marshal: %v", err)
 			}
 
 			if err := Unmarshal(encoded, i); err != nil {
-				t.Fatal("failed to unmarshal", err)
+				t.Fatalf("failed to unmarshal: %v", err)
 			}
 		}
 	})


### PR DESCRIPTION
[GODRIVER-3451](https://jira.mongodb.org/browse/GODRIVER-3451)

## Summary

* Fuzz `bson.MarshalValue` and `bson.UnmarshalValue`.
* Enable the data race detector during fuzzing

## Background & Motivation

