### PR TITLE
GODRIVER-3457: Add OpenSSF Scorecard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo"><img src="etc/assets/godev-mongo-blue.svg" alt="docs"></a>
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/bson"><img src="etc/assets/godev-bson-blue.svg" alt="docs"></a>
   <a href="https://www.mongodb.com/docs/drivers/go/current/"><img src="etc/assets/docs-mongodb-green.svg"></a>
+    <a href="https://securityscorecards.dev/viewer/?uri=github.com/mongodb/mongo-go-driver">
+    <img src="https://api.securityscorecards.dev/projects/github.com/mongodb/mongo-go-driver/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 # MongoDB Go Driver


### PR DESCRIPTION
# [GODRIVER-3457](https://jira.mongodb.org/browse/GODRIVER-3457)

## Summary
Added OpenSSF Scorecard to the README.

## Background & Motivation
Visualization of OpenSSF Scorecard.