### PR TITLE
Consider HTTP 429 a succcessful response in the Markdown link check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,9 @@ repos:
   hooks:
     - id: markdown-link-check
       exclude: ^(vendor)
+      # If the endpoint returns HTTP 429 (Too Many Requests), consider it a
+      # successful check.
+      args: ["-a 200,206,429"]
 
 - repo: local
   hooks:


### PR DESCRIPTION
This cherry-picks changes from #2191 to the 2.x release series to avoid a lengthy process of ignoring changes in an up-merge.