### PR TITLE
Eventually assertion in TestConnection should check the nil condition on done value

### DIFF
--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -151,13 +151,7 @@ func TestConnection(t *testing.T) {
 					close(doneChan)
 
 					assert.Eventually(t,
-						func() bool {
-							if done.Load() == nil {
-								return false
-							}
-
-							return done.Load().(bool)
-						},
+						func() bool { return done.Load() != nil && done.Load().(bool) },
 						100*time.Millisecond,
 						1*time.Millisecond,
 						"TODO")

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -151,7 +151,13 @@ func TestConnection(t *testing.T) {
 					close(doneChan)
 
 					assert.Eventually(t,
-						func() bool { return done.Load().(bool) },
+						func() bool {
+							if done.Load() == nil {
+								return false
+							}
+
+							return done.Load().(bool)
+						},
 						100*time.Millisecond,
 						1*time.Millisecond,
 						"TODO")


### PR DESCRIPTION
Currently this test can fail with the following error:

```
[2025/05/18 20:55:45.033] === RUN   TestConnection/connection/connect/context_is_not_pinned_by_connect/connect_cancelled
[2025/05/18 20:55:45.033] panic: interface conversion: interface {} is nil, not bool
[2025/05/18 20:55:45.033] goroutine 384 [running]:
[2025/05/18 20:55:45.033] go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.TestConnection.func1.2.3.2.4()
[2025/05/18 20:55:45.033] 	C:/data/mci/f9a2/src/go.mongodb.org/mongo-driver/x/mongo/driver/topology/connection_test.go:154 +0x73
[2025/05/18 20:55:45.033] go.mongodb.org/mongo-driver/v2/internal/assert.Eventually.func1()
[2025/05/18 20:55:45.033] 	C:/data/mci/f9a2/src/go.mongodb.org/mongo-driver/internal/assert/assertions.go:1053 +0x23
[2025/05/18 20:55:45.033] created by go.mongodb.org/mongo-driver/v2/internal/assert.Eventually in goroutine 382
[2025/05/18 20:55:45.033] 	C:/data/mci/f9a2/src/go.mongodb.org/mongo-driver/internal/assert/assertions.go:1053 +0x20e
[2025/05/18 20:55:45.033] FAIL	go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology	7.020s
```
