### PR TITLE
GODRIVER-3399: PoolClearedError should have TransientTransactionError label appended to it

### DIFF
--- a/x/mongo/driver/topology/pool_test.go
+++ b/x/mongo/driver/topology/pool_test.go
@@ -1586,7 +1586,6 @@ func TestPool_PoolMonitor(t *testing.T) {
 }
 
 func TestPool_Error(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("should have TransientTransactionError", func(t *testing.T) {
@@ -1607,6 +1606,5 @@ func TestPool_Error(t *testing.T) {
 		}
 
 		p.close(context.Background())
-
 	})
 }


### PR DESCRIPTION
[GODRIVER-3399](https://jira.mongodb.org/browse/GODRIVER-3399)

## Summary
Added `errorLabels` property to `PoolClearedError` so `TransentTransactionError` can be appended to it. Also added unit test to make sure label is appended properly.

## Background & Motivation
(From [DRIVERS-1815](https://jira.mongodb.org/browse/DRIVERS-1815)) In order for withTransaction to retry PoolClearedErrors, they need to have the TransientTransactionError label appended to them by the driver, similar to server selection errors.
