### PR TITLE
GODRIVER-3564: Add config and workflows for release note labels

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -410,32 +410,6 @@ functions:
           export HEAD_SHA=${github_commit}
           bash etc/api_report.sh
 
-  "add PR labels":
-    - command: shell.exec
-      type: test
-      params:
-        shell: "bash"
-        working_dir: src/go.mongodb.org/mongo-driver
-        add_expansions_to_env: true
-        script: |
-          ${PREPARE_SHELL}
-          export CONFIG=$PROJECT_DIRECTORY/.github/labeler.yml
-          export SCRIPT="$DRIVERS_TOOLS/.evergreen/github_app/apply-labels.sh"
-          bash $SCRIPT -l $CONFIG -h ${github_commit} -o "mongodb" -n "mongo-go-driver"
-
-  "add PR reviewer":
-    - command: shell.exec
-      type: test
-      params:
-        shell: "bash"
-        working_dir: src/go.mongodb.org/mongo-driver
-        add_expansions_to_env: true
-        script: |
-          ${PREPARE_SHELL}
-          export CONFIG=$PROJECT_DIRECTORY/.github/reviewers.txt
-          export SCRIPT="$DRIVERS_TOOLS/.evergreen/github_app/assign-reviewer.sh"
-          bash $SCRIPT -p $CONFIG -h ${github_commit} -o "mongodb" -n "mongo-go-driver"
-
   "backport pr":
     - command: subprocess.exec
       type: test
@@ -936,8 +910,6 @@ tasks:
     allowed_requesters: ["patch", "github_pr"]
     commands:
       - func: assume-test-secrets-ec2-role
-      - func: "add PR reviewer"  
-      - func: "add PR labels"
       - func: "create-api-report"
 
   - name: backport-pr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb/dbx-go

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,14 @@
-
 priority-3-low:
 - changed-files:
   - any-glob-to-any-file: '*'
 
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - docs/**
     - examples/**
 
 dependencies:
 - changed-files:
-  - any-glob-to-any-file: 
+  - any-glob-to-any-file:
     - go.mod

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - github_actions
+      - submodules
+    authors:
+      - mongodb-drivers-pr-bot
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking
+    - title: ✨ New Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Fixed
+      labels:
+        - bug
+    - title: 📦 Dependency Updates
+      labels:
+        - dependencies
+    - title: 📝 Other Changes
+      labels:
+        - "*"

--- a/.github/reviewers.txt
+++ b/.github/reviewers.txt
@@ -1,3 +1,0 @@
-qingyang-hu
-matthewdale
-prestonvasquez

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,19 @@
+name: Label Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: bug,feature,enhancement,documentation,dependencies
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
GODRIVER-3564

Targeting release/1.17 so the changes apply to future patch releases.

## Summary

Adds labeler and label-checker to ensure pull requests get the necessary labels to be used for release notes.

### Labels

The [labeler action](https://github.com/actions/labeler) automatically assign labels to pull requests. This was previously done through Evergreen, but using GitHub Actions makes more sense so we don't need to duplicate its code.
While working on this, I also noticed that we still use Evergreen to assign PR reviewers. Since reviewers are automatically assigned through branch rules, this task was not actually doing anything and has been removed.
The new [label checker](https://github.com/agilepathway/label-checker) workflow checks for certain label requirements. It requires that one of the following labels is used:
- `bug` for bug fixes
- `feature` for new features
- `enhancement` for smaller improvements
- `documentation` for docs changes
- `dependencies` for dependency updates (used by dependabot)
In addition, the `breaking` tag can be used to denote that a pull request contains breaking changes. This should always be combined with either `bug` or `feature`.

For the time being, the label checker won't be required; once we're confident it works this will be added as a required check, meaning that pull requests not containing one of the above labels can't be merged.

### Release Notes

The release notes configuration defines the following categories:
- ⚠️ Breaking Changes: this section contains everything using the `breaking` label and should only be used for major versions
- ✨ New Features: the `enhancement` and `feature` labels feed this category.
- 🐛 Fixed: anything labeled `bug`
- 📦 Dependency Updates: anything labeled `dependencies`.
- 📝 Other Changes: anything else; this list will match anything that didn't already fall into another category, e.g. pull requests only tagged with `documentation`

To clean up the release notes, the configuration excludes all pull requests created by the PR bot; this removes all "Merge branch <x> into <y>" entries we'd otherwise get. The `ignore-for-release` label can be used to specifically exclude a pull request from the changelog even if it would fall into other categories. To make sure we only report relevant dependency updates, the `github_actions` and `submodules` labels are also excluded. These are used by dependabot in combination with the `dependencies` label. Since it's impossible to configure a release note category that only takes in pull requests that have two or more labels (e.g. `dependencies` and `go`), we have to exclude all submodule and GitHub actions dependencies from the release notes. Since these dependencies are only for development, it's fine to exclude them completely.