### PR TITLE
GODRIVER-3035 Publish TopologyDescriptionChangedEvent on topology close.

### DIFF
--- a/internal/integration/unified/event.go
+++ b/internal/integration/unified/event.go
@@ -35,6 +35,8 @@ const (
 	serverHeartbeatStartedEvent     monitoringEventType = "ServerHeartbeatStartedEvent"
 	serverHeartbeatSucceededEvent   monitoringEventType = "ServerHeartbeatSucceededEvent"
 	topologyDescriptionChangedEvent monitoringEventType = "TopologyDescriptionChangedEvent"
+	topologyOpeningEvent            monitoringEventType = "TopologyOpeningEvent"
+	topologyClosedEvent             monitoringEventType = "TopologyClosedEvent"
 )
 
 func monitoringEventTypeFromString(eventStr string) (monitoringEventType, bool) {
@@ -77,6 +79,10 @@ func monitoringEventTypeFromString(eventStr string) (monitoringEventType, bool) 
 		return serverHeartbeatSucceededEvent, true
 	case "topologydescriptionchangedevent":
 		return topologyDescriptionChangedEvent, true
+	case "topologyopeningevent":
+		return topologyOpeningEvent, true
+	case "topologyclosedevent":
+		return topologyClosedEvent, true
 	default:
 		return "", false
 	}

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -89,10 +89,10 @@ type sdamEvent struct {
 
 	TopologyDescriptionChangedEvent *struct {
 		PreviousDescription *struct {
-			Type string `bson:"type"`
+			Type *string `bson:"type"`
 		} `bson:"previousDescription"`
 		NewDescription *struct {
-			Type string `bson:"type"`
+			Type *string `bson:"type"`
 		} `bson:"newDescription"`
 	} `bson:"topologyDescriptionChangedEvent"`
 	TopologyOpeningEvent *struct{} `bson:"topologyOpeningEvent"`
@@ -615,11 +615,11 @@ func verifySDAMEvents(client *clientEntity, expectedEvents *expectedEvents) erro
 				return newEventVerificationError(idx, client, "failed to get next description changed event: %v", err.Error())
 			}
 
