### PR TITLE
Add a convenience wrapper for profiling and tracing Go tests.

### DIFF
--- a/etc/profile-test.sh
+++ b/etc/profile-test.sh
@@ -2,16 +2,19 @@
 # Convenience wrapper for profiling and tracing Go tests.
 set -eu
 
-# Set the prompt for the select menu.
-PS3="Choose a profile type: "
+# Create a temporary file to store the profile or trace data. Trap the exit
+# signals to clean it up after the script exits (typically via Ctrl-C).
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT INT TERM
 
+# Set the prompt and options for the select menu.
+PS3="Choose a profile type: "
 options=("cpu" "mem" "block" "mutex" "trace")
 
 select choice in "${options[@]}"
 do
     case $choice in
         "cpu" | "mem" | "block" | "mutex")
-            tmpfile=$(mktemp)
             echo "Writing $choice profile to $tmpfile"
 
             go test -${choice}profile ${tmpfile} "$@"
@@ -19,7 +22,6 @@ do
             break
             ;;
         "trace")
-            tmpfile=$(mktemp)
             echo "Writing trace to $tmpfile"
 
             go test -trace ${tmpfile} "$@"

--- a/etc/profile-test.sh
+++ b/etc/profile-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Convenience wrapper for profiling and tracing Go tests.
+set -eu
+
+# Set the prompt for the select menu.
+PS3="Choose a profile type: "
+
+options=("cpu" "mem" "block" "mutex" "trace")
+
+select choice in "${options[@]}"
+do
+    case $choice in
+        "cpu" | "mem" | "block" | "mutex")
+            tmpfile=$(mktemp)
+            echo "Writing $choice profile to $tmpfile"
+
+            go test -${choice}profile ${tmpfile} "$@"
+            go tool pprof -http=: ${tmpfile}
+            break
+            ;;
+        "trace")
+            tmpfile=$(mktemp)
+            echo "Writing trace to $tmpfile"
+
+            go test -trace ${tmpfile} "$@"
+            go tool trace ${tmpfile}
+            break
+            ;;
+        *)
+            echo "Invalid option. Please try again."
+            ;;
+    esac
+done


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Add a script `etc/profile-test.sh` that makes profiling and tracing Go tests and benchmarks easier.

## Background & Motivation
The command syntax is identical to `go test`, but you replace `go test` with `etc/profile-test.sh`.

E.g.
```
❯ etc/profile-test.sh -timeout 30s -run ^TestRetryableReadsProse$ go.mongodb.org/mongo-driver/v2/internal/integration -v
1) cpu
2) mem
3) block
4) mutex
5) trace
Choose a profile type: 1
Writing cpu profile to /var/folders/jm/nk3y7g2d0539mxh5bhdcnhcm0000gp/T/tmp.WwVNvAewwl
=== RUN   TestRetryableReadsProse
=== RUN   TestRetryableReadsProse/PoolClearedError_retryability
=== RUN   TestRetryableReadsProse/retrying_in_sharded_cluster
    mongotest.go:112: skipping due to environmental constraints: topology kind "single" does not match any of the required kinds ["sharded"]
--- PASS: TestRetryableReadsProse (1.52s)
    --- PASS: TestRetryableReadsProse/PoolClearedError_retryability (1.52s)
    --- SKIP: TestRetryableReadsProse/retrying_in_sharded_cluster (0.00s)
PASS
ok      go.mongodb.org/mongo-driver/v2/internal/integration     1.945s
Serving web UI on http://localhost:58230
```
