### PR TITLE
GODRIVER-3515 Bump the minimum Go Version to 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the following resources to learn more about upgrading from version 1.x to 2.
 
 ## Requirements
 
-- Go 1.18 or higher. We aim to support the latest versions of Go.
+- Go 1.19 or higher. We aim to support the latest versions of Go.
 - Go 1.23 or higher is required to run the driver test suite.
 - MongoDB 4.0 and higher.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before starting to write code, look for existing [tickets](https://jira.mongodb.
 The Go Driver team uses GitHub to manage and review all code changes. Patches should generally be made against the master (default) branch and include relevant tests, if
 applicable.
 
-Code should compile and tests should pass under all Go versions which the driver currently supports. Currently the Go Driver supports a minimum version of Go 1.18 and requires Go 1.23 for development. Please run the following `Taskfile` targets to validate your changes:
+Code should compile and tests should pass under all Go versions which the driver currently supports. Currently the Go Driver supports a minimum version of Go 1.19 and requires Go 1.23 for development. Please run the following `Taskfile` targets to validate your changes:
 
 - `task fmt`
 - `task lint`

--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -1,7 +1,5 @@
 # Migrating from 1.x to 2.0
 
-The minimum supported version of Go for v2 is 1.18.
-
 To upgrade imports of the Go Driver from v1 to v2, we recommend using [marwan-at-work/mod
 ](https://github.com/marwan-at-work/mod):
 

--- a/etc/compile_check.sh
+++ b/etc/compile_check.sh
@@ -2,7 +2,7 @@
 set -e # exit when any command fails
 set -x # show all commands being run
 
-: ${GC:=go${GO_VERSION="1.18"}}
+: ${GC:=go${GO_VERSION="1.19"}}
 
 COMPILE_CHECK_DIR="internal/cmd/compilecheck"
 ARCHITECTURES=("386" "arm" "arm64" "ppc64le" "s390x")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mongodb.org/mongo-driver/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/internal/cmd/benchmark/go.mod
+++ b/internal/cmd/benchmark/go.mod
@@ -1,6 +1,6 @@
 module go.mongodb.go/mongo-driver/internal/cmd/benchmark
 
-go 1.18
+go 1.19
 
 replace go.mongodb.org/mongo-driver/v2 => ../../../
 

--- a/internal/cmd/compilecheck/go.mod
+++ b/internal/cmd/compilecheck/go.mod
@@ -1,6 +1,6 @@
 module go.mongodb.go/mongo-driver/internal/cmd/compilecheck
 
-go 1.18
+go 1.19
 
 replace go.mongodb.org/mongo-driver/v2 => ../../../
 

--- a/internal/test/compilecheck/compile_check_test.go
+++ b/internal/test/compilecheck/compile_check_test.go
@@ -27,7 +27,7 @@ import (
 // requires a version of klauspost/compress that is not compatible with the Go
 // Driver. Must use GOWORK=off to run this test.
 
-const minSupportedVersion = "1.18"
+const minSupportedVersion = "1.19"
 
 func TestCompileCheck(t *testing.T) {
 	cwd, err := os.Getwd()


### PR DESCRIPTION
GODRIVER-3515

## Summary

Bump minimum supported Go version to 1.19

