### PR TITLE
Retry Markdown link checks on HTTP 429 (v1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,8 @@ repos:
   hooks:
     - id: markdown-link-check
       exclude: ^(vendor)
+      # Retry when the endpoint returns HTTP 429 (Too Many Requests)
+      args: [-r]
 
 - repo: local
   hooks:


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Retry Markdown link checks when the endpoint responds with HTTP 429.

## Background & Motivation

The http://reneefrench.blogspot.com/ site returns HTTP 429 frequently, leading to failed pre-commit checks when run in the Github Actions runners. The [markdown-link-check](https://github.com/tcort/markdown-link-check) tool supports retrying after an HTTP 429, automatically waiting until the time specified by the "retry-after" HTTP header. See the [usage docs](https://github.com/tcort/markdown-link-check?tab=readme-ov-file#usage) for details.

See previous PR https://github.com/mongodb/mongo-go-driver/pull/2181