### PR TITLE
Replace all uses of 'interface{}' with 'any' in the x/ packages.

### DIFF
--- a/x/bsonx/bsoncore/bson_arraybuilder_test.go
+++ b/x/bsonx/bsoncore/bson_arraybuilder_test.go
@@ -21,50 +21,50 @@ func TestArrayBuilder(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		fn       interface{}
-		params   []interface{}
+		fn       any
+		params   []any
 		expected []byte
 	}{
 		{
 			"AppendInt32",
 			NewArrayBuilder().AppendInt32,
-			[]interface{}{int32(256)},
+			[]any{int32(256)},
 			BuildDocumentFromElements(nil, AppendInt32Element(nil, "0", int32(256))),
 		},
 		{
 			"AppendDouble",
 			NewArrayBuilder().AppendDouble,
-			[]interface{}{float64(3.14159)},
+			[]any{float64(3.14159)},
 			BuildDocumentFromElements(nil, AppendDoubleElement(nil, "0", float64(3.14159))),
 		},
 		{
 			"AppendString",
 			NewArrayBuilder().AppendString,
-			[]interface{}{"x"},
+			[]any{"x"},
 			BuildDocumentFromElements(nil, AppendStringElement(nil, "0", "x")),
 		},
 		{
 			"AppendDocument",
 			NewArrayBuilder().AppendDocument,
-			[]interface{}{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			BuildDocumentFromElements(nil, AppendDocumentElement(nil, "0", []byte{0x05, 0x00, 0x00, 0x00, 0x00})),
 		},
 		{
 			"AppendArray",
 			NewArrayBuilder().AppendArray,
-			[]interface{}{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			BuildDocumentFromElements(nil, AppendArrayElement(nil, "0", []byte{0x05, 0x00, 0x00, 0x00, 0x00})),
 		},
 		{
 			"AppendBinary",
 			NewArrayBuilder().AppendBinary,
-			[]interface{}{byte(0x02), []byte{0x01, 0x02, 0x03}},
+			[]any{byte(0x02), []byte{0x01, 0x02, 0x03}},
 			BuildDocumentFromElements(nil, AppendBinaryElement(nil, "0", byte(0x02), []byte{0x01, 0x02, 0x03})),
 		},
 		{
 			"AppendObjectID",
 			NewArrayBuilder().AppendObjectID,
-			[]interface{}{
+			[]any{
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 			},
 			BuildDocumentFromElements(nil, AppendObjectIDElement(nil, "0",
@@ -73,79 +73,79 @@ func TestArrayBuilder(t *testing.T) {
 		{
 			"AppendBoolean",
 			NewArrayBuilder().AppendBoolean,
-			[]interface{}{true},
+			[]any{true},
 			BuildDocumentFromElements(nil, AppendBooleanElement(nil, "0", true)),
 		},
 		{
 			"AppendDateTime",
 			NewArrayBuilder().AppendDateTime,
-			[]interface{}{int64(256)},
+			[]any{int64(256)},
 			BuildDocumentFromElements(nil, AppendDateTimeElement(nil, "0", int64(256))),
 		},
 		{
 			"AppendNull",
 			NewArrayBuilder().AppendNull,
-			[]interface{}{},
+			[]any{},
 			BuildDocumentFromElements(nil, AppendNullElement(nil, "0")),
 		},
 		{
 			"AppendRegex",
 			NewArrayBuilder().AppendRegex,
-			[]interface{}{"bar", "baz"},
+			[]any{"bar", "baz"},
 			BuildDocumentFromElements(nil, AppendRegexElement(nil, "0", "bar", "baz")),
 		},
 		{
 			"AppendJavaScript",
 			NewArrayBuilder().AppendJavaScript,
-			[]interface{}{"barbaz"},
+			[]any{"barbaz"},
 			BuildDocumentFromElements(nil, AppendJavaScriptElement(nil, "0", "barbaz")),
 		},
 		{
 			"AppendCodeWithScope",
 			NewArrayBuilder().AppendCodeWithScope,
-			[]interface{}{"barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00})},
+			[]any{"barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00})},
 			BuildDocumentFromElements(nil, AppendCodeWithScopeElement(nil, "0", "barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00}))),
 		},
 		{
 			"AppendTimestamp",
 			NewArrayBuilder().AppendTimestamp,
-			[]interface{}{uint32(65536), uint32(256)},
+			[]any{uint32(65536), uint32(256)},
 			BuildDocumentFromElements(nil, AppendTimestampElement(nil, "0", uint32(65536), uint32(256))),
 		},
 		{
 			"AppendInt64",
 			NewArrayBuilder().AppendInt64,
-			[]interface{}{int64(4294967296)},
+			[]any{int64(4294967296)},
 			BuildDocumentFromElements(nil, AppendInt64Element(nil, "0", int64(4294967296))),
 		},
 		{
 			"AppendDecimal128",
 			NewArrayBuilder().AppendDecimal128,
-			[]interface{}{uint64(4294967296), uint64(65536)},
+			[]any{uint64(4294967296), uint64(65536)},
 			BuildDocumentFromElements(nil, AppendDecimal128Element(nil, "0", 4294967296, 65536)),
 		},
 		{
 			"AppendMaxKey",
 			NewArrayBuilder().AppendMaxKey,
-			[]interface{}{},
+			[]any{},
 			BuildDocumentFromElements(nil, AppendMaxKeyElement(nil, "0")),
 		},
 		{
 			"AppendMinKey",
 			NewArrayBuilder().AppendMinKey,
-			[]interface{}{},
+			[]any{},
 			BuildDocumentFromElements(nil, AppendMinKeyElement(nil, "0")),
 		},
 		{
 			"AppendSymbol",
 			NewArrayBuilder().AppendSymbol,
-			[]interface{}{"barbaz"},
+			[]any{"barbaz"},
 			BuildDocumentFromElements(nil, AppendSymbolElement(nil, "0", "barbaz")),
 		},
 		{
 			"AppendDBPointer",
 			NewArrayBuilder().AppendDBPointer,
-			[]interface{}{"barbaz",
+			[]any{"barbaz",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C}},
 			BuildDocumentFromElements(nil, AppendDBPointerElement(nil, "0", "barbaz",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C})),
@@ -153,7 +153,7 @@ func TestArrayBuilder(t *testing.T) {
 		{
 			"AppendUndefined",
 			NewArrayBuilder().AppendUndefined,
-			[]interface{}{},
+			[]any{},
 			BuildDocumentFromElements(nil, AppendUndefinedElement(nil, "0")),
 		},
 	}

--- a/x/bsonx/bsoncore/bson_documentbuilder_test.go
+++ b/x/bsonx/bsoncore/bson_documentbuilder_test.go
@@ -21,50 +21,50 @@ func TestDocumentBuilder(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		fn       interface{}
-		params   []interface{}
+		fn       any
+		params   []any
 		expected []byte
 	}{
 		{
 			"AppendInt32",
 			NewDocumentBuilder().AppendInt32,
-			[]interface{}{"foobar", int32(256)},
+			[]any{"foobar", int32(256)},
 			BuildDocumentFromElements(nil, AppendInt32Element(nil, "foobar", 256)),
 		},
 		{
 			"AppendDouble",
 			NewDocumentBuilder().AppendDouble,
-			[]interface{}{"foobar", float64(3.14159)},
+			[]any{"foobar", float64(3.14159)},
 			BuildDocumentFromElements(nil, AppendDoubleElement(nil, "foobar", float64(3.14159))),
 		},
 		{
 			"AppendString",
 			NewDocumentBuilder().AppendString,
-			[]interface{}{"foobar", "x"},
+			[]any{"foobar", "x"},
 			BuildDocumentFromElements(nil, AppendStringElement(nil, "foobar", "x")),
 		},
 		{
 			"AppendDocument",
 			NewDocumentBuilder().AppendDocument,
-			[]interface{}{"foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{"foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			BuildDocumentFromElements(nil, AppendDocumentElement(nil, "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00})),
 		},
 		{
 			"AppendArray",
 			NewDocumentBuilder().AppendArray,
-			[]interface{}{"foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{"foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			BuildDocumentFromElements(nil, AppendArrayElement(nil, "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00})),
 		},
 		{
 			"AppendBinary",
 			NewDocumentBuilder().AppendBinary,
-			[]interface{}{"foobar", byte(0x02), []byte{0x01, 0x02, 0x03}},
+			[]any{"foobar", byte(0x02), []byte{0x01, 0x02, 0x03}},
 			BuildDocumentFromElements(nil, AppendBinaryElement(nil, "foobar", byte(0x02), []byte{0x01, 0x02, 0x03})),
 		},
 		{
 			"AppendObjectID",
 			NewDocumentBuilder().AppendObjectID,
-			[]interface{}{
+			[]any{
 				"foobar",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 			},
@@ -74,79 +74,79 @@ func TestDocumentBuilder(t *testing.T) {
 		{
 			"AppendBoolean",
 			NewDocumentBuilder().AppendBoolean,
-			[]interface{}{"foobar", true},
+			[]any{"foobar", true},
 			BuildDocumentFromElements(nil, AppendBooleanElement(nil, "foobar", true)),
 		},
 		{
 			"AppendDateTime",
 			NewDocumentBuilder().AppendDateTime,
-			[]interface{}{"foobar", int64(256)},
+			[]any{"foobar", int64(256)},
 			BuildDocumentFromElements(nil, AppendDateTimeElement(nil, "foobar", int64(256))),
 		},
 		{
 			"AppendNull",
 			NewDocumentBuilder().AppendNull,
-			[]interface{}{"foobar"},
+			[]any{"foobar"},
 			BuildDocumentFromElements(nil, AppendNullElement(nil, "foobar")),
 		},
 		{
 			"AppendRegex",
 			NewDocumentBuilder().AppendRegex,
-			[]interface{}{"foobar", "bar", "baz"},
+			[]any{"foobar", "bar", "baz"},
 			BuildDocumentFromElements(nil, AppendRegexElement(nil, "foobar", "bar", "baz")),
 		},
 		{
 			"AppendJavaScript",
 			NewDocumentBuilder().AppendJavaScript,
-			[]interface{}{"foobar", "barbaz"},
+			[]any{"foobar", "barbaz"},
 			BuildDocumentFromElements(nil, AppendJavaScriptElement(nil, "foobar", "barbaz")),
 		},
 		{
 			"AppendCodeWithScope",
 			NewDocumentBuilder().AppendCodeWithScope,
-			[]interface{}{"foobar", "barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00})},
+			[]any{"foobar", "barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00})},
 			BuildDocumentFromElements(nil, AppendCodeWithScopeElement(nil, "foobar", "barbaz", Document([]byte{0x05, 0x00, 0x00, 0x00, 0x00}))),
 		},
 		{
 			"AppendTimestamp",
 			NewDocumentBuilder().AppendTimestamp,
-			[]interface{}{"foobar", uint32(65536), uint32(256)},
+			[]any{"foobar", uint32(65536), uint32(256)},
 			BuildDocumentFromElements(nil, AppendTimestampElement(nil, "foobar", uint32(65536), uint32(256))),
 		},
 		{
 			"AppendInt64",
 			NewDocumentBuilder().AppendInt64,
-			[]interface{}{"foobar", int64(4294967296)},
+			[]any{"foobar", int64(4294967296)},
 			BuildDocumentFromElements(nil, AppendInt64Element(nil, "foobar", int64(4294967296))),
 		},
 		{
 			"AppendDecimal128",
 			NewDocumentBuilder().AppendDecimal128,
-			[]interface{}{"foobar", uint64(4294967296), uint64(65536)},
+			[]any{"foobar", uint64(4294967296), uint64(65536)},
 			BuildDocumentFromElements(nil, AppendDecimal128Element(nil, "foobar", 4294967296, 65536)),
 		},
 		{
 			"AppendMaxKey",
 			NewDocumentBuilder().AppendMaxKey,
-			[]interface{}{"foobar"},
+			[]any{"foobar"},
 			BuildDocumentFromElements(nil, AppendMaxKeyElement(nil, "foobar")),
 		},
 		{
 			"AppendMinKey",
 			NewDocumentBuilder().AppendMinKey,
-			[]interface{}{"foobar"},
+			[]any{"foobar"},
 			BuildDocumentFromElements(nil, AppendMinKeyElement(nil, "foobar")),
 		},
 		{
 			"AppendSymbol",
 			NewDocumentBuilder().AppendSymbol,
-			[]interface{}{"foobar", "barbaz"},
+			[]any{"foobar", "barbaz"},
 			BuildDocumentFromElements(nil, AppendSymbolElement(nil, "foobar", "barbaz")),
 		},
 		{
 			"AppendDBPointer",
 			NewDocumentBuilder().AppendDBPointer,
-			[]interface{}{"foobar", "barbaz",
+			[]any{"foobar", "barbaz",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C}},
 			BuildDocumentFromElements(nil, AppendDBPointerElement(nil, "foobar", "barbaz",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C})),
@@ -154,7 +154,7 @@ func TestDocumentBuilder(t *testing.T) {
 		{
 			"AppendUndefined",
 			NewDocumentBuilder().AppendUndefined,
-			[]interface{}{"foobar"},
+			[]any{"foobar"},
 			BuildDocumentFromElements(nil, AppendUndefinedElement(nil, "foobar")),
 		},
 	}

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -41,56 +41,56 @@ func TestAppend(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		fn       interface{}
-		params   []interface{}
+		fn       any
+		params   []any
 		expected []byte
 	}{
 		{
 			"AppendType",
 			AppendType,
-			[]interface{}{make([]byte, 0), TypeNull},
+			[]any{make([]byte, 0), TypeNull},
 			[]byte{byte(TypeNull)},
 		},
 		{
 			"AppendKey",
 			AppendKey,
-			[]interface{}{make([]byte, 0), "foobar"},
+			[]any{make([]byte, 0), "foobar"},
 			[]byte{'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 		{
 			"AppendHeader",
 			AppendHeader,
-			[]interface{}{make([]byte, 0), TypeNull, "foobar"},
+			[]any{make([]byte, 0), TypeNull, "foobar"},
 			[]byte{byte(TypeNull), 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 		{
 			"AppendValueElement",
 			AppendValueElement,
-			[]interface{}{make([]byte, 0), "testing", Value{Type: TypeBoolean, Data: []byte{0x01}}},
+			[]any{make([]byte, 0), "testing", Value{Type: TypeBoolean, Data: []byte{0x01}}},
 			[]byte{byte(TypeBoolean), 't', 'e', 's', 't', 'i', 'n', 'g', 0x00, 0x01},
 		},
 		{
 			"AppendDouble",
 			AppendDouble,
-			[]interface{}{make([]byte, 0), float64(3.14159)},
+			[]any{make([]byte, 0), float64(3.14159)},
 			pi,
 		},
 		{
 			"AppendDoubleElement",
 			AppendDoubleElement,
-			[]interface{}{make([]byte, 0), "foobar", float64(3.14159)},
+			[]any{make([]byte, 0), "foobar", float64(3.14159)},
 			append([]byte{byte(TypeDouble), 'f', 'o', 'o', 'b', 'a', 'r', 0x00}, pi...),
 		},
 		{
 			"AppendString",
 			AppendString,
-			[]interface{}{make([]byte, 0), "barbaz"},
+			[]any{make([]byte, 0), "barbaz"},
 			[]byte{0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00},
 		},
 		{
 			"AppendStringElement",
 			AppendStringElement,
-			[]interface{}{make([]byte, 0), "foobar", "barbaz"},
+			[]any{make([]byte, 0), "foobar", "barbaz"},
 			[]byte{byte(TypeString),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00,
@@ -99,13 +99,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendDocument",
 			AppendDocument,
-			[]interface{}{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{0x05, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendDocumentElement",
 			AppendDocumentElement,
-			[]interface{}{make([]byte, 0), "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{make([]byte, 0), "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{byte(TypeEmbeddedDocument),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x05, 0x00, 0x00, 0x00, 0x00,
@@ -114,13 +114,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendArray",
 			AppendArray,
-			[]interface{}{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{0x05, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendArrayElement",
 			AppendArrayElement,
-			[]interface{}{make([]byte, 0), "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{make([]byte, 0), "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{byte(TypeArray),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x05, 0x00, 0x00, 0x00, 0x00,
@@ -129,7 +129,7 @@ func TestAppend(t *testing.T) {
 		{
 			"BuildArray",
 			BuildArray,
-			[]interface{}{make([]byte, 0), Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)}},
+			[]any{make([]byte, 0), Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)}},
 			[]byte{
 				0x10, 0x00, 0x00, 0x00,
 				byte(TypeDouble), '0', 0x00,
@@ -140,7 +140,7 @@ func TestAppend(t *testing.T) {
 		{
 			"BuildArrayElement",
 			BuildArrayElement,
-			[]interface{}{make([]byte, 0), "foobar", Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)}},
+			[]any{make([]byte, 0), "foobar", Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)}},
 			[]byte{byte(TypeArray),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x10, 0x00, 0x00, 0x00,
@@ -152,13 +152,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendBinary Subtype2",
 			AppendBinary,
-			[]interface{}{make([]byte, 0), byte(0x02), []byte{0x01, 0x02, 0x03}},
+			[]any{make([]byte, 0), byte(0x02), []byte{0x01, 0x02, 0x03}},
 			[]byte{0x07, 0x00, 0x00, 0x00, 0x02, 0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
 		},
 		{
 			"AppendBinaryElement Subtype 2",
 			AppendBinaryElement,
-			[]interface{}{make([]byte, 0), "foobar", byte(0x02), []byte{0x01, 0x02, 0x03}},
+			[]any{make([]byte, 0), "foobar", byte(0x02), []byte{0x01, 0x02, 0x03}},
 			[]byte{byte(TypeBinary),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x07, 0x00, 0x00, 0x00,
@@ -169,13 +169,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendBinary",
 			AppendBinary,
-			[]interface{}{make([]byte, 0), byte(0xFF), []byte{0x01, 0x02, 0x03}},
+			[]any{make([]byte, 0), byte(0xFF), []byte{0x01, 0x02, 0x03}},
 			[]byte{0x03, 0x00, 0x00, 0x00, 0xFF, 0x01, 0x02, 0x03},
 		},
 		{
 			"AppendBinaryElement",
 			AppendBinaryElement,
-			[]interface{}{make([]byte, 0), "foobar", byte(0xFF), []byte{0x01, 0x02, 0x03}},
+			[]any{make([]byte, 0), "foobar", byte(0xFF), []byte{0x01, 0x02, 0x03}},
 			[]byte{byte(TypeBinary),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x03, 0x00, 0x00, 0x00,
@@ -186,13 +186,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendUndefinedElement",
 			AppendUndefinedElement,
-			[]interface{}{make([]byte, 0), "foobar"},
+			[]any{make([]byte, 0), "foobar"},
 			[]byte{byte(TypeUndefined), 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 		{
 			"AppendObjectID",
 			AppendObjectID,
-			[]interface{}{
+			[]any{
 				make([]byte, 0),
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 			},
@@ -201,7 +201,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendObjectIDElement",
 			AppendObjectIDElement,
-			[]interface{}{
+			[]any{
 				make([]byte, 0), "foobar",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 			},
@@ -213,49 +213,49 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendBoolean (true)",
 			AppendBoolean,
-			[]interface{}{make([]byte, 0), true},
+			[]any{make([]byte, 0), true},
 			[]byte{0x01},
 		},
 		{
 			"AppendBoolean (false)",
 			AppendBoolean,
-			[]interface{}{make([]byte, 0), false},
+			[]any{make([]byte, 0), false},
 			[]byte{0x00},
 		},
 		{
 			"AppendBooleanElement",
 			AppendBooleanElement,
-			[]interface{}{make([]byte, 0), "foobar", true},
+			[]any{make([]byte, 0), "foobar", true},
 			[]byte{byte(TypeBoolean), 'f', 'o', 'o', 'b', 'a', 'r', 0x00, 0x01},
 		},
 		{
 			"AppendDateTime",
 			AppendDateTime,
-			[]interface{}{make([]byte, 0), int64(256)},
+			[]any{make([]byte, 0), int64(256)},
 			[]byte{0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendDateTimeElement",
 			AppendDateTimeElement,
-			[]interface{}{make([]byte, 0), "foobar", int64(256)},
+			[]any{make([]byte, 0), "foobar", int64(256)},
 			[]byte{byte(TypeDateTime), 'f', 'o', 'o', 'b', 'a', 'r', 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendNullElement",
 			AppendNullElement,
-			[]interface{}{make([]byte, 0), "foobar"},
+			[]any{make([]byte, 0), "foobar"},
 			[]byte{byte(TypeNull), 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 		{
 			"AppendRegex",
 			AppendRegex,
-			[]interface{}{make([]byte, 0), "bar", "baz"},
+			[]any{make([]byte, 0), "bar", "baz"},
 			[]byte{'b', 'a', 'r', 0x00, 'b', 'a', 'z', 0x00},
 		},
 		{
 			"AppendRegexElement",
 			AppendRegexElement,
-			[]interface{}{make([]byte, 0), "foobar", "bar", "baz"},
+			[]any{make([]byte, 0), "foobar", "bar", "baz"},
 			[]byte{byte(TypeRegex),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				'b', 'a', 'r', 0x00, 'b', 'a', 'z', 0x00,
@@ -264,7 +264,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendDBPointer",
 			AppendDBPointer,
-			[]interface{}{
+			[]any{
 				make([]byte, 0),
 				"foobar",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
@@ -277,7 +277,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendDBPointerElement",
 			AppendDBPointerElement,
-			[]interface{}{
+			[]any{
 				make([]byte, 0), "foobar",
 				"barbaz",
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
@@ -291,13 +291,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendJavaScript",
 			AppendJavaScript,
-			[]interface{}{make([]byte, 0), "barbaz"},
+			[]any{make([]byte, 0), "barbaz"},
 			[]byte{0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00},
 		},
 		{
 			"AppendJavaScriptElement",
 			AppendJavaScriptElement,
-			[]interface{}{make([]byte, 0), "foobar", "barbaz"},
+			[]any{make([]byte, 0), "foobar", "barbaz"},
 			[]byte{byte(TypeJavaScript),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00,
@@ -306,13 +306,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendSymbol",
 			AppendSymbol,
-			[]interface{}{make([]byte, 0), "barbaz"},
+			[]any{make([]byte, 0), "barbaz"},
 			[]byte{0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00},
 		},
 		{
 			"AppendSymbolElement",
 			AppendSymbolElement,
-			[]interface{}{make([]byte, 0), "foobar", "barbaz"},
+			[]any{make([]byte, 0), "foobar", "barbaz"},
 			[]byte{byte(TypeSymbol),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x07, 0x00, 0x00, 0x00, 'b', 'a', 'r', 'b', 'a', 'z', 0x00,
@@ -321,7 +321,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendCodeWithScope",
 			AppendCodeWithScope,
-			[]interface{}{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{[]byte{0x05, 0x00, 0x00, 0x00, 0x00}, "foobar", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{0x05, 0x00, 0x00, 0x00, 0x00,
 				0x14, 0x00, 0x00, 0x00,
 				0x07, 0x00, 0x00, 0x00, 'f', 'o', 'o', 'b', 'a', 'r', 0x00,
@@ -331,7 +331,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendCodeWithScopeElement",
 			AppendCodeWithScopeElement,
-			[]interface{}{make([]byte, 0), "foobar", "barbaz", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{make([]byte, 0), "foobar", "barbaz", []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			[]byte{byte(TypeCodeWithScope),
 				'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x14, 0x00, 0x00, 0x00,
@@ -342,43 +342,43 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendInt32",
 			AppendInt32,
-			[]interface{}{make([]byte, 0), int32(256)},
+			[]any{make([]byte, 0), int32(256)},
 			[]byte{0x00, 0x01, 0x00, 0x00},
 		},
 		{
 			"AppendInt32Element",
 			AppendInt32Element,
-			[]interface{}{make([]byte, 0), "foobar", int32(256)},
+			[]any{make([]byte, 0), "foobar", int32(256)},
 			[]byte{byte(TypeInt32), 'f', 'o', 'o', 'b', 'a', 'r', 0x00, 0x00, 0x01, 0x00, 0x00},
 		},
 		{
 			"AppendTimestamp",
 			AppendTimestamp,
-			[]interface{}{make([]byte, 0), uint32(65536), uint32(256)},
+			[]any{make([]byte, 0), uint32(65536), uint32(256)},
 			[]byte{0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00},
 		},
 		{
 			"AppendTimestampElement",
 			AppendTimestampElement,
-			[]interface{}{make([]byte, 0), "foobar", uint32(65536), uint32(256)},
+			[]any{make([]byte, 0), "foobar", uint32(65536), uint32(256)},
 			[]byte{byte(TypeTimestamp), 'f', 'o', 'o', 'b', 'a', 'r', 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00},
 		},
 		{
 			"AppendInt64",
 			AppendInt64,
-			[]interface{}{make([]byte, 0), int64(4294967296)},
+			[]any{make([]byte, 0), int64(4294967296)},
 			[]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendInt64Element",
 			AppendInt64Element,
-			[]interface{}{make([]byte, 0), "foobar", int64(4294967296)},
+			[]any{make([]byte, 0), "foobar", int64(4294967296)},
 			[]byte{byte(TypeInt64), 'f', 'o', 'o', 'b', 'a', 'r', 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
 		},
 		{
 			"AppendDecimal128",
 			AppendDecimal128,
-			[]interface{}{make([]byte, 0), uint64(4294967296), uint64(65536)},
+			[]any{make([]byte, 0), uint64(4294967296), uint64(65536)},
 			[]byte{
 				0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
@@ -387,7 +387,7 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendDecimal128Element",
 			AppendDecimal128Element,
-			[]interface{}{make([]byte, 0), "foobar", uint64(4294967296), uint64(65536)},
+			[]any{make([]byte, 0), "foobar", uint64(4294967296), uint64(65536)},
 			[]byte{
 				byte(TypeDecimal128), 'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -397,13 +397,13 @@ func TestAppend(t *testing.T) {
 		{
 			"AppendMaxKeyElement",
 			AppendMaxKeyElement,
-			[]interface{}{make([]byte, 0), "foobar"},
+			[]any{make([]byte, 0), "foobar"},
 			[]byte{byte(TypeMaxKey), 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 		{
 			"AppendMinKeyElement",
 			AppendMinKeyElement,
-			[]interface{}{make([]byte, 0), "foobar"},
+			[]any{make([]byte, 0), "foobar"},
 			[]byte{byte(TypeMinKey), 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
 		},
 	}
@@ -441,147 +441,147 @@ func TestRead(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		fn       interface{}
+		fn       any
 		param    []byte
-		expected []interface{}
+		expected []any
 	}{
 		{
 			"ReadType/not enough bytes",
 			ReadType,
 			[]byte{},
-			[]interface{}{Type(0), []byte{}, false},
+			[]any{Type(0), []byte{}, false},
 		},
 		{
 			"ReadType/success",
 			ReadType,
 			[]byte{0x0A},
-			[]interface{}{TypeNull, []byte{}, true},
+			[]any{TypeNull, []byte{}, true},
 		},
 		{
 			"ReadKey/not enough bytes",
 			ReadKey,
 			[]byte{},
-			[]interface{}{"", []byte{}, false},
+			[]any{"", []byte{}, false},
 		},
 		{
 			"ReadKey/success",
 			ReadKey,
 			[]byte{'f', 'o', 'o', 'b', 'a', 'r', 0x00},
-			[]interface{}{"foobar", []byte{}, true},
+			[]any{"foobar", []byte{}, true},
 		},
 		{
 			"ReadHeader/not enough bytes (type)",
 			ReadHeader,
 			[]byte{},
-			[]interface{}{Type(0), "", []byte{}, false},
+			[]any{Type(0), "", []byte{}, false},
 		},
 		{
 			"ReadHeader/not enough bytes (key)",
 			ReadHeader,
 			[]byte{0x0A, 'f', 'o', 'o'},
-			[]interface{}{Type(0), "", []byte{0x0A, 'f', 'o', 'o'}, false},
+			[]any{Type(0), "", []byte{0x0A, 'f', 'o', 'o'}, false},
 		},
 		{
 			"ReadHeader/success",
 			ReadHeader,
 			[]byte{0x0A, 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
-			[]interface{}{TypeNull, "foobar", []byte{}, true},
+			[]any{TypeNull, "foobar", []byte{}, true},
 		},
 		{
 			"ReadDouble/not enough bytes",
 			ReadDouble,
 			[]byte{0x01, 0x02, 0x03, 0x04},
-			[]interface{}{float64(0.00), []byte{0x01, 0x02, 0x03, 0x04}, false},
+			[]any{float64(0.00), []byte{0x01, 0x02, 0x03, 0x04}, false},
 		},
 		{
 			"ReadDouble/success",
 			ReadDouble,
 			pi,
-			[]interface{}{float64(3.14159), []byte{}, true},
+			[]any{float64(3.14159), []byte{}, true},
 		},
 		{
 			"ReadString/not enough bytes (length)",
 			ReadString,
 			[]byte{},
-			[]interface{}{"", []byte{}, false},
+			[]any{"", []byte{}, false},
 		},
 		{
 			"ReadString/not enough bytes (value)",
 			ReadString,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadString/success",
 			ReadString,
 			[]byte{0x07, 0x00, 0x00, 0x00, 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
-			[]interface{}{"foobar", []byte{}, true},
+			[]any{"foobar", []byte{}, true},
 		},
 		{
 			"ReadDocument/not enough bytes (length)",
 			ReadDocument,
 			[]byte{},
-			[]interface{}{Document(nil), []byte{}, false},
+			[]any{Document(nil), []byte{}, false},
 		},
 		{
 			"ReadDocument/not enough bytes (value)",
 			ReadDocument,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{Document(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{Document(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadDocument/success",
 			ReadDocument,
 			[]byte{0x0A, 0x00, 0x00, 0x00, 0x0A, 'f', 'o', 'o', 0x00, 0x00},
-			[]interface{}{Document{0x0A, 0x00, 0x00, 0x00, 0x0A, 'f', 'o', 'o', 0x00, 0x00}, []byte{}, true},
+			[]any{Document{0x0A, 0x00, 0x00, 0x00, 0x0A, 'f', 'o', 'o', 0x00, 0x00}, []byte{}, true},
 		},
 		{
 			"ReadArray/not enough bytes (length)",
 			ReadArray,
 			[]byte{},
-			[]interface{}{Array(nil), []byte{}, false},
+			[]any{Array(nil), []byte{}, false},
 		},
 		{
 			"ReadArray/not enough bytes (value)",
 			ReadArray,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{Array(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{Array(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadArray/success",
 			ReadArray,
 			[]byte{0x08, 0x00, 0x00, 0x00, 0x0A, '0', 0x00, 0x00},
-			[]interface{}{Array{0x08, 0x00, 0x00, 0x00, 0x0A, '0', 0x00, 0x00}, []byte{}, true},
+			[]any{Array{0x08, 0x00, 0x00, 0x00, 0x0A, '0', 0x00, 0x00}, []byte{}, true},
 		},
 		{
 			"ReadBinary/not enough bytes (length)",
 			ReadBinary,
 			[]byte{},
-			[]interface{}{byte(0), []byte(nil), []byte{}, false},
+			[]any{byte(0), []byte(nil), []byte{}, false},
 		},
 		{
 			"ReadBinary/not enough bytes (subtype)",
 			ReadBinary,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{byte(0), []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{byte(0), []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadBinary/not enough bytes (value)",
 			ReadBinary,
 			[]byte{0x0F, 0x00, 0x00, 0x00, 0x00},
-			[]interface{}{byte(0), []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00, 0x00}, false},
+			[]any{byte(0), []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadBinary/not enough bytes (subtype 2 length)",
 			ReadBinary,
 			[]byte{0x03, 0x00, 0x00, 0x00, 0x02, 0x0F, 0x00, 0x00},
-			[]interface{}{byte(0), []byte(nil), []byte{0x03, 0x00, 0x00, 0x00, 0x02, 0x0F, 0x00, 0x00}, false},
+			[]any{byte(0), []byte(nil), []byte{0x03, 0x00, 0x00, 0x00, 0x02, 0x0F, 0x00, 0x00}, false},
 		},
 		{
 			"ReadBinary/not enough bytes (subtype 2 value)",
 			ReadBinary,
 			[]byte{0x0F, 0x00, 0x00, 0x00, 0x02, 0x0F, 0x00, 0x00, 0x00, 0x01, 0x02},
-			[]interface{}{
+			[]any{
 				byte(0), []byte(nil),
 				[]byte{0x0F, 0x00, 0x00, 0x00, 0x02, 0x0F, 0x00, 0x00, 0x00, 0x01, 0x02}, false,
 			},
@@ -590,25 +590,25 @@ func TestRead(t *testing.T) {
 			"ReadBinary/success (subtype 2)",
 			ReadBinary,
 			[]byte{0x06, 0x00, 0x00, 0x00, 0x02, 0x02, 0x00, 0x00, 0x00, 0x01, 0x02},
-			[]interface{}{byte(0x02), []byte{0x01, 0x02}, []byte{}, true},
+			[]any{byte(0x02), []byte{0x01, 0x02}, []byte{}, true},
 		},
 		{
 			"ReadBinary/success",
 			ReadBinary,
 			[]byte{0x03, 0x00, 0x00, 0x00, 0xFF, 0x01, 0x02, 0x03},
-			[]interface{}{byte(0xFF), []byte{0x01, 0x02, 0x03}, []byte{}, true},
+			[]any{byte(0xFF), []byte{0x01, 0x02, 0x03}, []byte{}, true},
 		},
 		{
 			"ReadObjectID/not enough bytes",
 			ReadObjectID,
 			[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-			[]interface{}{[12]byte{}, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, false},
+			[]any{[12]byte{}, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, false},
 		},
 		{
 			"ReadObjectID/success",
 			ReadObjectID,
 			[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
-			[]interface{}{
+			[]any{
 				[12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 				[]byte{}, true,
 			},
@@ -617,55 +617,55 @@ func TestRead(t *testing.T) {
 			"ReadBoolean/not enough bytes",
 			ReadBoolean,
 			[]byte{},
-			[]interface{}{false, []byte{}, false},
+			[]any{false, []byte{}, false},
 		},
 		{
 			"ReadBoolean/success",
 			ReadBoolean,
 			[]byte{0x01},
-			[]interface{}{true, []byte{}, true},
+			[]any{true, []byte{}, true},
 		},
 		{
 			"ReadDateTime/not enough bytes",
 			ReadDateTime,
 			[]byte{0x01, 0x02, 0x03, 0x04},
-			[]interface{}{int64(0), []byte{0x01, 0x02, 0x03, 0x04}, false},
+			[]any{int64(0), []byte{0x01, 0x02, 0x03, 0x04}, false},
 		},
 		{
 			"ReadDateTime/success",
 			ReadDateTime,
 			[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00},
-			[]interface{}{int64(65536), []byte{}, true},
+			[]any{int64(65536), []byte{}, true},
 		},
 		{
 			"ReadRegex/not enough bytes (pattern)",
 			ReadRegex,
 			[]byte{},
-			[]interface{}{"", "", []byte{}, false},
+			[]any{"", "", []byte{}, false},
 		},
 		{
 			"ReadRegex/not enough bytes (options)",
 			ReadRegex,
 			[]byte{'f', 'o', 'o', 0x00},
-			[]interface{}{"", "", []byte{'f', 'o', 'o', 0x00}, false},
+			[]any{"", "", []byte{'f', 'o', 'o', 0x00}, false},
 		},
 		{
 			"ReadRegex/success",
 			ReadRegex,
 			[]byte{'f', 'o', 'o', 0x00, 'b', 'a', 'r', 0x00},
-			[]interface{}{"foo", "bar", []byte{}, true},
+			[]any{"foo", "bar", []byte{}, true},
 		},
 		{
 			"ReadDBPointer/not enough bytes (ns)",
 			ReadDBPointer,
 			[]byte{},
-			[]interface{}{"", [12]byte{}, []byte{}, false},
+			[]any{"", [12]byte{}, []byte{}, false},
 		},
 		{
 			"ReadDBPointer/not enough bytes (objectID)",
 			ReadDBPointer,
 			[]byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00},
-			[]interface{}{"", [12]byte{}, []byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00}, false},
+			[]any{"", [12]byte{}, []byte{0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00}, false},
 		},
 		{
 			"ReadDBPointer/success",
@@ -674,7 +674,7 @@ func TestRead(t *testing.T) {
 				0x04, 0x00, 0x00, 0x00, 'f', 'o', 'o', 0x00,
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
 			},
-			[]interface{}{
+			[]any{
 				"foo", [12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C},
 				[]byte{}, true,
 			},
@@ -683,49 +683,49 @@ func TestRead(t *testing.T) {
 			"ReadJavaScript/not enough bytes (length)",
 			ReadJavaScript,
 			[]byte{},
-			[]interface{}{"", []byte{}, false},
+			[]any{"", []byte{}, false},
 		},
 		{
 			"ReadJavaScript/not enough bytes (value)",
 			ReadJavaScript,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadJavaScript/success",
 			ReadJavaScript,
 			[]byte{0x07, 0x00, 0x00, 0x00, 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
-			[]interface{}{"foobar", []byte{}, true},
+			[]any{"foobar", []byte{}, true},
 		},
 		{
 			"ReadSymbol/not enough bytes (length)",
 			ReadSymbol,
 			[]byte{},
-			[]interface{}{"", []byte{}, false},
+			[]any{"", []byte{}, false},
 		},
 		{
 			"ReadSymbol/not enough bytes (value)",
 			ReadSymbol,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{"", []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadSymbol/success",
 			ReadSymbol,
 			[]byte{0x07, 0x00, 0x00, 0x00, 'f', 'o', 'o', 'b', 'a', 'r', 0x00},
-			[]interface{}{"foobar", []byte{}, true},
+			[]any{"foobar", []byte{}, true},
 		},
 		{
 			"ReadCodeWithScope/ not enough bytes (length)",
 			ReadCodeWithScope,
 			[]byte{},
-			[]interface{}{"", []byte(nil), []byte{}, false},
+			[]any{"", []byte(nil), []byte{}, false},
 		},
 		{
 			"ReadCodeWithScope/ not enough bytes (value)",
 			ReadCodeWithScope,
 			[]byte{0x0F, 0x00, 0x00, 0x00},
-			[]interface{}{"", []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
+			[]any{"", []byte(nil), []byte{0x0F, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadCodeWithScope/not enough bytes (code value)",
@@ -735,7 +735,7 @@ func TestRead(t *testing.T) {
 				0x0F, 0x00, 0x00, 0x00,
 				'f', 'o', 'o', 0x00,
 			},
-			[]interface{}{
+			[]any{
 				"", []byte(nil),
 				[]byte{
 					0x0C, 0x00, 0x00, 0x00,
@@ -753,7 +753,7 @@ func TestRead(t *testing.T) {
 				0x07, 0x00, 0x00, 0x00, 'f', 'o', 'o', 'b', 'a', 'r', 0x00,
 				0x0A, 0x00, 0x00, 0x00, 0x0A, 'f', 'o', 'o', 0x00, 0x00,
 			},
-			[]interface{}{
+			[]any{
 				"foobar", []byte{0x0A, 0x00, 0x00, 0x00, 0x0A, 'f', 'o', 'o', 0x00, 0x00},
 				[]byte{}, true,
 			},
@@ -762,55 +762,55 @@ func TestRead(t *testing.T) {
 			"ReadInt32/not enough bytes",
 			ReadInt32,
 			[]byte{0x01},
-			[]interface{}{int32(0), []byte{0x01}, false},
+			[]any{int32(0), []byte{0x01}, false},
 		},
 		{
 			"ReadInt32/success",
 			ReadInt32,
 			[]byte{0x00, 0x01, 0x00, 0x00},
-			[]interface{}{int32(256), []byte{}, true},
+			[]any{int32(256), []byte{}, true},
 		},
 		{
 			"ReadTimestamp/not enough bytes (increment)",
 			ReadTimestamp,
 			[]byte{},
-			[]interface{}{uint32(0), uint32(0), []byte{}, false},
+			[]any{uint32(0), uint32(0), []byte{}, false},
 		},
 		{
 			"ReadTimestamp/not enough bytes (timestamp)",
 			ReadTimestamp,
 			[]byte{0x00, 0x01, 0x00, 0x00},
-			[]interface{}{uint32(0), uint32(0), []byte{0x00, 0x01, 0x00, 0x00}, false},
+			[]any{uint32(0), uint32(0), []byte{0x00, 0x01, 0x00, 0x00}, false},
 		},
 		{
 			"ReadTimestamp/success",
 			ReadTimestamp,
 			[]byte{0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00},
-			[]interface{}{uint32(65536), uint32(256), []byte{}, true},
+			[]any{uint32(65536), uint32(256), []byte{}, true},
 		},
 		{
 			"ReadInt64/not enough bytes",
 			ReadInt64,
 			[]byte{0x01},
-			[]interface{}{int64(0), []byte{0x01}, false},
+			[]any{int64(0), []byte{0x01}, false},
 		},
 		{
 			"ReadInt64/success",
 			ReadInt64,
 			[]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
-			[]interface{}{int64(4294967296), []byte{}, true},
+			[]any{int64(4294967296), []byte{}, true},
 		},
 		{
 			"ReadDecimal128/not enough bytes (low)",
 			ReadDecimal128,
 			[]byte{},
-			[]interface{}{uint64(0), uint64(0), []byte{}, false},
+			[]any{uint64(0), uint64(0), []byte{}, false},
 		},
 		{
 			"ReadDecimal128/not enough bytes (high)",
 			ReadDecimal128,
 			[]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
-			[]interface{}{uint64(0), uint64(0), []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}, false},
+			[]any{uint64(0), uint64(0), []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}, false},
 		},
 		{
 			"ReadDecimal128/success",
@@ -819,7 +819,7 @@ func TestRead(t *testing.T) {
 				0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
 			},
-			[]interface{}{uint64(4294967296), uint64(16777216), []byte{}, true},
+			[]any{uint64(4294967296), uint64(16777216), []byte{}, true},
 		},
 	}
 

--- a/x/bsonx/bsoncore/value_test.go
+++ b/x/bsonx/bsoncore/value_test.go
@@ -79,10 +79,10 @@ func TestValue(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		fn       interface{}
+		fn       any
 		val      Value
 		panicErr error
-		ret      []interface{}
+		ret      []any
 	}{
 		{
 			"Double/Not Double", Value.Double, Value{Type: TypeString},
@@ -97,22 +97,22 @@ func TestValue(t *testing.T) {
 		{
 			"Double/Success", Value.Double, Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)},
 			nil,
-			[]interface{}{float64(3.14159)},
+			[]any{float64(3.14159)},
 		},
 		{
 			"DoubleOK/Not Double", Value.DoubleOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{float64(0), false},
+			[]any{float64(0), false},
 		},
 		{
 			"DoubleOK/Insufficient Bytes", Value.DoubleOK, Value{Type: TypeDouble, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{float64(0), false},
+			[]any{float64(0), false},
 		},
 		{
 			"DoubleOK/Success", Value.DoubleOK, Value{Type: TypeDouble, Data: AppendDouble(nil, 3.14159)},
 			nil,
-			[]interface{}{float64(3.14159), true},
+			[]any{float64(3.14159), true},
 		},
 		{
 			"StringValue/Not String", Value.StringValue, Value{Type: TypeDouble},
@@ -132,27 +132,27 @@ func TestValue(t *testing.T) {
 		{
 			"StringValue/Success", Value.StringValue, Value{Type: TypeString, Data: AppendString(nil, "hello, world!")},
 			nil,
-			[]interface{}{"hello, world!"},
+			[]any{"hello, world!"},
 		},
 		{
 			"StringValueOK/Not String", Value.StringValueOK, Value{Type: TypeDouble},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"StringValueOK/Insufficient Bytes", Value.StringValueOK, Value{Type: TypeString, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"StringValueOK/Zero Length", Value.StringValueOK, Value{Type: TypeString, Data: []byte{0x00, 0x00, 0x00, 0x00}},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"StringValueOK/Success", Value.StringValueOK, Value{Type: TypeString, Data: AppendString(nil, "hello, world!")},
 			nil,
-			[]interface{}{"hello, world!", true},
+			[]any{"hello, world!", true},
 		},
 		{
 			"Document/Not Document", Value.Document, Value{Type: TypeString},
@@ -167,22 +167,22 @@ func TestValue(t *testing.T) {
 		{
 			"Document/Success", Value.Document, Value{Type: TypeEmbeddedDocument, Data: []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			nil,
-			[]interface{}{Document{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{Document{0x05, 0x00, 0x00, 0x00, 0x00}},
 		},
 		{
 			"DocumentOK/Not Document", Value.DocumentOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{Document(nil), false},
+			[]any{Document(nil), false},
 		},
 		{
 			"DocumentOK/Insufficient Bytes", Value.DocumentOK, Value{Type: TypeEmbeddedDocument, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{Document(nil), false},
+			[]any{Document(nil), false},
 		},
 		{
 			"DocumentOK/Success", Value.DocumentOK, Value{Type: TypeEmbeddedDocument, Data: []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			nil,
-			[]interface{}{Document{0x05, 0x00, 0x00, 0x00, 0x00}, true},
+			[]any{Document{0x05, 0x00, 0x00, 0x00, 0x00}, true},
 		},
 		{
 			"Array/Not Array", Value.Array, Value{Type: TypeString},
@@ -197,22 +197,22 @@ func TestValue(t *testing.T) {
 		{
 			"Array/Success", Value.Array, Value{Type: TypeArray, Data: []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			nil,
-			[]interface{}{Array{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{Array{0x05, 0x00, 0x00, 0x00, 0x00}},
 		},
 		{
 			"ArrayOK/Not Array", Value.ArrayOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{Array(nil), false},
+			[]any{Array(nil), false},
 		},
 		{
 			"ArrayOK/Insufficient Bytes", Value.ArrayOK, Value{Type: TypeArray, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{Array(nil), false},
+			[]any{Array(nil), false},
 		},
 		{
 			"ArrayOK/Success", Value.ArrayOK, Value{Type: TypeArray, Data: []byte{0x05, 0x00, 0x00, 0x00, 0x00}},
 			nil,
-			[]interface{}{Array{0x05, 0x00, 0x00, 0x00, 0x00}, true},
+			[]any{Array{0x05, 0x00, 0x00, 0x00, 0x00}, true},
 		},
 		{
 			"Binary/Not Binary", Value.Binary, Value{Type: TypeString},
@@ -227,22 +227,22 @@ func TestValue(t *testing.T) {
 		{
 			"Binary/Success", Value.Binary, Value{Type: TypeBinary, Data: AppendBinary(nil, 0xFF, []byte{0x01, 0x02, 0x03})},
 			nil,
-			[]interface{}{byte(0xFF), []byte{0x01, 0x02, 0x03}},
+			[]any{byte(0xFF), []byte{0x01, 0x02, 0x03}},
 		},
 		{
 			"BinaryOK/Not Binary", Value.BinaryOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{byte(0x00), []byte(nil), false},
+			[]any{byte(0x00), []byte(nil), false},
 		},
 		{
 			"BinaryOK/Insufficient Bytes", Value.BinaryOK, Value{Type: TypeBinary, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{byte(0x00), []byte(nil), false},
+			[]any{byte(0x00), []byte(nil), false},
 		},
 		{
 			"BinaryOK/Success", Value.BinaryOK, Value{Type: TypeBinary, Data: AppendBinary(nil, 0xFF, []byte{0x01, 0x02, 0x03})},
 			nil,
-			[]interface{}{byte(0xFF), []byte{0x01, 0x02, 0x03}, true},
+			[]any{byte(0xFF), []byte{0x01, 0x02, 0x03}, true},
 		},
 		{
 			"ObjectID/Not ObjectID", Value.ObjectID, Value{Type: TypeString},
@@ -257,22 +257,22 @@ func TestValue(t *testing.T) {
 		{
 			"ObjectID/Success", Value.ObjectID, Value{Type: TypeObjectID, Data: AppendObjectID(nil, [12]byte{0x01, 0x02})},
 			nil,
-			[]interface{}{[12]byte{0x01, 0x02}},
+			[]any{[12]byte{0x01, 0x02}},
 		},
 		{
 			"ObjectIDOK/Not ObjectID", Value.ObjectIDOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{[12]byte{}, false},
+			[]any{[12]byte{}, false},
 		},
 		{
 			"ObjectIDOK/Insufficient Bytes", Value.ObjectIDOK, Value{Type: TypeObjectID, Data: []byte{0x01, 0x02, 0x03, 0x04}},
 			nil,
-			[]interface{}{[12]byte{}, false},
+			[]any{[12]byte{}, false},
 		},
 		{
 			"ObjectIDOK/Success", Value.ObjectIDOK, Value{Type: TypeObjectID, Data: AppendObjectID(nil, [12]byte{0x01, 0x02})},
 			nil,
-			[]interface{}{[12]byte{0x01, 0x02}, true},
+			[]any{[12]byte{0x01, 0x02}, true},
 		},
 		{
 			"Boolean/Not Boolean", Value.Boolean, Value{Type: TypeString},
@@ -287,22 +287,22 @@ func TestValue(t *testing.T) {
 		{
 			"Boolean/Success", Value.Boolean, Value{Type: TypeBoolean, Data: AppendBoolean(nil, true)},
 			nil,
-			[]interface{}{true},
+			[]any{true},
 		},
 		{
 			"BooleanOK/Not Boolean", Value.BooleanOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{false, false},
+			[]any{false, false},
 		},
 		{
 			"BooleanOK/Insufficient Bytes", Value.BooleanOK, Value{Type: TypeBoolean, Data: []byte{}},
 			nil,
-			[]interface{}{false, false},
+			[]any{false, false},
 		},
 		{
 			"BooleanOK/Success", Value.BooleanOK, Value{Type: TypeBoolean, Data: AppendBoolean(nil, true)},
 			nil,
-			[]interface{}{true, true},
+			[]any{true, true},
 		},
 		{
 			"DateTime/Not DateTime", Value.DateTime, Value{Type: TypeString},
@@ -317,22 +317,22 @@ func TestValue(t *testing.T) {
 		{
 			"DateTime/Success", Value.DateTime, Value{Type: TypeDateTime, Data: AppendDateTime(nil, 12345)},
 			nil,
-			[]interface{}{int64(12345)},
+			[]any{int64(12345)},
 		},
 		{
 			"DateTimeOK/Not DateTime", Value.DateTimeOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{int64(0), false},
+			[]any{int64(0), false},
 		},
 		{
 			"DateTimeOK/Insufficient Bytes", Value.DateTimeOK, Value{Type: TypeDateTime, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{int64(0), false},
+			[]any{int64(0), false},
 		},
 		{
 			"DateTimeOK/Success", Value.DateTimeOK, Value{Type: TypeDateTime, Data: AppendDateTime(nil, 12345)},
 			nil,
-			[]interface{}{int64(12345), true},
+			[]any{int64(12345), true},
 		},
 		{
 			"Time/Not DateTime", Value.Time, Value{Type: TypeString},
@@ -347,22 +347,22 @@ func TestValue(t *testing.T) {
 		{
 			"Time/Success", Value.Time, Value{Type: TypeDateTime, Data: AppendTime(nil, now)},
 			nil,
-			[]interface{}{now},
+			[]any{now},
 		},
 		{
 			"TimeOK/Not DateTime", Value.TimeOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{time.Time{}, false},
+			[]any{time.Time{}, false},
 		},
 		{
 			"TimeOK/Insufficient Bytes", Value.TimeOK, Value{Type: TypeDateTime, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{time.Time{}, false},
+			[]any{time.Time{}, false},
 		},
 		{
 			"TimeOK/Success", Value.TimeOK, Value{Type: TypeDateTime, Data: AppendTime(nil, now)},
 			nil,
-			[]interface{}{now, true},
+			[]any{now, true},
 		},
 		{
 			"Regex/Not Regex", Value.Regex, Value{Type: TypeString},
@@ -377,22 +377,22 @@ func TestValue(t *testing.T) {
 		{
 			"Regex/Success", Value.Regex, Value{Type: TypeRegex, Data: AppendRegex(nil, "/abcdefg/", "hijkl")},
 			nil,
-			[]interface{}{"/abcdefg/", "hijkl"},
+			[]any{"/abcdefg/", "hijkl"},
 		},
 		{
 			"RegexOK/Not Regex", Value.RegexOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{"", "", false},
+			[]any{"", "", false},
 		},
 		{
 			"RegexOK/Insufficient Bytes", Value.RegexOK, Value{Type: TypeRegex, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{"", "", false},
+			[]any{"", "", false},
 		},
 		{
 			"RegexOK/Success", Value.RegexOK, Value{Type: TypeRegex, Data: AppendRegex(nil, "/abcdefg/", "hijkl")},
 			nil,
-			[]interface{}{"/abcdefg/", "hijkl", true},
+			[]any{"/abcdefg/", "hijkl", true},
 		},
 		{
 			"DBPointer/Not DBPointer", Value.DBPointer, Value{Type: TypeString},
@@ -407,22 +407,22 @@ func TestValue(t *testing.T) {
 		{
 			"DBPointer/Success", Value.DBPointer, Value{Type: TypeDBPointer, Data: AppendDBPointer(nil, "foobar", oid)},
 			nil,
-			[]interface{}{"foobar", oid},
+			[]any{"foobar", oid},
 		},
 		{
 			"DBPointerOK/Not DBPointer", Value.DBPointerOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{"", [12]byte{}, false},
+			[]any{"", [12]byte{}, false},
 		},
 		{
 			"DBPointerOK/Insufficient Bytes", Value.DBPointerOK, Value{Type: TypeDBPointer, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{"", [12]byte{}, false},
+			[]any{"", [12]byte{}, false},
 		},
 		{
 			"DBPointerOK/Success", Value.DBPointerOK, Value{Type: TypeDBPointer, Data: AppendDBPointer(nil, "foobar", oid)},
 			nil,
-			[]interface{}{"foobar", oid, true},
+			[]any{"foobar", oid, true},
 		},
 		{
 			"JavaScript/Not JavaScript", Value.JavaScript, Value{Type: TypeString},
@@ -437,22 +437,22 @@ func TestValue(t *testing.T) {
 		{
 			"JavaScript/Success", Value.JavaScript, Value{Type: TypeJavaScript, Data: AppendJavaScript(nil, "var hello = 'world';")},
 			nil,
-			[]interface{}{"var hello = 'world';"},
+			[]any{"var hello = 'world';"},
 		},
 		{
 			"JavaScriptOK/Not JavaScript", Value.JavaScriptOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"JavaScriptOK/Insufficient Bytes", Value.JavaScriptOK, Value{Type: TypeJavaScript, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"JavaScriptOK/Success", Value.JavaScriptOK, Value{Type: TypeJavaScript, Data: AppendJavaScript(nil, "var hello = 'world';")},
 			nil,
-			[]interface{}{"var hello = 'world';", true},
+			[]any{"var hello = 'world';", true},
 		},
 		{
 			"Symbol/Not Symbol", Value.Symbol, Value{Type: TypeString},
@@ -467,22 +467,22 @@ func TestValue(t *testing.T) {
 		{
 			"Symbol/Success", Value.Symbol, Value{Type: TypeSymbol, Data: AppendSymbol(nil, "symbol123456")},
 			nil,
-			[]interface{}{"symbol123456"},
+			[]any{"symbol123456"},
 		},
 		{
 			"SymbolOK/Not Symbol", Value.SymbolOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"SymbolOK/Insufficient Bytes", Value.SymbolOK, Value{Type: TypeSymbol, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{"", false},
+			[]any{"", false},
 		},
 		{
 			"SymbolOK/Success", Value.SymbolOK, Value{Type: TypeSymbol, Data: AppendSymbol(nil, "symbol123456")},
 			nil,
-			[]interface{}{"symbol123456", true},
+			[]any{"symbol123456", true},
 		},
 		{
 			"CodeWithScope/Not CodeWithScope", Value.CodeWithScope, Value{Type: TypeString},
@@ -497,22 +497,22 @@ func TestValue(t *testing.T) {
 		{
 			"CodeWithScope/Success", Value.CodeWithScope, Value{Type: TypeCodeWithScope, Data: AppendCodeWithScope(nil, "var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00})},
 			nil,
-			[]interface{}{"var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00}},
+			[]any{"var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00}},
 		},
 		{
 			"CodeWithScopeOK/Not CodeWithScope", Value.CodeWithScopeOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{"", Document(nil), false},
+			[]any{"", Document(nil), false},
 		},
 		{
 			"CodeWithScopeOK/Insufficient Bytes", Value.CodeWithScopeOK, Value{Type: TypeCodeWithScope, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{"", Document(nil), false},
+			[]any{"", Document(nil), false},
 		},
 		{
 			"CodeWithScopeOK/Success", Value.CodeWithScopeOK, Value{Type: TypeCodeWithScope, Data: AppendCodeWithScope(nil, "var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00})},
 			nil,
-			[]interface{}{"var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00}, true},
+			[]any{"var hello = 'world';", Document{0x05, 0x00, 0x00, 0x00, 0x00}, true},
 		},
 		{
 			"Int32/Not Int32", Value.Int32, Value{Type: TypeString},
@@ -527,22 +527,22 @@ func TestValue(t *testing.T) {
 		{
 			"Int32/Success", Value.Int32, Value{Type: TypeInt32, Data: AppendInt32(nil, 1234)},
 			nil,
-			[]interface{}{int32(1234)},
+			[]any{int32(1234)},
 		},
 		{
 			"Int32OK/Not Int32", Value.Int32OK, Value{Type: TypeString},
 			nil,
-			[]interface{}{int32(0), false},
+			[]any{int32(0), false},
 		},
 		{
 			"Int32OK/Insufficient Bytes", Value.Int32OK, Value{Type: TypeInt32, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{int32(0), false},
+			[]any{int32(0), false},
 		},
 		{
 			"Int32OK/Success", Value.Int32OK, Value{Type: TypeInt32, Data: AppendInt32(nil, 1234)},
 			nil,
-			[]interface{}{int32(1234), true},
+			[]any{int32(1234), true},
 		},
 		{
 			"Timestamp/Not Timestamp", Value.Timestamp, Value{Type: TypeString},
@@ -557,22 +557,22 @@ func TestValue(t *testing.T) {
 		{
 			"Timestamp/Success", Value.Timestamp, Value{Type: TypeTimestamp, Data: AppendTimestamp(nil, 12345, 67890)},
 			nil,
-			[]interface{}{uint32(12345), uint32(67890)},
+			[]any{uint32(12345), uint32(67890)},
 		},
 		{
 			"TimestampOK/Not Timestamp", Value.TimestampOK, Value{Type: TypeString},
 			nil,
-			[]interface{}{uint32(0), uint32(0), false},
+			[]any{uint32(0), uint32(0), false},
 		},
 		{
 			"TimestampOK/Insufficient Bytes", Value.TimestampOK, Value{Type: TypeTimestamp, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{uint32(0), uint32(0), false},
+			[]any{uint32(0), uint32(0), false},
 		},
 		{
 			"TimestampOK/Success", Value.TimestampOK, Value{Type: TypeTimestamp, Data: AppendTimestamp(nil, 12345, 67890)},
 			nil,
-			[]interface{}{uint32(12345), uint32(67890), true},
+			[]any{uint32(12345), uint32(67890), true},
 		},
 		{
 			"Int64/Not Int64", Value.Int64, Value{Type: TypeString},
@@ -587,22 +587,22 @@ func TestValue(t *testing.T) {
 		{
 			"Int64/Success", Value.Int64, Value{Type: TypeInt64, Data: AppendInt64(nil, 1234567890)},
 			nil,
-			[]interface{}{int64(1234567890)},
+			[]any{int64(1234567890)},
 		},
 		{
 			"Int64OK/Not Int64", Value.Int64OK, Value{Type: TypeString},
 			nil,
-			[]interface{}{int64(0), false},
+			[]any{int64(0), false},
 		},
 		{
 			"Int64OK/Insufficient Bytes", Value.Int64OK, Value{Type: TypeInt64, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{int64(0), false},
+			[]any{int64(0), false},
 		},
 		{
 			"Int64OK/Success", Value.Int64OK, Value{Type: TypeInt64, Data: AppendInt64(nil, 1234567890)},
 			nil,
-			[]interface{}{int64(1234567890), true},
+			[]any{int64(1234567890), true},
 		},
 		{
 			"Decimal128/Not Decimal128", Value.Decimal128, Value{Type: TypeString},
@@ -617,27 +617,27 @@ func TestValue(t *testing.T) {
 		{
 			"Decimal128/Success", Value.Decimal128, Value{Type: TypeDecimal128, Data: AppendDecimal128(nil, 12345, 67890)},
 			nil,
-			[]interface{}{uint64(12345), uint64(67890)},
+			[]any{uint64(12345), uint64(67890)},
 		},
 		{
 			"Decimal128OK/Not Decimal128", Value.Decimal128OK, Value{Type: TypeString},
 			nil,
-			[]interface{}{uint64(0), uint64(0), false},
+			[]any{uint64(0), uint64(0), false},
 		},
 		{
 			"Decimal128OK/Insufficient Bytes", Value.Decimal128OK, Value{Type: TypeDecimal128, Data: []byte{0x01, 0x02, 0x03}},
 			nil,
-			[]interface{}{uint64(0), uint64(0), false},
+			[]any{uint64(0), uint64(0), false},
 		},
 		{
 			"Decimal128OK/Success", Value.Decimal128OK, Value{Type: TypeDecimal128, Data: AppendDecimal128(nil, 12345, 67890)},
 			nil,
-			[]interface{}{uint64(12345), uint64(67890), true},
+			[]any{uint64(12345), uint64(67890), true},
 		},
 		{
 			"Timestamp.String/Success", Value.String, Value{Type: TypeTimestamp, Data: AppendTimestamp(nil, 12345, 67890)},
 			nil,
-			[]interface{}{"{\"$timestamp\":{\"t\":12345,\"i\":67890}}"},
+			[]any{"{\"$timestamp\":{\"t\":12345,\"i\":67890}}"},
 		},
 	}
 

--- a/x/mongo/driver/auth/auth_spec_test.go
+++ b/x/mongo/driver/auth/auth_spec_test.go
@@ -23,7 +23,7 @@ type credential struct {
 	Password  *string
 	Source    string
 	Mechanism string
-	MechProps map[string]interface{} `json:"mechanism_properties"`
+	MechProps map[string]any `json:"mechanism_properties"`
 }
 
 type testCase struct {
@@ -97,8 +97,8 @@ func runTest(t *testing.T, test testCase) {
 	}
 }
 
-// Convert each interface{} value in the map to a string.
-func mapInterfaceToString(m map[string]interface{}) map[string]string {
+// Convert each any value in the map to a string.
+func mapInterfaceToString(m map[string]any) map[string]string {
 	out := make(map[string]string)
 
 	for key, value := range m {

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -34,7 +34,7 @@ var ErrNoCursor = errors.New("database response does not contain a cursor")
 type BatchCursor struct {
 	clientSession        *session.Client
 	clock                *session.ClusterClock
-	comment              interface{}
+	comment              any
 	encoderFn            codecutil.EncoderFn
 	database             string
 	collection           string
@@ -531,7 +531,7 @@ func (bc *BatchCursor) SetMaxAwaitTime(dur time.Duration) {
 }
 
 // SetComment sets the comment for future getMore operations.
-func (bc *BatchCursor) SetComment(comment interface{}) {
+func (bc *BatchCursor) SetComment(comment any) {
 	bc.comment = comment
 }
 

--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -110,7 +110,7 @@ func (e *zlibEncoder) Encode(dst, src []byte) ([]byte, error) {
 }
 
 var zstdBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		s := make([]byte, 0)
 		return &s
 	},
@@ -147,7 +147,7 @@ func CompressPayload(in []byte, opts CompressionOpts) ([]byte, error) {
 }
 
 var zstdReaderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		r, _ := zstd.NewReader(nil)
 		return r
 	},

--- a/x/mongo/driver/connstring/connstring_spec_test.go
+++ b/x/mongo/driver/connstring/connstring_spec_test.go
@@ -40,7 +40,7 @@ type testCase struct {
 	Warning     bool
 	Hosts       []host
 	Auth        *auth
-	Options     map[string]interface{}
+	Options     map[string]any
 }
 
 type testContainer struct {
@@ -167,7 +167,7 @@ func TestURIOptionsSpec(t *testing.T) {
 }
 
 // verifyConnStringOptions verifies the options on the connection string.
-func verifyConnStringOptions(t *testing.T, cs *connstring.ConnString, options map[string]interface{}) {
+func verifyConnStringOptions(t *testing.T, cs *connstring.ConnString, options map[string]any) {
 	// Check that all options are present.
 	for key, value := range options {
 
@@ -180,7 +180,7 @@ func verifyConnStringOptions(t *testing.T, cs *connstring.ConnString, options ma
 		case "authmechanism":
 			require.Equal(t, value, cs.AuthMechanism)
 		case "authmechanismproperties":
-			convertedMap := value.(map[string]interface{})
+			convertedMap := value.(map[string]any)
 			require.Equal(t,
 				mapInterfaceToString(convertedMap),
 				cs.AuthMechanismProperties)
@@ -216,11 +216,11 @@ func verifyConnStringOptions(t *testing.T, cs *connstring.ConnString, options ma
 		case "readpreference":
 			require.Equal(t, value, cs.ReadPreference)
 		case "readpreferencetags":
-			sm, ok := value.([]interface{})
+			sm, ok := value.([]any)
 			require.True(t, ok)
 			tags := make([]map[string]string, 0, len(sm))
 			for _, i := range sm {
-				m, ok := i.(map[string]interface{})
+				m, ok := i.(map[string]any)
 				require.True(t, ok)
 				tags = append(tags, mapInterfaceToString(m))
 			}
@@ -283,8 +283,8 @@ func verifyConnStringOptions(t *testing.T, cs *connstring.ConnString, options ma
 	}
 }
 
-// Convert each interface{} value in the map to a string.
-func mapInterfaceToString(m map[string]interface{}) map[string]string {
+// Convert each any value in the map to a string.
+func mapInterfaceToString(m map[string]any) map[string]string {
 	out := make(map[string]string)
 
 	for key, value := range m {
@@ -297,7 +297,7 @@ func mapInterfaceToString(m map[string]interface{}) map[string]string {
 // getIntFromInterface attempts to convert an empty interface value to an integer.
 //
 // Returns nil if it is not possible.
-func getIntFromInterface(i interface{}) *int64 {
+func getIntFromInterface(i any) *int64 {
 	var out int64
 
 	switch v := i.(type) {
@@ -328,8 +328,8 @@ func getIntFromInterface(i interface{}) *int64 {
 	return &out
 }
 
-func convertToStringSlice(i interface{}) []string {
-	s, ok := i.([]interface{})
+func convertToStringSlice(i any) []string {
+	s, ok := i.([]any)
 	if !ok {
 		return nil
 	}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -504,7 +504,7 @@ func (op Operation) Validate() error {
 }
 
 var memoryPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		// Start with 1kb buffers.
 		b := make([]byte, 1024)
 		// Return a pointer as the static analysis tool suggests.

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -59,7 +59,7 @@ type LastErrorObject struct {
 	// True if an update modified an existing document
 	UpdatedExisting bool
 	// Object ID of the upserted document.
-	Upserted interface{}
+	Upserted any
 }
 
 // FindAndModifyResult represents a findAndModify result returned by the server.

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -52,7 +52,7 @@ type Update struct {
 // Upsert contains the information for an upsert in an Update operation.
 type Upsert struct {
 	Index int64
-	ID    interface{} `bson:"_id"`
+	ID    any `bson:"_id"`
 }
 
 // UpdateResult contains information for the result of an Update operation.

--- a/x/mongo/driver/topology/CMAP_spec_test.go
+++ b/x/mongo/driver/topology/CMAP_spec_test.go
@@ -63,11 +63,11 @@ var skippedTestDescriptions = map[string]string{
 }
 
 type cmapEvent struct {
-	EventType    string      `json:"type"`
-	Address      interface{} `json:"address"`
-	ConnectionID int64       `json:"connectionId"`
-	Options      interface{} `json:"options"`
-	Reason       string      `json:"reason"`
+	EventType    string `json:"type"`
+	Address      any    `json:"address"`
+	ConnectionID int64  `json:"connectionId"`
+	Options      any    `json:"options"`
+	Reason       string `json:"reason"`
 }
 
 type poolOptions struct {
@@ -80,16 +80,16 @@ type poolOptions struct {
 }
 
 type cmapTestFile struct {
-	Version     uint64                   `json:"version"`
-	Style       string                   `json:"style"`
-	Description string                   `json:"description"`
-	SkipReason  string                   `json:"skipReason"`
-	FailPoint   map[string]interface{}   `json:"failPoint"`
-	PoolOptions poolOptions              `json:"poolOptions"`
-	Operations  []map[string]interface{} `json:"operations"`
-	Error       *cmapTestError           `json:"error"`
-	Events      []cmapEvent              `json:"events"`
-	Ignore      []string                 `json:"ignore"`
+	Version     uint64           `json:"version"`
+	Style       string           `json:"style"`
+	Description string           `json:"description"`
+	SkipReason  string           `json:"skipReason"`
+	FailPoint   map[string]any   `json:"failPoint"`
+	PoolOptions poolOptions      `json:"poolOptions"`
+	Operations  []map[string]any `json:"operations"`
+	Error       *cmapTestError   `json:"error"`
+	Events      []cmapEvent      `json:"events"`
+	Ignore      []string         `json:"ignore"`
 }
 
 type cmapTestError struct {
@@ -105,7 +105,7 @@ type simThread struct {
 }
 
 type testInfo struct {
-	objects                map[string]interface{}
+	objects                map[string]any
 	originalEventChan      chan *event.PoolEvent
 	finalEventChan         chan *event.PoolEvent
 	threads                map[string]*simThread
@@ -140,7 +140,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 	}
 
 	testInfo := &testInfo{
-		objects:                make(map[string]interface{}),
+		objects:                make(map[string]any),
 		originalEventChan:      make(chan *event.PoolEvent, 200),
 		finalEventChan:         make(chan *event.PoolEvent, 200),
 		threads:                make(map[string]*simThread),
@@ -175,7 +175,7 @@ func runCMAPTest(t *testing.T, testFileName string) {
 	var closeConnection bool
 
 	if test.FailPoint != nil {
-		data, ok := test.FailPoint["data"].(map[string]interface{})
+		data, ok := test.FailPoint["data"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected to find \"data\" map in failPoint (%v)", test.FailPoint)
 		}
@@ -324,7 +324,7 @@ func checkEvents(t *testing.T, expectedEvents []cmapEvent, actualEvents chan *ev
 					t.Errorf("expected poolevent options but found none")
 				}
 			} else {
-				opts, ok := expectedEvent.Options.(map[string]interface{})
+				opts, ok := expectedEvent.Options.(map[string]any)
 				if !ok {
 					t.Errorf("event options were unexpected type: %T for %v", expectedEvent.Options, expectedEvent.EventType)
 				}
@@ -363,7 +363,7 @@ NextEvent:
 	}
 }
 
-func runOperation(t *testing.T, operation map[string]interface{}, testInfo *testInfo, s *Server, checkOutTimeout int32) error {
+func runOperation(t *testing.T, operation map[string]any, testInfo *testInfo, s *Server, checkOutTimeout int32) error {
 	threadName, ok := operation["thread"]
 	if ok { // to be run in background thread
 		testInfo.Lock()
@@ -398,7 +398,7 @@ func runOperation(t *testing.T, operation map[string]interface{}, testInfo *test
 	return runOperationInThread(t, operation, testInfo, s, checkOutTimeout)
 }
 
-func runOperationInThread(t *testing.T, operation map[string]interface{}, testInfo *testInfo, s *Server, checkOutTimeout int32) error {
+func runOperationInThread(t *testing.T, operation map[string]any, testInfo *testInfo, s *Server, checkOutTimeout int32) error {
 	name, ok := operation["name"]
 	if !ok {
 		t.Fatalf("unable to find name in operation")
@@ -507,7 +507,7 @@ func runOperationInThread(t *testing.T, operation map[string]interface{}, testIn
 			t.Fatalf("unable to find connection to checkin")
 		}
 
-		var cEmptyInterface interface{}
+		var cEmptyInterface any
 		testInfo.Lock()
 		cEmptyInterface, ok = testInfo.objects[cName.(string)]
 		delete(testInfo.objects, cName.(string))

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -584,7 +584,7 @@ func TestConnection(t *testing.T) {
 				}
 			}()
 
-			var want, got interface{}
+			var want, got any
 
 			want = ErrConnectionClosed
 			got = conn.Write(context.Background(), nil)

--- a/x/mongo/driver/topology/pool.go
+++ b/x/mongo/driver/topology/pool.go
@@ -143,7 +143,7 @@ func mustLogPoolMessage(pool *pool) bool {
 		logger.LevelDebug, logger.ComponentConnection)
 }
 
-func logPoolMessage(pool *pool, msg string, keysAndValues ...interface{}) {
+func logPoolMessage(pool *pool, msg string, keysAndValues ...any) {
 	host, port, err := net.SplitHostPort(pool.address.String())
 	if err != nil {
 		host = pool.address.String()

--- a/x/mongo/driver/topology/sdam_spec_test.go
+++ b/x/mongo/driver/topology/sdam_spec_test.go
@@ -205,7 +205,7 @@ func serverClosed(e *event.ServerClosedEvent) {
 
 var testsDir = spectest.Path("server-discovery-and-monitoring/tests")
 
-var publishedEvents []interface{}
+var publishedEvents []any
 var lock sync.Mutex
 
 func (r *response) UnmarshalBSON(buf []byte) error {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -228,7 +228,7 @@ func mustLogServerMessage(srv *Server) bool {
 		logger.LevelDebug, logger.ComponentTopology)
 }
 
-func logServerMessage(srv *Server, msg string, keysAndValues ...interface{}) {
+func logServerMessage(srv *Server, msg string, keysAndValues ...any) {
 	serverHost, serverPort, err := net.SplitHostPort(srv.address.String())
 	if err != nil {
 		serverHost = srv.address.String()

--- a/x/mongo/driver/topology/server_rtt_test.go
+++ b/x/mongo/driver/topology/server_rtt_test.go
@@ -22,9 +22,9 @@ func TestServerSelectionRTTSpec(t *testing.T) {
 
 	type testCase struct {
 		// AvgRttMs is either "NULL" or float
-		AvgRttMs  interface{} `json:"avg_rtt_ms"`
-		NewRttMs  float64     `json:"new_rtt_ms"`
-		NewAvgRtt float64     `json:"new_avg_rtt"`
+		AvgRttMs  any     `json:"avg_rtt_ms"`
+		NewRttMs  float64 `json:"new_rtt_ms"`
+		NewAvgRtt float64 `json:"new_avg_rtt"`
 	}
 
 	testsDir := spectest.Path("server-selection/tests/rtt")

--- a/x/mongo/driver/topology/server_test.go
+++ b/x/mongo/driver/topology/server_test.go
@@ -715,7 +715,7 @@ func TestServer(t *testing.T) {
 		}
 	})
 	t.Run("heartbeat monitoring", func(t *testing.T) {
-		var publishedEvents []interface{}
+		var publishedEvents []any
 
 		serverHeartbeatStarted := func(e *event.ServerHeartbeatStartedEvent) {
 			publishedEvents = append(publishedEvents, *e)

--- a/x/mongo/driver/topology/topology.go
+++ b/x/mongo/driver/topology/topology.go
@@ -167,7 +167,7 @@ func mustLogTopologyMessage(topo *Topology, level logger.Level) bool {
 		level, logger.ComponentTopology)
 }
 
-func logTopologyMessage(topo *Topology, level logger.Level, msg string, keysAndValues ...interface{}) {
+func logTopologyMessage(topo *Topology, level logger.Level, msg string, keysAndValues ...any) {
 	topo.cfg.logger.Print(level,
 		logger.ComponentTopology,
 		msg,
@@ -218,7 +218,7 @@ func logServerSelection(
 	level logger.Level,
 	msg string,
 	srvSelector description.ServerSelector,
-	keysAndValues ...interface{},
+	keysAndValues ...any,
 ) {
 	var srvSelectorString string
 

--- a/x/mongo/driver/topology/topology_test.go
+++ b/x/mongo/driver/topology/topology_test.go
@@ -537,10 +537,10 @@ type mockLogSink struct {
 	msgs []string
 }
 
-func (s *mockLogSink) Info(_ int, msg string, _ ...interface{}) {
+func (s *mockLogSink) Info(_ int, msg string, _ ...any) {
 	s.msgs = append(s.msgs, msg)
 }
-func (*mockLogSink) Error(error, string, ...interface{}) {
+func (*mockLogSink) Error(error, string, ...any) {
 	// Do nothing.
 }
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Replace all uses of `interface{}` with `any` in the "x/" packages.

## Background & Motivation

[any](https://pkg.go.dev/builtin#any) is a type alias for `interface{}`, so is semantically identical. The only change is a slightly cleaner syntax.
