### PR TITLE
GODRIVER-3550 Update Documentation for Go Driver Branching and Merge …

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -110,7 +110,7 @@ gitGraph
 When the "Merge up" GitHub Action is enabled, multiple merge-up pull requests (such as PR1, PR2, and PR3) can be
 automatically created at the same time for different bug fixes or features that all target, for example, the
 release/2.x branch. At first, PR1, PR2, and PR3 exist side by side—each handling separate changes. When PR1 and PR2 are
-closed (merged), the Action automatically combines their changes into PR3. This final PR3 then contains all updates,
+closed, the Action automatically combines their changes into PR3. This final PR3 then contains all updates,
 allowing you to merge everything into release/2.x+1 in a single, streamlined step.
 
 ```mermaid

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,7 +76,7 @@ regression is found in the release/2.1 branch, you would create a pull request t
 branch, release/2.3. Once this pull request is merged, the "Merge up" GitHub Action will automatically create a pull
 request to merge the changes from release/2.3 into the master branch.
 
-```
+```mermaid
 gitGraph
    commit tag: "Initial main setup"
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ PR [#1962](https://github.com/mongodb/mongo-go-driver/pull/1962) added the "Merg
 
 #### Regression
 
-If a regression is identified in the release/2.x branch, a fix should be submitted as a pull request targeting
+If a regression is identified in the release/2.x branch, a fix can be submitted as a pull request targeting
 release/2.x. Once this PR is merged, the "Merge up" GitHub Action will automatically create a pull request to merge
 release/2.x into release/2.x+1. This process is repeated until changes are merged all the way up to release/2.latest,
 which is then merged into the master branch.
@@ -104,6 +104,8 @@ gitGraph
    merge release/2.3 tag: "Merge updates from release/2.3 (GitHub Actions)"
    commit
 ```
