### PR TITLE
GODRIVER-3472: Add support for unmarshaling BSON Vector binary values into slices

### DIFF
--- a/bson/vector.go
+++ b/bson/vector.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 )
 
 // BSON binary vector types as described in https://bsonspec.org/spec.html.
@@ -25,6 +26,14 @@ var (
 	errInsufficientVectorData = errors.New("insufficient data")
 	errNonZeroVectorPadding   = errors.New("padding must be 0")
 	errVectorPaddingTooLarge  = errors.New("padding cannot be larger than 7")
+	errNotAVectorBinary       = errors.New("not a vector binary")
+)
+
+var (
+	// TInt8 is the reflect.Type for int8
+	TInt8 = reflect.TypeOf(int8(0))
+	// TFloat32 is the reflect.Type for float32
+	TFloat32 = reflect.TypeOf(float32(0))
 )
 
 type vectorTypeError struct {
@@ -265,4 +274,61 @@ func newBitVector(b []byte) (Vector, error) {
 		return Vector{}, errInsufficientVectorData
 	}
 	return NewPackedBitVector(b[1:], b[0])
+}
+
+// DecodeVectorInt8 decodes a BSON Vector binary value (subtype 9) into a []int8 slice.
+// The binary data should be in the format: [<vector type> <padding> <data>]
+// For int8 vectors, the vector type is 0x01.
+func DecodeVectorInt8(data []byte) ([]int8, error) {
+	if len(data) < 2 {
+		return nil, errors.New("insufficient bytes to decode vector: expected at least 2 bytes")
+	}
+
+	vectorType := data[0]
+	if vectorType != 0x01 { // Int8Vector
+		return nil, errors.New("invalid vector type: expected int8 vector (0x01)")
+	}
+
+	if padding := data[1]; padding != 0 {
+		return nil, errors.New("invalid vector: padding byte must be 0")
+	}
+	values := make([]int8, 0, len(data)-2)
+	for i := 2; i < len(data); i++ {
+		values = append(values, int8(data[i]))
+	}
+
+	return values, nil
+}
+
+// DecodeVectorFloat32 decodes a BSON Vector binary value (subtype 9) into a []float32 slice.
+// The binary data should be in the format: [<vector type> <padding> <data>]
+// For float32 vectors, the vector type is 0x02 and data must be a multiple of 4 bytes.
+func DecodeVectorFloat32(data []byte) ([]float32, error) {
+	if len(data) < 2 {
+		return nil, errors.New("insufficient bytes to decode vector: expected at least 2 bytes")
+	}
+
+	vectorType := data[0]
+	if vectorType != 0x02 { // Float32Vector
+		return nil, errors.New("invalid vector type: expected float32 vector (0x02)")
+	}
+
+	if padding := data[1]; padding != 0 {
+		return nil, errors.New("invalid vector: padding byte must be 0")
+	}
+	floatData := data[2:]
+	if len(floatData)%4 != 0 {
+		return nil, errors.New("invalid float32 vector: data length must be a multiple of 4")
+	}
+
+	values := make([]float32, 0, len(floatData)/4)
+	for i := 0; i < len(floatData); i += 4 {
+		if i+4 > len(floatData) {
+			return nil, errors.New("invalid float32 vector: truncated data")
+		}
+		bits := binary.LittleEndian.Uint32(floatData[i : i+4])
+		values = append(values, math.Float32frombits(bits))
+	}
+
+	return values, nil
 }

