### PR TITLE
Fix the issue in getOrQueueForIdleConn where connectionPerished conn.…

### DIFF
--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -169,7 +169,7 @@ type reason struct {
 // connectionPerished checks if a given connection is perished and should be removed from the pool.
 func connectionPerished(conn *connection) (reason, bool) {
 	switch {
-	case conn.closed() || !conn.isAlive():
+	case conn.closed():
 		// A connection would only be closed if it encountered a network error
 		// during an operation and closed itself. If a connection is not alive
 		// (e.g. the connection was closed by the server-side), it's also


### PR DESCRIPTION
…isAlive involves network requests, which can cause the p.idleMu.Lock() when obtaining conn from the pool to be blocked for too long.

<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary
the lock in `getOrQueueForIdleConn` will cause connection acquisition to block under high concurrency due to the IO request in `c.nc.Read(b[:])` inside isAlive.
```
func (p *pool) getOrQueueForIdleConn(w *wantConn) bool {
        p.idleMu.Lock()
	defer p.idleMu.Unlock()

	// Try to deliver an idle connection from the idleConns stack first.
	for len(p.idleConns) > 0 {
		conn := p.idleConns[len(p.idleConns)-1]
		p.idleConns = p.idleConns[:len(p.idleConns)-1]

		if conn == nil {
			continue
		}

		if reason, perished := connectionPerished(conn); perished {
     ...
}

func (c *connection) isAlive() bool {
	if c.nc == nil {
		return false
	}
      ...
	err := c.nc.SetReadDeadline(time.Now().Add(1 * time.Millisecond))
	if err != nil {
		return false
	}
	var b [1]byte
	_, err = c.nc.Read(b[:])
	return errors.Is(err, os.ErrDeadlineExceeded)
}
```

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation

<!--- Rationale for the pull request. -->
### Before modifying isAlive
![image](https://github.com/user-attachments/assets/3770f220-7190-4780-8853-03141dfaccef)
![image](https://github.com/user-attachments/assets/ff114299-b5cc-46c0-b3c6-ea33599bf584)
![756dcec288ac87b30a40a38327d9c1b4](https://github.com/user-attachments/assets/dcca0ded-e4aa-48b6-a9fc-dcfe6d33412c)

### After
![image](https://github.com/user-attachments/assets/43fca8c1-ecab-406e-97e5-4c64357e3e18)
![image](https://github.com/user-attachments/assets/85a62b57-1a30-4544-9a4b-04763a8ef0bc)


