### PR TITLE
GODRIVER-3538 Remove serverless variants from Atlas test package.

### DIFF
--- a/internal/cmd/testatlas/atlas_test.go
+++ b/internal/cmd/testatlas/atlas_test.go
@@ -67,12 +67,6 @@ func TestAtlas(t *testing.T) {
 			wantErr:     "",
 		},
 		{
-			name:        "Atlas with serverless",
-			envVar:      "ATLAS_SERVERLESS",
-			certKeyFile: "",
-			wantErr:     "",
-		},
-		{
 			name:        "Atlas with srv file on replica set",
 			envVar:      "ATLAS_SRV_REPL",
 			certKeyFile: "",
@@ -99,12 +93,6 @@ func TestAtlas(t *testing.T) {
 		{
 			name:        "Atlas with srv file on TLS 1.2",
 			envVar:      "ATLAS_SRV_TLS12",
-			certKeyFile: "",
-			wantErr:     "",
-		},
-		{
-			name:        "Atlas with srv file on serverless",
-			envVar:      "ATLAS_SRV_SERVERLESS",
 			certKeyFile: "",
 			wantErr:     "",
 		},


### PR DESCRIPTION
[GODRIVER-3538](https://jira.mongodb.org/browse/GODRIVER-3538)

## Summary

Remove the two remaining Atlas Serverless tests from the `internal/cmd/testatlas` package.

## Background & Motivation

