### PR TITLE
optimize build document and array

### DIFF
--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"math"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -952,4 +953,34 @@ func TestInvalidBytes(t *testing.T) {
 		assert.False(t, ok, "expected not ok response for invalid length read")
 		assert.Equal(t, 4, len(src), "expected src to contain the size parameter still")
 	})
+}
+
+func BenchmarkBuildDocument(b *testing.B) {
+	for _, size := range []int{10, 100, 1000} {
+		elements := make([][]byte, size)
+		for i := 0; i < size; i++ {
+			elements[i] = AppendDoubleElement(nil, "pi"+strconv.Itoa(i), 3.14159)
+		}
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				BuildDocument(nil, elements...)
+			}
+		})
+	}
+}
+
+func BenchmarkBuildArray(b *testing.B) {
+	for _, size := range []int{10, 100, 1000} {
+		elements := make([]Value, size)
+		for i := 0; i < size; i++ {
+			elements[i] = Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)}
+		}
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				BuildArray(nil, elements...)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation

<!--- Rationale for the pull request. -->

Before:
```
BenchmarkBuildDocument
BenchmarkBuildDocument/10
BenchmarkBuildDocument/10-32    	22190841	     138.9 ns/op	     144 B/op	       1 allocs/op
BenchmarkBuildDocument/100
BenchmarkBuildDocument/100-32         	  986715	      1316 ns/op	    1408 B/op	       1 allocs/op
BenchmarkBuildDocument/1000
BenchmarkBuildDocument/1000-32        	  187330	     13960 ns/op	   16384 B/op	       1 allocs/op
BenchmarkBuildArray
BenchmarkBuildArray/10
BenchmarkBuildArray/10-32             	 6625070	     193.0 ns/op	     128 B/op	       1 allocs/op
BenchmarkBuildArray/100
BenchmarkBuildArray/100-32            	  492061	      2624 ns/op	    1280 B/op	       1 allocs/op
BenchmarkBuildArray/1000
BenchmarkBuildArray/1000-32           	   34568	     29539 ns/op	   16448 B/op	     901 allocs/op
```
After
```
BenchmarkBuildDocument
BenchmarkBuildDocument/10
BenchmarkBuildDocument/10-32 	         4024838	     312.1 ns/op	     368 B/op	       5 allocs/op
BenchmarkBuildDocument/100
BenchmarkBuildDocument/100-32         	  689899	      2679 ns/op	    4400 B/op	       9 allocs/op
BenchmarkBuildDocument/1000
BenchmarkBuildDocument/1000-32        	   43088	     30843 ns/op	   61616 B/op	      16 allocs/op
BenchmarkBuildArray
BenchmarkBuildArray/10
BenchmarkBuildArray/10-32             	 6181608	     374.4 ns/op	     248 B/op	       5 allocs/op
BenchmarkBuildArray/100
BenchmarkBuildArray/100-32            	  429356	      3296 ns/op	    3320 B/op	       9 allocs/op
BenchmarkBuildArray/1000
BenchmarkBuildArray/1000-32           	   12564	     98475 ns/op	   65856 B/op	     917 allocs/op
```