--- a/bson/vector_unmarshal_test.go
+++ b/bson/vector_unmarshal_test.go
@@ -1,0 +1,159 @@
+// Copyright (C) MongoDB, Inc. 2025-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bson
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function to create a BSON document with a vector binary field (subtype 0x09)
+func createBSONWithBinary(data []byte) []byte {
+	// Document format: {"v": BinData(subtype, data)}
+	buf := make([]byte, 0, 32+len(data))
+
+	buf = append(buf, 0x00, 0x00, 0x00, 0x00) // Length placeholder
+	buf = append(buf, 0x05)                   // Binary type
+	buf = append(buf, 'v', 0x00)              // Field name "v"
+
+	buf = append(buf,
+		byte(len(data)),  // Length of binary data
+		0x00, 0x00, 0x00, // 4-byte length (little endian)
+		0x09, // Binary subtype for Vector
+	)
+	buf = append(buf, data...)
+	buf = append(buf, 0x00)
+
+	docLen := len(buf)
+	buf[0] = byte(docLen)
+	buf[1] = byte(docLen >> 8)
+	buf[2] = byte(docLen >> 16)
+	buf[3] = byte(docLen >> 24)
+
+	return buf
+}
+
+func TestVectorBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshal to Vector field", func(t *testing.T) {
+		t.Parallel()
+
+		vectorData := []byte{
+			0x03,                   // int8 vector type (0x03 is Int8Vector)
+			0x00,                   // padding
+			0x01, 0x02, 0x03, 0x04, // int8 values
+		}
+
+		doc := createBSONWithBinary(vectorData)
+
+		var result struct {
+			V Vector
+		}
+		err := Unmarshal(doc, &result)
+		require.NoError(t, err)
+
+		require.Equal(t, Int8Vector, result.V.Type())
+		int8Data, ok := result.V.Int8OK()
+		require.True(t, ok, "expected int8 vector")
+		require.Equal(t, []int8{1, 2, 3, 4}, int8Data)
+	})
+}
+
+func TestUnmarshalVectorToSlices(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int8 vector to []int8", func(t *testing.T) {
+		t.Parallel()
+
+		vectorData := []byte{
+			0x01,                   // int8 vector type
+			0x00,                   // padding
+			0x01, 0x02, 0x03, 0x04, // int8 values
+		}
+
+		bsonData := createBSONWithBinary(vectorData)
+
+		var result struct{ V []int8 }
+		err := Unmarshal(bsonData, &result)
+		require.NoError(t, err)
+		require.Equal(t, []int8{1, 2, 3, 4}, result.V)
+	})
+
+	t.Run("float32 vector to []float32", func(t *testing.T) {
+		t.Parallel()
+
+		vectorData := make([]byte, 2+4*4) // type + padding + 4 float32s
+		vectorData[0] = 0x02              // float32 vector type
+		vectorData[1] = 0x00              // padding
+
+		binary.LittleEndian.PutUint32(vectorData[2:], math.Float32bits(1.0))
+		binary.LittleEndian.PutUint32(vectorData[6:], math.Float32bits(2.0))
+		binary.LittleEndian.PutUint32(vectorData[10:], math.Float32bits(3.0))
+		binary.LittleEndian.PutUint32(vectorData[14:], math.Float32bits(4.0))
+
+		bsonData := createBSONWithBinary(vectorData)
+
+		var result struct{ V []float32 }
+		err := Unmarshal(bsonData, &result)
+		require.NoError(t, err)
+		require.InEpsilonSlice(t, []float32{1.0, 2.0, 3.0, 4.0}, result.V, 0.0001)
+	})
+
+	t.Run("invalid vector type to slice", func(t *testing.T) {
+		t.Parallel()
+
+		vectorData := []byte{
+			0x10,       // packed bit vector type (unsupported for direct unmarshaling)
+			0x00,       // padding
+			0x01, 0x02, // some data
+		}
+		bsonData := createBSONWithBinary(vectorData)
+
+		t.Run("to []int8", func(t *testing.T) {
+			t.Parallel()
+			var result struct{ V []int8 }
+			err := Unmarshal(bsonData, &result)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid vector type: expected int8 vector (0x01)")
+		})
+
+		t.Run("to []float32", func(t *testing.T) {
+			t.Parallel()
+			var result struct{ V []float32 }
+			err := Unmarshal(bsonData, &result)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid vector type: expected float32 vector (0x02)")
+		})
+	})
+
+	t.Run("invalid binary data", func(t *testing.T) {
+		t.Parallel()
+
+		invalidData := []byte{0x01, 0x01, 0x02, 0x03}
+		bsonData := createBSONWithBinary(invalidData)
+
+		t.Run("to []int8", func(t *testing.T) {
+			t.Parallel()
+			var result struct{ V []int8 }
+			err := Unmarshal(bsonData, &result)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid vector: padding byte must be 0")
+		})
+
+		t.Run("to []float32", func(t *testing.T) {
+			t.Parallel()
+			var result struct{ V []float32 }
+			err := Unmarshal(bsonData, &result)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid vector type: expected float32 vector (0x02)")
+		})
+	})
+}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
[GODRIVER-3472](https://jira.mongodb.org/browse/GODRIVER-3472)

## Summary
This change adds support for direct unmarshaling of BSON Vector binary (subtype 0x09)
values into native Go slice types `[]int8` and `[]float32`. 
<!--- A summary of the changes proposed by this pull request. -->