### PR TITLE
GODRIVER-3560 Use lambda-specific arn for FaaS

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1988,11 +1988,11 @@ tasks:
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           shell: bash
+          add_expansions_to_env: true
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/internal/test/faas/awslambda
             LAMBDA_STACK_NAME: dbx-go-lambda
             AWS_REGION: us-east-1
-          include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           script: |
             ${PREPARE_SHELL}
             pushd $TEST_LAMBDA_DIRECTORY/mongodb
@@ -2357,7 +2357,10 @@ task_groups:
     setup_group:
       - func: fetch-source
       - func: prepare-resources
-      - func: assume-test-secrets-ec2-role
+      - command: ec2.assume_role
+        params:
+          role_arn: ${LAMBDA_AWS_ROLE_ARN}
+          duration_seconds: 3600
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
@@ -2375,6 +2378,7 @@ task_groups:
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
+          add_expansions_to_env: true
           env:
             LAMBDA_STACK_NAME: dbx-go-lambda
             AWS_REGION: us-east-1

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -27,7 +27,7 @@ timeout:
         ls -la
 functions:
   assume-test-secrets-ec2-role:
-    - command: ec2.assume_rol
+    - command: ec2.assume_role
       params:
         role_arn: ${aws_test_secrets_role}
         duration_seconds: ${ec2_assume_role_duration|3600}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -30,7 +30,6 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: ${aws_test_secrets_role}
-        duration_seconds: ${ec2_assume_role_duration|3600}
 
   fetch-source:
     # Executes clone and applies the submitted patch, if any

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -26,10 +26,11 @@ timeout:
       script: |
         ls -la
 functions:
-  assume-test-secrets-ec2-role: 
-    - command: ec2.assume_role
+  assume-test-secrets-ec2-role:
+    - command: ec2.assume_rol
       params:
         role_arn: ${aws_test_secrets_role}
+        duration_seconds: ${ec2_assume_role_duration|3600}
 
   fetch-source:
     # Executes clone and applies the submitted patch, if any
@@ -2361,10 +2362,7 @@ task_groups:
     setup_group:
       - func: fetch-source
       - func: prepare-resources
-      - command: ec2.assume_role
-        params:
-          role_arn: ${LAMBDA_AWS_ROLE_ARN}
-          duration_seconds: 3600
+      - func: assume-test-secrets-ec2-role
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -403,6 +403,7 @@ functions:
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
+        add_expansions_to_env: true
         script: |
           ${PREPARE_SHELL}
           export BASE_SHA=${revision}
@@ -415,6 +416,7 @@ functions:
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
+        add_expansions_to_env: true
         script: |
           ${PREPARE_SHELL}
           export CONFIG=$PROJECT_DIRECTORY/.github/labeler.yml
@@ -427,6 +429,7 @@ functions:
       params:
         shell: "bash"
         working_dir: src/go.mongodb.org/mongo-driver
+        add_expansions_to_env: true
         script: |
           ${PREPARE_SHELL}
           export CONFIG=$PROJECT_DIRECTORY/.github/reviewers.txt
@@ -932,6 +935,7 @@ tasks:
   - name: pull-request-helpers
     allowed_requesters: ["patch", "github_pr"]
     commands:
+      - func: assume-test-secrets-ec2-role
       - func: "add PR reviewer"  
       - func: "add PR labels"
       - func: "create-api-report"

--- a/internal/test/faas/awslambda/template.yaml
+++ b/internal/test/faas/awslambda/template.yaml
@@ -32,20 +32,6 @@ Resources:
         Variables:
           MONGODB_URI: !Ref MongoDbUri
 
-  ApplicationResourceGroup:
-    Type: AWS::ResourceGroups::Group
-    Properties:
-      Name:
-        Fn::Sub: ApplicationInsights-SAM-${AWS::StackName}
-      ResourceQuery:
-        Type: CLOUDFORMATION_STACK_1_0
-  ApplicationInsightsMonitoring:
-    Type: AWS::ApplicationInsights::Application
-    Properties:
-      ResourceGroupName:
-        Ref: ApplicationResourceGroup
-      AutoConfigurationEnabled: 'true'
-
 Outputs:
   MongoDBApi:
     Description: "API Gateway endpoint URL for Prod stage for MongoDB function"


### PR DESCRIPTION
GODRIVER-3560

## Summary

Extend env variables from assuming role.

## Background & Motivation

Evergreen CI for FaaS isn't tearing down the resulting Atlas cluster. 
