### PR TITLE
GODRIVER-3445 Update specifications submodule weekly with dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
[GODRIVER-3445](https://jira.mongodb.org/browse/GODRIVER-3445)

## Summary

* Use Github Dependabot to update the [specifications](https://github.com/mongodb/specifications) submodule weekly.

## Background & Motivation

<!--- Rationale for the pull request. -->
