### PR TITLE
Use require instead of assert for error checking in GridFS tests.

### DIFF
--- a/internal/integration/gridfs_test.go
+++ b/internal/integration/gridfs_test.go
@@ -414,7 +414,7 @@ func TestGridFS(x *testing.T) {
 			cancel()
 
 			_, err = ds.Skip(int64(len(fileData)))
-			assert.Error(mt, err, "expected error from Skip, got nil")
+			assert.Error(mt, err, "expected error from Skip")
 			assert.ErrorIs(mt, context.Canceled, err)
 		})
 	})


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Use `require.NoError` instead of `assert.Nil` when checking errors in the GridFS integration tests to prevent the test from continuing after an unexpected error.

## Background & Motivation
The GridFS tests in the "internal/integration" package will continue after an error and possibly reference uninitialized values, leading to a panic like:
```
=== RUN   TestGridFS/skipping_download/read_all,_skip_beyond
    gridfs_test.go:77: 
        	Error Trace:	go.mongodb.org\mongo-driver\internal\integration\gridfs_test.go:77
        	            				go.mongodb.org\mongo-driver\internal\integration\mongotest.go:232
        	Error:      	Expected nil, but got: topology.ConnectionError{ConnectionID:"", Wrapped:(*net.OpError)(0xc02b0c8960), init:true, message:"failed to connect to localhost:27017"}
        	Test:       	TestGridFS/skipping_download/read_all,_skip_beyond
        	Messages:   	OpenUploadStream error: connection() error occurred during connection handshake: failed to connect to localhost:27017: dial tcp [::1]:27017: connectex: Only one usage of each socket address (protocol/network address/port) is normally permitted.
        --- FAIL: TestGridFS/skipping_download/read_all,_skip_beyond (0.09s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x10 pc=0x7ff6d24487f4]
goroutine 419948 [running]:
...
go.mongodb.org/mongo-driver/v2/internal/integration.TestGridFS.func1.1(0xc02ad641c0)
	go.mongodb.org/mongo-driver/internal/integration/gridfs_test.go:79 +0x454
go.mongodb.org/mongo-driver/v2/internal/integration/mtest.(*T).Run.(*T).RunOpts.func1(0xc02b5604e0?)
```
