### PR TITLE
Consider HTTP 429 a succcessful response in the Markdown link check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,9 @@ repos:
   hooks:
     - id: markdown-link-check
       exclude: ^(vendor)
-      # Retry when the endpoint returns HTTP 429 (Too Many Requests)
-      args: [-r]
+      # If the endpoint returns HTTP 429 (Too Many Requests), consider it a
+      # successful check.
+      args: ["-a 200,206,429"]
 
 - repo: local
   hooks:


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

When checking Markdown links, if the endpoint returns HTTP 429 (Too Many Requests), consider it a successful check.

## Background & Motivation

The previous attempt to fix this (https://github.com/mongodb/mongo-go-driver/pull/2186) didn't work. Use this approach instead.
