### PR TITLE
DEVPROD-17319 - update perf.send command to new results end point

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -246,22 +246,16 @@ functions:
         script: |
           # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
           if [ "${requester}" == "commit" ]; then
-            echo "is_mainline: true" >> expansion.yml
+            is_mainline=true
           else
-            echo "is_mainline: false" >> expansion.yml
+            is_mainline=false
           fi
 
           # We parse the username out of the order_id as patches append that in and SPS does not need that information
-          echo "parsed_order_id: $(echo "${revision_order_id}" | awk -F'_' '{print $NF}')"  >> expansion.yml
-    - command: expansions.update
-      params:
-        file: expansion.yml
-    - command: shell.exec
-      params:
-        script: |
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
           # Submit the performance data to the SPS endpoint
           response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
-            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=${parsed_order_id}&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=${is_mainline}" \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
             -H 'accept: application/json' \
             -H 'Content-Type: application/json' \
             -d @src/go.mongodb.org/mongo-driver/perf.json)

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -240,9 +240,44 @@ functions:
         args: [*task-runner, pr-task]
 
   send-perf-data:
-    - command: perf.send
+    # Here we begin to generate the request to send the data to SPS
+    - command: shell.exec
       params:
-        file: src/go.mongodb.org/mongo-driver/perf.json
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            echo "is_mainline: true" >> expansion.yml
+          else
+            echo "is_mainline: false" >> expansion.yml
+          fi
+
+          # We parse the username out of the order_id as patches append that in and SPS does not need that information
+          echo "parsed_order_id: $(echo "${revision_order_id}" | awk -F'_' '{print $NF}')"  >> expansion.yml
+    - command: expansions.update
+      params:
+        file: expansion.yml
+    - command: shell.exec
+      params:
+        script: |
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=${parsed_order_id}&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=${is_mainline}" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @src/go.mongodb.org/mongo-driver/perf.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
 
   run-enterprise-auth-tests:
     - command: ec2.assume_role


### PR DESCRIPTION
[DEVPROD-17319](https://jira.mongodb.org/browse/DEVPROD-17319)

## Summary

The perf.send command is no longer being maintained and is actually in a maintenance state and will be decommissioned eventually. It has been replaced instead by a new end point that users are able to call from their evergreen files; [this doc](https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/migrating_from_perfSend_to_sps.md) outlines a drop in solution that we apply to the existing evergreen config file in this PR.

## Background & Motivation

Update the Mongo-Go-Driver project to send performance data downstream using the newest supported method.

Successful patch test with changes can be found here: https://spruce.mongodb.com/version/68124eebfead0f0007f06d23/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Updated patch without needing to use expansions:
https://spruce.mongodb.com/version/681289a627095700079a00a4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
