### PR TITLE
Ignore unmaintained branches when merging up

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -27,10 +27,11 @@ jobs:
 
       - name: Create pull request
         id: create-pull-request
-        uses: alcaeus/automatic-merge-up-action@main
+        uses: alcaeus/automatic-merge-up-action@1.0.0
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'release/<major>.<minor>'
           devBranchNamePattern: 'v<major>'
           fallbackBranch: 'master'
+          ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
           enableAutoMerge: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
           push_changes: ${{ inputs.push_changes }}
+          ignored_branches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
 
   static-scan:
     needs: [pre-publish]


### PR DESCRIPTION
Note: needs https://github.com/mongodb-labs/drivers-github-tools/pull/82 and a new release of drivers-github-tools to work.

This PR adds ignored branches to the merge-up action to reduce the number of pull requests when merging changes to older, still supported branches. The list of ignored branches is maintained as a repository variable so that updating that list doesn't need a pull request itself.