### PR TITLE
GODRIVER-3633 Set correct MONGODB_VERSION on FaaS and search index tasks.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2056,8 +2056,9 @@ task_groups:
         params:
           working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           env:
+            MONGODB_VERSION: ${VERSION}
             LAMBDA_STACK_NAME: dbx-go-lambda
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh
@@ -2087,7 +2088,7 @@ task_groups:
           working_dir: src/go.mongodb.org/mongo-driver
           binary: bash
           env:
-            MONGODB_VERSION: "7.0"
+            MONGODB_VERSION: ${VERSION}
             LAMBDA_STACK_NAME: dbx-go-lambda
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh


### PR DESCRIPTION
[GODRIVER-3636](https://jira.mongodb.org/browse/GODRIVER-3636)

## Summary

* Set the `MONGODB_VERSION` based on the task matrix variable for the FaaS and search index tasks.
* Fixes [GODRIVER-3636](https://jira.mongodb.org/browse/GODRIVER-3636).

## Background & Motivation

<!--- Rationale for the pull request. -->
