### PR TITLE
Prevent integration tests from running when testing with -short

### DIFF
--- a/internal/integtest/integtest.go
+++ b/internal/integtest/integtest.go
@@ -223,6 +223,10 @@ func AddServerlessAuthCredentials(uri string) (string, error) {
 
 // ConnString gets the globally configured connection string.
 func ConnString(t *testing.T) *connstring.ConnString {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	connectionStringOnce.Do(func() {
 		uri, err := MongoDBURI()
 		require.NoError(t, err, "error constructing mongodb URI: %v", err)

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -130,6 +130,9 @@ func (d *timeoutDialer) DialContext(ctx context.Context, network, address string
 
 // TestServerHeartbeatTimeout tests timeout retry and preemptive canceling.
 func TestServerHeartbeatTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	if os.Getenv("DOCKER_RUNNING") != "" {
 		t.Skip("Skipping this test in docker.")
 	}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

* Skip tests that call `integtest.ConnString` if running with `-short`.
* Skip the `TestServerHeartbeatTimeout` test if running with `-short` because it's an integration test.

## Background & Motivation

This should also fix the "Docker Runner Test" task.
