### PR TITLE
GODRIVER-3582 Add custom options to client bulkWrite.

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -963,6 +963,16 @@ func (c *Client) BulkWrite(ctx context.Context, writes []ClientBulkWrite,
 			op.rawData = &rawData
 		}
 	}
+	if bypassEmptyTsReplacementOpt := optionsutil.Value(bwo.Internal, "bypassEmptyTsReplacement"); bypassEmptyTsReplacementOpt != nil {
+		if bypassEmptyTsReplacement, ok := bypassEmptyTsReplacementOpt.(bool); ok {
+			op.bypassEmptyTsReplacement = &bypassEmptyTsReplacement
+		}
+	}
+	if commandCallbackOpt := optionsutil.Value(bwo.Internal, "commandCallback"); commandCallbackOpt != nil {
+		if commandCallback, ok := commandCallbackOpt.(func([]byte, description.SelectedServer) ([]byte, error)); ok {
+			op.commandCallback = commandCallback
+		}
+	}
 	if bwo.VerboseResults == nil || !(*bwo.VerboseResults) {
 		op.errorsOnly = true
 	} else if !acknowledged {

--- a/x/mongo/driver/xoptions/options.go
+++ b/x/mongo/driver/xoptions/options.go
@@ -12,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/optionsutil"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
 )
 
 // SetInternalClientOptions sets internal options for ClientOptions.
@@ -99,6 +100,24 @@ func SetInternalClientBulkWriteOptions(a *options.ClientBulkWriteOptionsBuilder,
 		}
 		a.Opts = append(a.Opts, func(opts *options.ClientBulkWriteOptions) error {
 			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	case "bypassEmptyTsReplacement":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.ClientBulkWriteOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	case "commandCallback":
+		cb, ok := option.(func([]byte, description.SelectedServer) ([]byte, error))
+		if !ok {
+			return typeErrFunc("func([]byte, description.SelectedServer) ([]byte, error)")
+		}
+		a.Opts = append(a.Opts, func(opts *options.ClientBulkWriteOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, cb)
 			return nil
 		})
 	default:


### PR DESCRIPTION
GODRIVER-3582

## Summary
 - Add bypassEmptyTsReplacement for client bulkWrite.
 - Add a generic callback function to allow undocumented parameters in client bulkWrite commands

## Background & Motivation

<!--- Rationale for the pull request. -->
