### PR TITLE
Replace all uses of 'interface{}' with 'any' in the internal/ packages.

### DIFF
--- a/internal/bsonutil/bsonutil.go
+++ b/internal/bsonutil/bsonutil.go
@@ -52,9 +52,9 @@ func RawArrayToDocuments(arr bson.RawArray) []bson.Raw {
 	return out
 }
 
-// RawToInterfaces takes one or many bson.Raw documents and returns them as a []interface{}.
-func RawToInterfaces(docs ...bson.Raw) []interface{} {
-	out := make([]interface{}, len(docs))
+// RawToInterfaces takes one or many bson.Raw documents and returns them as a []any.
+func RawToInterfaces(docs ...bson.Raw) []any {
+	out := make([]any, len(docs))
 	for i := range docs {
 		out[i] = docs[i]
 	}

--- a/internal/cmd/benchmark/benchmark_test.go
+++ b/internal/cmd/benchmark/benchmark_test.go
@@ -663,8 +663,8 @@ type poplarTestArtifact struct {
 // poplarTestMetrics was copied from
 // https://github.com/evergreen-ci/poplar/blob/8d03d2bacde0897cedd73ed79ddc167ed1ed4c77/report.go#L124
 type poplarTestMetrics struct {
-	Name    string      `bson:"name" json:"name" yaml:"name"`
-	Version int         `bson:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
-	Type    string      `bson:"type" json:"type" yaml:"type"`
-	Value   interface{} `bson:"value" json:"value" yaml:"value"`
+	Name    string `bson:"name" json:"name" yaml:"name"`
+	Version int    `bson:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
+	Type    string `bson:"type" json:"type" yaml:"type"`
+	Value   any    `bson:"value" json:"value" yaml:"value"`
 }

--- a/internal/cmd/testkms/main.go
+++ b/internal/cmd/testkms/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 	defer func() { _ = keyVaultClient.Disconnect(context.Background()) }()
 
-	kmsProvidersMap := map[string]map[string]interface{}{
+	kmsProvidersMap := map[string]map[string]any{
 		provider: {},
 	}
 	ceOpts := options.ClientEncryption().SetKmsProviders(kmsProvidersMap).SetKeyVaultNamespace("keyvault.datakeys")

--- a/internal/codecutil/encoding.go
+++ b/internal/codecutil/encoding.go
@@ -22,7 +22,7 @@ var ErrNilValue = errors.New("value is nil")
 // MarshalError is returned when attempting to transform a value into a document
 // results in an error.
 type MarshalError struct {
-	Value interface{}
+	Value any
 	Err   error
 }
 
@@ -39,7 +39,7 @@ type EncoderFn func(io.Writer) *bson.Encoder
 
 // MarshalValue will attempt to encode the value with the encoder returned by
 // the encoder function.
-func MarshalValue(val interface{}, encFn EncoderFn) (bsoncore.Value, error) {
+func MarshalValue(val any, encFn EncoderFn) (bsoncore.Value, error) {
 	// If the val is already a bsoncore.Value, then do nothing.
 	if bval, ok := val.(bsoncore.Value); ok {
 		return bval, nil

--- a/internal/codecutil/encoding_test.go
+++ b/internal/codecutil/encoding_test.go
@@ -28,7 +28,7 @@ func TestMarshalValue(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		val      interface{}
+		val      any
 		registry *bson.Registry
 		encFn    EncoderFn
 		want     string
@@ -49,7 +49,7 @@ func TestMarshalValue(t *testing.T) {
 		},
 		{
 			name:  "map",
-			val:   map[string]interface{}{"foo": "bar"},
+			val:   map[string]any{"foo": "bar"},
 			want:  `{"foo": "bar"}`,
 			encFn: testEncFn(t),
 		},

--- a/internal/csot/csot_test.go
+++ b/internal/csot/csot_test.go
@@ -157,7 +157,7 @@ func TestWithTimeout(t *testing.T) {
 		timeout      *time.Duration
 		wantTimeout  time.Duration
 		wantDeadline bool
-		wantValues   []interface{}
+		wantValues   []any
 	}{
 		{
 			name:         "deadline set with non-zero timeout",
@@ -165,7 +165,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      ptrutil.Ptr(time.Duration(2)),
 			wantTimeout:  1,
 			wantDeadline: true,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 		{
 			name:         "deadline set with zero timeout",
@@ -173,7 +173,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      ptrutil.Ptr(time.Duration(0)),
 			wantTimeout:  1,
 			wantDeadline: true,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 		{
 			name:         "deadline set with nil timeout",
@@ -181,7 +181,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      nil,
 			wantTimeout:  1,
 			wantDeadline: true,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 		{
 			name:         "deadline unset with non-zero timeout",
@@ -189,7 +189,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      ptrutil.Ptr(time.Duration(1)),
 			wantTimeout:  1,
 			wantDeadline: true,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 		{
 			name:         "deadline unset with zero timeout",
@@ -197,7 +197,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      ptrutil.Ptr(time.Duration(0)),
 			wantTimeout:  0,
 			wantDeadline: false,
-			wantValues:   []interface{}{clientLevel{}},
+			wantValues:   []any{clientLevel{}},
 		},
 		{
 			name:         "deadline unset with nil timeout",
@@ -205,7 +205,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      nil,
 			wantTimeout:  0,
 			wantDeadline: false,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 		{
 			// If "clientLevel" has been set, but a new timeout is applied
@@ -216,7 +216,7 @@ func TestWithTimeout(t *testing.T) {
 			timeout:      ptrutil.Ptr(time.Duration(1)),
 			wantTimeout:  0,
 			wantDeadline: false,
-			wantValues:   []interface{}{},
+			wantValues:   []any{},
 		},
 	}
 

--- a/internal/docexamples/examples.go
+++ b/internal/docexamples/examples.go
@@ -98,7 +98,7 @@ func InsertExamples(t *testing.T, db *mongo.Database) {
 
 		result, err := coll.InsertMany(
 			context.TODO(),
-			[]interface{}{
+			[]any{
 				bson.D{
 					{"item", "journal"},
 					{"qty", int32(25)},
@@ -149,7 +149,7 @@ func QueryToplevelFieldsExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 6
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"qty", 25},
@@ -318,7 +318,7 @@ func QueryEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 14
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"qty", 25},
@@ -480,7 +480,7 @@ func QueryArraysExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 20
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"qty", 25},
@@ -667,7 +667,7 @@ func QueryArrayEmbeddedDocumentsExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 29
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"instock", bson.A{
@@ -897,7 +897,7 @@ func QueryNullMissingFieldsExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 38
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"_id", 1},
 				{"item", nil},
@@ -976,7 +976,7 @@ func ProjectionExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 42
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"status", "A"},
@@ -1361,7 +1361,7 @@ func UpdateExamples(t *testing.T, db *mongo.Database) {
 	{
 		// Start Example 51
 
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "canvas"},
 				{"qty", 100},
@@ -1641,7 +1641,7 @@ func DeleteExamples(t *testing.T, db *mongo.Database) {
 
 	{
 		// Start Example 55
-		docs := []interface{}{
+		docs := []any{
 			bson.D{
 				{"item", "journal"},
 				{"qty", 25},
@@ -1985,7 +1985,7 @@ func WithTransactionExample(ctx context.Context) error {
 	barColl := client.Database("mydb1").Collection("bar", wcMajorityCollectionOpts)
 
 	// Step 1: Define the callback that specifies the sequence of operations to perform inside the transaction.
-	callback := func(sesctx context.Context) (interface{}, error) {
+	callback := func(sesctx context.Context) (any, error) {
 		// Important: You must pass sesctx as the Context parameter to the operations for them to be executed in the
 		// transaction.
 		if _, err := fooColl.InsertOne(sesctx, bson.D{{"abc", 1}}); err != nil {
@@ -2145,7 +2145,7 @@ func AggregationExamples(t *testing.T, db *mongo.Database) {
 	date20180205 := parseDate(t, "2018-02-05T06:03:00.000Z")
 	date20180111 := parseDate(t, "2018-01-11T07:15:00.000Z")
 
-	sales := []interface{}{
+	sales := []any{
 		bson.D{
 			{"date", date20180208},
 			{"items", bson.A{
@@ -2242,7 +2242,7 @@ func AggregationExamples(t *testing.T, db *mongo.Database) {
 			}},
 		},
 	}
-	airlines := []interface{}{
+	airlines := []any{
 		bson.D{
 			{"airline", 17},
 			{"name", "Air Canada"},
@@ -2314,7 +2314,7 @@ func AggregationExamples(t *testing.T, db *mongo.Database) {
 			{"base", "CYS"},
 		},
 	}
-	airAlliances := []interface{}{
+	airAlliances := []any{
 		bson.D{
 			{"name", "Star Alliance"},
 			{"airlines", bson.A{
@@ -2670,7 +2670,7 @@ func IndexExamples(t *testing.T, db *mongo.Database) {
 	err = restaurantsColl.Drop(ctx)
 	assert.NoError(t, err)
 
-	records := []interface{}{
+	records := []any{
 		bson.D{
 			{"student", "Marty McFly"},
 			{"classYear", 1986},
@@ -2691,7 +2691,7 @@ func IndexExamples(t *testing.T, db *mongo.Database) {
 			{"score", 99.9},
 		},
 	}
-	restaurants := []interface{}{
+	restaurants := []any{
 		bson.D{
 			{"name", "Chez Panisse"},
 			{"cuisine", "American/French"},
@@ -2884,7 +2884,7 @@ func StableAPIStrictCountExample(t *testing.T) {
 	// Start Versioned API Example 5
 
 	coll := client.Database("db").Collection("sales")
-	docs := []interface{}{
+	docs := []any{
 		bson.D{{"_id", 1}, {"item", "abc"}, {"price", 10}, {"quantity", 2}, {"date", "2021-01-01T08:00:00Z"}},
 		bson.D{{"_id", 2}, {"item", "jkl"}, {"price", 20}, {"quantity", 1}, {"date", "2021-02-03T09:00:00Z"}},
 		bson.D{{"_id", 3}, {"item", "xyz"}, {"price", 5}, {"quantity", 5}, {"date", "2021-02-03T09:05:00Z"}},
@@ -2938,7 +2938,7 @@ func StableAPIExamples() {
 
 func insertSnapshotQueryTestData(mt *mtest.T) {
 	catColl := mt.CreateCollection(mtest.Collection{Name: "cats"}, true)
-	_, err := catColl.InsertMany(context.Background(), []interface{}{
+	_, err := catColl.InsertMany(context.Background(), []any{
 		bson.D{
 			{"adoptable", false},
 			{"name", "Miyagi"},
@@ -2955,7 +2955,7 @@ func insertSnapshotQueryTestData(mt *mtest.T) {
 	assert.NoError(mt, err)
 
 	dogColl := mt.CreateCollection(mtest.Collection{Name: "dogs"}, true)
-	_, err = dogColl.InsertMany(context.Background(), []interface{}{
+	_, err = dogColl.InsertMany(context.Background(), []any{
 		bson.D{
 			{"adoptable", true},
 			{"name", "Cormac"},
@@ -2972,7 +2972,7 @@ func insertSnapshotQueryTestData(mt *mtest.T) {
 	assert.NoError(mt, err)
 
 	salesColl := mt.CreateCollection(mtest.Collection{Name: "sales"}, true)
-	_, err = salesColl.InsertMany(context.Background(), []interface{}{
+	_, err = salesColl.InsertMany(context.Background(), []any{
 		bson.D{
 			{"shoeType", "hiking boot"},
 			{"price", 30.0},

--- a/internal/errutil/join.go
+++ b/internal/errutil/join.go
@@ -77,7 +77,7 @@ func (e *joinError) Is(target error) bool {
 }
 
 // As calls [errors.As] with the first error in the slice.
-func (e *joinError) As(target interface{}) bool {
+func (e *joinError) As(target any) bool {
 	if len(e.errs) == 0 {
 		return false
 	}

--- a/internal/errutil/join_test.go
+++ b/internal/errutil/join_test.go
@@ -170,7 +170,7 @@ func TestJoin_ErrorsAs(t *testing.T) {
 	tests := []struct {
 		desc   string
 		errs   []error
-		target interface{}
+		target any
 	}{{
 		desc:   "one error with a matching target",
 		errs:   []error{err1},

--- a/internal/failpoint/failpoint.go
+++ b/internal/failpoint/failpoint.go
@@ -26,9 +26,9 @@ const (
 // https://github.com/mongodb/specifications/tree/HEAD/source/transactions/tests#server-fail-point
 type FailPoint struct {
 	ConfigureFailPoint string `bson:"configureFailPoint"`
-	// Mode should be a string, FailPointMode, or map[string]interface{}
-	Mode interface{} `bson:"mode"`
-	Data Data        `bson:"data"`
+	// Mode should be a string, FailPointMode, or map[string]any
+	Mode any  `bson:"mode"`
+	Data Data `bson:"data"`
 }
 
 // Mode configures when a fail point will be enabled. It is used to set the

--- a/internal/logger/component.go
+++ b/internal/logger/component.go
@@ -75,10 +75,10 @@ const (
 )
 
 // KeyValues is a list of key-value pairs.
-type KeyValues []interface{}
+type KeyValues []any
 
 // Add adds a key-value pair to an instance of a KeyValues list.
-func (kvs *KeyValues) Add(key string, value interface{}) {
+func (kvs *KeyValues) Add(key string, value any) {
 	*kvs = append(*kvs, key, value)
 }
 
@@ -157,9 +157,9 @@ type Command struct {
 }
 
 // SerializeCommand takes a command and a variable number of key-value pairs and
-// returns a slice of interface{} that can be passed to the logger for
+// returns a slice of any that can be passed to the logger for
 // structured logging.
-func SerializeCommand(cmd Command, extraKeysAndValues ...interface{}) KeyValues {
+func SerializeCommand(cmd Command, extraKeysAndValues ...any) KeyValues {
 	// Initialize the boilerplate keys and values.
 	keysAndValues := KeyValues{
 		KeyCommandName, cmd.Name,
@@ -203,7 +203,7 @@ type Connection struct {
 
 // SerializeConnection serializes a Connection message into a slice of keys and
 // values that can be passed to a logger.
-func SerializeConnection(conn Connection, extraKeysAndValues ...interface{}) KeyValues {
+func SerializeConnection(conn Connection, extraKeysAndValues ...any) KeyValues {
 	// Initialize the boilerplate keys and values.
 	keysAndValues := KeyValues{
 		KeyMessage, conn.Message,
@@ -235,7 +235,7 @@ type Server struct {
 
 // SerializeServer serializes a Server message into a slice of keys and
 // values that can be passed to a logger.
-func SerializeServer(srv Server, extraKV ...interface{}) KeyValues {
+func SerializeServer(srv Server, extraKV ...any) KeyValues {
 	// Initialize the boilerplate keys and values.
 	keysAndValues := KeyValues{
 		KeyDriverConnectionID, srv.DriverConnectionID,
@@ -272,7 +272,7 @@ type ServerSelection struct {
 
 // SerializeServerSelection serializes a Topology message into a slice of keys
 // and values that can be passed to a logger.
-func SerializeServerSelection(srvSelection ServerSelection, extraKV ...interface{}) KeyValues {
+func SerializeServerSelection(srvSelection ServerSelection, extraKV ...any) KeyValues {
 	keysAndValues := KeyValues{
 		KeySelector, srvSelection.Selector,
 		KeyOperation, srvSelection.Operation,
@@ -299,7 +299,7 @@ type Topology struct {
 
 // SerializeTopology serializes a Topology message into a slice of keys and
 // values that can be passed to a logger.
-func SerializeTopology(topo Topology, extraKV ...interface{}) KeyValues {
+func SerializeTopology(topo Topology, extraKV ...any) KeyValues {
 	keysAndValues := KeyValues{
 		KeyTopologyID, topo.ID.Hex(),
 	}

--- a/internal/logger/component_test.go
+++ b/internal/logger/component_test.go
@@ -31,7 +31,7 @@ func TestSerializeCommand(t *testing.T) {
 	tests := []struct {
 		name               string
 		cmd                Command
-		extraKeysAndValues []interface{}
+		extraKeysAndValues []any
 		want               KeyValues
 	}{
 		{
@@ -93,7 +93,7 @@ func TestSerializeConnection(t *testing.T) {
 	tests := []struct {
 		name               string
 		conn               Connection
-		extraKeysAndValues []interface{}
+		extraKeysAndValues []any
 		want               KeyValues
 	}{
 		{
@@ -139,7 +139,7 @@ func TestSerializeServer(t *testing.T) {
 	tests := []struct {
 		name               string
 		srv                Server
-		extraKeysAndValues []interface{}
+		extraKeysAndValues []any
 		want               KeyValues
 	}{
 		{
@@ -193,7 +193,7 @@ func TestSerializeTopology(t *testing.T) {
 	tests := []struct {
 		name               string
 		topo               Topology
-		extraKeysAndValues []interface{}
+		extraKeysAndValues []any
 		want               KeyValues
 	}{
 		{

--- a/internal/logger/context_test.go
+++ b/internal/logger/context_test.go
@@ -55,7 +55,7 @@ func TestContext_OperationName(t *testing.T) {
 	tests := []struct {
 		name   string
 		ctx    context.Context
-		opName interface{}
+		opName any
 		ok     bool
 	}{
 		{
@@ -141,7 +141,7 @@ func TestContext_OperationID(t *testing.T) {
 	tests := []struct {
 		name string
 		ctx  context.Context
-		opID interface{}
+		opID any
 		ok   bool
 	}{
 		{

--- a/internal/logger/io_sink.go
+++ b/internal/logger/io_sink.go
@@ -36,12 +36,12 @@ func NewIOSink(out io.Writer) *IOSink {
 }
 
 // Info will write a JSON-encoded message to the io.Writer.
-func (sink *IOSink) Info(_ int, msg string, keysAndValues ...interface{}) {
+func (sink *IOSink) Info(_ int, msg string, keysAndValues ...any) {
 	mapSize := len(keysAndValues) / 2
 	if math.MaxInt-mapSize >= 2 {
 		mapSize += 2
 	}
-	kvMap := make(map[string]interface{}, mapSize)
+	kvMap := make(map[string]any, mapSize)
 
 	kvMap[KeyTimestamp] = time.Now().UnixNano()
 	kvMap[KeyMessage] = msg
@@ -57,7 +57,7 @@ func (sink *IOSink) Info(_ int, msg string, keysAndValues ...interface{}) {
 }
 
 // Error will write a JSON-encoded error message to the io.Writer.
-func (sink *IOSink) Error(err error, msg string, kv ...interface{}) {
+func (sink *IOSink) Error(err error, msg string, kv ...any) {
 	kv = append(kv, KeyError, err.Error())
 	sink.Info(0, msg, kv...)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -36,10 +36,10 @@ const maxDocumentLengthEnvVar = "MONGODB_LOG_MAX_DOCUMENT_LENGTH"
 type LogSink interface {
 	// Info logs a non-error message with the given key/value pairs. The
 	// level argument is provided for optional logging.
-	Info(level int, msg string, keysAndValues ...interface{})
+	Info(level int, msg string, keysAndValues ...any)
 
 	// Error logs an error, with the given message and key/value pairs.
-	Error(err error, msg string, keysAndValues ...interface{})
+	Error(err error, msg string, keysAndValues ...any)
 }
 
 // Logger represents the configuration for the internal logger.
@@ -112,7 +112,7 @@ func (logger *Logger) LevelComponentEnabled(level Level, component Component) bo
 // this function is implemented based on the go-logr/logr LogSink interface,
 // which is why "Print" has a message parameter. Any duplication in code is
 // intentional to adhere to the logr pattern.
-func (logger *Logger) Print(level Level, component Component, msg string, keysAndValues ...interface{}) {
+func (logger *Logger) Print(level Level, component Component, msg string, keysAndValues ...any) {
 	// If the level is not enabled for the component, then
 	// skip the message.
 	if !logger.LevelComponentEnabled(level, component) {
@@ -130,7 +130,7 @@ func (logger *Logger) Print(level Level, component Component, msg string, keysAn
 // Error logs an error, with the given message and key/value pairs.
 // It functions similarly to Print, but may have unique behavior, and should be
 // preferred for logging errors.
-func (logger *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (logger *Logger) Error(err error, msg string, keysAndValues ...any) {
 	if logger.Sink == nil {
 		return
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -23,8 +23,8 @@ import (
 
 type mockLogSink struct{}
 
-func (mockLogSink) Info(int, string, ...interface{})    {}
-func (mockLogSink) Error(error, string, ...interface{}) {}
+func (mockLogSink) Info(int, string, ...any)    {}
+func (mockLogSink) Error(error, string, ...any) {}
 
 func BenchmarkLoggerWithLargeDocuments(b *testing.B) {
 	// Define the large document test cases
@@ -159,9 +159,9 @@ func BenchmarkLogger(b *testing.B) {
 	})
 }
 
-func mockKeyValues(length int) (KeyValues, map[string]interface{}) {
+func mockKeyValues(length int) (KeyValues, map[string]any) {
 	keysAndValues := KeyValues{}
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	for i := 0; i < length; i++ {
 		keyName := fmt.Sprintf("key%d", i)
@@ -214,7 +214,7 @@ func TestIOSinkInfo(t *testing.T) {
 
 	dec := json.NewDecoder(buf)
 	for dec.More() {
-		var m map[string]interface{}
+		var m map[string]any
 		if err := dec.Decode(&m); err != nil {
 			t.Fatalf("error unmarshaling JSON: %v", err)
 		}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Replace all uses of `interface{}` with `any` in the "internal/" packages
- Excludes the "internal/integration/" packages, which are changed in https://github.com/mongodb/mongo-go-driver/pull/2141
- Excludes any packages with code copied from other repos ("internal/assert", "internal/require", "internal/rand", and "internal/aws/credentials") because they are generally not edited except for updating from the canonical code.

## Background & Motivation

[any](https://pkg.go.dev/builtin#any) is a type alias for `interface{}`, so is semantically identical. The only change is a slightly cleaner syntax.
