### PR TITLE
GODRIVER-3768 Check unmatched type in Unmarshal().

### DIFF
--- a/bson/array_codec.go
+++ b/bson/array_codec.go
@@ -7,6 +7,7 @@
 package bson
 
 import (
+	"fmt"
 	"reflect"
 
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
@@ -29,6 +30,9 @@ func (ac *arrayCodec) EncodeValue(_ EncodeContext, vw ValueWriter, val reflect.V
 func (ac *arrayCodec) DecodeValue(_ DecodeContext, vr ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tCoreArray {
 		return ValueDecoderError{Name: "CoreArrayDecodeValue", Types: []reflect.Type{tCoreArray}, Received: val}
+	}
+	if vrType := vr.Type(); vrType != TypeArray {
+		return fmt.Errorf("cannot decode %v into a %s", vrType, val.Type())
 	}
 
 	if val.IsNil() {

--- a/bson/default_value_decoders.go
+++ b/bson/default_value_decoders.go
@@ -1310,6 +1310,11 @@ func coreDocumentDecodeValue(_ DecodeContext, vr ValueReader, val reflect.Value)
 	if !val.CanSet() || val.Type() != tCoreDocument {
 		return ValueDecoderError{Name: "CoreDocumentDecodeValue", Types: []reflect.Type{tCoreDocument}, Received: val}
 	}
+	vrType := vr.Type()
+	isDocument := vrType == Type(0) || vrType == TypeEmbeddedDocument || vrType == TypeArray
+	if !isDocument {
+		return fmt.Errorf("cannot decode %v into a %s", vrType, val.Type())
+	}
 
 	if val.IsNil() {
 		val.Set(reflect.MakeSlice(val.Type(), 0, 0))

--- a/bson/primitive_codecs.go
+++ b/bson/primitive_codecs.go
@@ -78,6 +78,11 @@ func rawDecodeValue(_ DecodeContext, vr ValueReader, val reflect.Value) error {
 	if !val.CanSet() || val.Type() != tRaw {
 		return ValueDecoderError{Name: "RawDecodeValue", Types: []reflect.Type{tRaw}, Received: val}
 	}
+	vrType := vr.Type()
+	isDocument := vrType == Type(0) || vrType == TypeEmbeddedDocument || vrType == TypeArray
+	if !isDocument {
+		return fmt.Errorf("cannot decode %v into a %s", vrType, val.Type())
+	}
 
 	if val.IsNil() {
 		val.Set(reflect.MakeSlice(val.Type(), 0, 0))

--- a/bson/unmarshal_test.go
+++ b/bson/unmarshal_test.go
@@ -846,7 +846,7 @@ func TestUnmarshalTypeCompatibility(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {
 		t.Parallel()
 
-		testcases := []struct {
+		testCases := []struct {
 			name   string
 			val    any
 			data   []byte
@@ -893,7 +893,7 @@ func TestUnmarshalTypeCompatibility(t *testing.T) {
 				errMsg: "cannot decode embedded document into a bsoncore.Array",
 			},
 		}
-		for _, tc := range testcases {
+		for _, tc := range testCases {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()


### PR DESCRIPTION
GODRIVER-3768

## Summary
Add type check in `Unmarshal()` for `bsoncore.Array`, `bsoncore.Document` and  `bson.Raw`.

## Background & Motivation
**Question**: Is this a breaking change?