### PR TITLE
GODRIVER-3494 Deprecate hedged read preference methods.

### DIFF
--- a/mongo/readpref/options.go
+++ b/mongo/readpref/options.go
@@ -71,10 +71,15 @@ func WithTagSets(tagSets ...tag.Set) Option {
 	}
 }
 
-// WithHedgeEnabled specifies whether or not hedged reads should be enabled in the server. This feature requires MongoDB
-// server version 4.4 or higher. For more information about hedged reads, see
-// https://www.mongodb.com/docs/manual/core/sharded-cluster-query-router/#mongos-hedged-reads. If not specified, the default
-// is to not send a value to the server, which will result in the server defaults being used.
+// WithHedgeEnabled specifies whether or not hedged reads should be enabled in
+// the server. This feature requires MongoDB server version 4.4 or higher. For
+// more information about hedged reads, see
+// https://www.mongodb.com/docs/manual/core/sharded-cluster-query-router/#mongos-hedged-reads.
+// If not specified, the default is to not send a value to the server, which
+// will result in the server defaults being used.
+//
+// Deprecated: Hedged reads are deprecated in MongoDB 8.0 and may be removed in
+// a future MongoDB version.
 func WithHedgeEnabled(hedgeEnabled bool) Option {
 	return func(rp *ReadPref) error {
 		rp.hedgeEnabled = &hedgeEnabled

--- a/mongo/readpref/readpref.go
+++ b/mongo/readpref/readpref.go
@@ -103,8 +103,12 @@ func (r *ReadPref) TagSets() []tag.Set {
 	return r.tagSets
 }
 
-// HedgeEnabled returns whether or not hedged reads are enabled for this read preference. If this option was not
-// specified during read preference construction, nil is returned.
+// HedgeEnabled returns whether or not hedged reads are enabled for this read
+// preference. If this option was not specified during read preference
+// construction, nil is returned.
+//
+// Deprecated: Hedged reads are deprecated in MongoDB 8.0 and may be removed in
+// a future MongoDB version.
 func (r *ReadPref) HedgeEnabled() *bool {
 	return r.hedgeEnabled
 }


### PR DESCRIPTION
[GODRIVER-3494](https://jira.mongodb.org/browse/GODRIVER-3494)

## Summary

Deprecate `readpref.WithHedgeEnabled` and `redpref.ReadPref.HedgeEnabled`. Note that hedged reads are deprecated in MongoDB 8.0 and may be removed in a future version.

## Background & Motivation

Hedged reads are deprecated in MongoDB 8.0 and may be removed in a future version.
