### PR TITLE
change_stream: prevent timeout on polling

### DIFF
--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -702,12 +702,6 @@ func (cs *ChangeStream) loopNext(ctx context.Context, nonBlocking bool) {
 		return
 	}
 
-	// Apply the client-level timeout if the operation-level timeout is not set.
-	// This calculation is also done in "executeOperation" but cursor.Next is also
-	// blocking and should honor client-level timeouts.
-	ctx, cancel := csot.WithTimeout(ctx, cs.client.timeout)
-	defer cancel()
-
 	for {
 		if cs.cursor == nil {
 			return


### PR DESCRIPTION
If there are multiple polls in loopNext, the timeout will cause a spurious error if there hasn't been any batches returned within the client timeout period.

For more background see: https://github.com/redpanda-data/connect/issues/3425