### PR TITLE
Add configuration for automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - submodules
+    authors:
+      - mongodb-drivers-pr-bot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Fixed
+      labels:
+        - bug
+        - fixed
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

This PR adds a config file for automated release notes. We exclude all pull requests from the PR bot to ensure the changelog doesn't get flooded with merge-up pull requests. Also excluded are submodule dependency updates (e.g. for spec tests) and anything we tag with a (yet to create) `ignore-for-release` label.

I've also included a sample categorisation into breaking changes, new features, fixes, and other changes. We can customise these based on our preferences - the current categorisation is simply what we use for PHP's Laravel integration.