### PR TITLE
GODRIVER-3638 Prohibit using failpoints on sharded topologies.

### DIFF
--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -499,7 +499,10 @@ func TestClientBulkWriteProse(t *testing.T) {
 		assert.Equal(mt, 1, opsCnt[1], "expected %d secondEvent.command.ops, got: %d", 1, opsCnt[1])
 	})
 
-	mt.Run("5. MongoClient.bulkWrite collects WriteConcernErrors across batches", func(mt *mtest.T) {
+	// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+	// topologies. Allow running on sharded topologies once that is fixed.
+	noShardedOpts := mtest.NewOptions().Topologies(mtest.Single, mtest.ReplicaSet, mtest.LoadBalanced)
+	mt.RunOpts("5. MongoClient.bulkWrite collects WriteConcernErrors across batches", noShardedOpts, func(mt *mtest.T) {
 		var eventCnt int
 		monitor := &event.CommandMonitor{
 			Started: func(_ context.Context, e *event.CommandStartedEvent) {
@@ -715,7 +718,9 @@ func TestClientBulkWriteProse(t *testing.T) {
 			assert.Equal(mt, 1, getMoreCalled, "expected %d getMore call, got: %d", 1, getMoreCalled)
 		})
 
-	mt.Run("9. MongoClient.bulkWrite handles a getMore error", func(mt *mtest.T) {
+	// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+	// topologies. Allow running on sharded topologies once that is fixed.
+	mt.RunOpts("9. MongoClient.bulkWrite handles a getMore error", noShardedOpts, func(mt *mtest.T) {
 		var getMoreCalled int
 		var killCursorsCalled int
 		monitor := &event.CommandMonitor{

--- a/internal/integration/csot_prose_test.go
+++ b/internal/integration/csot_prose_test.go
@@ -238,7 +238,10 @@ func TestCSOTProse_GridFS(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
 
 	mt.RunOpts("6. gridfs - upload", mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
-		mt.Run("uploads via openUploadStream can be timed out", func(mt *mtest.T) {
+		// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+		// topologies. Allow running on sharded topologies once that is fixed.
+		noShardedOpts := mtest.NewOptions().Topologies(mtest.Single, mtest.ReplicaSet, mtest.LoadBalanced)
+		mt.RunOpts("uploads via openUploadStream can be timed out", noShardedOpts, func(mt *mtest.T) {
 			// Drop and re-create the db.fs.files and db.fs.chunks collections.
 			err := mt.Client.Database("db").Collection("fs.files").Drop(context.Background())
 			assert.NoError(mt, err, "failed to drop files")
@@ -298,7 +301,9 @@ func TestCSOTProse_GridFS(t *testing.T) {
 			assert.Error(t, err, context.DeadlineExceeded)
 		})
 
-		mt.Run("Aborting an upload stream can be timed out", func(mt *mtest.T) {
+		// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+		// topologies. Allow running on sharded topologies once that is fixed.
+		mt.RunOpts("Aborting an upload stream can be timed out", noShardedOpts, func(mt *mtest.T) {
 			// Drop and re-create the db.fs.files and db.fs.chunks collections.
 			err := mt.Client.Database("db").Collection("fs.files").Drop(context.Background())
 			assert.NoError(mt, err, "failed to drop files")
@@ -414,7 +419,12 @@ func TestCSOTProse_GridFS(t *testing.T) {
 	})
 
 	const test62 = "6.2 gridfs - upload with operation-level timeout"
-	mt.RunOpts(test62, mtest.NewOptions().MinServerVersion("4.4"), func(mt *mtest.T) {
+	mtOpts := mtest.NewOptions().
+		MinServerVersion("4.4").
+		// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+		// topologies. Allow running on sharded topologies once that is fixed.
+		Topologies(mtest.Single, mtest.ReplicaSet, mtest.LoadBalanced)
+	mt.RunOpts(test62, mtOpts, func(mt *mtest.T) {
 		// Drop and re-create the db.fs.files and db.fs.chunks collections.
 		err := mt.Client.Database("db").Collection("fs.files").Drop(context.Background())
 		assert.NoError(mt, err, "failed to drop files")

--- a/internal/integration/mtest/options.go
+++ b/internal/integration/mtest/options.go
@@ -281,3 +281,18 @@ func (op *Options) RequireAPIVersion(rav bool) *Options {
 	})
 	return op
 }
+
+// AllowFailPointsOnSharded bypasses the check for failpoints used on sharded
+// topologies.
+//
+// Failpoints are generally unreliable on sharded topologies, but can be used if
+// the failpoint is explicitly applied to every mongoS node in the cluster.
+//
+// TODO(GODRIVER-3328): Remove this option once we set failpoints on every
+// mongoS in sharded topologies.
+func (op *Options) AllowFailPointsOnSharded() *Options {
+	op.optFuncs = append(op.optFuncs, func(t *T) {
+		t.allowFailPointsOnSharded = true
+	})
+	return op
+}

--- a/internal/integration/sdam_prose_test.go
+++ b/internal/integration/sdam_prose_test.go
@@ -98,7 +98,10 @@ func TestSDAMProse(t *testing.T) {
 			SetAppName("streamingRttTest")
 		mtOpts := mtest.NewOptions().
 			MinServerVersion("4.4").
-			ClientOptions(clientOpts)
+			ClientOptions(clientOpts).
+			// TODO(GODRIVER-3328): FailPoints are not currently reliable on sharded
+			// clusters. Remove this exclusion once we fix that.
+			Topologies(mtest.Single, mtest.ReplicaSet, mtest.LoadBalanced)
 		mt.RunOpts("rtt is continuously updated", mtOpts, func(mt *mtest.T) {
 			// Test that the RTT monitor updates the RTT for server descriptions.
 

--- a/internal/integration/server_selection_prose_test.go
+++ b/internal/integration/server_selection_prose_test.go
@@ -112,7 +112,7 @@ func TestServerSelectionProse(t *testing.T) {
 
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
 
-	mtOpts := mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.9")
+	mtOpts := mtest.NewOptions().Topologies(mtest.Sharded).MinServerVersion("4.9").AllowFailPointsOnSharded()
 	mt.RunOpts("operationCount-based selection within latency window, with failpoint", mtOpts, func(mt *mtest.T) {
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
 		require.NoError(mt, err, "InsertOne() error")


### PR DESCRIPTION
[GODRIVER-3638](https://jira.mongodb.org/browse/GODRIVER-3638)

## Summary

* If `SetFailPoint` is called when `mtest` is connected to a sharded topology.
* Add an `mtest` option `AllowFailPointsOnSharded` to allow using failpoints on sharded topologies.

## Background & Motivation

On sharded topologies, failpoints are applied to only a single mongoS. If the driver is connected to multiple mongoS instances, there's a possibility a different mongoS will be selected for a subsequent command. In that case, the failpoint is effectively ignored, leading to a test failure that is extremely difficult to diagnose.

Note that if we implement [GODRIVER-3328](https://jira.mongodb.org/browse/GODRIVER-3328), we no longer need to prohibit using failpoints on sharded topologies.
