### PR TITLE
Replace all uses of 'interface{}' with 'any' in the internal/integration/ packages.

### DIFF
--- a/internal/integration/clam_prose_test.go
+++ b/internal/integration/clam_prose_test.go
@@ -36,7 +36,7 @@ func clamDefaultTruncLimitOp(ctx context.Context, mt *mtest.T, coll *mongo.Colle
 
 	// Construct an array of docs containing the document {"x" : "y"}
 	// repeated "documentSize" times.
-	docs := []interface{}{}
+	docs := []any{}
 	for i := 0; i < documentsSize; i++ {
 		docs = append(docs, bson.D{{"x", "y"}})
 	}
@@ -346,7 +346,7 @@ func TestCommandLoggingAndMonitoringProse(t *testing.T) {
 			sinkCtx, sinkCancel := context.WithDeadline(ctx, time.Now().Add(deadline))
 			defer sinkCancel()
 
-			validator := func(order int, _ int, _ string, keysAndValues ...interface{}) error {
+			validator := func(order int, _ int, _ string, keysAndValues ...any) error {
 				// If the order exceeds the length of the
 				// "orderedCaseValidators," then throw an error.
 				if order >= len(tcase.orderedLogValidators) {

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -63,7 +63,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 	defaultKvClientOptions := options.Client().ApplyURI(mtest.ClusterURI())
 	integtest.AddTestServerAPIVersion(defaultKvClientOptions)
-	fullKmsProvidersMap := map[string]map[string]interface{}{
+	fullKmsProvidersMap := map[string]map[string]any{
 		"aws": {
 			"accessKeyId":     awsAccessKeyID,
 			"secretAccessKey": awsSecretAccessKey,
@@ -183,10 +183,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				}},
 			}},
 		}
-		schemaMap := map[string]interface{}{"db.coll": schema}
+		schemaMap := map[string]any{"db.coll": schema}
 		tlsConfig := make(map[string]*tls.Config)
 		if tlsCAFileKMIP != "" && tlsClientCertificateKeyFileKMIP != "" {
-			tlsOpts := map[string]interface{}{
+			tlsOpts := map[string]any{
 				"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 				"tlsCAFile":             tlsCAFileKMIP,
 			}
@@ -224,7 +224,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		kmipMasterKey := bson.D{}
 		testCases := []struct {
 			provider  string
-			masterKey interface{}
+			masterKey any
 		}{
 			{"local", nil},
 			{"aws", awsMasterKey},
@@ -322,12 +322,12 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		for _, tc := range testCases {
 			mt.Run(tc.name, func(mt *mtest.T) {
 				// setup options structs
-				kmsProviders := map[string]map[string]interface{}{
+				kmsProviders := map[string]map[string]any{
 					"local": {
 						"key": localMasterKey,
 					},
 				}
-				schemaMap := map[string]interface{}{"db.coll": readJSONFile(mt, "external-schema.json")}
+				schemaMap := map[string]any{"db.coll": readJSONFile(mt, "external-schema.json")}
 				aeo := options.AutoEncryption().
 					SetKmsProviders(kmsProviders).
 					SetKeyVaultNamespace(kvNamespace).
@@ -378,7 +378,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 	mt.Run("4. bson size limits", func(mt *mtest.T) {
-		kmsProviders := map[string]map[string]interface{}{
+		kmsProviders := map[string]map[string]any{
 			"local": {
 				"key": localMasterKey,
 			},
@@ -438,7 +438,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		cpt.cseStarted = cpt.cseStarted[:0]
 		firstDoc := bson.D{{"_id", "over_2mib_1"}, {"unencrypted", complete2mbStr}}
 		secondDoc := bson.D{{"_id", "over_2mib_2"}, {"unencrypted", complete2mbStr}}
-		_, err = cpt.cseColl.InsertMany(context.Background(), []interface{}{firstDoc, secondDoc})
+		_, err = cpt.cseColl.InsertMany(context.Background(), []any{firstDoc, secondDoc})
 		assert.Nil(mt, err, "InsertMany error for small documents: %v", err)
 		assert.Equal(mt, 2, len(cpt.cseStarted), "expected 2 insert events, got %d", len(cpt.cseStarted))
 
@@ -459,7 +459,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		secondBulkDoc, _ = bsoncore.AppendDocumentEnd(secondBulkDoc, 0)
 
 		cpt.cseStarted = cpt.cseStarted[:0]
-		_, err = cpt.cseColl.InsertMany(context.Background(), []interface{}{firstBulkDoc, secondBulkDoc})
+		_, err = cpt.cseColl.InsertMany(context.Background(), []any{firstBulkDoc, secondBulkDoc})
 		assert.Nil(mt, err, "InsertMany error for large documents: %v", err)
 		assert.Equal(mt, 2, len(cpt.cseStarted), "expected 2 insert events, got %d", len(cpt.cseStarted))
 
@@ -481,7 +481,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 	mt.Run("5. views are prohibited", func(mt *mtest.T) {
 		mt.Parallel()
 
-		kmsProviders := map[string]map[string]interface{}{
+		kmsProviders := map[string]map[string]any{
 			"local": {
 				"key": localMasterKey,
 			},
@@ -514,13 +514,13 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			mt.Skipf("Skipping test as KMS_MOCK_SERVERS_RUNNING is not set")
 		}
 		corpusSchema := readJSONFile(mt, "corpus-schema.json")
-		localSchemaMap := map[string]interface{}{
+		localSchemaMap := map[string]any{
 			"db.coll": corpusSchema,
 		}
 
 		tlsConfig := make(map[string]*tls.Config)
 		if tlsCAFileKMIP != "" && tlsClientCertificateKeyFileKMIP != "" {
-			tlsOpts := map[string]interface{}{
+			tlsOpts := map[string]any{
 				"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 				"tlsCAFile":             tlsCAFileKMIP,
 			}
@@ -569,7 +569,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				}
 
 				// Manually insert keys for each KMS provider into the key vault.
-				_, err := cpt.keyVaultColl.InsertMany(context.Background(), []interface{}{
+				_, err := cpt.keyVaultColl.InsertMany(context.Background(), []any{
 					readJSONFile(mt, "corpus-key-local.json"),
 					readJSONFile(mt, "corpus-key-aws.json"),
 					readJSONFile(mt, "corpus-key-azure.json"),
@@ -747,7 +747,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 	})
 	mt.Run("7. custom endpoint", func(mt *mtest.T) {
-		validKmsProviders := map[string]map[string]interface{}{
+		validKmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -770,7 +770,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		tlsConfig := make(map[string]*tls.Config)
 		if tlsCAFileKMIP != "" && tlsClientCertificateKeyFileKMIP != "" {
-			tlsOpts := map[string]interface{}{
+			tlsOpts := map[string]any{
 				"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 				"tlsCAFile":             tlsCAFileKMIP,
 			}
@@ -784,7 +784,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace).
 			SetTLSConfig(tlsConfig)
 
-		invalidKmsProviders := map[string]map[string]interface{}{
+		invalidKmsProviders := map[string]map[string]any{
 			"azure": {
 				"tenantId":                 azureTenantID,
 				"clientId":                 azureClientID,
@@ -806,60 +806,60 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace).
 			SetTLSConfig(tlsConfig)
 
-		awsSuccessWithoutEndpoint := map[string]interface{}{
+		awsSuccessWithoutEndpoint := map[string]any{
 			"region": "us-east-1",
 			"key":    "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 		}
-		awsSuccessWithEndpoint := map[string]interface{}{
+		awsSuccessWithEndpoint := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "kms.us-east-1.amazonaws.com",
 		}
-		awsSuccessWithHTTPSEndpoint := map[string]interface{}{
+		awsSuccessWithHTTPSEndpoint := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "kms.us-east-1.amazonaws.com:443",
 		}
-		awsFailureConnectionError := map[string]interface{}{
+		awsFailureConnectionError := map[string]any{
 			"keyId":    "1",
 			"endpoint": "localhost:12345",
 		}
-		awsFailureInvalidEndpoint := map[string]interface{}{
+		awsFailureInvalidEndpoint := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "kms.us-east-2.amazonaws.com",
 		}
-		awsFailureParseError := map[string]interface{}{
+		awsFailureParseError := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "doesnotexist.invalid",
 		}
-		azure := map[string]interface{}{
+		azure := map[string]any{
 			"keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
 			"keyName":          "key-name-csfle",
 		}
-		gcpSuccess := map[string]interface{}{
+		gcpSuccess := map[string]any{
 			"projectId": "devprod-drivers",
 			"location":  "global",
 			"keyRing":   "key-ring-csfle",
 			"keyName":   "key-name-csfle",
 			"endpoint":  "cloudkms.googleapis.com:443",
 		}
-		gcpFailure := map[string]interface{}{
+		gcpFailure := map[string]any{
 			"projectId": "devprod-drivers",
 			"location":  "global",
 			"keyRing":   "key-ring-csfle",
 			"keyName":   "key-name-csfle",
 			"endpoint":  "doesnotexist.invalid:443",
 		}
-		kmipSuccessWithoutEndpoint := map[string]interface{}{
+		kmipSuccessWithoutEndpoint := map[string]any{
 			"keyId": "1",
 		}
-		kmipSuccessWithEndpoint := map[string]interface{}{
+		kmipSuccessWithEndpoint := map[string]any{
 			"keyId":    "1",
 			"endpoint": "localhost:5698",
 		}
-		kmipFailureInvalidEndpoint := map[string]interface{}{
+		kmipFailureInvalidEndpoint := map[string]any{
 			"keyId":    "1",
 			"endpoint": "doesnotexist.invalid:5698",
 		}
@@ -876,7 +876,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		testCases := []struct {
 			name                                  string
 			provider                              string
-			masterKey                             interface{}
+			masterKey                             any
 			errorSubstring                        []string
 			testInvalidClientEncryption           bool
 			invalidClientEncryptionErrorSubstring []string
@@ -1030,12 +1030,12 @@ func TestClientSideEncryptionProse(t *testing.T) {
 	mt.RunOpts("8. bypass mongocryptd spawning", noClientOpts, func(mt *mtest.T) {
 		mt.Parallel()
 
-		kmsProviders := map[string]map[string]interface{}{
+		kmsProviders := map[string]map[string]any{
 			"local": {
 				"key": localMasterKey,
 			},
 		}
-		schemaMap := map[string]interface{}{
+		schemaMap := map[string]any{
 			"db.coll": readJSONFile(mt, "external-schema.json"),
 		}
 
@@ -1043,25 +1043,25 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		// with mongocryptd instances spawned by previous tests. Explicitly disable loading the
 		// crypt_shared library to make sure we're testing mongocryptd spawning behavior that is not
 		// influenced by loading the crypt_shared library.
-		mongocryptdBypassSpawnTrue := map[string]interface{}{
+		mongocryptdBypassSpawnTrue := map[string]any{
 			"mongocryptdBypassSpawn":              true,
 			"mongocryptdURI":                      "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000",
 			"mongocryptdSpawnArgs":                []string{"--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"},
 			"__cryptSharedLibDisabledForTestOnly": true, // Disable loading the crypt_shared library.
 		}
-		mongocryptdBypassSpawnFalse := map[string]interface{}{
+		mongocryptdBypassSpawnFalse := map[string]any{
 			"mongocryptdBypassSpawn":              false,
 			"mongocryptdSpawnArgs":                []string{"--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"},
 			"__cryptSharedLibDisabledForTestOnly": true, // Disable loading the crypt_shared library.
 		}
-		mongocryptdBypassSpawnNotSet := map[string]interface{}{
+		mongocryptdBypassSpawnNotSet := map[string]any{
 			"mongocryptdSpawnArgs":                []string{"--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"},
 			"__cryptSharedLibDisabledForTestOnly": true, // Disable loading the crypt_shared library.
 		}
 
 		testCases := []struct {
 			name                    string
-			mongocryptdOpts         map[string]interface{}
+			mongocryptdOpts         map[string]any
 			setBypassAutoEncryption bool
 			bypassAutoEncryption    bool
 			bypassQueryAnalysis     bool
@@ -1097,7 +1097,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			{
 				name:         "use shared library",
 				useSharedLib: true,
-				mongocryptdOpts: map[string]interface{}{
+				mongocryptdOpts: map[string]any{
 					"mongocryptdURI":       "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000",
 					"mongocryptdSpawnArgs": []string{"--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"},
 					"cryptSharedLibPath":   os.Getenv("CRYPT_SHARED_LIB_PATH"),
@@ -1174,10 +1174,10 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		}
 		decodeJSONFile(mt, "change-streams-test.json", &testConfig)
 
-		schemaMap := map[string]interface{}{
+		schemaMap := map[string]any{
 			"db.coll": testConfig.JSONSchema,
 		}
-		kmsProviders := map[string]map[string]interface{}{
+		kmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -1318,7 +1318,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				d := newDeadlockTest(mt)
 				defer d.disconnect(mt)
 
-				kmsProviders := map[string]map[string]interface{}{
+				kmsProviders := map[string]map[string]any{
 					"local": {"key": localMasterKey},
 				}
 				aeOpts := options.AutoEncryption()
@@ -1449,7 +1449,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			mt.Fatal("Env vars CSFLE_TLS_CA_FILE and CSFLE_TLS_CLIENT_CERT_FILE must be set")
 		}
 
-		validKmsProviders := map[string]map[string]interface{}{
+		validKmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -1470,7 +1470,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			},
 		}
 
-		expiredKmsProviders := map[string]map[string]interface{}{
+		expiredKmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -1491,7 +1491,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			},
 		}
 
-		invalidKmsProviders := map[string]map[string]interface{}{
+		invalidKmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -1518,7 +1518,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			SetKeyVaultNamespace(kvNamespace)
 
 		// make TLS opts containing client certificate and CA file
-		clientAndCATLSConfig, err := options.BuildTLSConfig(map[string]interface{}{
+		clientAndCATLSConfig, err := options.BuildTLSConfig(map[string]any{
 			"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 			"tlsCAFile":             tlsCAFileKMIP,
 		})
@@ -1536,7 +1536,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			})
 
 		// make TLS opts containing only CA file
-		caTLSConfig, err := options.BuildTLSConfig(map[string]interface{}{
+		caTLSConfig, err := options.BuildTLSConfig(map[string]any{
 			"tlsCAFile": tlsCAFileKMIP,
 		})
 		assert.Nil(mt, err, "BuildTLSConfig error: %v", err)
@@ -1563,44 +1563,44 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				"kmip":  caTLSConfig,
 			})
 
-		awsMasterKeyNoClientCert := map[string]interface{}{
+		awsMasterKeyNoClientCert := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "127.0.0.1:9002",
 		}
-		awsMasterKeyWithTLS := map[string]interface{}{
+		awsMasterKeyWithTLS := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "127.0.0.1:9002",
 		}
-		awsMasterKeyExpired := map[string]interface{}{
+		awsMasterKeyExpired := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "127.0.0.1:9000",
 		}
-		awsMasterKeyInvalidHostname := map[string]interface{}{
+		awsMasterKeyInvalidHostname := map[string]any{
 			"region":   "us-east-1",
 			"key":      "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 			"endpoint": "127.0.0.1:9001",
 		}
-		azureMasterKey := map[string]interface{}{
+		azureMasterKey := map[string]any{
 			"keyVaultEndpoint": "doesnotexist.invalid",
 			"keyName":          "foo",
 		}
-		gcpMasterKey := map[string]interface{}{
+		gcpMasterKey := map[string]any{
 			"projectId": "foo",
 			"location":  "bar",
 			"keyRing":   "baz",
 			"keyName":   "foo",
 		}
-		kmipMasterKey := map[string]interface{}{}
+		kmipMasterKey := map[string]any{}
 
 		testCases := []struct {
 			name                     string
-			masterKeyNoClientCert    interface{}
-			masterKeyWithTLS         interface{}
-			masterKeyExpired         interface{}
-			masterKeyInvalidHostname interface{}
+			masterKeyNoClientCert    any
+			masterKeyWithTLS         any
+			masterKeyExpired         any
+			masterKeyInvalidHostname any
 			tlsError                 string
 			expiredError             string
 			invalidHostnameError     string
@@ -2020,7 +2020,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 			tlsConfig := make(map[string]*tls.Config)
 			if tlsCAFileKMIP != "" && tlsClientCertificateKeyFileKMIP != "" {
-				tlsOpts := map[string]interface{}{
+				tlsOpts := map[string]any{
 					"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 					"tlsCAFile":             tlsCAFileKMIP,
 				}
@@ -2161,7 +2161,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 	mt.RunOpts("18. Azure IMDS Credentials", noClientOpts, func(mt *mtest.T) {
 		buf := new(bytes.Buffer)
-		kmsProvidersMap := map[string]map[string]interface{}{
+		kmsProvidersMap := map[string]map[string]any{
 			"azure": {},
 		}
 		vw := bson.NewDocumentWriter(buf)
@@ -2270,7 +2270,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 				return
 			}
 
-			kmsProviders := map[string]map[string]interface{}{
+			kmsProviders := map[string]map[string]any{
 				"local": {
 					"key": localMasterKey,
 				},
@@ -2284,7 +2284,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			defer listener.Close()
 
 			uri := "mongodb://" + listener.Addr().String()
-			mongocryptdSpawnArgs := map[string]interface{}{
+			mongocryptdSpawnArgs := map[string]any{
 				"mongocryptdURI":     uri,
 				"cryptSharedLibPath": cryptSharedLibPath,
 			}
@@ -3011,7 +3011,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 		tlsCAFile := os.Getenv("KMS_FAILPOINT_CA_FILE")
 		require.NotEqual(mt, tlsCAFile, "", "failed to load CA file")
 
-		clientAndCATlsMap := map[string]interface{}{
+		clientAndCATlsMap := map[string]any{
 			"tlsCAFile": tlsCAFile,
 		}
 		tlsCfg, err := options.BuildTLSConfig(clientAndCATlsMap)
@@ -3037,7 +3037,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 			return res.Body.Close()
 		}
 
-		kmsProviders := map[string]map[string]interface{}{
+		kmsProviders := map[string]map[string]any{
 			"aws": {
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
@@ -3057,7 +3057,7 @@ func TestClientSideEncryptionProse(t *testing.T) {
 
 		dataKeys := []struct {
 			provider  string
-			masterKey interface{}
+			masterKey any
 		}{
 			{"aws", bson.D{
 				{"region", "foo"},
@@ -3235,7 +3235,7 @@ func readJSONFile(mt *mtest.T, file string) bson.Raw {
 	return doc
 }
 
-func decodeJSONFile(mt *mtest.T, file string, val interface{}) bson.Raw {
+func decodeJSONFile(mt *mtest.T, file string, val any) bson.Raw {
 	mt.Helper()
 
 	content, err := ioutil.ReadFile(filepath.Join(clientEncryptionProseDir, file))
@@ -3303,7 +3303,7 @@ func newDeadlockTest(mt *mtest.T) *deadlockTest {
 	err = d.clientTest.Database("db").CreateCollection(context.Background(), "coll", createOpts)
 	assert.Nil(mt, err, "CreateCollection error: %v", err)
 
-	kmsProviders := map[string]map[string]interface{}{
+	kmsProviders := map[string]map[string]any{
 		"local": {"key": localMasterKey},
 	}
 	ceOpts := options.ClientEncryption().SetKmsProviders(kmsProviders).SetKeyVaultNamespace("keyvault.datakeys")

--- a/internal/integration/client_side_encryption_test.go
+++ b/internal/integration/client_side_encryption_test.go
@@ -37,7 +37,7 @@ func createDataKeyAndEncrypt(mt *mtest.T, keyName string) bson.Binary {
 
 	integtest.AddTestServerAPIVersion(kvClientOpts)
 
-	kmsProvidersMap := map[string]map[string]interface{}{
+	kmsProvidersMap := map[string]map[string]any{
 		"local": {"key": localMasterKey},
 	}
 
@@ -95,7 +95,7 @@ func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 	verifyClientSideEncryptionVarsSet(t)
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").Enterprise(true).CreateClient(false))
 
-	kmsProvidersMap := map[string]map[string]interface{}{
+	kmsProvidersMap := map[string]map[string]any{
 		"local": {"key": localMasterKey},
 	}
 
@@ -111,7 +111,7 @@ func TestClientSideEncryptionWithExplicitSessions(t *testing.T) {
 			}},
 		}},
 	}
-	schemaMap := map[string]interface{}{"db.coll": schema}
+	schemaMap := map[string]any{"db.coll": schema}
 
 	mt.Run("automatic encryption", func(mt *mtest.T) {
 		createDataKeyAndEncrypt(mt, "myKey")
@@ -343,7 +343,7 @@ func (c *customCrypt) RewrapDataKey(_ context.Context, _ []byte,
 func TestClientSideEncryptionCustomCrypt(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.2").Enterprise(true).CreateClient(false))
 
-	kmsProvidersMap := map[string]map[string]interface{}{
+	kmsProvidersMap := map[string]map[string]any{
 		"local": {"key": localMasterKey},
 	}
 
@@ -493,7 +493,7 @@ func TestFLE2DocsExample(t *testing.T) {
 			assert.Nil(mt, err, "error in Drop: %v", err)
 		}
 
-		kmsProvidersMap := map[string]map[string]interface{}{
+		kmsProvidersMap := map[string]map[string]any{
 			"local": {"key": localMasterKey},
 		}
 
@@ -618,7 +618,7 @@ func TestFLE2CreateCollectionWithAutoEncryption(t *testing.T) {
 			assert.Nil(mt, err, "error in Drop: %v", err)
 		}
 
-		kmsProvidersMap := map[string]map[string]interface{}{
+		kmsProvidersMap := map[string]map[string]any{
 			"local": {"key": localMasterKey},
 		}
 

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -871,9 +871,9 @@ func TestClient_BSONOptions(t *testing.T) {
 	testCases := []struct {
 		name       string
 		bsonOpts   *options.BSONOptions
-		doc        interface{}
-		decodeInto func() interface{}
-		want       interface{}
+		doc        any
+		decodeInto func() any
+		want       any
 		wantRaw    bson.Raw
 	}{
 		{
@@ -886,7 +886,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				B: "banana",
 				C: "carrot",
 			},
-			decodeInto: func() interface{} { return &jsonTagsTest{} },
+			decodeInto: func() any { return &jsonTagsTest{} },
 			want: &jsonTagsTest{
 				A: "apple",
 				B: "banana",
@@ -904,7 +904,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				IntMinSize: true,
 			},
 			doc:        bson.D{{Key: "x", Value: int64(1)}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "x", Value: int32(1)}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendInt32("x", 1).
@@ -916,7 +916,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				NilMapAsEmpty: true,
 			},
 			doc:        bson.D{{Key: "x", Value: map[string]string(nil)}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "x", Value: bson.D{}}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendDocument("x", bsoncore.NewDocumentBuilder().Build()).
@@ -928,7 +928,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				NilSliceAsEmpty: true,
 			},
 			doc:        bson.D{{Key: "x", Value: []int(nil)}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "x", Value: bson.A{}}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendArray("x", bsoncore.NewDocumentBuilder().Build()).
@@ -940,7 +940,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				NilByteSliceAsEmpty: true,
 			},
 			doc:        bson.D{{Key: "x", Value: []byte(nil)}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "x", Value: bson.Binary{Data: []byte{}}}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendBinary("x", 0, nil).
@@ -952,7 +952,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				OmitZeroStruct: true,
 			},
 			doc:        omitemptyTest{},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{},
 			wantRaw:    bson.Raw(bsoncore.NewDocumentBuilder().Build()),
 		},
@@ -965,7 +965,7 @@ func TestClient_BSONOptions(t *testing.T) {
 			doc: struct {
 				X jsonTagsTest `bson:"x"`
 			}{},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{},
 			wantRaw:    bson.Raw(bsoncore.NewDocumentBuilder().Build()),
 		},
@@ -975,7 +975,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				StringifyMapKeysWithFmt: true,
 			},
 			doc:        map[intKey]string{intKey(42): "foo"},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{"42", "foo"}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendString("42", "foo").
@@ -987,7 +987,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				AllowTruncatingDoubles: true,
 			},
 			doc:        bson.D{{Key: "x", Value: 3.14}},
-			decodeInto: func() interface{} { return &truncatingDoublesTest{} },
+			decodeInto: func() any { return &truncatingDoublesTest{} },
 			want:       &truncatingDoublesTest{3},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendDouble("x", 3.14).
@@ -999,7 +999,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				BinaryAsSlice: true,
 			},
 			doc:        bson.D{{Key: "x", Value: []byte{42}}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "x", Value: []byte{42}}},
 			wantRaw: bson.Raw(bsoncore.NewDocumentBuilder().
 				AppendBinary("x", 0, []byte{42}).
@@ -1011,7 +1011,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				DefaultDocumentM: true,
 			},
 			doc:        bson.D{{Key: "doc", Value: bson.D{{Key: "a", Value: int64(1)}}}},
-			decodeInto: func() interface{} { return &bson.D{} },
+			decodeInto: func() any { return &bson.D{} },
 			want:       &bson.D{{Key: "doc", Value: bson.M{"a": int64(1)}}},
 		},
 		{
@@ -1020,7 +1020,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				UseLocalTimeZone: true,
 			},
 			doc:        bson.D{{Key: "x", Value: timestamp}},
-			decodeInto: func() interface{} { return &timeZoneTest{} },
+			decodeInto: func() any { return &timeZoneTest{} },
 			want:       &timeZoneTest{timestamp.In(time.Local)},
 		},
 		{
@@ -1029,7 +1029,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				ZeroMaps: true,
 			},
 			doc: bson.D{{"a", "apple"}, {"b", "banana"}},
-			decodeInto: func() interface{} {
+			decodeInto: func() any {
 				return &map[string]string{
 					"b": "berry",
 					"c": "carrot",
@@ -1046,7 +1046,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				ZeroStructs: true,
 			},
 			doc: bson.D{{"a", "apple"}, {"x", "broccoli"}},
-			decodeInto: func() interface{} {
+			decodeInto: func() any {
 				return &jsonTagsTest{
 					B: "banana",
 					C: "carrot",
@@ -1160,7 +1160,7 @@ func TestClientStress(t *testing.T) {
 		findOne := func(coll *mongo.Collection, timeout time.Duration) error {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			var res map[string]interface{}
+			var res map[string]any
 			return coll.FindOne(ctx, bson.D{{Key: "_id", Value: oid}}).Decode(&res)
 		}
 

--- a/internal/integration/cmd_monitoring_helpers_test.go
+++ b/internal/integration/cmd_monitoring_helpers_test.go
@@ -295,7 +295,7 @@ func checkExpectations(mt *mtest.T, expectations *[]*expectation, id0, id1 bson.
 }
 
 // newMatchError appends `expected` and `actual` BSON data to an error.
-func newMatchError(mt *mtest.T, expected bson.Raw, actual bson.Raw, format string, args ...interface{}) error {
+func newMatchError(mt *mtest.T, expected bson.Raw, actual bson.Raw, format string, args ...any) error {
 	mt.Helper()
 	msg := fmt.Sprintf(format, args...)
 	expectedJSON, err := bson.MarshalExtJSON(expected, true, false)

--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -127,7 +127,7 @@ func TestCollection(t *testing.T) {
 
 			want1 := int32(11)
 			want2 := int32(12)
-			docs := []interface{}{
+			docs := []any{
 				bson.D{{"_id", want1}},
 				bson.D{{"x", 6}},
 				bson.D{{"_id", want2}},
@@ -147,7 +147,7 @@ func TestCollection(t *testing.T) {
 				megabyte = 10 * 10 * 10 * 10 * 10 * 10
 				numDocs  = 700000
 			)
-			var docs []interface{}
+			var docs []any
 			total := uint32(0)
 			expectedDocSize := uint32(26)
 			for i := 0; i < numDocs; i++ {
@@ -169,7 +169,7 @@ func TestCollection(t *testing.T) {
 		mt.Run("large document batches", func(mt *mtest.T) {
 			mt.Parallel()
 
-			docs := []interface{}{create16MBDocument(mt), create16MBDocument(mt), create16MBDocument(mt)}
+			docs := []any{create16MBDocument(mt), create16MBDocument(mt), create16MBDocument(mt)}
 			_, err := mt.Coll.InsertMany(context.Background(), docs)
 			assert.Nil(mt, err, "InsertMany error: %v", err)
 			evt := mt.GetStartedEvent()
@@ -180,7 +180,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("write error", noClientOpts, func(mt *mtest.T) {
 			mt.Parallel()
 
-			docs := []interface{}{
+			docs := []any{
 				bson.D{{"_id", bson.NewObjectID()}},
 				bson.D{{"_id", bson.NewObjectID()}},
 				bson.D{{"_id", bson.NewObjectID()}},
@@ -213,7 +213,7 @@ func TestCollection(t *testing.T) {
 			mt.Parallel()
 
 			id := int32(15)
-			docs := []interface{}{
+			docs := []any{
 				bson.D{{"_id", id}},
 				bson.D{{"_id", id}},
 				bson.D{{"x", 6}},
@@ -262,7 +262,7 @@ func TestCollection(t *testing.T) {
 
 			// force multiple batches
 			numDocs := 700000
-			var docs []interface{}
+			var docs []any
 			for i := 0; i < numDocs; i++ {
 				d := bson.D{
 					{"a", int32(i)},
@@ -287,7 +287,7 @@ func TestCollection(t *testing.T) {
 		wcCollOpts := options.Collection().SetWriteConcern(impossibleWc)
 		wcTestOpts := mtest.NewOptions().CollectionOptions(wcCollOpts).Topologies(mtest.ReplicaSet)
 		mt.RunOpts("write concern error", wcTestOpts, func(mt *mtest.T) {
-			_, err := mt.Coll.InsertMany(context.Background(), []interface{}{bson.D{{"_id", 1}}})
+			_, err := mt.Coll.InsertMany(context.Background(), []any{bson.D{{"_id", 1}}})
 			we, ok := err.(mongo.BulkWriteException)
 			assert.True(mt, ok, "expected error type %v, got %v", mongo.BulkWriteException{}, err)
 			assert.NotNil(mt, we.WriteConcernError, "expected write concern error, got %+v", err)
@@ -505,7 +505,7 @@ func TestCollection(t *testing.T) {
 
 			testCases := []struct {
 				name   string
-				update interface{}
+				update any
 			}{
 				{"bson Document", bsoncore.Document(docBytes)},
 				{"bson Raw", bson.Raw(docBytes)},
@@ -538,7 +538,7 @@ func TestCollection(t *testing.T) {
 		mt.RunOpts("found", noClientOpts, func(mt *mtest.T) {
 			testCases := []struct {
 				name string
-				id   interface{}
+				id   any
 			}{
 				{"objectID", bson.NewObjectID()},
 				{"string", "foo"},
@@ -1049,7 +1049,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					var insertDocs []interface{}
+					var insertDocs []any
 					for i := 1; i <= 201; i++ {
 						insertDocs = append(insertDocs, bson.D{{"x", int32(i)}})
 					}
@@ -1062,7 +1062,7 @@ func TestCollection(t *testing.T) {
 					cursor, err := mt.Coll.Find(context.Background(), bson.D{}, findOptions)
 					assert.Nil(mt, err, "Find error: %v", err)
 
-					var docs []interface{}
+					var docs []any
 					err = cursor.All(context.Background(), &docs)
 					assert.Nil(mt, err, "All error: %v", err)
 					if (201 - tc.skip) < tc.limit {
@@ -1097,7 +1097,7 @@ func TestCollection(t *testing.T) {
 			}
 			for _, tc := range testCases {
 				mt.Run(tc.name, func(mt *mtest.T) {
-					var insertDocs []interface{}
+					var insertDocs []any
 					for i := 1; i <= 201; i++ {
 						insertDocs = append(insertDocs, bson.D{{"x", int32(i)}})
 					}
@@ -1108,7 +1108,7 @@ func TestCollection(t *testing.T) {
 					cursor, err := mt.Coll.Find(context.Background(), bson.D{}, opts)
 					assert.Nil(mt, err, "Find error with limit %v: %v", tc.limit, err)
 
-					var docs []interface{}
+					var docs []any
 					err = cursor.All(context.Background(), &docs)
 					assert.Nil(mt, err, "All error with limit %v: %v", tc.limit, err)
 
@@ -1511,7 +1511,7 @@ func TestCollection(t *testing.T) {
 		})
 
 		mt.Run("insert many", func(mt *mtest.T) {
-			docs := []interface{}{
+			docs := []any{
 				bson.D{{"x", 1}},
 				bson.D{{"y", 1}},
 			}
@@ -2031,7 +2031,7 @@ func TestCollection(t *testing.T) {
 func initCollection(mt *mtest.T, coll *mongo.Collection) {
 	mt.Helper()
 
-	var docs []interface{}
+	var docs []any
 	for i := 1; i <= 5; i++ {
 		docs = append(docs, bson.D{{"x", int32(i)}})
 	}

--- a/internal/integration/crud_helpers_test.go
+++ b/internal/integration/crud_helpers_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 // create an update document or pipeline from a bson.RawValue
-func createUpdate(mt *mtest.T, updateVal bson.RawValue) interface{} {
+func createUpdate(mt *mtest.T, updateVal bson.RawValue) any {
 	switch updateVal.Type {
 	case bson.TypeEmbeddedDocument:
 		return updateVal.Document()
@@ -64,10 +64,10 @@ func createUpdate(mt *mtest.T, updateVal bson.RawValue) interface{} {
 }
 
 // create a hint string or document from a bson.RawValue
-func createHint(mt *mtest.T, val bson.RawValue) interface{} {
+func createHint(mt *mtest.T, val bson.RawValue) any {
 	mt.Helper()
 
-	var hint interface{}
+	var hint any
 	switch val.Type {
 	case bson.TypeString:
 		hint = val.StringValue()
@@ -155,18 +155,18 @@ func runCommandOnAllServers(commandFn func(client *mongo.Client) error) error {
 
 // aggregator is an interface used to run collection and database-level aggregations
 type aggregator interface {
-	Aggregate(context.Context, interface{}, ...options.Lister[options.AggregateOptions]) (*mongo.Cursor, error)
+	Aggregate(context.Context, any, ...options.Lister[options.AggregateOptions]) (*mongo.Cursor, error)
 }
 
 // watcher is an interface used to create client, db, and collection-level change streams
 type watcher interface {
-	Watch(context.Context, interface{}, ...options.Lister[options.ChangeStreamOptions]) (*mongo.ChangeStream, error)
+	Watch(context.Context, any, ...options.Lister[options.ChangeStreamOptions]) (*mongo.ChangeStream, error)
 }
 
 func executeAggregate(mt *mtest.T, agg aggregator, sess *mongo.Session, args bson.Raw) (*mongo.Cursor, error) {
 	mt.Helper()
 
-	var pipeline []interface{}
+	var pipeline []any
 	opts := options.Aggregate()
 
 	elems, _ := args.Elements()
@@ -204,7 +204,7 @@ func executeAggregate(mt *mtest.T, agg aggregator, sess *mongo.Session, args bso
 func executeWatch(mt *mtest.T, w watcher, sess *mongo.Session, args bson.Raw) (*mongo.ChangeStream, error) {
 	mt.Helper()
 
-	pipeline := []interface{}{}
+	pipeline := []any{}
 	elems, _ := args.Elements()
 	for _, elem := range elems {
 		key := elem.Key()
@@ -305,7 +305,7 @@ func executeInsertOne(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.I
 func executeInsertMany(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.InsertManyResult, error) {
 	mt.Helper()
 
-	var docs []interface{}
+	var docs []any
 	opts := options.InsertMany()
 
 	elems, _ := args.Elements()
@@ -691,7 +691,7 @@ func executeFindOneAndUpdate(mt *mtest.T, sess *mongo.Session, args bson.Raw) *m
 	mt.Helper()
 
 	filter := emptyDoc
-	var update interface{} = emptyDoc
+	var update any = emptyDoc
 	opts := options.FindOneAndUpdate()
 
 	elems, _ := args.Elements()
@@ -873,7 +873,7 @@ func executeUpdateOne(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.U
 	mt.Helper()
 
 	filter := emptyDoc
-	var update interface{} = emptyDoc
+	var update any = emptyDoc
 	opts := options.UpdateOne()
 
 	elems, _ := args.Elements()
@@ -925,7 +925,7 @@ func executeUpdateMany(mt *mtest.T, sess *mongo.Session, args bson.Raw) (*mongo.
 	mt.Helper()
 
 	filter := emptyDoc
-	var update interface{} = emptyDoc
+	var update any = emptyDoc
 	opts := options.UpdateMany()
 
 	elems, _ := args.Elements()
@@ -1066,7 +1066,7 @@ func executeWithTransaction(mt *mtest.T, sess *mongo.Session, args bson.Raw) err
 	assert.Nil(mt, err, "error creating withTransactionArgs: %v", err)
 	opts := createTransactionOptions(mt, testArgs.Options)
 
-	_, err = sess.WithTransaction(context.Background(), func(_ context.Context) (interface{}, error) {
+	_, err = sess.WithTransaction(context.Background(), func(_ context.Context) (any, error) {
 		err := runWithTransactionOperations(mt, testArgs.Callback.Operations, sess)
 		return nil, err
 	}, opts)
@@ -1437,7 +1437,7 @@ func executeAdminCommand(mt *mtest.T, op *operation) {
 func executeAdminCommandWithRetry(
 	mt *mtest.T,
 	client *mongo.Client,
-	cmd interface{},
+	cmd any,
 	opts ...options.Lister[options.RunCmdOptions],
 ) {
 	mt.Helper()
@@ -1459,7 +1459,7 @@ func executeAdminCommandWithRetry(
 }
 
 // verification function to use for all count operations
-func verifyCountResult(mt *mtest.T, actualResult int64, expectedResult interface{}) {
+func verifyCountResult(mt *mtest.T, actualResult int64, expectedResult any) {
 	mt.Helper()
 	if expectedResult == nil {
 		return
@@ -1470,7 +1470,7 @@ func verifyCountResult(mt *mtest.T, actualResult int64, expectedResult interface
 	assert.Equal(mt, *expected, actualResult, "count mismatch; expected %v, got %v", *expected, actualResult)
 }
 
-func verifyBulkWriteResult(mt *mtest.T, actualResult *mongo.BulkWriteResult, expectedResult interface{}) {
+func verifyBulkWriteResult(mt *mtest.T, actualResult *mongo.BulkWriteResult, expectedResult any) {
 	mt.Helper()
 
 	if expectedResult == nil {
@@ -1478,12 +1478,12 @@ func verifyBulkWriteResult(mt *mtest.T, actualResult *mongo.BulkWriteResult, exp
 	}
 
 	var expected struct {
-		InsertedCount int64                  `bson:"insertedCount"`
-		MatchedCount  int64                  `bson:"matchedCount"`
-		ModifiedCount int64                  `bson:"modifiedCount"`
-		DeletedCount  int64                  `bson:"deletedCount"`
-		UpsertedCount int64                  `bson:"upsertedCount"`
-		UpsertedIDs   map[string]interface{} `bson:"upsertedIds"`
+		InsertedCount int64          `bson:"insertedCount"`
+		MatchedCount  int64          `bson:"matchedCount"`
+		ModifiedCount int64          `bson:"modifiedCount"`
+		DeletedCount  int64          `bson:"deletedCount"`
+		UpsertedCount int64          `bson:"upsertedCount"`
+		UpsertedIDs   map[string]any `bson:"upsertedIds"`
 	}
 	err := bson.Unmarshal(expectedResult.(bson.Raw), &expected)
 	assert.Nil(mt, err, "error creating BulkWriteResult: %v", err)
@@ -1510,7 +1510,7 @@ func verifyBulkWriteResult(mt *mtest.T, actualResult *mongo.BulkWriteResult, exp
 	}
 }
 
-func verifyUpdateResult(mt *mtest.T, res *mongo.UpdateResult, result interface{}) {
+func verifyUpdateResult(mt *mtest.T, res *mongo.UpdateResult, result any) {
 	mt.Helper()
 
 	if result == nil {
@@ -1538,7 +1538,7 @@ func verifyUpdateResult(mt *mtest.T, res *mongo.UpdateResult, result interface{}
 		"upserted count mismatch; expected %v, got %v", expected.UpsertedCount, actualUpsertedCount)
 }
 
-func verifyDeleteResult(mt *mtest.T, res *mongo.DeleteResult, result interface{}) {
+func verifyDeleteResult(mt *mtest.T, res *mongo.DeleteResult, result any) {
 	mt.Helper()
 
 	if result == nil {
@@ -1557,7 +1557,7 @@ func verifyDeleteResult(mt *mtest.T, res *mongo.DeleteResult, result interface{}
 func verifyDistinctResult(
 	mt *mtest.T,
 	got bson.RawArray,
-	want interface{},
+	want any,
 ) {
 	mt.Helper()
 
@@ -1585,7 +1585,7 @@ func verifyDistinctResult(
 	}
 }
 
-func verifyInsertOneResult(mt *mtest.T, actualResult *mongo.InsertOneResult, expectedResult interface{}) {
+func verifyInsertOneResult(mt *mtest.T, actualResult *mongo.InsertOneResult, expectedResult any) {
 	mt.Helper()
 
 	if expectedResult == nil {
@@ -1608,7 +1608,7 @@ func verifyInsertOneResult(mt *mtest.T, actualResult *mongo.InsertOneResult, exp
 	}
 }
 
-func verifyInsertManyResult(mt *mtest.T, actualResult *mongo.InsertManyResult, expectedResult interface{}) {
+func verifyInsertManyResult(mt *mtest.T, actualResult *mongo.InsertManyResult, expectedResult any) {
 	mt.Helper()
 
 	if expectedResult == nil {
@@ -1616,7 +1616,7 @@ func verifyInsertManyResult(mt *mtest.T, actualResult *mongo.InsertManyResult, e
 	}
 
 	assert.NotNil(mt, actualResult, "expected InsertMany result %v but got nil", expectedResult)
-	var expected struct{ InsertedIDs map[string]interface{} }
+	var expected struct{ InsertedIDs map[string]any }
 	err := bson.Unmarshal(expectedResult.(bson.Raw), &expected)
 	assert.Nil(mt, err, "error creating expected InsertMany result: %v", err)
 
@@ -1633,7 +1633,7 @@ func verifyInsertManyResult(mt *mtest.T, actualResult *mongo.InsertManyResult, e
 	}
 }
 
-func verifyListDatabasesResult(mt *mtest.T, actualResult mongo.ListDatabasesResult, expectedResult interface{}) {
+func verifyListDatabasesResult(mt *mtest.T, actualResult mongo.ListDatabasesResult, expectedResult any) {
 	mt.Helper()
 
 	if expectedResult == nil {
@@ -1647,7 +1647,7 @@ func verifyListDatabasesResult(mt *mtest.T, actualResult mongo.ListDatabasesResu
 	assert.Equal(mt, expected, actualResult, "ListDatabasesResult mismatch; expected %v, got %v", expected, actualResult)
 }
 
-func verifyCursorResult(mt *mtest.T, cur *mongo.Cursor, result interface{}) {
+func verifyCursorResult(mt *mtest.T, cur *mongo.Cursor, result any) {
 	mt.Helper()
 
 	// The Atlas Data Lake tests expect a getMore to be sent even though the operation does not have a Result field.
@@ -1673,7 +1673,7 @@ func verifyCursorResult(mt *mtest.T, cur *mongo.Cursor, result interface{}) {
 func verifySingleResult(
 	mt *mtest.T,
 	actualResult *mongo.SingleResult,
-	expectedResult interface{},
+	expectedResult any,
 ) {
 	mt.Helper()
 

--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -51,7 +51,7 @@ func TestWriteErrorsWithLabels(t *testing.T) {
 		})
 
 		_, err := mt.Coll.InsertMany(context.Background(),
-			[]interface{}{
+			[]any{
 				bson.D{
 					{"a", 1},
 				},
@@ -169,7 +169,7 @@ func TestWriteErrorsDetails(t *testing.T) {
 				desc: "InsertMany schema validation errors should include Details",
 				operation: func(coll *mongo.Collection) error {
 					// Try to insert a document that doesn't contain the required properties.
-					_, err := coll.InsertMany(context.Background(), []interface{}{bson.D{{"nope", 1}}})
+					_, err := coll.InsertMany(context.Background(), []any{bson.D{{"nope", 1}}})
 					return err
 				},
 				expectBulkError:     true,
@@ -210,7 +210,7 @@ func TestWriteErrorsDetails(t *testing.T) {
 				{
 					_, err := mt.Coll.InsertMany(
 						context.Background(),
-						[]interface{}{
+						[]any{
 							bson.D{{"a", "str1"}, {"b", 1}},
 							bson.D{{"a", "str2"}, {"b", 2}},
 						})
@@ -704,7 +704,7 @@ func TestClientBulkWriteProse(t *testing.T) {
 					},
 				},
 			}
-			result, err := session.WithTransaction(context.Background(), func(ctx context.Context) (interface{}, error) {
+			result, err := session.WithTransaction(context.Background(), func(ctx context.Context) (any, error) {
 				return mt.Client.BulkWrite(ctx, models, options.ClientBulkWrite().SetVerboseResults(true))
 			})
 			require.NoError(mt, err, "BulkWrite error: %v", err)
@@ -935,7 +935,7 @@ func TestClientBulkWriteProse(t *testing.T) {
 
 		autoEncryptionOpts := options.AutoEncryption().
 			SetKeyVaultNamespace("db.coll").
-			SetKmsProviders(map[string]map[string]interface{}{
+			SetKmsProviders(map[string]map[string]any{
 				"aws": {
 					"accessKeyId":     "foo",
 					"secretAccessKey": "bar",
@@ -961,7 +961,7 @@ func TestClientBulkWriteProse(t *testing.T) {
 		type cmd struct {
 			Ops          []bson.D
 			WriteConcern struct {
-				W interface{}
+				W any
 			}
 		}
 		var bwCmd []cmd

--- a/internal/integration/csot_cse_prose_test.go
+++ b/internal/integration/csot_cse_prose_test.go
@@ -29,12 +29,12 @@ func TestCSOTClientSideEncryptionProse(t *testing.T) {
 
 	mt.RunOpts("2. maxTimeMS is not set for commands sent to mongocryptd",
 		noClientOpts, func(mt *mtest.T) {
-			kmsProviders := map[string]map[string]interface{}{
+			kmsProviders := map[string]map[string]any{
 				"local": {
 					"key": localMasterKey,
 				},
 			}
-			mongocryptdSpawnArgs := map[string]interface{}{
+			mongocryptdSpawnArgs := map[string]any{
 				// Pass a custom pidfilepath to ensure a new mongocryptd process is spawned.
 				"mongocryptdSpawnArgs": []string{"--port=23000", "--pidfilepath=TestCSOTClientSideEncryptionProse_1.pid"},
 				"mongocryptdURI":       "mongodb://localhost:23000",

--- a/internal/integration/csot_prose_test.go
+++ b/internal/integration/csot_prose_test.go
@@ -78,7 +78,7 @@ func TestCSOTProse(t *testing.T) {
 			bigStringBuilder.WriteByte('a')
 		}
 		bigString := bigStringBuilder.String()
-		var docs []interface{}
+		var docs []any
 		for i := 0; i < 50; i++ {
 			docs = append(docs, bson.D{{"1mb", bigString}})
 		}

--- a/internal/integration/csot_test.go
+++ b/internal/integration/csot_test.go
@@ -119,7 +119,7 @@ func TestCSOT_maxTimeMS(t *testing.T) {
 			desc:        "InsertMany",
 			commandName: "insert",
 			operation: func(ctx context.Context, coll *mongo.Collection) error {
-				_, err := coll.InsertMany(ctx, []interface{}{bson.D{}})
+				_, err := coll.InsertMany(ctx, []any{bson.D{}})
 				return err
 			},
 			sendsMaxTimeMS: true,
@@ -207,7 +207,7 @@ func TestCSOT_maxTimeMS(t *testing.T) {
 			desc:        "Cursor getMore",
 			commandName: "getMore",
 			setup: func(coll *mongo.Collection) error {
-				_, err := coll.InsertMany(context.Background(), []interface{}{bson.D{}, bson.D{}})
+				_, err := coll.InsertMany(context.Background(), []any{bson.D{}, bson.D{}})
 				return err
 			},
 			operation: func(ctx context.Context, coll *mongo.Collection) error {

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -345,7 +345,7 @@ func TestDatabase(t *testing.T) {
 	})
 
 	mt.RunOpts("run command cursor", noClientOpts, func(mt *mtest.T) {
-		var data []interface{}
+		var data []any
 		for i := 0; i < 5; i++ {
 			data = append(data, bson.D{{"x", i}})
 		}
@@ -363,8 +363,8 @@ func TestDatabase(t *testing.T) {
 		testCases := []struct {
 			name        string
 			collName    string
-			cmd         interface{}
-			toInsert    []interface{}
+			cmd         any
+			toInsert    []any
 			expectedErr error
 			numExpected int
 			minVersion  string

--- a/internal/integration/gridfs_test.go
+++ b/internal/integration/gridfs_test.go
@@ -269,7 +269,7 @@ func TestGridFS(x *testing.T) {
 
 			testCases := []struct {
 				name   string
-				fileID interface{}
+				fileID any
 			}{
 				{"default ID", nil},
 				{"custom ID type", "customID"},

--- a/internal/integration/index_view_test.go
+++ b/internal/integration/index_view_test.go
@@ -214,7 +214,7 @@ func TestIndexView(t *testing.T) {
 				name             string
 				opts             *options.CreateIndexesOptionsBuilder
 				expectError      bool
-				expectedValue    interface{} // ignored if expectError is true
+				expectedValue    any // ignored if expectError is true
 				minServerVersion string
 				maxServerVersion string
 			}{
@@ -239,7 +239,7 @@ func TestIndexView(t *testing.T) {
 					sentBSONValue, err := cmd.LookupErr("commitQuorum")
 					assert.Nil(mt, err, "expected commitQuorum in command %s", cmd)
 
-					var sentValue interface{}
+					var sentValue any
 					err = sentBSONValue.Unmarshal(&sentValue)
 					assert.Nil(mt, err, "Unmarshal error: %v", err)
 
@@ -360,7 +360,7 @@ func TestIndexView(t *testing.T) {
 				name             string
 				opts             *options.CreateIndexesOptionsBuilder
 				expectError      bool
-				expectedValue    interface{} // ignored if expectError is true
+				expectedValue    any // ignored if expectError is true
 				minServerVersion string
 				maxServerVersion string
 			}{
@@ -385,7 +385,7 @@ func TestIndexView(t *testing.T) {
 					sentBSONValue, err := cmd.LookupErr("commitQuorum")
 					assert.Nil(mt, err, "expected commitQuorum in command %s", cmd)
 
-					var sentValue interface{}
+					var sentValue any
 					err = sentBSONValue.Unmarshal(&sentValue)
 					assert.Nil(mt, err, "Unmarshal error: %v", err)
 

--- a/internal/integration/json_helpers_test.go
+++ b/internal/integration/json_helpers_test.go
@@ -141,7 +141,7 @@ func createAutoEncryptionOptions(t testing.TB, opts bson.Raw) *options.AutoEncry
 			tlsConfigs := createTLSOptsMap(t, opt.Document())
 			aeo.SetKmsProviders(createKmsProvidersMap(t, opt.Document())).SetTLSConfig(tlsConfigs)
 		case "schemaMap":
-			var schemaMap map[string]interface{}
+			var schemaMap map[string]any
 			err := bson.Unmarshal(opt.Document(), &schemaMap)
 			if err != nil {
 				t.Fatalf("error creating schema map: %v", err)
@@ -154,7 +154,7 @@ func createAutoEncryptionOptions(t testing.TB, opts bson.Raw) *options.AutoEncry
 		case "bypassAutoEncryption":
 			aeo.SetBypassAutoEncryption(opt.Boolean())
 		case "encryptedFieldsMap":
-			var encryptedFieldsMap map[string]interface{}
+			var encryptedFieldsMap map[string]any
 			err := bson.Unmarshal(opt.Document(), &encryptedFieldsMap)
 			if err != nil {
 				t.Fatalf("error creating encryptedFieldsMap: %v", err)
@@ -185,7 +185,7 @@ func createTLSOptsMap(t testing.TB, opts bson.Raw) map[string]*tls.Config {
 		provider := elem.Key()
 
 		if provider == "kmip" {
-			tlsOptsMap := map[string]interface{}{
+			tlsOptsMap := map[string]any{
 				"tlsCertificateKeyFile": tlsClientCertificateKeyFileKMIP,
 				"tlsCAFile":             tlsCAFileKMIP,
 			}
@@ -201,10 +201,10 @@ func createTLSOptsMap(t testing.TB, opts bson.Raw) map[string]*tls.Config {
 	return tlsMap
 }
 
-func createKmsProvidersMap(t testing.TB, opts bson.Raw) map[string]map[string]interface{} {
+func createKmsProvidersMap(t testing.TB, opts bson.Raw) map[string]map[string]any {
 	t.Helper()
 
-	kmsMap := make(map[string]map[string]interface{})
+	kmsMap := make(map[string]map[string]any)
 	elems, _ := opts.Elements()
 
 	for _, elem := range elems {
@@ -213,25 +213,25 @@ func createKmsProvidersMap(t testing.TB, opts bson.Raw) map[string]map[string]in
 
 		switch provider {
 		case "aws":
-			awsMap := map[string]interface{}{
+			awsMap := map[string]any{
 				"accessKeyId":     awsAccessKeyID,
 				"secretAccessKey": awsSecretAccessKey,
 			}
 			kmsMap["aws"] = awsMap
 		case "azure":
-			kmsMap["azure"] = map[string]interface{}{
+			kmsMap["azure"] = map[string]any{
 				"tenantId":     azureTenantID,
 				"clientId":     azureClientID,
 				"clientSecret": azureClientSecret,
 			}
 		case "gcp":
-			kmsMap["gcp"] = map[string]interface{}{
+			kmsMap["gcp"] = map[string]any{
 				"email":      gcpEmail,
 				"privateKey": gcpPrivateKey,
 			}
 		case "local":
 			_, key := providerOpt.Document().Lookup("key").Binary()
-			localMap := map[string]interface{}{
+			localMap := map[string]any{
 				"key": key,
 			}
 			kmsMap["local"] = localMap
@@ -245,7 +245,7 @@ func createKmsProvidersMap(t testing.TB, opts bson.Raw) map[string]map[string]in
 			if awsTempSessionToken == "" {
 				t.Fatal("AWS temp session token not set")
 			}
-			awsMap := map[string]interface{}{
+			awsMap := map[string]any{
 				"accessKeyId":     awsTempAccessKeyID,
 				"secretAccessKey": awsTempSecretAccessKey,
 				"sessionToken":    awsTempSessionToken,
@@ -258,13 +258,13 @@ func createKmsProvidersMap(t testing.TB, opts bson.Raw) map[string]map[string]in
 			if awsTempSecretAccessKey == "" {
 				t.Fatal("AWS temp secret access key not set")
 			}
-			awsMap := map[string]interface{}{
+			awsMap := map[string]any{
 				"accessKeyId":     awsTempAccessKeyID,
 				"secretAccessKey": awsTempSecretAccessKey,
 			}
 			kmsMap["aws"] = awsMap
 		case "kmip":
-			kmipMap := map[string]interface{}{
+			kmipMap := map[string]any{
 				"endpoint": "localhost:5698",
 			}
 			kmsMap["kmip"] = kmipMap
@@ -440,7 +440,7 @@ func createReadPref(opt bson.RawValue) *readpref.ReadPref {
 }
 
 // retrieve the error associated with a result.
-func errorFromResult(t testing.TB, result interface{}) *operationError {
+func errorFromResult(t testing.TB, result any) *operationError {
 	t.Helper()
 
 	// embedded doc will be unmarshalled as Raw
@@ -551,7 +551,7 @@ func verifyError(expected *operationError, actual error) error {
 }
 
 // get the underlying value of i as an int64. returns nil if i is not an int, int32, or int64 type.
-func getIntFromInterface(i interface{}) *int64 {
+func getIntFromInterface(i any) *int64 {
 	var out int64
 
 	switch v := i.(type) {

--- a/internal/integration/mock_find_test.go
+++ b/internal/integration/mock_find_test.go
@@ -19,24 +19,24 @@ import (
 
 // finder is an object that implements FindOne and Find.
 type finder interface {
-	FindOne(context.Context, interface{}, ...options.Lister[options.FindOneOptions]) *mongo.SingleResult
-	Find(context.Context, interface{}, ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
+	FindOne(context.Context, any, ...options.Lister[options.FindOneOptions]) *mongo.SingleResult
+	Find(context.Context, any, ...options.Lister[options.FindOptions]) (*mongo.Cursor, error)
 }
 
 // mockFinder implements finder.
 type mockFinder struct {
-	docs     []interface{}
+	docs     []any
 	err      error
 	registry *bson.Registry
 }
 
 // FindOne mocks a findOne operation using NewSingleResultFromDocument.
-func (mf *mockFinder) FindOne(_ context.Context, _ interface{}, _ ...options.Lister[options.FindOneOptions]) *mongo.SingleResult {
+func (mf *mockFinder) FindOne(_ context.Context, _ any, _ ...options.Lister[options.FindOneOptions]) *mongo.SingleResult {
 	return mongo.NewSingleResultFromDocument(mf.docs[0], mf.err, mf.registry)
 }
 
 // Find mocks a find operation using NewCursorFromDocuments.
-func (mf *mockFinder) Find(context.Context, interface{}, ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
+func (mf *mockFinder) Find(context.Context, any, ...options.Lister[options.FindOptions]) (*mongo.Cursor, error) {
 	return mongo.NewCursorFromDocuments(mf.docs, mf.err, mf.registry)
 }
 
@@ -69,12 +69,12 @@ func getItems(f finder) ([]ShopItem, error) {
 func TestMockFind(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
 
-	insertItems := []interface{}{
+	insertItems := []any{
 		ShopItem{ID: 0, Price: 1.5},
 		ShopItem{ID: 1, Price: 5.7},
 		ShopItem{ID: 2, Price: 0.25},
 	}
-	insertItem := []interface{}{ShopItem{ID: 1, Price: 5.7}}
+	insertItem := []any{ShopItem{ID: 1, Price: 5.7}}
 
 	mt.Run("mongo.Collection can be passed as interface", func(mt *mtest.T) {
 		// Actually insert documents to collection.

--- a/internal/integration/mtest/mongotest.go
+++ b/internal/integration/mtest/mongotest.go
@@ -394,7 +394,7 @@ type Collection struct {
 	Opts               *options.CollectionOptionsBuilder
 	CreateOpts         *options.CreateCollectionOptionsBuilder
 	ViewOn             string
-	ViewPipeline       interface{}
+	ViewPipeline       any
 	hasDifferentClient bool
 	created            *mongo.Collection // the actual collection that was created
 }
@@ -449,7 +449,7 @@ func (t *T) CreateCollection(coll Collection, createOnServer bool) *mongo.Collec
 
 // DropEncryptedCollection drops a collection with EncryptedFields.
 // The EncryptedFields option is not supported in Collection.Drop(). See GODRIVER-2413.
-func DropEncryptedCollection(t *T, coll *mongo.Collection, encryptedFields interface{}) {
+func DropEncryptedCollection(t *T, coll *mongo.Collection, encryptedFields any) {
 	t.Helper()
 
 	var efBSON bsoncore.Document
@@ -502,7 +502,7 @@ func (t *T) ClearCollections() {
 // in command monitoring channels. The fail point will automatically be disabled after this test has run.
 func (t *T) SetFailPoint(fp failpoint.FailPoint) {
 	// ensure mode fields are int32
-	if modeMap, ok := fp.Mode.(map[string]interface{}); ok {
+	if modeMap, ok := fp.Mode.(map[string]any); ok {
 		var key string
 		var err error
 
@@ -858,7 +858,7 @@ func (t *T) verifyConstraints() error {
 	return fmt.Errorf("no matching RunOnBlock; comparison errors: %v", runOnErrors)
 }
 
-func (t *T) interfaceToInt32(i interface{}) (int32, error) {
+func (t *T) interfaceToInt32(i any) (int32, error) {
 	switch conv := i.(type) {
 	case int:
 		return int32(conv), nil

--- a/internal/integration/mtest/options.go
+++ b/internal/integration/mtest/options.go
@@ -74,7 +74,7 @@ func (r *RunOnBlock) UnmarshalBSON(data []byte) error {
 		Auth             *bool                    `bson:"auth"`
 		AuthEnabled      *bool                    `bson:"authEnabled"`
 		CSFLE            *bool                    `bson:"csfle"`
-		Extra            map[string]interface{}   `bson:",inline"`
+		Extra            map[string]any           `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary RunOnBlock object: %w", err)

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -40,11 +40,11 @@ func TestRetryableWritesProse(t *testing.T) {
 		insertOneDoc := bson.D{{"x", 1}}
 		insertManyOrderedArgs := bson.D{
 			{"options", bson.D{{"ordered", true}}},
-			{"documents", []interface{}{insertOneDoc}},
+			{"documents", []any{insertOneDoc}},
 		}
 		insertManyUnorderedArgs := bson.D{
 			{"options", bson.D{{"ordered", true}}},
-			{"documents", []interface{}{insertOneDoc}},
+			{"documents", []any{insertOneDoc}},
 		}
 
 		testCases := []struct {
@@ -389,7 +389,7 @@ type crudOperation struct {
 
 type crudOutcome struct {
 	Error      bool               `bson:"error"` // only used by retryable writes tests
-	Result     interface{}        `bson:"result"`
+	Result     any                `bson:"result"`
 	Collection *outcomeCollection `bson:"collection"`
 }
 

--- a/internal/integration/sessions_test.go
+++ b/internal/integration/sessions_test.go
@@ -210,10 +210,10 @@ func TestSessionsProse(t *testing.T) {
 		CreateClient(false)
 
 	mt.RunOpts("3 clusterTime in commands", clusterTimeOpts, func(mt *mtest.T) {
-		serverStatus := sessionFunction{"server status", "database", "RunCommand", []interface{}{bson.D{{"serverStatus", 1}}}}
-		insert := sessionFunction{"insert one", "collection", "InsertOne", []interface{}{bson.D{{"x", 1}}}}
-		agg := sessionFunction{"aggregate", "collection", "Aggregate", []interface{}{mongo.Pipeline{}}}
-		find := sessionFunction{"find", "collection", "Find", []interface{}{bson.D{}}}
+		serverStatus := sessionFunction{"server status", "database", "RunCommand", []any{bson.D{{"serverStatus", 1}}}}
+		insert := sessionFunction{"insert one", "collection", "InsertOne", []any{bson.D{{"x", 1}}}}
+		agg := sessionFunction{"aggregate", "collection", "Aggregate", []any{mongo.Pipeline{}}}
+		find := sessionFunction{"find", "collection", "Find", []any{bson.D{}}}
 
 		sessionFunctions := []sessionFunction{serverStatus, insert, agg, find}
 		for _, sf := range sessionFunctions {
@@ -338,7 +338,7 @@ func TestSessionsProse(t *testing.T) {
 		func(mt *mtest.T) {
 			// Client-side cursor that exhausts the results after a getMore immediately returns the implicit session to the pool.
 
-			var docs []interface{}
+			var docs []any
 			for i := 0; i < 5; i++ {
 				docs = append(docs, bson.D{{"x", i}})
 			}
@@ -369,7 +369,7 @@ func TestSessionsProse(t *testing.T) {
 	})
 
 	mt.Run("11 for every combination of topology and readPreference, ensure that find and getMore both send the same session id", func(mt *mtest.T) {
-		var docs []interface{}
+		var docs []any
 		for i := 0; i < 3; i++ {
 			docs = append(docs, bson.D{{"x", i}})
 		}
@@ -514,7 +514,7 @@ type sessionFunction struct {
 	name   string
 	target string
 	fnName string
-	params []interface{} // should not include context
+	params []any // should not include context
 }
 
 func (sf sessionFunction) execute(mt *mtest.T, sess *mongo.Session) error {
@@ -556,7 +556,7 @@ func (sf sessionFunction) execute(mt *mtest.T, sess *mongo.Session) error {
 }
 
 func createFunctionsSlice() []sessionFunction {
-	insertManyDocs := []interface{}{bson.D{{"x", 1}}}
+	insertManyDocs := []any{bson.D{{"x", 1}}}
 	fooIndex := mongo.IndexModel{
 		Keys:    bson.D{{"foo", -1}},
 		Options: options.Index().SetName("fooIndex"),
@@ -565,27 +565,27 @@ func createFunctionsSlice() []sessionFunction {
 	updateDoc := bson.D{{"$inc", bson.D{{"x", 1}}}}
 
 	return []sessionFunction{
-		{"list databases", "client", "ListDatabases", []interface{}{bson.D{}}},
-		{"insert one", "collection", "InsertOne", []interface{}{bson.D{{"x", 1}}}},
-		{"insert many", "collection", "InsertMany", []interface{}{insertManyDocs}},
-		{"delete one", "collection", "DeleteOne", []interface{}{bson.D{}}},
-		{"delete many", "collection", "DeleteMany", []interface{}{bson.D{}}},
-		{"update one", "collection", "UpdateOne", []interface{}{bson.D{}, updateDoc}},
-		{"update many", "collection", "UpdateMany", []interface{}{bson.D{}, updateDoc}},
-		{"replace one", "collection", "ReplaceOne", []interface{}{bson.D{}, bson.D{}}},
-		{"aggregate", "collection", "Aggregate", []interface{}{mongo.Pipeline{}}},
+		{"list databases", "client", "ListDatabases", []any{bson.D{}}},
+		{"insert one", "collection", "InsertOne", []any{bson.D{{"x", 1}}}},
+		{"insert many", "collection", "InsertMany", []any{insertManyDocs}},
+		{"delete one", "collection", "DeleteOne", []any{bson.D{}}},
+		{"delete many", "collection", "DeleteMany", []any{bson.D{}}},
+		{"update one", "collection", "UpdateOne", []any{bson.D{}, updateDoc}},
+		{"update many", "collection", "UpdateMany", []any{bson.D{}, updateDoc}},
+		{"replace one", "collection", "ReplaceOne", []any{bson.D{}, bson.D{}}},
+		{"aggregate", "collection", "Aggregate", []any{mongo.Pipeline{}}},
 		{"estimated document count", "collection", "EstimatedDocumentCount", nil},
-		{"distinct", "collection", "Distinct", []interface{}{"field", bson.D{}}},
-		{"find", "collection", "Find", []interface{}{bson.D{}}},
-		{"find one and delete", "collection", "FindOneAndDelete", []interface{}{bson.D{}}},
-		{"find one and replace", "collection", "FindOneAndReplace", []interface{}{bson.D{}, bson.D{}}},
-		{"find one and update", "collection", "FindOneAndUpdate", []interface{}{bson.D{}, updateDoc}},
+		{"distinct", "collection", "Distinct", []any{"field", bson.D{}}},
+		{"find", "collection", "Find", []any{bson.D{}}},
+		{"find one and delete", "collection", "FindOneAndDelete", []any{bson.D{}}},
+		{"find one and replace", "collection", "FindOneAndReplace", []any{bson.D{}, bson.D{}}},
+		{"find one and update", "collection", "FindOneAndUpdate", []any{bson.D{}, updateDoc}},
 		{"drop collection", "collection", "Drop", nil},
-		{"list collections", "database", "ListCollections", []interface{}{bson.D{}}},
+		{"list collections", "database", "ListCollections", []any{bson.D{}}},
 		{"drop database", "database", "Drop", nil},
-		{"create one index", "indexView", "CreateOne", []interface{}{fooIndex}},
-		{"create many indexes", "indexView", "CreateMany", []interface{}{manyIndexes}},
-		{"drop one index", "indexView", "DropOne", []interface{}{"barIndex"}},
+		{"create one index", "indexView", "CreateOne", []any{fooIndex}},
+		{"create many indexes", "indexView", "CreateMany", []any{manyIndexes}},
+		{"drop one index", "indexView", "DropOne", []any{"barIndex"}},
 		{"drop all indexes", "indexView", "DropAll", nil},
 		{"list indexes", "indexView", "List", nil},
 	}
@@ -610,7 +610,7 @@ func sessionIDsEqual(mt *mtest.T, id1, id2 bson.Raw) bool {
 	return bytes.Equal(firstUUID, secondUUID)
 }
 
-func interfaceSliceToValueSlice(args []interface{}) []reflect.Value {
+func interfaceSliceToValueSlice(args []any) []reflect.Value {
 	vals := make([]reflect.Value, 0, len(args))
 	for _, arg := range args {
 		vals = append(vals, reflect.ValueOf(arg))

--- a/internal/integration/unified/bsonutil.go
+++ b/internal/integration/unified/bsonutil.go
@@ -73,7 +73,7 @@ func lookupInteger(doc bson.Raw, key string) int64 {
 	return doc.Lookup(key).AsInt64()
 }
 
-func mapKeys(m map[string]interface{}) []string {
+func mapKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/internal/integration/unified/bucket_options.go
+++ b/internal/integration/unified/bucket_options.go
@@ -24,12 +24,12 @@ var _ bson.Unmarshaler = (*gridFSBucketOptions)(nil)
 
 func (bo *gridFSBucketOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
-		Name      *string                `bson:"name"`
-		ChunkSize *int32                 `bson:"chunkSizeBytes"`
-		RC        *readConcern           `bson:"readConcern"`
-		RP        *ReadPreference        `bson:"readPreference"`
-		WC        *writeConcern          `bson:"writeConcern"`
-		Extra     map[string]interface{} `bson:",inline"`
+		Name      *string         `bson:"name"`
+		ChunkSize *int32          `bson:"chunkSizeBytes"`
+		RC        *readConcern    `bson:"readConcern"`
+		RP        *ReadPreference `bson:"readPreference"`
+		WC        *writeConcern   `bson:"writeConcern"`
+		Extra     map[string]any  `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary gridFSBucketOptions object: %w", err)

--- a/internal/integration/unified/bulkwrite_helpers.go
+++ b/internal/integration/unified/bulkwrite_helpers.go
@@ -70,7 +70,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 	case "updateOne":
 		uom := mongo.NewUpdateOneModel()
 		var filter bson.Raw
-		var update interface{}
+		var update any
 		var err error
 
 		elems, _ := args.Elements()
@@ -121,7 +121,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 	case "updateMany":
 		umm := mongo.NewUpdateManyModel()
 		var filter bson.Raw
-		var update interface{}
+		var update any
 		var err error
 
 		elems, _ := args.Elements()
@@ -276,7 +276,7 @@ func createBulkWriteModel(rawModel bson.Raw) (mongo.WriteModel, error) {
 
 // createUpdateValue converts the provided RawValue to a value that can be passed to UpdateOne/UpdateMany functions.
 // This helper handles both document and pipeline-style updates.
-func createUpdateValue(updateVal bson.RawValue) (interface{}, error) {
+func createUpdateValue(updateVal bson.RawValue) (any, error) {
 	switch updateVal.Type {
 	case bson.TypeEmbeddedDocument:
 		return updateVal.Document(), nil

--- a/internal/integration/unified/client_encryption_operation_execution.go
+++ b/internal/integration/unified/client_encryption_operation_execution.go
@@ -29,7 +29,7 @@ func parseDataKeyOptions(opts bson.Raw) (*options.DataKeyOptionsBuilder, error) 
 		val := elem.Value()
 		switch key {
 		case "masterKey":
-			masterKey := make(map[string]interface{})
+			masterKey := make(map[string]any)
 			if err := val.Unmarshal(&masterKey); err != nil {
 				return nil, fmt.Errorf("error unmarshaling 'masterKey': %w", err)
 			}

--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -25,7 +25,7 @@ import (
 
 func executeCreateChangeStream(ctx context.Context, operation *operation) (*operationResult, error) {
 	var watcher interface {
-		Watch(context.Context, interface{}, ...options.Lister[options.ChangeStreamOptions]) (*mongo.ChangeStream, error)
+		Watch(context.Context, any, ...options.Lister[options.ChangeStreamOptions]) (*mongo.ChangeStream, error)
 	}
 	var err error
 
@@ -40,7 +40,7 @@ func executeCreateChangeStream(ctx context.Context, operation *operation) (*oper
 		return nil, fmt.Errorf("no client, database, or collection entity found with ID %q", operation.Object)
 	}
 
-	var pipeline []interface{}
+	var pipeline []any
 	opts := options.ChangeStream()
 
 	elems, _ := operation.Arguments.Elements()
@@ -324,8 +324,8 @@ func createClientUpdateOneModel(value bson.Raw) (*mongo.ClientBulkWrite, error) 
 	var v struct {
 		Namespace    string
 		Filter       bson.Raw
-		Update       interface{}
-		ArrayFilters []interface{}
+		Update       any
+		ArrayFilters []any
 		Collation    *options.Collation
 		Hint         *bson.RawValue
 		Upsert       *bool
@@ -335,14 +335,14 @@ func createClientUpdateOneModel(value bson.Raw) (*mongo.ClientBulkWrite, error) 
 	if err != nil {
 		return nil, err
 	}
-	var hint interface{}
+	var hint any
 	if v.Hint != nil {
 		hint, err = createHint(*v.Hint)
 		if err != nil {
 			return nil, err
 		}
 	}
-	var sort interface{}
+	var sort any
 	if v.Sort != nil {
 		sort = v.Sort.Document()
 	}
@@ -369,8 +369,8 @@ func createClientUpdateManyModel(value bson.Raw) (*mongo.ClientBulkWrite, error)
 	var v struct {
 		Namespace    string
 		Filter       bson.Raw
-		Update       interface{}
-		ArrayFilters []interface{}
+		Update       any
+		ArrayFilters []any
 		Collation    *options.Collation
 		Hint         *bson.RawValue
 		Upsert       *bool
@@ -379,7 +379,7 @@ func createClientUpdateManyModel(value bson.Raw) (*mongo.ClientBulkWrite, error)
 	if err != nil {
 		return nil, err
 	}
-	var hint interface{}
+	var hint any
 	if v.Hint != nil {
 		hint, err = createHint(*v.Hint)
 		if err != nil {
@@ -418,14 +418,14 @@ func createClientReplaceOneModel(value bson.Raw) (*mongo.ClientBulkWrite, error)
 	if err != nil {
 		return nil, err
 	}
-	var hint interface{}
+	var hint any
 	if v.Hint != nil {
 		hint, err = createHint(*v.Hint)
 		if err != nil {
 			return nil, err
 		}
 	}
-	var sort interface{}
+	var sort any
 	if v.Sort != nil {
 		sort = v.Sort.Document()
 	}
@@ -455,7 +455,7 @@ func createClientDeleteOneModel(value bson.Raw) (*mongo.ClientBulkWrite, error) 
 	if err != nil {
 		return nil, err
 	}
-	var hint interface{}
+	var hint any
 	if v.Hint != nil {
 		hint, err = createHint(*v.Hint)
 		if err != nil {
@@ -485,7 +485,7 @@ func createClientDeleteManyModel(value bson.Raw) (*mongo.ClientBulkWrite, error)
 	if err != nil {
 		return nil, err
 	}
-	var hint interface{}
+	var hint any
 	if v.Hint != nil {
 		hint, err = createHint(*v.Hint)
 		if err != nil {

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -25,7 +25,7 @@ import (
 
 func executeAggregate(ctx context.Context, operation *operation) (*operationResult, error) {
 	var aggregator interface {
-		Aggregate(context.Context, interface{}, ...options.Lister[options.AggregateOptions]) (*mongo.Cursor, error)
+		Aggregate(context.Context, any, ...options.Lister[options.AggregateOptions]) (*mongo.Cursor, error)
 	}
 	var err error
 
@@ -37,7 +37,7 @@ func executeAggregate(ctx context.Context, operation *operation) (*operationResu
 		return nil, fmt.Errorf("no database or collection entity found with ID %q", operation.Object)
 	}
 
-	var pipeline []interface{}
+	var pipeline []any
 	opts := options.Aggregate()
 
 	elems, err := operation.Arguments.Elements()
@@ -314,7 +314,7 @@ func executeCreateSearchIndex(ctx context.Context, operation *operation) (*opera
 		switch key {
 		case "model":
 			var m struct {
-				Definition interface{}
+				Definition any
 				Name       *string
 				Type       *string
 			}
@@ -364,7 +364,7 @@ func executeCreateSearchIndexes(ctx context.Context, operation *operation) (*ope
 			}
 			for _, val := range vals {
 				var m struct {
-					Definition interface{}
+					Definition any
 					Name       *string
 					Type       *string
 				}
@@ -953,7 +953,7 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 	}
 
 	var filter bson.Raw
-	var update interface{}
+	var update any
 	opts := options.FindOneAndUpdate()
 
 	elems, err := operation.Arguments.Elements()
@@ -1044,7 +1044,7 @@ func executeInsertMany(ctx context.Context, operation *operation) (*operationRes
 		return nil, err
 	}
 
-	var documents []interface{}
+	var documents []any
 	opts := options.InsertMany()
 
 	elems, err := operation.Arguments.Elements()
@@ -1073,7 +1073,7 @@ func executeInsertMany(ctx context.Context, operation *operation) (*operationRes
 	res, err := coll.InsertMany(ctx, documents, opts)
 	raw := emptyCoreDocument
 	if res != nil {
-		// We return InsertedIDs as []interface{} but the CRUD spec documents it as a map[int64]interface{}, so
+		// We return InsertedIDs as []any but the CRUD spec documents it as a map[int64]any, so
 		// comparisons will fail if we include it in the result document. This is marked as an optional field and is
 		// always surrounded in an $$unsetOrMatches assertion, so we leave it out of the document.
 		raw = bsoncore.NewDocumentBuilder().
@@ -1360,7 +1360,7 @@ func executeUpdateSearchIndex(ctx context.Context, operation *operation) (*opera
 	}
 
 	var name string
-	var definition interface{}
+	var definition any
 
 	elems, err := operation.Arguments.Elements()
 	if err != nil {

--- a/internal/integration/unified/common_options.go
+++ b/internal/integration/unified/common_options.go
@@ -28,8 +28,8 @@ func (rc *readConcern) toReadConcernOption() *readconcern.ReadConcern {
 }
 
 type writeConcern struct {
-	Journal *bool       `bson:"journal"`
-	W       interface{} `bson:"w"`
+	Journal *bool `bson:"journal"`
+	W       any   `bson:"w"`
 }
 
 func (wc *writeConcern) toWriteConcernOption() (*writeconcern.WriteConcern, error) {

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -22,7 +22,7 @@ func newMissingArgumentError(arg string) error {
 
 type updateArguments struct {
 	filter bson.Raw
-	update interface{}
+	update any
 }
 
 func createUpdateManyArguments(args bson.Raw) (*updateArguments, *options.UpdateManyOptionsBuilder, error) {
@@ -201,8 +201,8 @@ func createCollation(args bson.Raw) (*options.Collation, error) {
 	return &collation, nil
 }
 
-func createHint(val bson.RawValue) (interface{}, error) {
-	var hint interface{}
+func createHint(val bson.RawValue) (any, error) {
+	var hint any
 
 	switch val.Type {
 	case bson.TypeString:

--- a/internal/integration/unified/cursor_entity.go
+++ b/internal/integration/unified/cursor_entity.go
@@ -15,7 +15,7 @@ import (
 // under a single interface (e.g. mongo.Cursor and mongo.ChangeStream).
 type cursor interface {
 	Close(context.Context) error
-	Decode(interface{}) error
+	Decode(any) error
 	Err() error
 	Next(context.Context) bool
 	TryNext(context.Context) bool

--- a/internal/integration/unified/database_operation_execution.go
+++ b/internal/integration/unified/database_operation_execution.go
@@ -27,7 +27,7 @@ func executeCreateView(ctx context.Context, operation *operation) (*operationRes
 	var collName string
 	var cvo options.CreateViewOptionsBuilder
 	var viewOn string
-	pipeline := make([]interface{}, 0)
+	pipeline := make([]any, 0)
 
 	elems, err := operation.Arguments.Elements()
 	if err != nil {

--- a/internal/integration/unified/db_collection_options.go
+++ b/internal/integration/unified/db_collection_options.go
@@ -24,10 +24,10 @@ var _ bson.Unmarshaler = (*dbOrCollectionOptions)(nil)
 // to their corresponding Go objects.
 func (d *dbOrCollectionOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
-		RC    *readConcern           `bson:"readConcern"`
-		RP    *ReadPreference        `bson:"readPreference"`
-		WC    *writeConcern          `bson:"writeConcern"`
-		Extra map[string]interface{} `bson:",inline"`
+		RC    *readConcern    `bson:"readConcern"`
+		RP    *ReadPreference `bson:"readPreference"`
+		WC    *writeConcern   `bson:"writeConcern"`
+		Extra map[string]any  `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary dbOrCollectionOptions object: %w", err)

--- a/internal/integration/unified/entity.go
+++ b/internal/integration/unified/entity.go
@@ -597,11 +597,11 @@ func getKmsCredential(kmsDocument bson.Raw, credentialName string, envVar string
 
 func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) error {
 	// Construct KMS providers.
-	kmsProviders := make(map[string]map[string]interface{})
+	kmsProviders := make(map[string]map[string]any)
 	ceo := entityOptions.ClientEncryptionOpts
 	tlsconf := make(map[string]*tls.Config)
 	if aws, ok := ceo.KmsProviders["aws"]; ok {
-		kmsProviders["aws"] = make(map[string]interface{})
+		kmsProviders["aws"] = make(map[string]any)
 
 		awsSessionToken, err := getKmsCredential(aws, "sessionToken", "CSFLE_AWS_TEMP_SESSION_TOKEN", "")
 		if err != nil {
@@ -646,7 +646,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	}
 
 	if azure, ok := ceo.KmsProviders["azure"]; ok {
-		kmsProviders["azure"] = make(map[string]interface{})
+		kmsProviders["azure"] = make(map[string]any)
 
 		azureTenantID, err := getKmsCredential(azure, "tenantId", "FLE_AZURE_TENANTID", "")
 		if err != nil {
@@ -674,7 +674,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	}
 
 	if gcp, ok := ceo.KmsProviders["gcp"]; ok {
-		kmsProviders["gcp"] = make(map[string]interface{})
+		kmsProviders["gcp"] = make(map[string]any)
 
 		gcpEmail, err := getKmsCredential(gcp, "email", "FLE_GCP_EMAIL", "")
 		if err != nil {
@@ -694,7 +694,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	}
 
 	if kmip, ok := ceo.KmsProviders["kmip"]; ok {
-		kmsProviders["kmip"] = make(map[string]interface{})
+		kmsProviders["kmip"] = make(map[string]any)
 
 		kmipEndpoint, err := getKmsCredential(kmip, "endpoint", "", "localhost:5698")
 		if err != nil {
@@ -702,7 +702,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 		}
 
 		if tlsClientCertificateKeyFile != "" && tlsCAFile != "" {
-			cfg, err := options.BuildTLSConfig(map[string]interface{}{
+			cfg, err := options.BuildTLSConfig(map[string]any{
 				"tlsCertificateKeyFile": tlsClientCertificateKeyFile,
 				"tlsCAFile":             tlsCAFile,
 			})
@@ -718,7 +718,7 @@ func (em *EntityMap) addClientEncryptionEntity(entityOptions *entityOptions) err
 	}
 
 	if local, ok := ceo.KmsProviders["local"]; ok {
-		kmsProviders["local"] = make(map[string]interface{})
+		kmsProviders["local"] = make(map[string]any)
 
 		defaultLocalKeyBase64 := "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
 		localKey, err := getKmsCredential(local, "key", "", defaultLocalKeyBase64)

--- a/internal/integration/unified/event_verification.go
+++ b/internal/integration/unified/event_verification.go
@@ -114,11 +114,11 @@ func (e *expectedEvents) UnmarshalBSON(data []byte) error {
 	// We use the "eventType" value to determine which struct field should be used to deserialize the "events" array.
 
 	var temp struct {
-		ClientID          string                 `bson:"client"`
-		EventType         string                 `bson:"eventType"`
-		Events            bson.RawValue          `bson:"events"`
-		IgnoreExtraEvents *bool                  `bson:"ignoreExtraEvents"`
-		Extra             map[string]interface{} `bson:",inline"`
+		ClientID          string         `bson:"client"`
+		EventType         string         `bson:"eventType"`
+		Events            bson.RawValue  `bson:"events"`
+		IgnoreExtraEvents *bool          `bson:"ignoreExtraEvents"`
+		Extra             map[string]any `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary expectedEvents object: %w", err)
@@ -132,7 +132,7 @@ func (e *expectedEvents) UnmarshalBSON(data []byte) error {
 		return fmt.Errorf("expected 'events' to be an array but got a %q", temp.Events.Type)
 	}
 
-	var target interface{}
+	var target any
 	switch temp.EventType {
 	case "command", "":
 		target = &e.CommandEvents
@@ -418,7 +418,7 @@ func verifyServerConnectionID(expectedHasSCID bool, scid *int64) error {
 	return nil
 }
 
-func newEventVerificationError(idx int, client *clientEntity, msg string, args ...interface{}) error {
+func newEventVerificationError(idx int, client *clientEntity, msg string, args ...any) error {
 	fullMsg := fmt.Sprintf(msg, args...)
 	return fmt.Errorf("event comparison failed at index %d: %s; all events found for client: %s", idx, fullMsg,
 		stringifyEventsForClient(client))

--- a/internal/integration/unified/logger.go
+++ b/internal/integration/unified/logger.go
@@ -54,7 +54,7 @@ func newLogger(olm *observeLogMessages, bufSize int, ignoreMessages []*logMessag
 
 // Info implements the logger.Sink interface's "Info" method for printing log
 // messages.
-func (log *Logger) Info(level int, msg string, args ...interface{}) {
+func (log *Logger) Info(level int, msg string, args ...any) {
 	log.orderMu.Lock()
 	defer log.orderMu.Unlock()
 
@@ -100,7 +100,7 @@ func (log *Logger) Info(level int, msg string, args ...interface{}) {
 // Error implements the logger.Sink interface's "Error" method for printing log
 // errors. In this case, if an error occurs we will simply treat it as
 // informational.
-func (log *Logger) Error(err error, msg string, args ...interface{}) {
+func (log *Logger) Error(err error, msg string, args ...any) {
 	args = append(args, "error", err)
 	log.Info(int(logger.LevelInfo), msg, args)
 }

--- a/internal/integration/unified/logger_verification.go
+++ b/internal/integration/unified/logger_verification.go
@@ -29,7 +29,7 @@ type logMessage struct {
 
 // newLogMessage will create a "logMessage" from the level and a slice of
 // arguments.
-func newLogMessage(level int, msg string, args ...interface{}) (*logMessage, error) {
+func newLogMessage(level int, msg string, args ...any) (*logMessage, error) {
 	logMessage := new(logMessage)
 
 	// Iterate over the literal levels until we get the first

--- a/internal/integration/unified/matches.go
+++ b/internal/integration/unified/matches.go
@@ -384,7 +384,7 @@ func convertStringToBSONType(typeStr string) (bson.Type, error) {
 // newMatchingError creates an error to convey that BSON value comparison failed at the provided key path. If the
 // key path is empty (e.g. because the values being compared were not documents), the error message will contain the
 // phrase "top-level" instead of the path.
-func newMatchingError(keyPath, msg string, args ...interface{}) error {
+func newMatchingError(keyPath, msg string, args ...any) error {
 	fullMsg := fmt.Sprintf(msg, args...)
 	if keyPath == "" {
 		return fmt.Errorf("comparison error at top-level: %s", fullMsg)

--- a/internal/integration/unified/matches_test.go
+++ b/internal/integration/unified/matches_test.go
@@ -30,7 +30,7 @@ func TestMatches(t *testing.T) {
 		assert.Nil(t, err, "UnmarshalExtJSON error: %v", err)
 		return val
 	}
-	marshalValue := func(t *testing.T, val interface{}) bson.RawValue {
+	marshalValue := func(t *testing.T, val any) bson.RawValue {
 		t.Helper()
 
 		valType, data, err := bson.MarshalValue(val)

--- a/internal/integration/unified/server_api_options.go
+++ b/internal/integration/unified/server_api_options.go
@@ -25,10 +25,10 @@ var _ bson.Unmarshaler = (*serverAPIOptions)(nil)
 
 func (s *serverAPIOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
-		ServerAPIVersion  serverAPIVersion       `bson:"version"`
-		DeprecationErrors *bool                  `bson:"deprecationErrors"`
-		Strict            *bool                  `bson:"strict"`
-		Extra             map[string]interface{} `bson:",inline"`
+		ServerAPIVersion  serverAPIVersion `bson:"version"`
+		DeprecationErrors *bool            `bson:"deprecationErrors"`
+		Strict            *bool            `bson:"strict"`
+		Extra             map[string]any   `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary serverAPIOptions object: %v", err)

--- a/internal/integration/unified/session_operation_execution.go
+++ b/internal/integration/unified/session_operation_execution.go
@@ -102,7 +102,7 @@ func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan 
 		return fmt.Errorf("error unmarshalling arguments to transactionOptions: %v", err)
 	}
 
-	_, err = sess.WithTransaction(ctx, func(ctx context.Context) (interface{}, error) {
+	_, err = sess.WithTransaction(ctx, func(ctx context.Context) (any, error) {
 		for idx, oper := range operations {
 			if err := oper.execute(ctx, loopDone); err != nil {
 				return nil, fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, err)

--- a/internal/integration/unified/session_options.go
+++ b/internal/integration/unified/session_options.go
@@ -24,10 +24,10 @@ var _ bson.Unmarshaler = (*transactionOptions)(nil)
 
 func (to *transactionOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
-		RC    *readConcern           `bson:"readConcern"`
-		RP    *ReadPreference        `bson:"readPreference"`
-		WC    *writeConcern          `bson:"writeConcern"`
-		Extra map[string]interface{} `bson:",inline"`
+		RC    *readConcern    `bson:"readConcern"`
+		RP    *ReadPreference `bson:"readPreference"`
+		WC    *writeConcern   `bson:"writeConcern"`
+		Extra map[string]any  `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary transactionOptions object: %v", err)
@@ -67,10 +67,10 @@ var _ bson.Unmarshaler = (*sessionOptions)(nil)
 
 func (so *sessionOptions) UnmarshalBSON(data []byte) error {
 	var temp struct {
-		Causal     *bool                  `bson:"causalConsistency"`
-		TxnOptions *transactionOptions    `bson:"defaultTransactionOptions"`
-		Snapshot   *bool                  `bson:"snapshot"`
-		Extra      map[string]interface{} `bson:",inline"`
+		Causal     *bool               `bson:"causalConsistency"`
+		TxnOptions *transactionOptions `bson:"defaultTransactionOptions"`
+		Snapshot   *bool               `bson:"snapshot"`
+		Extra      map[string]any      `bson:",inline"`
 	}
 	if err := bson.Unmarshal(data, &temp); err != nil {
 		return fmt.Errorf("error unmarshalling to temporary sessionOptions object: %v", err)

--- a/internal/integration/unified/unified_spec_runner.go
+++ b/internal/integration/unified/unified_spec_runner.go
@@ -197,10 +197,10 @@ func (tc *TestCase) EndLoop() {
 
 // LoggerSkipper is passed to TestCase.Run to allow it to perform logging and skipping operations
 type LoggerSkipper interface {
-	Log(args ...interface{})
-	Logf(format string, args ...interface{})
-	Skip(args ...interface{})
-	Skipf(format string, args ...interface{})
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Skip(args ...any)
+	Skipf(format string, args ...any)
 }
 
 // skipTestError indicates that a test must be skipped because the runner cannot execute it (e.g. the test requires

--- a/internal/integration/unified_spec_test.go
+++ b/internal/integration/unified_spec_test.go
@@ -110,14 +110,14 @@ type testCase struct {
 }
 
 type operation struct {
-	Name              string      `bson:"name"`
-	Object            string      `bson:"object"`
-	CollectionOptions bson.Raw    `bson:"collectionOptions"`
-	DatabaseOptions   bson.Raw    `bson:"databaseOptions"`
-	Result            interface{} `bson:"result"`
-	Arguments         bson.Raw    `bson:"arguments"`
-	Error             bool        `bson:"error"`
-	CommandName       string      `bson:"command_name"`
+	Name              string   `bson:"name"`
+	Object            string   `bson:"object"`
+	CollectionOptions bson.Raw `bson:"collectionOptions"`
+	DatabaseOptions   bson.Raw `bson:"databaseOptions"`
+	Result            any      `bson:"result"`
+	Arguments         bson.Raw `bson:"arguments"`
+	Error             bool     `bson:"error"`
+	CommandName       string   `bson:"command_name"`
 
 	// set in code after determining whether or not result represents an error
 	opError *operationError
@@ -125,19 +125,19 @@ type operation struct {
 
 type expectation struct {
 	CommandStartedEvent *struct {
-		CommandName  string                 `bson:"command_name"`
-		DatabaseName string                 `bson:"database_name"`
-		Command      bson.Raw               `bson:"command"`
-		Extra        map[string]interface{} `bson:",inline"`
+		CommandName  string         `bson:"command_name"`
+		DatabaseName string         `bson:"database_name"`
+		Command      bson.Raw       `bson:"command"`
+		Extra        map[string]any `bson:",inline"`
 	} `bson:"command_started_event"`
 	CommandSucceededEvent *struct {
-		CommandName string                 `bson:"command_name"`
-		Reply       bson.Raw               `bson:"reply"`
-		Extra       map[string]interface{} `bson:",inline"`
+		CommandName string         `bson:"command_name"`
+		Reply       bson.Raw       `bson:"reply"`
+		Extra       map[string]any `bson:",inline"`
 	} `bson:"command_succeeded_event"`
 	CommandFailedEvent *struct {
-		CommandName string                 `bson:"command_name"`
-		Extra       map[string]interface{} `bson:",inline"`
+		CommandName string         `bson:"command_name"`
+		Extra       map[string]any `bson:",inline"`
 	} `bson:"command_failed_event"`
 }
 
@@ -146,8 +146,8 @@ type outcome struct {
 }
 
 type outcomeCollection struct {
-	Name string      `bson:"name"`
-	Data interface{} `bson:"data"`
+	Name string `bson:"name"`
+	Data any    `bson:"data"`
 }
 
 type operationError struct {
@@ -273,7 +273,7 @@ func runSpecTestCase(mt *mtest.T, test *testCase, testFile testFile) {
 
 			if !bypassAutoEncryption && !bypassQueryAnalysis {
 				if aeOpts.ExtraOptions == nil {
-					aeOpts.ExtraOptions = make(map[string]interface{})
+					aeOpts.ExtraOptions = make(map[string]any)
 				}
 
 				for k, v := range getCryptSharedLibExtraOptions() {
@@ -963,12 +963,12 @@ func getTopologyFromClient(client *mongo.Client) *topology.Topology {
 
 // getCryptSharedLibExtraOptions returns an AutoEncryption extra options map with crypt_shared
 // library path information if the CRYPT_SHARED_LIB_PATH environment variable is set.
-func getCryptSharedLibExtraOptions() map[string]interface{} {
+func getCryptSharedLibExtraOptions() map[string]any {
 	path := os.Getenv("CRYPT_SHARED_LIB_PATH")
 	if path == "" {
 		return nil
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"cryptSharedLibRequired": true,
 		"cryptSharedLibPath":     path,
 	}


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Replace all uses of `interface{}` with `any` in the "internal/integration/" packages.

## Background & Motivation

[any](https://pkg.go.dev/builtin#any) is a type alias for `interface{}`, so is semantically identical. The only change is a slightly cleaner syntax.
