### PR TITLE
GODRIVER-3373: Use non-default global DefaultTransport for DefaultClient

### DIFF
--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -10,9 +10,17 @@ import (
 	"net/http"
 )
 
-// DefaultHTTPClient is the default HTTP client used across the driver.
-var DefaultHTTPClient = &http.Client{
-	Transport: http.DefaultTransport.(*http.Transport).Clone(),
+var DefaultHTTPClient = &http.Client{}
+
+// NewHTTPClient will return the globally-defined DefaultHTTPClient, updating
+// the transport if it differs from the http package DefaultTransport.
+func NewHTTPClient() *http.Client {
+	client := DefaultHTTPClient
+	if _, ok := http.DefaultTransport.(*http.Transport); !ok {
+		client.Transport = http.DefaultTransport
+	}
+
+	return client
 }
 
 // CloseIdleHTTPConnections closes any connections which were previously

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package httputil
+
+import (
+	"net/http"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/internal/assert"
+)
+
+type nonDefaultTransport struct{}
+
+func (*nonDefaultTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func TestDefaultHTTPClientTransport(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		client := NewHTTPClient()
+
+		val := assert.ObjectsAreEqual(http.DefaultClient, client)
+
+		assert.True(t, val)
+		assert.Equal(t, DefaultHTTPClient, client)
+	})
+
+	t.Run("non-default global transport", func(t *testing.T) {
+		http.DefaultTransport = &nonDefaultTransport{}
+
+		client := NewHTTPClient()
+
+		val := assert.ObjectsAreEqual(&nonDefaultTransport{}, client.Transport)
+
+		assert.True(t, val)
+		assert.Equal(t, DefaultHTTPClient, client)
+		assert.NotEqual(t, http.DefaultClient, client) // Sanity Check
+	})
+}


### PR DESCRIPTION
# [GODRIVER-3373](https://jira.mongodb.org/browse/GODRIVER-3373)

## Summary
`NewHTTPClient` returns a globally defined `DefaultHTTPClient` that returns DefaultTransport or updates the transport if it is replaced with a non-default transport.

## Background & Motivation
Users can now use non-default transports without panic.