### PR TITLE
GODRIVER-3810 Update WithTransaction to raise timeout error.

### DIFF
--- a/internal/integration/unified/operation.go
+++ b/internal/integration/unified/operation.go
@@ -28,26 +28,26 @@ type operation struct {
 
 // execute runs the operation and verifies the returned result and/or error. If the result needs to be saved as
 // an entity, it also updates the entityMap associated with ctx to do so.
-func (op *operation) execute(ctx context.Context, loopDone <-chan struct{}) error {
+func (op *operation) execute(ctx context.Context, loopDone <-chan struct{}) (*operationResult, error) {
 	res, err := op.run(ctx, loopDone)
 	if err != nil {
-		return fmt.Errorf("execution failed: %v", err)
+		return nil, fmt.Errorf("execution failed: %v", err)
 	}
 
 	if op.IgnoreResultAndError {
-		return nil
+		return nil, nil
 	}
 
 	if err := verifyOperationError(ctx, op.ExpectedError, res); err != nil {
-		return fmt.Errorf("error verification failed: %v", err)
+		return nil, fmt.Errorf("error verification failed: %v", err)
 	}
 
 	if op.ExpectedResult != nil {
 		if err := verifyOperationResult(ctx, *op.ExpectedResult, res); err != nil {
-			return fmt.Errorf("result verification failed: %v", err)
+			return nil, fmt.Errorf("result verification failed: %v", err)
 		}
 	}
-	return nil
+	return res, nil
 }
 
 // isCreateView will return true if the operation is to create a collection with a view.
@@ -125,8 +125,9 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 	case "startTransaction":
 		return executeStartTransaction(ctx, op)
 	case "withTransaction":
-		// executeWithTransaction internally verifies results/errors for each operation, so it doesn't return a result.
-		return newEmptyResult(), executeWithTransaction(ctx, op, loopDone)
+		// executeWithTransaction internally verifies results/errors for each operation.
+		// The error from WithTransaction() is wrapped in the result.
+		return executeWithTransaction(ctx, op, loopDone)
 	case "getSnapshotTime":
 		// executeGetSnapshotTime stores the snapshot time of the session as on
 		// the entity map for subsequent use.

--- a/internal/integration/unified/session_operation_execution.go
+++ b/internal/integration/unified/session_operation_execution.go
@@ -81,38 +81,47 @@ func executeStartTransaction(ctx context.Context, operation *operation) (*operat
 	return newErrorResult(sess.StartTransaction(opts)), nil
 }
 
-func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan struct{}) error {
+func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan struct{}) (*operationResult, error) {
 	sess, err := entities(ctx).session(op.Object)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Process the "callback" argument. This is an array of operation objects, each of which should be executed inside
 	// the transaction.
 	callback, err := op.Arguments.LookupErr("callback")
 	if err != nil {
-		return newMissingArgumentError("callback")
+		return nil, newMissingArgumentError("callback")
 	}
 	var operations []*operation
 	if err := callback.Unmarshal(&operations); err != nil {
-		return fmt.Errorf("error transforming callback option to slice of operations: %v", err)
+		return nil, fmt.Errorf("error transforming callback option to slice of operations: %v", err)
 	}
 
 	// Remove the "callback" field and process the other options.
 	var temp transactionOptions
 	if err := bson.Unmarshal(removeFieldsFromDocument(op.Arguments, "callback"), &temp); err != nil {
-		return fmt.Errorf("error unmarshalling arguments to transactionOptions: %v", err)
+		return nil, fmt.Errorf("error unmarshalling arguments to transactionOptions: %v", err)
 	}
 
-	_, err = sess.WithTransaction(ctx, func(ctx context.Context) (any, error) {
+	_, withTransErr := sess.WithTransaction(ctx, func(ctx context.Context) (any, error) {
+		var cbErr error
 		for idx, oper := range operations {
-			if err := oper.execute(ctx, loopDone); err != nil {
-				return nil, fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, err)
+			res, execErr := oper.execute(ctx, loopDone)
+			if execErr != nil {
+				err = fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, execErr)
+				return nil, nil
+			}
+			if cbErr == nil && res != nil {
+				cbErr = res.Err
 			}
 		}
-		return nil, nil
+		return nil, cbErr
 	}, temp.TransactionOptionsBuilder)
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &operationResult{Err: withTransErr}, nil
 }
 
 func executeGetSnapshotTime(ctx context.Context, op *operation) (*operationResult, error) {

--- a/internal/integration/unified/session_operation_execution.go
+++ b/internal/integration/unified/session_operation_execution.go
@@ -109,6 +109,7 @@ func executeWithTransaction(ctx context.Context, op *operation, loopDone <-chan 
 		for idx, oper := range operations {
 			res, execErr := oper.execute(ctx, loopDone)
 			if execErr != nil {
+				// Capture the error but continue executing the remaining operations in the callback.
 				err = fmt.Errorf("error executing operation %q at index %d: %v", oper.Name, idx, execErr)
 				return nil, nil
 			}

--- a/internal/integration/unified/testrunner_operation.go
+++ b/internal/integration/unified/testrunner_operation.go
@@ -259,8 +259,8 @@ func executeTestRunnerOperation(ctx context.Context, op *operation, loopDone <-c
 			return fmt.Errorf("run on unknown thread: %s", thread)
 		}
 		routine.(*backgroundRoutine).addTask(threadOp.Name, func() error {
-			_, err = threadOp.execute(ctx, loopDone)
-			return err
+			_, execErr := threadOp.execute(ctx, loopDone)
+			return execErr
 		})
 		return nil
 	case "waitForThread":

--- a/internal/integration/unified/testrunner_operation.go
+++ b/internal/integration/unified/testrunner_operation.go
@@ -259,7 +259,8 @@ func executeTestRunnerOperation(ctx context.Context, op *operation, loopDone <-c
 			return fmt.Errorf("run on unknown thread: %s", thread)
 		}
 		routine.(*backgroundRoutine).addTask(threadOp.Name, func() error {
-			return threadOp.execute(ctx, loopDone)
+			_, err = threadOp.execute(ctx, loopDone)
+			return err
 		})
 		return nil
 	case "waitForThread":
@@ -323,7 +324,7 @@ func executeLoop(ctx context.Context, args *loopArgs, loopDone <-chan struct{}) 
 				if operation.Name == "loop" {
 					return fmt.Errorf("loop sub-operations should not include loop")
 				}
-				loopErr = operation.execute(ctx, loopDone)
+				_, loopErr = operation.execute(ctx, loopDone)
 
 				// if the operation errors, stop this loop
 				if loopErr != nil {

--- a/internal/integration/unified/unified_spec_runner.go
+++ b/internal/integration/unified/unified_spec_runner.go
@@ -292,7 +292,7 @@ func (tc *TestCase) Run(ls LoggerSkipper) error {
 	}
 
 	for idx, operation := range tc.Operations {
-		if err := operation.execute(testCtx, tc.loopDone); err != nil {
+		if _, err := operation.execute(testCtx, tc.loopDone); err != nil {
 			if isSkipTestError(err) {
 				ls.Skip(err)
 			}

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -427,7 +427,6 @@ var skipTests = map[string][]string{
 		"TestUnifiedSpec/client-side-operations-timeout/tests/close-cursors.json/timeoutMS_is_refreshed_for_close",
 		"TestUnifiedSpec/client-side-operations-timeout/tests/convenient-transactions.json/withTransaction_raises_a_client-side_error_if_timeoutMS_is_overridden_inside_the_callback",
 		"TestUnifiedSpec/client-side-operations-timeout/tests/convenient-transactions.json/timeoutMS_is_not_refreshed_for_each_operation_in_the_callback",
-		"TestUnifiedSpec/client-side-operations-timeout/tests/convenient-transactions.json/withTransaction_surfaces_a_timeout_after_exhausting_transient_transaction_retries,_retaining_the_last_transient_error_as_the_timeout_cause.",
 		"TestUnifiedSpec/client-side-operations-timeout/tests/cursors.json/find_errors_if_timeoutMode_is_set_and_timeoutMS_is_not",
 		"TestUnifiedSpec/client-side-operations-timeout/tests/cursors.json/collection_aggregate_errors_if_timeoutMode_is_set_and_timeoutMS_is_not",
 		"TestUnifiedSpec/client-side-operations-timeout/tests/cursors.json/database_aggregate_errors_if_timeoutMode_is_set_and_timeoutMS_is_not",

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -205,6 +205,9 @@ func IsTimeout(err error) bool {
 	if errors.As(err, &topology.WaitQueueTimeoutError{}) {
 		return true
 	}
+	if errors.As(err, &timeoutError{}) {
+		return true
+	}
 	if ce := (CommandError{}); errors.As(err, &ce) && ce.IsMaxTimeMSExpiredError() {
 		return true
 	}
@@ -827,13 +830,15 @@ func (bwe ClientBulkWriteException) Error() string {
 	return "bulk write exception: " + strings.Join(causes, ", ")
 }
 
-// TimeoutError represents an error that occurred due to a timeout.
-type TimeoutError struct {
+var _ LabeledError = timeoutError{}
+
+// timeoutError represents an error that occurred due to a timeout.
+type timeoutError struct {
 	Wrapped error
 }
 
 // Error implements the error interface.
-func (e TimeoutError) Error() string {
+func (e timeoutError) Error() string {
 	const timeoutMsg = "operation timed out"
 	if e.Wrapped == nil {
 		return timeoutMsg
@@ -842,15 +847,13 @@ func (e TimeoutError) Error() string {
 }
 
 // Unwrap returns the underlying error.
-func (e TimeoutError) Unwrap() error {
+func (e timeoutError) Unwrap() error {
 	return e.Wrapped
 }
 
 // HasErrorLabel returns true if the error contains the specified label.
-func (e TimeoutError) HasErrorLabel(label string) bool {
-	if label == "ExceededTimeLimitError" {
-		return true
-	} else if le := LabeledError(nil); errors.As(e.Wrapped, &le) {
+func (e timeoutError) HasErrorLabel(label string) bool {
+	if le := LabeledError(nil); errors.As(e.Wrapped, &le) {
 		return le.HasErrorLabel(label)
 	}
 	return false

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -834,6 +834,9 @@ type TimeoutError struct {
 
 // Error implements the error interface.
 func (e TimeoutError) Error() string {
+	if e.Wrapped == nil {
+		return "operation timed out"
+	}
 	return e.Wrapped.Error()
 }
 

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -827,6 +827,31 @@ func (bwe ClientBulkWriteException) Error() string {
 	return "bulk write exception: " + strings.Join(causes, ", ")
 }
 
+// TimeoutError represents an error that occurred due to a timeout.
+type TimeoutError struct {
+	Wrapped error
+}
+
+// Error implements the error interface.
+func (e TimeoutError) Error() string {
+	return e.Wrapped.Error()
+}
+
+// Unwrap returns the underlying error.
+func (e TimeoutError) Unwrap() error {
+	return e.Wrapped
+}
+
+// HasErrorLabel returns true if the error contains the specified label.
+func (e TimeoutError) HasErrorLabel(label string) bool {
+	if label == "ExceededTimeLimitError" {
+		return true
+	} else if le := LabeledError(nil); errors.As(e.Wrapped, &le) {
+		return le.HasErrorLabel(label)
+	}
+	return false
+}
+
 // returnResult is used to determine if a function calling processWriteError should return
 // the result or return nil. Since the processWriteError function is used by many different
 // methods, both *One and *Many, we need a way to differentiate if the method should return

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -834,10 +834,11 @@ type TimeoutError struct {
 
 // Error implements the error interface.
 func (e TimeoutError) Error() string {
+	const timeoutMsg = "operation timed out"
 	if e.Wrapped == nil {
-		return "operation timed out"
+		return timeoutMsg
 	}
-	return e.Wrapped.Error()
+	return fmt.Sprintf("%s: %v", timeoutMsg, e.Wrapped.Error())
 }
 
 // Unwrap returns the underlying error.

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -667,7 +667,7 @@ func TestIsTimeout(t *testing.T) {
 		},
 		{
 			name:   "timeout error",
-			err:    TimeoutError{},
+			err:    timeoutError{},
 			result: true,
 		},
 		{
@@ -687,21 +687,21 @@ func TestIsTimeout(t *testing.T) {
 func TestTimeoutError(t *testing.T) {
 	tests := []struct {
 		name   string
-		err    TimeoutError
+		err    timeoutError
 		errMsg string
 		labels []string
 	}{
 		{
 			name: "TimeoutError without wrapped error",
-			err: TimeoutError{
+			err: timeoutError{
 				Wrapped: nil,
 			},
 			errMsg: "operation timed out",
-			labels: []string{"ExceededTimeLimitError"},
+			labels: []string{},
 		},
 		{
 			name: "TimeoutError with wrapped LabeledError",
-			err: TimeoutError{
+			err: timeoutError{
 				Wrapped: CommandError{
 					Code:    100,
 					Message: "",
@@ -712,23 +712,25 @@ func TestTimeoutError(t *testing.T) {
 				},
 			},
 			errMsg: "operation timed out: (blah): context deadline exceeded",
-			labels: []string{"ExceededTimeLimitError", "other"},
+			labels: []string{"other"},
 		},
 		{
 			name: "TimeoutError with wrapped non-LabeledError",
-			err: TimeoutError{
+			err: timeoutError{
 				Wrapped: context.DeadlineExceeded,
 			},
 			errMsg: "operation timed out: context deadline exceeded",
-			labels: []string{"ExceededTimeLimitError"},
+			labels: []string{},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.True(t, IsTimeout(tc.err), "expected a timeout error")
 			assert.Equal(t, tc.err.Error(), tc.errMsg, "expected error message %q, got %q", tc.errMsg, tc.err.Error())
+			var lerr LabeledError
+			require.True(t, errors.As(tc.err, &lerr), "expected a LabeledError")
 			for _, label := range tc.labels {
-				assert.True(t, tc.err.HasErrorLabel(label), "expected label %q", label)
+				assert.True(t, lerr.HasErrorLabel(label), "expected label %q", label)
 			}
 		})
 	}

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -666,6 +666,11 @@ func TestIsTimeout(t *testing.T) {
 			result: true,
 		},
 		{
+			name:   "timeout error",
+			err:    TimeoutError{},
+			result: true,
+		},
+		{
 			name:   "other error",
 			err:    errors.New("foo"),
 			result: false,
@@ -675,6 +680,56 @@ func TestIsTimeout(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := IsTimeout(tc.err)
 			assert.Equal(t, res, tc.result, "expected IsTimeout %v, got %v", tc.result, res)
+		})
+	}
+}
+
+func TestTimeoutError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    TimeoutError
+		errMsg string
+		labels []string
+	}{
+		{
+			name: "TimeoutError without wrapped error",
+			err: TimeoutError{
+				Wrapped: nil,
+			},
+			errMsg: "operation timed out",
+			labels: []string{"ExceededTimeLimitError"},
+		},
+		{
+			name: "TimeoutError with wrapped LabeledError",
+			err: TimeoutError{
+				Wrapped: CommandError{
+					Code:    100,
+					Message: "",
+					Labels:  []string{"other"},
+					Name:    "blah",
+					Wrapped: context.DeadlineExceeded,
+					Raw:     nil,
+				},
+			},
+			errMsg: "(blah): context deadline exceeded",
+			labels: []string{"ExceededTimeLimitError", "other"},
+		},
+		{
+			name: "TimeoutError with wrapped non-LabeledError",
+			err: TimeoutError{
+				Wrapped: context.DeadlineExceeded,
+			},
+			errMsg: "context deadline exceeded",
+			labels: []string{"ExceededTimeLimitError"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, IsTimeout(tc.err), "expected a timeout error")
+			assert.Equal(t, tc.err.Error(), tc.errMsg, "expected error message %q, got %q", tc.errMsg, tc.err.Error())
+			for _, label := range tc.labels {
+				assert.True(t, tc.err.HasErrorLabel(label), "expected label %q", label)
+			}
 		})
 	}
 }

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -711,7 +711,7 @@ func TestTimeoutError(t *testing.T) {
 					Raw:     nil,
 				},
 			},
-			errMsg: "(blah): context deadline exceeded",
+			errMsg: "operation timed out: (blah): context deadline exceeded",
 			labels: []string{"ExceededTimeLimitError", "other"},
 		},
 		{
@@ -719,7 +719,7 @@ func TestTimeoutError(t *testing.T) {
 			err: TimeoutError{
 				Wrapped: context.DeadlineExceeded,
 			},
-			errMsg: "context deadline exceeded",
+			errMsg: "operation timed out: context deadline exceeded",
 			labels: []string{"ExceededTimeLimitError"},
 		},
 	}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -148,13 +148,13 @@ func (s *Session) WithTransaction(
 			}
 			backoff := expDur * time.Duration(jitter.Int63n(512)) / 512
 			if time.Since(startTime)+backoff > transTimeout {
-				return nil, err
+				return nil, TimeoutError{Wrapped: err}
 			}
 			sleep := time.NewTimer(backoff)
 			select {
 			case <-timeout.C:
 				sleep.Stop()
-				return nil, err
+				return nil, TimeoutError{Wrapped: err}
 			case <-sleep.C:
 			}
 			if expDur < backoffMax {
@@ -178,7 +178,7 @@ func (s *Session) WithTransaction(
 
 			select {
 			case <-timeout.C:
-				return nil, err
+				return nil, TimeoutError{Wrapped: err}
 			default:
 			}
 

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -148,13 +148,13 @@ func (s *Session) WithTransaction(
 			}
 			backoff := expDur * time.Duration(jitter.Int63n(512)) / 512
 			if time.Since(startTime)+backoff > transTimeout {
-				return nil, TimeoutError{Wrapped: err}
+				return nil, timeoutError{Wrapped: err}
 			}
 			sleep := time.NewTimer(backoff)
 			select {
 			case <-timeout.C:
 				sleep.Stop()
-				return nil, TimeoutError{Wrapped: err}
+				return nil, timeoutError{Wrapped: err}
 			case <-sleep.C:
 			}
 			if expDur < backoffMax {
@@ -178,7 +178,7 @@ func (s *Session) WithTransaction(
 
 			select {
 			case <-timeout.C:
-				return nil, TimeoutError{Wrapped: err}
+				return nil, timeoutError{Wrapped: err}
 			default:
 			}
 
@@ -222,7 +222,7 @@ func (s *Session) WithTransaction(
 				if cerr.HasErrorLabel(driver.UnknownTransactionCommitResult) && !cerr.IsMaxTimeMSExpiredError() {
 					select {
 					case <-timeout.C:
-						return res, TimeoutError{Wrapped: err}
+						return res, timeoutError{Wrapped: err}
 					default:
 					}
 					continue

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -219,7 +219,7 @@ func (s *Session) WithTransaction(
 
 			select {
 			case <-timeout.C:
-				return res, err
+				return res, TimeoutError{Wrapped: err}
 			default:
 			}
 

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -217,15 +217,14 @@ func (s *Session) WithTransaction(
 				return res, nil
 			}
 
-			select {
-			case <-timeout.C:
-				return res, TimeoutError{Wrapped: err}
-			default:
-			}
-
 			var cerr CommandError
 			if errors.As(err, &cerr) {
 				if cerr.HasErrorLabel(driver.UnknownTransactionCommitResult) && !cerr.IsMaxTimeMSExpiredError() {
+					select {
+					case <-timeout.C:
+						return res, TimeoutError{Wrapped: err}
+					default:
+					}
 					continue
 				}
 				if cerr.HasErrorLabel(driver.TransientTransactionError) {


### PR DESCRIPTION
GODRIVER-3810, GODRIVER-3853

**NOTE**: GODRIVER-3853 supersedes some of the changes introduced by GODRIVER-3810.

## Summary
Create a `TimeoutError` type to be used for backoff timeouts in `WithTransaction()`.

## Background & Motivation

<!--- Rationale for the pull request. -->