+
+**Note**: In general, bug fixes should only target the latest release branch, since we only support patching the latest version. However, this is just a rule of thumb—exceptions can be made when necessary.
 
 #### Pull Request Management
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,19 +53,6 @@ PR [#1962](https://github.com/mongodb/mongo-go-driver/pull/1962) added the "Merg
 
 #### Regression
 
-If a regression is identified in the release/2.x branch, a fix can be submitted as a pull request targeting
-release/2.x. Once this PR is merged, the "Merge up" GitHub Action will automatically create a pull request to merge
-release/2.x into release/2.x+1. This process is repeated until changes are merged all the way up to release/2.latest,
-which is then merged into the master branch.
-
-For example, suppose we have four minor release branches: release/2.0, release/2.1, release/2.2, and release/2.3. If a
-regression is identified in the release/2.1 branch, you would first create a pull request to fix the issue in
-release/2.1. Once this pull request is merged, the "Merge up" GitHub Action automatically initiates a pull request to
-merge the changes from release/2.1 into release/2.2. After that merge is completed, the action continues to create a
-pull request to merge release/2.2 into release/2.3. Finally, once the changes have successfully rolled through all the
-release branches, the updates in release/2.3 are prepared to be merged into the master branch, ensuring all the bug
-fixes are incorporated into the latest codebase.
-
 If a regression is identified in an older branch, the fix should be applied directly to the latest
 release branch. Once the pull request with the fix is merged into latest, the "Merge up" GitHub Action will
 automatically create a pull request to merge these changes into the master branch. This ensures that all bug fixes are

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,6 +66,55 @@ pull request to merge release/2.2 into release/2.3. Finally, once the changes ha
 release branches, the updates in release/2.3 are prepared to be merged into the master branch, ensuring all the bug
 fixes are incorporated into the latest codebase.
 
+If a regression is identified in an older branch, the fix should be applied directly to the latest
+release branch. Once the pull request with the fix is merged into latest, the "Merge up" GitHub Action will
+automatically create a pull request to merge these changes into the master branch. This ensures that all bug fixes are
+incorporated into the latest codebase and actively supported versions.
+
+For example, suppose we have four minor release branches: release/2.0, release/2.1, release/2.2, and release/2.3. If a
+regression is found in the release/2.1 branch, you would create a pull request to fix the issue in the latest supported
+branch, release/2.3. Once this pull request is merged, the "Merge up" GitHub Action will automatically create a pull
+request to merge the changes from release/2.3 into the master branch.
+
+```
+gitGraph
+   commit tag: "Initial main setup"
+
+   branch release/2.0
+   checkout release/2.0
+   commit tag: "Initial release/2.0"
+
+   checkout main
+   branch release/2.1
+   checkout release/2.1
+   commit tag: "Bug introduced"
+
+   checkout main
+   branch release/2.2
+   checkout release/2.2
+   commit tag: "Initial release/2.2"
+
+   checkout main
+   branch release/2.3
+   checkout release/2.3
+   commit tag: "Initial release/2.3"
+
+   checkout release/2.1
+   commit tag: "Bug found in release/2.1"
+
+   checkout release/2.3
+   commit tag: "Bug fix applied in release/2.3 (Manual PR)"
+
+   checkout main
+   merge release/2.3 tag: "Merge fix from release/2.3 into master (GitHub Actions)"
+   commit
+```
+
+However, it is also possible to apply the fix to the older branch where the bug was originally found. In our example,
+once the pull request is merged into release/2.1, the "Merge up" GitHub Action will initiate a series of pull requests
+to roll the fix forward: first into release/2.2, then into release/2.3, and finally into master. This process makes sure
+that the change cascades through every intermediate supported version.
+
 ```mermaid
 gitGraph
    commit tag: "Initial main setup"
@@ -104,8 +153,6 @@ gitGraph
    merge release/2.3 tag: "Merge updates from release/2.3 (GitHub Actions)"
    commit
 ```
-
-**Note**: In general, bug fixes should only target the latest release branch, since we only support patching the latest version. However, this is just a rule of thumb—exceptions can be made when necessary.
 
 #### Pull Request Management
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,38 +68,41 @@ fixes are incorporated into the latest codebase.
 
 ```mermaid
 gitGraph
-  commit tag: "Initial main setup"
+   commit tag: "Initial main setup"
 
-  branch release/2.0
-  checkout release/2.0
-  commit tag: "Initial release/2.0"
+   branch release/2.0
+   checkout release/2.0
+   commit tag: "Initial release/2.0"
 
-  branch release/2.1
-  checkout release/2.1
-  commit tag: "Bug introduced"
+   checkout main
+   branch release/2.1
+   checkout release/2.1
+   commit tag: "Bug introduced"
 
-  branch release/2.2
-  checkout release/2.2
-  commit tag: "Initial release/2.2"
+   checkout main
+   branch release/2.2
+   checkout release/2.2
+   commit tag: "Initial release/2.2"
 
-  branch release/2.3
-  checkout release/2.3
-  commit tag: "Initial release/2.3"
+   checkout main
+   branch release/2.3
+   checkout release/2.3
+   commit tag: "Initial release/2.3"
 
-  checkout release/2.1
-  commit tag: "Bug fix in release/2.1 (Manual PR)"
+   checkout release/2.1
+   commit tag: "Bug fix in release/2.1 (Manual PR)"
 
-  checkout release/2.2
-  merge release/2.1 tag: "Merge fix from release/2.1 (GitHub Actions)"
-  commit
+   checkout release/2.2
+   merge release/2.1 tag: "Merge fix from release/2.1 (GitHub Actions)"
+   commit
 
-  checkout release/2.3
-  merge release/2.2 tag: "Merge updates from release/2.2 (GitHub Actions)"
-  commit
+   checkout release/2.3
+   merge release/2.2 tag: "Merge updates from release/2.2 (GitHub Actions)"
+   commit
 
-  checkout main
-  merge release/2.3 tag: "Merge updates from release/2.3 (Github Actions)"
-  commit
+   checkout main
+   merge release/2.3 tag: "Merge updates from release/2.3 (GitHub Actions)"
+   commit
 ```
 
 #### Pull Request Management

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ incorporated into the latest codebase and actively supported versions.
 For example, suppose we have four minor release branches: release/2.0, release/2.1, release/2.2, and release/2.3. If a
 regression is found in the release/2.1 branch, you would create a pull request to fix the issue in the latest supported
 branch, release/2.3. Once this pull request is merged, the "Merge up" GitHub Action will automatically create a pull
-request to merge the changes from release/2.3 into the master branch.
+request to merge the changes from release/2.3 into the master branch. Then you can proceed to release release/2.3.latest+1.
 
 ```mermaid
 gitGraph
@@ -97,7 +97,7 @@ gitGraph
    commit
 ```
 
-However, it is also possible to apply the fix to the older branch where the bug was originally found. In our example,
+If necessary, it is also possible to apply the fix to the older branch where the bug was originally found. In our example,
 once the pull request is merged into release/2.1, the "Merge up" GitHub Action will initiate a series of pull requests
 to roll the fix forward: first into release/2.2, then into release/2.3, and finally into master. This process makes sure
 that the change cascades through every intermediate supported version.


### PR DESCRIPTION
GODRIVER-3559

## Summary

Clarify the "Merge up" logic in the CONTRIBUTING.md file.

## Background & Motivation

PR #[1962](https://github.com/mongodb/mongo-go-driver/pull/1962) added the “merge up” GitHub Actions workflow to automatically roll changes from old branches into new ones. This section outlines how this process works. This is to become standard practice when resolving bugs and evergreen configurations in the Go Driver.
