### PR TITLE
Allow ignore-for-release label to satisfy label checker [v2]

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: bug,feature,enhancement,documentation,dependencies
+          one_of: bug,feature,enhancement,documentation,dependencies,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cherry-pick of https://github.com/mongodb/mongo-go-driver/commit/21f47d4287f28410b3d1852128ed299ba7b2609e