### PR TITLE
GODRIVER-3631 Assume correct EC2 role in search index test task.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2078,10 +2078,12 @@ task_groups:
   - name: test-search-index-task-group
     setup_group:
       - func: setup-system
+      - func: assume-test-secrets-ec2-role
       - command: subprocess.exec
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           env:
             MONGODB_VERSION: "7.0"
             LAMBDA_STACK_NAME: dbx-go-lambda


### PR DESCRIPTION
[GODRIVER-3631](https://jira.mongodb.org/browse/GODRIVER-3631)

## Summary

Call function `assume-test-secrets-ec2-role` and pass in the AWS creds in the `test-search-index-task-group` task group setup.

## Background & Motivation

Currently the `test-search-index` Evergreen tasks all fail with an error like:
```
 Getting secrets: drivers/atlas-qa...
 Using Python binary /opt/python/Current/bin/python3
 Traceback (most recent call last):
   File "drivers-evergreen-tools/.evergreen/secrets_handling/setup_secrets.py", line 30, in get_secrets
...
     raise ValueError(
         "Please provide a profile (typically using AWS_PROFILE)"
     ) from e
 ValueError: Please provide a profile (typically using AWS_PROFILE)
```

The other Evergreen task that calls `.evergreen/atlas/setup.sh` also calls `assume-test-secrets-ec2-role` first.