### PR TITLE
GODRIVER-3513 Fix OIDC Evergreen task failures.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -57,6 +57,7 @@ functions:
   handle-test-artifacts:
     - command: gotest.parse_files
       params:
+        optional_output: "true"
         files:
           - "src/go.mongodb.org/mongo-driver/*.suite"
     - command: ec2.assume_role
@@ -1932,7 +1933,10 @@ task_groups:
   - name: testoidc_task_group
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
-    teardown_task_can_fail_task: true
+    # TODO(DRIVERS-3141): Uncomment the following line once the teardown bug is
+    # fixed. See DRIVERS-3141 for more context.
+    #
+    # teardown_task_can_fail_task: true
     teardown_group_timeout_secs: 180 # 3 minutes (max allowed time)
     setup_group:
       - func: setup-system

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,7 +199,7 @@ tasks:
 
   evg-test-deployed-lambda-aws: bash ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
 
-  evg-gather-test-suites: find . -name \*.suite | xargs tar czf test_suite.tgz || true
+  evg-gather-test-suites: find . -name \*.suite | xargs --no-run-if-empty tar czf test_suite.tgz
 
   build-kms-test: go build ${BUILD_TAGS} ./internal/cmd/testkms
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,7 +199,7 @@ tasks:
 
   evg-test-deployed-lambda-aws: bash ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
 
-  evg-gather-test-suites: find . -name \*.suite | xargs tar czf test_suite.tgz
+  evg-gather-test-suites: find . -name \*.suite | xargs tar czf test_suite.tgz || true
 
   build-kms-test: go build ${BUILD_TAGS} ./internal/cmd/testkms
 

--- a/internal/cmd/testoidcauth/main.go
+++ b/internal/cmd/testoidcauth/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -1781,14 +1782,16 @@ func machine51azureWithNoUsername() error {
 
 func machine52azureWithBadUsername() error {
 	opts := options.Client().ApplyURI(uriSingle)
-	cred := options.Credential{
-		AuthMechanism: "MONGODB-OIDC",
-		Username:      "bad",
-	}
-	opts.SetAuth(cred)
+
 	if opts == nil {
 		return fmt.Errorf("machine_5_2: failed parsing uri: %q", uriSingle)
 	}
+	if opts.Auth == nil || opts.Auth.AuthMechanism != "MONGODB-OIDC" {
+		return errors.New("machine_5_2: expected URI to contain MONGODB-OIDC auth information")
+	}
+
+	opts.Auth.Username = "bad"
+
 	client, err := mongo.Connect(opts)
 	if err != nil {
 		return fmt.Errorf("machine_5_2: failed connecting client: %v", err)


### PR DESCRIPTION
[GODRIVER-3513](https://jira.mongodb.org/browse/GODRIVER-3513)

## Summary

* Mark the `gotest.parse_files` step as optional for tasks that still want to run `handle-test-artifacts` (e.g. to collect other app/server logs), but don't write any Go test output (e.g. the current OIDC tasks).
* Comment out `teardown_task_can_fail_task: true` from `testoidc_task_group` until the bug [DRIVERS-3141](https://jira.mongodb.org/browse/DRIVERS-3141), which prevents successful Atlas cluster teardown in OIDC tests, is fixed.
* Prevent Taskfile task `evg-gather-test-suites` from failing the Evergreen task if there are no `*.suite`files to archive.

## Background & Motivation

Some OIDC tasks started failing after merging https://github.com/mongodb/mongo-go-driver/pull/1976. All of the failures were due to pre-existing problems in the test setup that surfaced after the config changes in that PR.
