### PR TITLE
GODRIVER-3519 Test sharded clusters with requireApiVersion=1

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1482,6 +1482,23 @@ tasks:
           SSL: "nossl"
           REQUIRE_API_VERSION: true
 
+  - name: "test-sharded-versioned-api"
+    tags: ["versioned-api"]
+    commands:
+      - func: bootstrap-mongo-orchestration
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "auth"
+          SSL: "nossl"
+          REQUIRE_API_VERSION: true
+      - func: start-cse-servers
+      - func: run-versioned-api-test
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          AUTH: "auth"
+          SSL: "nossl"
+          REQUIRE_API_VERSION: true
+
   - name: "test-standalone-versioned-api-test-commands"
     tags: ["versioned-api"]
     commands:


### PR DESCRIPTION
GODRIVER-3519

## Summary

Add tests for sharded clusters with requireApiVersion=1

## Background & Motivation

Previously we were only testing with standalone servers.  We are now unblocked from testing on sharded clusters, but not yet on replica sets.
