### PR TITLE
Allow ignore-for-release label to satisfy label checker

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: bug,feature,enhancement,documentation,dependencies
+          one_of: bug,feature,enhancement,documentation,dependencies,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The label check requires one of the categorisation labels that is then used for release notes, but it does not pass when using the `ignore-for-release` label that excludes a pull request from release notes. This pull request rectifies this.