### PR TITLE
Update default review priority tag

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-priority-3-low:
+review-priority-normal:
 - changed-files:
   - any-glob-to-any-file: '*'
 


### PR DESCRIPTION
The review priority tags were recently renamed and thus need to be updated in the labeler config.