### PR TITLE
Pin drivers-evergreen-tools to rev 98f6b0e in v1.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -146,12 +146,9 @@ functions:
         script: |
           ${PREPARE_SHELL}
           rm -rf $DRIVERS_TOOLS
-          if [ "${project}" = "drivers-tools" ]; then
-            # If this was a patch build, doing a fresh clone would not actually test the patch
-            cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
-          else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
-          fi
+          git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          # Pin drivers-evergreen-tools to revision 98f6b0e (Aug 20, 2025).
+          git -C $DRIVERS_TOOLS checkout 98f6b0e
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
     - command: shell.exec
       params:


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Pin drivers-evergreen-tools to rev 98f6b0e in v1.

## Background & Motivation

As the `v1` / `release/1.17` branches continue to get more stale, the probability of breaking changes in the orchestration scripts increases. Pin the drivers-evergreen-tools repo to a version from Aug 20, 2025.

Fixes build failures in https://github.com/mongodb/mongo-go-driver/pull/2183.