-			if want := evt.TopologyDescriptionChangedEvent.PreviousDescription; want != nil && want.Type != got.PreviousDescription.Kind {
-				return newEventVerificationError(idx, client, "want previous description %v, got %v", want.Type, got.PreviousDescription.Kind)
+			if want := evt.TopologyDescriptionChangedEvent.PreviousDescription; want != nil && want.Type != nil && *want.Type != got.PreviousDescription.Kind {
+				return newEventVerificationError(idx, client, "want previous description %v, got %v", *want.Type, got.PreviousDescription.Kind)
 			}
-			if want := evt.TopologyDescriptionChangedEvent.NewDescription; want != nil && want.Type != got.NewDescription.Kind {
-				return newEventVerificationError(idx, client, "want new description %v, got %v", want.Type, got.NewDescription.Kind)
+			if want := evt.TopologyDescriptionChangedEvent.NewDescription; want != nil && want.Type != nil && *want.Type != got.NewDescription.Kind {
+				return newEventVerificationError(idx, client, "want new description %v, got %v", *want.Type, got.NewDescription.Kind)
 			}
 		case evt.TopologyOpeningEvent != nil:
 			if _, topening, err = getNextTopologyOpeningEvent(topening); err != nil {

--- a/testdata/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.json
+++ b/testdata/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.json
@@ -1,0 +1,88 @@
+{
+  "description": "loadbalanced-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 2
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {}
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "newDescription": {
+                  "type": "LoadBalanced"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.yml
+++ b/testdata/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.yml
@@ -1,0 +1,49 @@
+description: "loadbalanced-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - load-balanced
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and server connect event.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 2
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription: {}
+          - topologyDescriptionChangedEvent:  # unknown w disconnected server -> loadBalanced
+              newDescription:
+                type: "LoadBalanced"
+          - topologyDescriptionChangedEvent:  # loadbalanced -> unknown
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/testdata/server-discovery-and-monitoring/unified/logging-loadbalanced.json
+++ b/testdata/server-discovery-and-monitoring/unified/logging-loadbalanced.json
@@ -136,6 +136,22 @@
               "level": "debug",
               "component": "topology",
               "data": {
+                "message": "Topology description changed",
+                "topologyId": {
+                  "$$exists": true
+                },
+                "previousDescription": {
+                  "$$exists": true
+                },
+                "newDescription": {
+                  "$$exists": true
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "topology",
+              "data": {
                 "message": "Stopped topology monitoring",
                 "topologyId": {
                   "$$exists": true

--- a/testdata/server-discovery-and-monitoring/unified/logging-loadbalanced.yml
+++ b/testdata/server-discovery-and-monitoring/unified/logging-loadbalanced.yml
@@ -70,5 +70,12 @@ tests:
           - level: debug
             component: topology
             data:
+              message: "Topology description changed"
+              topologyId: { $$exists: true }
+              previousDescription: { $$exists: true } # loadBalanced topology
+              newDescription: { $$exists: true } # unknown topology
+          - level: debug
+            component: topology
+            data:
               message: "Stopped topology monitoring"
               topologyId: { $$exists: true }

--- a/testdata/server-discovery-and-monitoring/unified/logging-replicaset.json
+++ b/testdata/server-discovery-and-monitoring/unified/logging-replicaset.json
@@ -224,6 +224,22 @@
               "level": "debug",
               "component": "topology",
               "data": {
+                "message": "Topology description changed",
+                "topologyId": {
+                  "$$exists": true
+                },
+                "previousDescription": {
+                  "$$exists": true
+                },
+                "newDescription": {
+                  "$$exists": true
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "topology",
+              "data": {
                 "message": "Stopped topology monitoring",
                 "topologyId": {
                   "$$exists": true

--- a/testdata/server-discovery-and-monitoring/unified/logging-replicaset.yml
+++ b/testdata/server-discovery-and-monitoring/unified/logging-replicaset.yml
@@ -109,13 +109,6 @@ tests:
               topologyId: { $$exists: true }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-          # TODO(GODRIVER-2967): The following log message has been removed from
-          # the JSON analogue because it assumes that 
-          # "TopologyDescriptionChangedEvent" should occur when a topolgoy is 
-          # closed. This behavior is not clearly defined anywhere and some 
-          # drivers support and some don't.
-          #
-          # Need to sync whenever GODRIVER-2967 is unblocked.
           - level: debug
             component: topology
             data:

--- a/testdata/server-discovery-and-monitoring/unified/logging-sharded.json
+++ b/testdata/server-discovery-and-monitoring/unified/logging-sharded.json
@@ -191,6 +191,22 @@
               "level": "debug",
               "component": "topology",
               "data": {
+                "message": "Topology description changed",
+                "topologyId": {
+                  "$$exists": true
+                },
+                "previousDescription": {
+                  "$$exists": true
+                },
+                "newDescription": {
+                  "$$exists": true
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "topology",
+              "data": {
                 "message": "Stopped topology monitoring",
                 "topologyId": {
                   "$$exists": true

--- a/testdata/server-discovery-and-monitoring/unified/logging-sharded.yml
+++ b/testdata/server-discovery-and-monitoring/unified/logging-sharded.yml
@@ -97,13 +97,6 @@ tests:
               topologyId: { $$exists: true }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-          # TODO(GODRIVER-2967): The following log message has been removed from
-          # the JSON analogue because it assumes that 
-          # "TopologyDescriptionChangedEvent" should occur when a topolgoy is 
-          # closed. This behavior is not clearly defined anywhere and some 
-          # drivers support and some don't.
-          #
-          # Need to sync whenever GODRIVER-2967 is unblocked.
           - level: debug
             component: topology
             data:

--- a/testdata/server-discovery-and-monitoring/unified/logging-standalone.json
+++ b/testdata/server-discovery-and-monitoring/unified/logging-standalone.json
@@ -166,6 +166,22 @@
               "level": "debug",
               "component": "topology",
               "data": {
+                "message": "Topology description changed",
+                "topologyId": {
+                  "$$exists": true
+                },
+                "previousDescription": {
+                  "$$exists": true
+                },
+                "newDescription": {
+                  "$$exists": true
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "topology",
+              "data": {
                 "message": "Stopped topology monitoring",
                 "topologyId": {
                   "$$exists": true

--- a/testdata/server-discovery-and-monitoring/unified/logging-standalone.yml
+++ b/testdata/server-discovery-and-monitoring/unified/logging-standalone.yml
@@ -84,13 +84,6 @@ tests:
               topologyId: { $$exists: true }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-          # TODO(GODRIVER-2967): The following log message has been removed from
-          # the JSON analogue because it assumes that 
-          # "TopologyDescriptionChangedEvent" should occur when a topolgoy is 
-          # closed. This behavior is not clearly defined anywhere and some 
-          # drivers support and some don't.
-          #
-          # Need to sync whenever GODRIVER-2967 is unblocked.
           - level: debug
             component: topology
             data:

--- a/testdata/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.json
+++ b/testdata/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.json
@@ -1,0 +1,89 @@
+{
+  "description": "replicaset-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 4
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "ReplicaSetWithPrimary"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.yml
+++ b/testdata/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.yml
@@ -1,0 +1,49 @@
+description: "replicaset-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - replicaset
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and 3 server connect events.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 4
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: {} # unknown -> replset no primary
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent:  # replicaset -> unknown
+              previousDescription:
+                type: "ReplicaSetWithPrimary"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/testdata/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.json
+++ b/testdata/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.json
@@ -1,0 +1,108 @@
+{
+  "description": "sharded-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "sharded"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ],
+                  "useMultipleMongoses": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 3
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Sharded"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Sharded"
+                },
+                "newDescription": {
+                  "type": "Sharded"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Sharded"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.yml
+++ b/testdata/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.yml
@@ -1,0 +1,62 @@
+description: "sharded-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - sharded
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+                useMultipleMongoses: true
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial cluster type change from unknown to sharded and connect events
+      # for each of 2 servers
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 3
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription:
+                type: "Unknown"
+          - topologyDescriptionChangedEvent:  # server connected
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Sharded"
+          - topologyDescriptionChangedEvent:  # server connected
+              previousDescription:
+                type: "Sharded"
+              newDescription:
+                type: "Sharded"
+          - topologyDescriptionChangedEvent:  # sharded -> unknown
+              previousDescription:
+                type: "Sharded"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/testdata/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.json
+++ b/testdata/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.json
@@ -1,0 +1,97 @@
+{
+  "description": "standalone-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 2
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Single"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Single"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.yml
+++ b/testdata/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.yml
@@ -1,0 +1,55 @@
+description: "standalone-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - single
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and server connect event.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 2
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false 
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription: 
+                type: "Unknown"
+          - topologyDescriptionChangedEvent:  # unknown w disconnected server -> standalone 
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Single"
+          - topologyDescriptionChangedEvent:  # standalone -> unknown
+              previousDescription:
+                type: "Single"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -405,7 +405,10 @@ func (t *Topology) Disconnect(ctx context.Context) error {
 		t.pollingwg.Wait()
 	}
 
-	t.desc.Store(description.Topology{})
+	oldDesc := t.fsm.Topology
+	t.fsm = newFSM()
+	t.desc.Store(t.fsm.Topology)
+	t.publishTopologyDescriptionChangedEvent(oldDesc, t.fsm.Topology)
 
 	atomic.StoreInt64(&t.state, topologyDisconnected)
 	t.publishTopologyClosedEvent()


### PR DESCRIPTION
GODRIVER-3035

## Summary
Publish TopologyDescriptionChangedEvent on topology close.

Stacked on the top of https://github.com/mongodb/mongo-go-driver/pull/1964

Also updated spec tests for GODRIVER-2967

## Background & Motivation

<!--- Rationale for the pull request. -->
