### PR TITLE
Update govulncheck Go version and mark the command as type 'test'.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -642,6 +642,7 @@ tasks:
     tags: ["static-analysis"]
     commands:
       - command: subprocess.exec
+        type: test
         params:
           binary: bash
           args: [*task-runner, govulncheck]

--- a/etc/govulncheck.sh
+++ b/etc/govulncheck.sh
@@ -7,7 +7,7 @@ set -ex
 # Note: this needs to be updated if the listed Go version has vulnerabilities
 # discovered because they will show up in the scan results along with Go Driver
 # and dependency vulnerabilities.
-GO_VERSION=1.24.5
+GO_VERSION=1.25.1
 
 go install golang.org/dl/go$GO_VERSION@latest
 go${GO_VERSION} download


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Bump the Go version in the govulncheck script to the latest Go version. Also mark the govulncheck command in the Evergreen config as type "test".

## Background & Motivation

Go 1.24.5 is subject to vulnerability [GO-2025-3849](https://pkg.go.dev/vuln/GO-2025-3849), so that shows up in the `govulncheck` output. Also, the govulncheck command in the Evergreen config is currently type "setup", so failures are incorrectly marked as setup failures.
