### PR TITLE
GODRIVER-3549 Fix timeouts in CSE custom endpoint test

### DIFF
--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -797,7 +797,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				"endpoint":   "doesnotexist.invalid:443",
 			},
 			"kmip": {
-				"endpoint": "doesnotexist.local:5698",
+				"endpoint": "doesnotexist.invalid:5698",
 			},
 		}
 
@@ -821,9 +821,8 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			"endpoint": "kms.us-east-1.amazonaws.com:443",
 		}
 		awsFailureConnectionError := map[string]interface{}{
-			"region":   "us-east-1",
-			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-			"endpoint": "kms.us-east-1.amazonaws.com:12345",
+			"keyId":    "1",
+			"endpoint": "localhost:12345",
 		}
 		awsFailureInvalidEndpoint := map[string]interface{}{
 			"region":   "us-east-1",
@@ -862,7 +861,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 		kmipFailureInvalidEndpoint := map[string]interface{}{
 			"keyId":    "1",
-			"endpoint": "doesnotexist.local:5698",
+			"endpoint": "doesnotexist.invalid:5698",
 		}
 
 		const (
@@ -908,7 +907,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			},
 			{
 				name:                                  "Case 4: aws failure with connection error",
-				provider:                              "aws",
+				provider:                              "kmip",
 				masterKey:                             awsFailureConnectionError,
 				errorSubstring:                        []string{errConnectionRefused, errWindowsTLSConnectionRefused},
 				testInvalidClientEncryption:           false,
@@ -1585,7 +1584,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			"endpoint": "127.0.0.1:9001",
 		}
 		azureMasterKey := map[string]interface{}{
-			"keyVaultEndpoint": "doesnotexist.local",
+			"keyVaultEndpoint": "doesnotexist.invalid",
 			"keyName":          "foo",
 		}
 		gcpMasterKey := map[string]interface{}{


### PR DESCRIPTION
GODRIVER-3546

## Summary

Update Client-Side Encryption prose test 7 (Custom Endpoint) to fix possible timeouts against (intentionally) invalid URIs.

