### PR TITLE
GODRIVER-3542 use pointers to optimize equalTopologies func

### DIFF
--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -809,14 +809,14 @@ func equalTopologies(topo1, topo2 description.Topology) bool {
 		return false
 	}
 
-	topoServers := make(map[string]description.Server, len(topo1.Servers))
-	for _, s := range topo1.Servers {
-		topoServers[s.Addr.String()] = s
+	topoServers := make(map[string]*description.Server, len(topo1.Servers))
+	for i := range topo1.Servers {
+		topoServers[topo1.Servers[i].Addr.String()] = &topo1.Servers[i]
 	}
 
-	otherServers := make(map[string]description.Server, len(topo2.Servers))
-	for _, s := range topo2.Servers {
-		otherServers[s.Addr.String()] = s
+	otherServers := make(map[string]*description.Server, len(topo2.Servers))
+	for i := range topo2.Servers {
+		otherServers[topo2.Servers[i].Addr.String()] = &topo2.Servers[i]
 	}
 
 	if len(topoServers) != len(otherServers) {
@@ -826,7 +826,7 @@ func equalTopologies(topo1, topo2 description.Topology) bool {
 	for _, server := range topoServers {
 		otherServer := otherServers[server.Addr.String()]
 
-		if !driverutil.EqualServers(server, otherServer) {
+		if !driverutil.EqualServers(*server, *otherServer) {
 			return false
 		}
 	}

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -823,8 +823,8 @@ func equalTopologies(topo1, topo2 description.Topology) bool {
 		return false
 	}
 
-	for _, server := range topoServers {
-		otherServer, ok := otherServers[server.Addr.String()]
+	for addr, server := range topoServers {
+		otherServer, ok := otherServers[addr]
 		if !ok {
 			return false
 		}

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -824,7 +824,10 @@ func equalTopologies(topo1, topo2 description.Topology) bool {
 	}
 
 	for _, server := range topoServers {
-		otherServer := otherServers[server.Addr.String()]
+		otherServer, ok := otherServers[server.Addr.String()]
+		if !ok {
+			return false
+		}
 
 		if !driverutil.EqualServers(*server, *otherServer) {
 			return false

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1039,4 +1040,29 @@ func BenchmarkSelectServerFromDescription(b *testing.B) {
 			})
 		})
 	}
+}
+
+func BenchmarkEqualTopologies(b *testing.B) {
+	servers := make([]description.Server, 100)
+	for i := 0; i < len(servers); i++ {
+		servers[i] = description.Server{
+			Addr:              address.Address("127.0.0." + strconv.Itoa(i) + ":27017"),
+			HeartbeatInterval: time.Duration(10) * time.Second,
+			LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
+			LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
+			Kind:              description.ServerKindMongos,
+			WireVersion:       &description.VersionRange{Min: 6, Max: 21},
+		}
+	}
+	desc := description.Topology{
+		Servers: servers,
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		b.ReportAllocs()
+		for p.Next() {
+			_ = equalTopologies(desc, desc)
+		}
+	})
 }

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -1042,6 +1042,31 @@ func BenchmarkSelectServerFromDescription(b *testing.B) {
 	}
 }
 
+func TestEqualTopologies(t *testing.T) {
+	assert.True(t, equalTopologies(
+		description.Topology{
+			Servers: []description.Server{{
+				Addr: "127.0.0.1:27017",
+			}},
+		}, description.Topology{
+			Servers: []description.Server{{
+				Addr: "127.0.0.1:27017",
+			}},
+		},
+	))
+	assert.False(t, equalTopologies(
+		description.Topology{
+			Servers: []description.Server{{
+				Addr: "127.0.0.1:27017",
+			}},
+		}, description.Topology{
+			Servers: []description.Server{{
+				Addr: "127.0.0.2:27017",
+			}},
+		},
+	))
+}
+
 func BenchmarkEqualTopologies(b *testing.B) {
 	servers := make([]description.Server, 100)
 	for i := 0; i < len(servers); i++ {

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -1068,26 +1068,30 @@ func TestEqualTopologies(t *testing.T) {
 }
 
 func BenchmarkEqualTopologies(b *testing.B) {
-	servers := make([]description.Server, 100)
-	for i := 0; i < len(servers); i++ {
-		servers[i] = description.Server{
-			Addr:              address.Address("127.0.0." + strconv.Itoa(i) + ":27017"),
-			HeartbeatInterval: time.Duration(10) * time.Second,
-			LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
-			LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
-			Kind:              description.ServerKindMongos,
-			WireVersion:       &description.VersionRange{Min: 6, Max: 21},
-		}
-	}
-	desc := description.Topology{
-		Servers: servers,
-	}
+	for _, bsize := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(bsize), func(b *testing.B) {
+			servers := make([]description.Server, bsize)
+			for i := 0; i < len(servers); i++ {
+				servers[i] = description.Server{
+					Addr:              address.Address("127.0.0." + strconv.Itoa(i) + ":27017"),
+					HeartbeatInterval: time.Duration(10) * time.Second,
+					LastWriteTime:     time.Date(2017, 2, 11, 14, 0, 0, 0, time.UTC),
+					LastUpdateTime:    time.Date(2017, 2, 11, 14, 0, 2, 0, time.UTC),
+					Kind:              description.ServerKindMongos,
+					WireVersion:       &description.VersionRange{Min: 6, Max: 21},
+				}
+			}
+			desc := description.Topology{
+				Servers: servers,
+			}
 
-	b.ResetTimer()
-	b.RunParallel(func(p *testing.PB) {
-		b.ReportAllocs()
-		for p.Next() {
-			_ = equalTopologies(desc, desc)
-		}
-	})
+			b.ResetTimer()
+			b.RunParallel(func(p *testing.PB) {
+				b.ReportAllocs()
+				for p.Next() {
+					_ = equalTopologies(desc, desc)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3542

Optimize equalTopologies

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation
In our idle service this method in about 2 hours generates about 1GB of allocations. I want to reduce CPU load on GC from this idle service.
![image](https://github.com/user-attachments/assets/d2b43bc6-c4d9-411e-ada6-ca3d225cb477)

<!--- Rationale for the pull request. -->

Included benchmark on my machine produces the following results before
```
BenchmarkEqualTopologies
BenchmarkEqualTopologies-32    	   82350	     13399 ns/op	   90195 B/op	     206 allocs/op
PASS
```
and after
```
BenchmarkEqualTopologies
BenchmarkEqualTopologies-32    	  198764	      8329 ns/op	    6992 B/op	       6 allocs/op
PASS
```
this change.