### PR TITLE
GODRIVER-3658 Implement backpressure retry logic.

### DIFF
--- a/internal/integration/backpressure_prose_test.go
+++ b/internal/integration/backpressure_prose_test.go
@@ -1,0 +1,86 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/event"
+	"go.mongodb.org/mongo-driver/v2/internal/assert"
+	"go.mongodb.org/mongo-driver/v2/internal/failpoint"
+	"go.mongodb.org/mongo-driver/v2/internal/integration/mtest"
+	"go.mongodb.org/mongo-driver/v2/internal/randutil"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func TestBackpressureProse(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().MinServerVersion("4.4").ClientType(mtest.Pinned).
+		CreateClient(false).AllowFailPointsOnSharded())
+	mt.Run("1. Operation Retry Uses Exponential Backoff", func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode:               failpoint.ModeAlwaysOn,
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorCode:    2,
+				ErrorLabels:  &[]string{"SystemOverloadedError", "RetryableError"},
+			},
+		})
+
+		mt.ResetClient(options.Client())
+
+		transWithJitter := func(t *mtest.T, ratio float64) time.Duration {
+			defer randutil.SetJitterForTesting(ratio)()
+
+			startTime := time.Now()
+			_, err := t.Coll.InsertOne(context.Background(), bson.D{{"a", 1}})
+			assert.IsTypef(t, mongo.CommandError{}, err, "expected a CommandError, got: %T", err)
+			return time.Since(startTime)
+		}
+		noBackoffTime := transWithJitter(mt, 0)
+		withBackoffTime := transWithJitter(mt, 1)
+		assert.GreaterOrEqualf(
+			mt,
+			withBackoffTime, noBackoffTime+2_100*time.Millisecond,
+			"with backoff time: %v, no backoff time: %v", withBackoffTime, noBackoffTime,
+		)
+	})
+	mt.Run("3. Overload Errors are Retried a Maximum of MAX_RETRIES times", func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode:               failpoint.ModeAlwaysOn,
+			Data: failpoint.Data{
+				FailCommands: []string{"find"},
+				ErrorCode:    462,
+				ErrorLabels:  &[]string{"SystemOverloadedError", "RetryableError"},
+			},
+		})
+
+		var opsCnt int
+		monitor := &event.CommandMonitor{
+			Started: func(_ context.Context, e *event.CommandStartedEvent) {
+				if e.CommandName == "find" {
+					opsCnt++
+				}
+			},
+		}
+		mt.ResetClient(options.Client().SetMonitor(monitor))
+
+		_, err := mt.Coll.Find(context.Background(), bson.D{})
+		var cmdErr mongo.CommandError
+		require.Truef(mt, errors.As(err, &cmdErr), "expected a CommandError, got %T: %v", err, err)
+		assert.True(mt, cmdErr.HasErrorLabel("RetryableError"), `expected error has "RetryableError" label`)
+		assert.True(mt, cmdErr.HasErrorLabel("SystemOverloadedError"), `expected error has "SystemOverloadedError" label`)
+		assert.Equalf(mt, 6, opsCnt, "expected 6 attempts (1 original + 5 retries), got %d", opsCnt)
+	})
+}

--- a/internal/integration/handshake_test.go
+++ b/internal/integration/handshake_test.go
@@ -1252,6 +1252,25 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 	}
 }
 
+// Test 9: Handshake documents include backpressure: true
+func TestHandshakeProse_Handshake_Documents(t *testing.T) {
+	mt := mtest.New(t,
+		mtest.NewOptions().CreateCollection(false).ClientType(mtest.Proxy),
+	)
+	mt.ResetClient(options.Client())
+	err := mt.Client.Ping(context.Background(), nil)
+	require.NoError(mt, err, "Ping error: %v", err)
+
+	firstMessage := mt.GetProxyCapture().TryNext()
+	require.NotNil(mt, firstMessage, "expected to capture a proxied message")
+
+	require.True(mt, firstMessage.IsHandshake(), "expected first message to be a handshake")
+
+	v, err := firstMessage.Sent.Command.LookupErr("backpressure")
+	require.NoError(mt, err, "expected backpressure field in handshake command document")
+	require.True(mt, v.Boolean(), "expected backpressure field to be true")
+}
+
 // mustMarshalBSON marshals a value to BSON. It panics if any error occurs.
 func mustMarshalBSON(val interface{}) []byte {
 	bytes, err := bson.Marshal(val)

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -388,7 +388,7 @@ func TestRetryableWritesProse(t *testing.T) {
 }
 
 func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
-	mt := mtest.New(t, mtest.NewOptions().
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false).
 		MinServerVersion("6.0").
 		Topologies(mtest.ReplicaSet))
 
@@ -401,10 +401,8 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 		return false
 	}
 
-	mt.Run("Case 1: Test that drivers return the correct error when receiving only errors without NoWritesPerformed", func(subt *mtest.T) {
-		defer subt.ClearFailPoints()
-
-		subt.SetFailPoint(failpoint.FailPoint{
+	mt.Run("Case 1: Test that drivers return the correct error when receiving only errors without NoWritesPerformed", func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: failpoint.Mode{
 				Times: 1,
@@ -422,7 +420,7 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 					return
 				}
 				if errorCodesContains(event.Failure, 91) {
-					subt.SetFailPoint(failpoint.FailPoint{
+					mt.SetFailPoint(failpoint.FailPoint{
 						ConfigureFailPoint: "failCommand",
 						Mode:               failpoint.ModeAlwaysOn,
 						Data: failpoint.Data{
@@ -436,13 +434,11 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 		}
 		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
-		require.True(subt, errorCodesContains(err, 10107), "Expect the error code of the server error to be 10107")
+		require.True(mt, errorCodesContains(err, 10107), "Expect the error code of the server error to be 10107")
 	})
 
-	mt.Run("Case 2: Test that drivers return the correct error when receiving only errors with NoWritesPerformed", func(subt *mtest.T) {
-		defer subt.ClearFailPoints()
-
-		subt.SetFailPoint(failpoint.FailPoint{
+	mt.Run("Case 2: Test that drivers return the correct error when receiving only errors with NoWritesPerformed", func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode: failpoint.Mode{
 				Times: 1,
@@ -460,7 +456,7 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 					return
 				}
 				if errorCodesContains(event.Failure, 91) {
-					subt.SetFailPoint(failpoint.FailPoint{
+					mt.SetFailPoint(failpoint.FailPoint{
 						ConfigureFailPoint: "failCommand",
 						Mode:               failpoint.ModeAlwaysOn,
 						Data: failpoint.Data{
@@ -474,13 +470,11 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 		}
 		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
-		require.True(subt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
+		require.True(mt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
 	})
 
-	mt.Run("Case 3: Test that drivers return the correct error when receiving some errors with NoWritesPerformed and some without NoWritesPerformed", func(subt *mtest.T) {
-		defer subt.ClearFailPoints()
-
-		subt.SetFailPoint(failpoint.FailPoint{
+	mt.Run("Case 3: Test that drivers return the correct error when receiving some errors with NoWritesPerformed and some without NoWritesPerformed", func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
 			ConfigureFailPoint: "failCommand",
 			Mode:               failpoint.ModeAlwaysOn,
 			Data: failpoint.Data{
@@ -496,7 +490,7 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 					return
 				}
 				if errorCodesContains(event.Failure, 91) {
-					subt.SetFailPoint(failpoint.FailPoint{
+					mt.SetFailPoint(failpoint.FailPoint{
 						ConfigureFailPoint: "failCommand",
 						Mode: failpoint.Mode{
 							Times: 1,
@@ -512,10 +506,10 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 		}
 		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
 		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
-		require.True(subt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
+		require.True(mt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
 		var labeledError driver.Error
-		require.True(subt, errors.As(err, &labeledError), "expected error to be a labeled error")
-		require.NotContains(subt, labeledError.Labels, "NoWritesPerformed", "expected error labels to not contain NoWritesPerformed")
+		require.True(mt, errors.As(err, &labeledError), "expected error to be a labeled error")
+		require.NotContains(mt, labeledError.Labels, "NoWritesPerformed", "expected error labels to not contain NoWritesPerformed")
 	})
 }
 

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -9,6 +9,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -383,6 +384,138 @@ func TestRetryableWritesProse(t *testing.T) {
 				assert.Equal(mt, tc.expectedSuccessCount, successCount)
 			})
 		}
+	})
+}
+
+func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().
+		MinServerVersion("6.0").
+		Topologies(mtest.ReplicaSet))
+
+	errorCodesContains := func(err error, code int) bool {
+		for _, ec := range mongo.ErrorCodes(err) {
+			if ec == code {
+				return true
+			}
+		}
+		return false
+	}
+
+	mt.Run("Case 1: Test that drivers return the correct error when receiving only errors without NoWritesPerformed", func(subt *mtest.T) {
+		defer subt.ClearFailPoints()
+
+		subt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: failpoint.Mode{
+				Times: 1,
+			},
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError"},
+				ErrorCode:    91,
+			},
+		})
+
+		monitor := &event.CommandMonitor{
+			Failed: func(_ context.Context, event *event.CommandFailedEvent) {
+				if event.CommandName != "insert" {
+					return
+				}
+				if errorCodesContains(event.Failure, 91) {
+					subt.SetFailPoint(failpoint.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode:               failpoint.ModeAlwaysOn,
+						Data: failpoint.Data{
+							FailCommands: []string{"insert"},
+							ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError"},
+							ErrorCode:    10107,
+						},
+					})
+				}
+			},
+		}
+		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+		require.True(subt, errorCodesContains(err, 10107), "Expect the error code of the server error to be 10107")
+	})
+
+	mt.Run("Case 2: Test that drivers return the correct error when receiving only errors with NoWritesPerformed", func(subt *mtest.T) {
+		defer subt.ClearFailPoints()
+
+		subt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: failpoint.Mode{
+				Times: 1,
+			},
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError", "NoWritesPerformed"},
+				ErrorCode:    91,
+			},
+		})
+
+		monitor := &event.CommandMonitor{
+			Failed: func(_ context.Context, event *event.CommandFailedEvent) {
+				if event.CommandName != "insert" {
+					return
+				}
+				if errorCodesContains(event.Failure, 91) {
+					subt.SetFailPoint(failpoint.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode:               failpoint.ModeAlwaysOn,
+						Data: failpoint.Data{
+							FailCommands: []string{"insert"},
+							ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError", "NoWritesPerformed"},
+							ErrorCode:    10107,
+						},
+					})
+				}
+			},
+		}
+		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+		require.True(subt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
+	})
+
+	mt.Run("Case 3: Test that drivers return the correct error when receiving some errors with NoWritesPerformed and some without NoWritesPerformed", func(subt *mtest.T) {
+		defer subt.ClearFailPoints()
+
+		subt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode:               failpoint.ModeAlwaysOn,
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError", "NoWritesPerformed"},
+				ErrorCode:    91,
+			},
+		})
+
+		monitor := &event.CommandMonitor{
+			Failed: func(_ context.Context, event *event.CommandFailedEvent) {
+				if event.CommandName != "insert" {
+					return
+				}
+				if errorCodesContains(event.Failure, 91) {
+					subt.SetFailPoint(failpoint.FailPoint{
+						ConfigureFailPoint: "failCommand",
+						Mode: failpoint.Mode{
+							Times: 1,
+						},
+						Data: failpoint.Data{
+							FailCommands: []string{"insert"},
+							ErrorLabels:  &[]string{"RetryableError", "SystemOverloadedError"},
+							ErrorCode:    91,
+						},
+					})
+				}
+			},
+		}
+		mt.ResetClient(options.Client().SetRetryWrites(true).SetMonitor(monitor))
+		_, err := mt.Coll.InsertOne(context.Background(), bson.D{})
+		require.True(subt, errorCodesContains(err, 91), "Expect the error code of the server error to be 91")
+		var labeledError driver.Error
+		require.True(subt, errors.As(err, &labeledError), "expected error to be a labeled error")
+		require.NotContains(subt, labeledError.Labels, "NoWritesPerformed", "expected error labels to not contain NoWritesPerformed")
 	})
 }
 

--- a/internal/integration/unified/client_entity.go
+++ b/internal/integration/unified/client_entity.go
@@ -24,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
 )
@@ -817,6 +818,21 @@ func setClientOptionsFromURIOptions(clientOpts *options.ClientOptions, uriOpts b
 			clientOpts.SetServerSelectionTimeout(time.Duration(value.(int32)) * time.Millisecond)
 		case "servermonitoringmode":
 			clientOpts.SetServerMonitoringMode(value.(string))
+		case "readpreference":
+			switch rPref := value.(string); strings.ToLower(rPref) {
+			case "primary":
+				clientOpts.SetReadPreference(readpref.Primary())
+			case "primarypreferred":
+				clientOpts.SetReadPreference(readpref.PrimaryPreferred())
+			case "secondary":
+				clientOpts.SetReadPreference(readpref.Secondary())
+			case "secondarypreferred":
+				clientOpts.SetReadPreference(readpref.SecondaryPreferred())
+			case "nearest":
+				clientOpts.SetReadPreference(readpref.Nearest())
+			default:
+				return fmt.Errorf("unrecognized read preference %s", rPref)
+			}
 		default:
 			return fmt.Errorf("unrecognized URI option %s", key)
 		}

--- a/internal/integration/unified/unified_spec_test.go
+++ b/internal/integration/unified/unified_spec_test.go
@@ -37,6 +37,8 @@ var (
 		"run-command/tests/unified",
 		"index-management/tests",
 		"mongodb-handshake/tests/unified",
+		"client-backpressure/tests",
+		"transactions/tests/unified",
 	}
 	failDirectories = []string{
 		"unified-test-format/tests/valid-fail",

--- a/internal/randutil/jitter.go
+++ b/internal/randutil/jitter.go
@@ -6,22 +6,20 @@
 
 package randutil
 
-import (
-	"sync/atomic"
-)
-
-var presetRatio atomic.Pointer[float64]
+var presetRatio *float64
 
 var globalRand = NewLockedRand()
 
-// JitterInt63n returns a random int64 in [0, n) by default. If a preset jitter ratio is set
-// for testing, it returns a value based on the ratio instead of a random value.
+// JitterInt63n returns, as an int64, a non-negative pseudo-random number in
+// the half-open interval [0,n). It panics if n <= 0.
+//
+// If a static jitter ratio is set by calling SetJitterForTesting, JitterInt63n
+// returns int64(n*ratio) in [0,n].
 func JitterInt63n(n int64) int64 {
-	ratioPtr := presetRatio.Load()
-	if ratioPtr == nil {
+	if presetRatio == nil {
 		return globalRand.Int63n(n)
 	}
-	val := int64(*ratioPtr * float64(n))
+	val := int64(*presetRatio * float64(n))
 	if val < 0 {
 		return 0
 	}
@@ -33,6 +31,6 @@ func JitterInt63n(n int64) int64 {
 
 // SetJitterForTesting sets a preset jitter ratio for testing and returns a restore function.
 func SetJitterForTesting(ratio float64) func() {
-	presetRatio.Store(&ratio)
-	return func() { presetRatio.Store(nil) }
+	presetRatio = &ratio
+	return func() { presetRatio = nil }
 }

--- a/internal/randutil/jitter.go
+++ b/internal/randutil/jitter.go
@@ -1,0 +1,38 @@
+// Copyright (C) MongoDB, Inc. 2022-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package randutil
+
+import (
+	"sync/atomic"
+)
+
+var presetRatio atomic.Pointer[float64]
+
+var globalRand = NewLockedRand()
+
+// JitterInt63n returns a random int64 in [0, n) by default. If a preset jitter ratio is set
+// for testing, it returns a value based on the ratio instead of a random value.
+func JitterInt63n(n int64) int64 {
+	ratioPtr := presetRatio.Load()
+	if ratioPtr == nil {
+		return globalRand.Int63n(n)
+	}
+	val := int64(*ratioPtr * float64(n))
+	if val < 0 {
+		return 0
+	}
+	if val > n {
+		return n
+	}
+	return int64(val)
+}
+
+// SetJitterForTesting sets a preset jitter ratio for testing and returns a restore function.
+func SetJitterForTesting(ratio float64) func() {
+	presetRatio.Store(&ratio)
+	return func() { presetRatio.Store(nil) }
+}

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -261,12 +261,12 @@ var skipTests = map[string][]string{
 	// TODO(GODRIVER-3034): Drivers should unpin connections when ending a
 	// session.
 	"Unpin connections at session end (GODRIVER-3034)": {
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_on_successful_abort",
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_after_non-transient_error_on_abort",
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_after_TransientTransactionError_error_on_abort",
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_when_a_new_transaction_is_started",
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_when_a_non-transaction_write_operation_uses_a_session",
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_when_a_non-transaction_read_operation_uses_a_session",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_on_successful_abort",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_after_non-transient_error_on_abort",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_after_TransientTransactionError_error_on_abort",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_when_a_new_transaction_is_started",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_when_a_non-transaction_write_operation_uses_a_session",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_when_a_non-transaction_read_operation_uses_a_session",
 	},
 
 	// TODO(GODRIVER-3146): Convert retryable reads spec tests to unified test format.
@@ -759,7 +759,7 @@ var skipTests = map[string][]string{
 	// TODO(GODRIVER-3137): Gossip cluster time from internal MongoClient to
 	// session entities.
 	"Must advance cluster times in unified spec runner (GODRIVER-3137)": {
-		"TestUnifiedSpec/transactions/unified/mongos-unpin.json/unpin_after_TransientTransactionError_error_on_commit",
+		"TestUnifiedSpec/transactions/tests/unified/mongos-unpin.json/unpin_after_TransientTransactionError_error_on_commit",
 		// This test fails with the same error as GODRIVER-3137, but is not
 		// directly referenced as an impacted test case by DRIVERS-2816. It
 		// seems likely that the same change will resolve the failure, so I'm
@@ -850,12 +850,28 @@ var skipTests = map[string][]string{
 		"TestUnifiedSpec/client-side-encryption/tests/unified/accessToken-azure.json/Explicit_encrypt_using_access_token_Azure_credentials",
 		"TestUnifiedSpec/client-side-encryption/tests/unified/accessToken-gcp.json/Auto_encrypt_using_access_token_GCP_credentials",
 		"TestUnifiedSpec/client-side-encryption/tests/unified/accessToken-gcp.json/Explicit_encrypt_using_access_token_GCP_credentials",
-		"TestURIOptionsSpec/client-backpressure-options.json/adaptiveRetries_with_invalid_value_causes_a_warning",
 	},
 
 	// TODO(GODRIVER-3637): Implement client backpressure.
 	"Implement client backpressure": {
 		"TestURIOptionsSpec/client-backpressure-options.json/adaptiveRetries_with_invalid_value_causes_a_warning",
+	},
+
+	// TODO(GODRIVER-3484): Rename WriteConcernFailed code name to WriteConcernTimeout.
+	"Rename WriteConcernFailed code name to WriteConcernTimeout": {
+		"TestUnifiedSpec/transactions/tests/unified/error-labels.json/add_UnknownTransactionCommitResult_label_to_MaxTimeMSExpired",
+		"TestUnifiedSpec/transactions/tests/unified/error-labels.json/do_not_add_UnknownTransactionCommitResult_label_to_MaxTimeMSExpired_inside_transactions",
+		"TestUnifiedSpec/transactions/tests/unified/error-labels.json/add_UnknownTransactionCommitResult_label_to_writeConcernError_MaxTimeMSExpired",
+	},
+
+	// GODRIVER-2348
+	"transactions CSOT Options": {
+		"TestUnifiedSpec/transactions/tests/unified/retryable-commit.json/commitTransaction_applies_majority_write_concern_on_retries",
+		"TestUnifiedSpec/transactions/tests/unified/transaction-options.json/transaction_options_inherited_from_client",
+		"TestUnifiedSpec/transactions/tests/unified/transaction-options.json/transaction_options_inherited_from_defaultTransactionOptions",
+		"TestUnifiedSpec/transactions/tests/unified/transaction-options.json/startTransaction_options_override_defaults",
+		"TestUnifiedSpec/transactions/tests/unified/transaction-options.json/defaultTransactionOptions_override_client_options",
+		"TestUnifiedSpec/transactions/tests/unified/transaction-options.json/readConcern_local_in_defaultTransactionOptions",
 	},
 }
 

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -199,6 +199,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (inser
 		timeout:       bw.collection.client.timeout,
 		logger:        bw.collection.client.logger,
 		authenticator: bw.collection.client.authenticator,
+		retryOverload: bw.collection.client.retryWrites,
 	}
 
 	if bw.comment != nil {
@@ -271,10 +272,16 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		i++
 	}
 
+	retry := driver.RetryNone
+	if bw.collection.client.retryWrites && batch.canRetry {
+		retry = driver.RetryOncePerCommand
+	}
+
 	op := operation.NewDelete(docs...).
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
+		Retry(retry).RetryOverload(bw.collection.client.retryWrites).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ServerAPI(bw.collection.client.serverAPI).Timeout(bw.collection.client.timeout).
 		Logger(bw.collection.client.logger).Authenticator(bw.collection.client.authenticator)
@@ -295,11 +302,6 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
 	}
-	retry := driver.RetryNone
-	if bw.collection.client.retryWrites && batch.canRetry {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	if bw.rawData != nil {
 		op.RawData(*bw.rawData)
@@ -404,10 +406,16 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		docs[i] = doc
 	}
 
+	retry := driver.RetryNone
+	if bw.collection.client.retryWrites && batch.canRetry {
+		retry = driver.RetryOncePerCommand
+	}
+
 	op := operation.NewUpdate(docs...).
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
+		Retry(retry).RetryOverload(bw.collection.client.retryWrites).
 		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.cryptFLE).Hint(hasHint).
 		ArrayFilters(hasArrayFilters).ServerAPI(bw.collection.client.serverAPI).
 		Timeout(bw.collection.client.timeout).Logger(bw.collection.client.logger).
@@ -432,11 +440,6 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 	if bw.bypassDocumentValidation != nil && *bw.bypassDocumentValidation {
 		op = op.BypassDocumentValidation(*bw.bypassDocumentValidation)
 	}
-	retry := driver.RetryNone
-	if bw.collection.client.retryWrites && batch.canRetry {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	if bw.rawData != nil {
 		op.RawData(*bw.rawData)

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -24,7 +24,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/mnet"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/operation"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 )
@@ -145,7 +144,8 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline an
 	cs.aggregate = operation.NewAggregate(nil).
 		ReadPreference(config.readPreference).ReadConcern(config.readConcern).
 		Deployment(cs.client.deployment).ClusterClock(cs.client.clock).
-		CommandMonitor(cs.client.monitor).Session(cs.sess).ServerSelector(cs.selector).Retry(driver.RetryNone).
+		CommandMonitor(cs.client.monitor).Session(cs.sess).ServerSelector(cs.selector).
+		Retry(driver.RetryNone).RetryOverload(cs.client.retryReads).
 		ServerAPI(cs.client.serverAPI).Crypt(config.crypt).Timeout(cs.client.timeout).
 		Authenticator(cs.client.authenticator)
 
@@ -241,36 +241,63 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline an
 	return cs, cs.Err()
 }
 
-func (cs *ChangeStream) createOperationDeployment(server driver.Server, connection *mnet.Connection) driver.Deployment {
-	return &changeStreamDeployment{
+func (cs *ChangeStream) createOperationDeployment(ctx context.Context) (*changeStreamDeployment, error) {
+	var cancel context.CancelFunc
+
+	deployment := &changeStreamDeployment{
 		topologyKind: cs.client.deployment.Kind(),
-		server:       server,
-		conn:         connection,
 	}
+	deployment.close = func() error {
+		var err error
+		if deployment.conn != nil {
+			err = deployment.conn.Close()
+		}
+		if cancel != nil {
+			cancel()
+		}
+		return err
+	}
+	deployment.reset = func() error {
+		_ = deployment.close()
+
+		var err error
+		var connCtx context.Context
+		connCtx, cancel = csot.WithServerSelectionTimeout(ctx, cs.client.deployment.GetServerSelectionTimeout())
+		deployment.server, err = cs.client.deployment.SelectServer(connCtx, cs.selector)
+		if err != nil {
+			cancel()
+			return err
+		}
+		deployment.conn, err = deployment.server.Connection(connCtx)
+		if err != nil {
+			cancel()
+			return err
+		}
+		cs.wireVersion = deployment.conn.Description().WireVersion
+		return nil
+	}
+	if err := deployment.reset(); err != nil {
+		return nil, err
+	}
+	return deployment, nil
 }
 
 func (cs *ChangeStream) executeOperation(ctx context.Context, resuming bool) error {
-	var server driver.Server
-	var conn *mnet.Connection
+	var deployment *changeStreamDeployment
 
 	// Apply the client-level timeout if the operation-level timeout is not set.
 	ctx, cancel := csot.WithTimeout(ctx, cs.client.timeout)
 	defer cancel()
 
-	connCtx, cancel := csot.WithServerSelectionTimeout(ctx, cs.client.deployment.GetServerSelectionTimeout())
-	defer cancel()
-
-	if server, cs.err = cs.client.deployment.SelectServer(connCtx, cs.selector); cs.err != nil {
+	deployment, cs.err = cs.createOperationDeployment(ctx)
+	if cs.err != nil {
 		return cs.Err()
 	}
+	defer func() {
+		_ = deployment.close()
+	}()
 
-	if conn, cs.err = server.Connection(connCtx); cs.err != nil {
-		return cs.Err()
-	}
-	defer conn.Close()
-	cs.wireVersion = conn.Description().WireVersion
-
-	cs.aggregate.Deployment(cs.createOperationDeployment(server, conn))
+	cs.aggregate.Deployment(deployment)
 
 	if resuming {
 		cs.replaceOptions(cs.wireVersion)
@@ -319,30 +346,15 @@ AggregateExecuteLoop:
 				break AggregateExecuteLoop
 			}
 
-			connCtx, cancel := csot.WithServerSelectionTimeout(ctx, cs.client.deployment.GetServerSelectionTimeout())
-			defer cancel()
-
 			// If error is retryable: subtract 1 from retries, redo server selection, checkout
 			// a connection, and restart loop.
 			retries--
-			server, err = cs.client.deployment.SelectServer(connCtx, cs.selector)
-			if err != nil {
-				break AggregateExecuteLoop
-			}
-
-			conn.Close()
-
-			conn, err = server.Connection(connCtx)
-			if err != nil {
-				break AggregateExecuteLoop
-			}
-			defer conn.Close()
-
-			// Update the wire version with data from the new connection.
-			cs.wireVersion = conn.Description().WireVersion
 
 			// Reset deployment.
-			cs.aggregate.Deployment(cs.createOperationDeployment(server, conn))
+			err = deployment.reset()
+			if err != nil {
+				break AggregateExecuteLoop
+			}
 		} else {
 			// Do not retry if error is not a driver error.
 			break AggregateExecuteLoop
@@ -354,7 +366,7 @@ AggregateExecuteLoop:
 	}
 
 	cr := cs.aggregate.ResultCursorResponse()
-	cr.Server = server
+	cr.Server = deployment.server
 
 	cs.cursor, cs.err = driver.NewBatchCursor(cr, cs.sess, cs.client.clock, cs.cursorOptions)
 	if cs.err = wrapErrors(cs.err); cs.err != nil {

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -19,6 +19,9 @@ type changeStreamDeployment struct {
 	topologyKind description.TopologyKind
 	server       driver.Server
 	conn         *mnet.Connection
+
+	reset func() error
+	close func() error
 }
 
 var (
@@ -36,7 +39,11 @@ func (c *changeStreamDeployment) Kind() description.TopologyKind {
 }
 
 func (c *changeStreamDeployment) Connection(context.Context) (*mnet.Connection, error) {
-	return c.conn, nil
+	var err error
+	if c.conn == nil || c.conn.Closed() {
+		err = c.reset()
+	}
+	return c.conn, err
 }
 
 func (c *changeStreamDeployment) RTTMonitor() driver.RTTMonitor {

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -760,6 +760,11 @@ func (c *Client) ListDatabases(ctx context.Context, filter any, opts ...options.
 		return ListDatabasesResult{}, err
 	}
 
+	retry := driver.RetryNone
+	if c.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	var selector description.ServerSelector
 
 	selector = &serverselector.Composite{
@@ -777,6 +782,7 @@ func (c *Client) ListDatabases(ctx context.Context, filter any, opts ...options.
 	}
 	op := operation.NewListDatabases(filterDoc).
 		Session(sess).ReadPreference(c.readPreference).CommandMonitor(c.monitor).
+		Retry(retry).RetryOverload(c.retryReads).
 		ServerSelector(selector).ClusterClock(c.clock).Database("admin").Deployment(c.deployment).Crypt(c.cryptFLE).
 		ServerAPI(c.serverAPI).Timeout(c.timeout).Authenticator(c.authenticator)
 
@@ -786,12 +792,6 @@ func (c *Client) ListDatabases(ctx context.Context, filter any, opts ...options.
 	if lda.AuthorizedDatabases != nil {
 		op = op.AuthorizedDatabases(*lda.AuthorizedDatabases)
 	}
-
-	retry := driver.RetryNone
-	if c.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op.Retry(retry)
 
 	err = op.Execute(ctx)
 	if err != nil {
@@ -1012,6 +1012,7 @@ func (c *Client) BulkWrite(ctx context.Context, writes []ClientBulkWrite,
 		client:                   c,
 		selector:                 selector,
 		writeConcern:             wc,
+		retryOverload:            c.retryWrites,
 	}
 	if rawData, ok := optionsutil.Value(bwo.Internal, "rawData").(bool); ok {
 		op.rawData = &rawData

--- a/mongo/client_bulk_write.go
+++ b/mongo/client_bulk_write.go
@@ -46,6 +46,7 @@ type clientBulkWrite struct {
 	writeConcern             *writeconcern.WriteConcern
 	rawData                  *bool
 	additionalCmd            bson.D
+	retryOverload            bool
 
 	result ClientBulkWriteResult
 }
@@ -73,6 +74,7 @@ func (bw *clientBulkWrite) execute(ctx context.Context) error {
 		Client:            bw.session,
 		Clock:             bw.client.clock,
 		RetryMode:         &batches.retryMode,
+		RetryOverload:     bw.retryOverload,
 		Type:              driver.Write,
 		Batches:           batches,
 		CommandMonitor:    bw.client.monitor,

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -54,7 +54,6 @@ type aggregateParams struct {
 	registry       *bson.Registry
 	readConcern    *readconcern.ReadConcern
 	writeConcern   *writeconcern.WriteConcern
-	retryRead      bool
 	db             string
 	col            string
 	readSelector   description.ServerSelector
@@ -311,6 +310,7 @@ func (coll *Collection) insert(
 		session:       sess,
 		writeConcern:  wc,
 		monitor:       coll.client.monitor,
+		retryOverload: coll.client.retryWrites,
 		selector:      selector,
 		clock:         coll.client.clock,
 		database:      coll.db.name,
@@ -521,6 +521,12 @@ func (coll *Collection) delete(
 		sess = nil
 	}
 
+	// deleteMany cannot be retried
+	retryMode := driver.RetryNone
+	if deleteOne && coll.client.retryWrites {
+		retryMode = driver.RetryOncePerCommand
+	}
+
 	selector := makePinnedSelector(sess, coll.writeSelector)
 
 	var limit int32
@@ -549,6 +555,7 @@ func (coll *Collection) delete(
 
 	op := operation.NewDelete(doc).
 		Session(sess).WriteConcern(wc).CommandMonitor(coll.client.monitor).
+		Retry(retryMode).RetryOverload(coll.client.retryWrites).
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).Ordered(true).
@@ -574,12 +581,6 @@ func (coll *Collection) delete(
 		op = op.RawData(rawData)
 	}
 
-	// deleteMany cannot be retried
-	retryMode := driver.RetryNone
-	if deleteOne && coll.client.retryWrites {
-		retryMode = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retryMode)
 	rr, err := processWriteError(op.Execute(ctx))
 	if rr&expectedRr == 0 {
 		return nil, err
@@ -693,10 +694,17 @@ func (coll *Collection) updateOrReplace(
 		sess = nil
 	}
 
+	retry := driver.RetryNone
+	// retryable writes are only enabled updateOne/replaceOne operations
+	if !multi && coll.client.retryWrites {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector := makePinnedSelector(sess, coll.writeSelector)
 
 	op := operation.NewUpdate(updateDoc).
 		Session(sess).WriteConcern(wc).CommandMonitor(coll.client.monitor).
+		Retry(retry).RetryOverload(coll.client.retryWrites).
 		ServerSelector(selector).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).Hint(args.Hint != nil).
@@ -726,12 +734,6 @@ func (coll *Collection) updateOrReplace(
 	if additionalCmd, ok := optionsutil.Value(args.Internal, "addCommandFields").(bson.D); ok {
 		op = op.AdditionalCmd(additionalCmd)
 	}
-	retry := driver.RetryNone
-	// retryable writes are only enabled updateOne/replaceOne operations
-	if !multi && coll.client.retryWrites {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 	err = op.Execute(ctx)
 
 	rr, err := processWriteError(err)
@@ -941,7 +943,6 @@ func (coll *Collection) Aggregate(
 		readConcern:    coll.readConcern,
 		writeConcern:   coll.writeConcern,
 		bsonOpts:       coll.bsonOpts,
-		retryRead:      coll.client.retryReads,
 		db:             coll.db.name,
 		col:            coll.name,
 		readSelector:   coll.readSelector,
@@ -973,6 +974,7 @@ func aggregate(a aggregateParams, opts ...options.Lister[options.AggregateOption
 	if sess == nil && a.client.sessionPool != nil {
 		sess = session.NewImplicitClientSession(a.client.sessionPool, a.client.id)
 	}
+
 	if err = a.client.validSession(sess); err != nil {
 		return nil, err
 	}
@@ -989,6 +991,11 @@ func aggregate(a aggregateParams, opts ...options.Lister[options.AggregateOption
 	if !wc.Acknowledged() {
 		closeImplicitSession(sess)
 		sess = nil
+	}
+
+	retry := driver.RetryNone
+	if a.client.retryReads && !hasOutputStage {
+		retry = driver.RetryOncePerCommand
 	}
 
 	selector := makeReadPrefSelector(sess, a.readSelector, a.client.localThreshold)
@@ -1011,6 +1018,8 @@ func aggregate(a aggregateParams, opts ...options.Lister[options.AggregateOption
 		ReadConcern(rc).
 		ReadPreference(a.readPreference).
 		CommandMonitor(a.client.monitor).
+		Retry(retry).
+		RetryOverload((a.client.retryReads && !hasOutputStage) || (a.client.retryWrites && hasOutputStage)).
 		ServerSelector(selector).
 		ClusterClock(a.client.clock).
 		Database(a.db).
@@ -1087,12 +1096,6 @@ func aggregate(a aggregateParams, opts ...options.Lister[options.AggregateOption
 		op = op.RawData(rawData)
 	}
 
-	retry := driver.RetryNone
-	if a.retryRead && !hasOutputStage {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
-
 	err = op.Execute(a.ctx)
 	if err != nil {
 		var wce driver.WriteCommandError
@@ -1155,8 +1158,14 @@ func (coll *Collection) CountDocuments(ctx context.Context, filter any,
 		rc = nil
 	}
 
+	retry := driver.RetryNone
+	if coll.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector := makeReadPrefSelector(sess, coll.readSelector, coll.client.localThreshold)
 	op := operation.NewAggregate(pipelineArr).Session(sess).ReadConcern(rc).ReadPreference(coll.readPreference).
+		Retry(retry).RetryOverload(coll.client.retryReads).
 		CommandMonitor(coll.client.monitor).ServerSelector(selector).ClusterClock(coll.client.clock).Database(coll.db.name).
 		Collection(coll.name).Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
 		Timeout(coll.client.timeout).Authenticator(coll.client.authenticator)
@@ -1184,11 +1193,6 @@ func (coll *Collection) CountDocuments(ctx context.Context, filter any,
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-	retry := driver.RetryNone
-	if coll.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	err = op.Execute(ctx)
 	if err != nil {
@@ -1251,10 +1255,16 @@ func (coll *Collection) EstimatedDocumentCount(
 		return 0, fmt.Errorf("failed to construct options from builder: %w", err)
 	}
 
+	retry := driver.RetryNone
+	if coll.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector := makeReadPrefSelector(sess, coll.readSelector, coll.client.localThreshold)
 	op := operation.NewCount().Session(sess).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).CommandMonitor(coll.client.monitor).
 		Deployment(coll.client.deployment).ReadConcern(rc).ReadPreference(coll.readPreference).
+		Retry(retry).RetryOverload(coll.client.retryReads).
 		ServerSelector(selector).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
 		Timeout(coll.client.timeout).Authenticator(coll.client.authenticator)
 
@@ -1268,12 +1278,6 @@ func (coll *Collection) EstimatedDocumentCount(
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-
-	retry := driver.RetryNone
-	if coll.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op.Retry(retry)
 
 	err = op.Execute(ctx)
 	return op.Result().N, wrapErrors(err)
@@ -1321,6 +1325,11 @@ func (coll *Collection) Distinct(
 		rc = nil
 	}
 
+	retry := driver.RetryNone
+	if coll.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector := makeReadPrefSelector(sess, coll.readSelector, coll.client.localThreshold)
 
 	args, err := mongoutil.NewOptions[options.DistinctOptions](opts...)
@@ -1334,6 +1343,7 @@ func (coll *Collection) Distinct(
 		Session(sess).ClusterClock(coll.client.clock).
 		Database(coll.db.name).Collection(coll.name).CommandMonitor(coll.client.monitor).
 		Deployment(coll.client.deployment).ReadConcern(rc).ReadPreference(coll.readPreference).
+		Retry(retry).RetryOverload(coll.client.retryReads).
 		ServerSelector(selector).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
 		Timeout(coll.client.timeout).Authenticator(coll.client.authenticator)
 
@@ -1360,11 +1370,6 @@ func (coll *Collection) Distinct(
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-	retry := driver.RetryNone
-	if coll.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	err = op.Execute(ctx)
 	if err != nil {
@@ -1444,10 +1449,16 @@ func (coll *Collection) find(
 		rc = nil
 	}
 
+	retry := driver.RetryNone
+	if coll.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector := makeReadPrefSelector(sess, coll.readSelector, coll.client.localThreshold)
 	op := operation.NewFind(f).
 		Session(sess).ReadConcern(rc).ReadPreference(coll.readPreference).
 		CommandMonitor(coll.client.monitor).ServerSelector(selector).
+		Retry(retry).RetryOverload(coll.client.retryReads).
 		ClusterClock(coll.client.clock).Database(coll.db.name).Collection(coll.name).
 		Deployment(coll.client.deployment).Crypt(coll.client.cryptFLE).ServerAPI(coll.client.serverAPI).
 		Timeout(coll.client.timeout).Logger(coll.client.logger).Authenticator(coll.client.authenticator).
@@ -1566,11 +1577,6 @@ func (coll *Collection) find(
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-	retry := driver.RetryNone
-	if coll.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	if err = op.Execute(ctx); err != nil {
 		return nil, wrapErrors(err)
@@ -1677,6 +1683,7 @@ func (coll *Collection) findAndModify(ctx context.Context, op *operation.FindAnd
 		Collection(coll.name).
 		Deployment(coll.client.deployment).
 		Retry(retry).
+		RetryOverload(coll.client.retryWrites).
 		Crypt(coll.client.cryptFLE)
 
 	rr, err := processWriteError(op.Execute(ctx))

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -140,7 +140,6 @@ func (db *Database) Aggregate(
 		registry:       db.registry,
 		readConcern:    db.readConcern,
 		writeConcern:   db.writeConcern,
-		retryRead:      db.client.retryReads,
 		db:             db.name,
 		readSelector:   db.readSelector,
 		writeSelector:  db.writeSelector,
@@ -211,6 +210,7 @@ func (db *Database) processRunCommand(
 	return op.Session(sess).CommandMonitor(db.client.monitor).
 		ServerSelector(readSelect).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).
+		RetryOverload(db.client.retryReads && db.client.retryWrites).
 		Crypt(db.client.cryptFLE).ReadPreference(args.ReadPreference).ServerAPI(db.client.serverAPI).
 		Timeout(db.client.timeout).Logger(db.client.logger).Authenticator(db.client.authenticator), sess, nil
 }
@@ -456,6 +456,11 @@ func (db *Database) ListCollections(
 		return nil, err
 	}
 
+	retry := driver.RetryNone
+	if db.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	var selector description.ServerSelector
 
 	selector = &serverselector.Composite{
@@ -469,6 +474,7 @@ func (db *Database) ListCollections(
 
 	op := operation.NewListCollections(filterDoc).
 		Session(sess).ReadPreference(db.readPreference).CommandMonitor(db.client.monitor).
+		Retry(retry).RetryOverload(db.client.retryReads).
 		ServerSelector(selector).ClusterClock(db.client.clock).
 		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.cryptFLE).
 		ServerAPI(db.client.serverAPI).Timeout(db.client.timeout).Authenticator(db.client.authenticator)
@@ -490,12 +496,6 @@ func (db *Database) ListCollections(
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-
-	retry := driver.RetryNone
-	if db.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op = op.Retry(retry)
 
 	err = op.Execute(ctx)
 	if err != nil {

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -74,6 +74,11 @@ func (iv IndexView) List(ctx context.Context, opts ...options.Lister[options.Lis
 	}
 	var selector description.ServerSelector
 
+	retry := driver.RetryNone
+	if iv.coll.client.retryReads {
+		retry = driver.RetryOncePerCommand
+	}
+
 	selector = &serverselector.Composite{
 		Selectors: []description.ServerSelector{
 			&serverselector.ReadPref{ReadPref: readpref.Primary()},
@@ -85,6 +90,7 @@ func (iv IndexView) List(ctx context.Context, opts ...options.Lister[options.Lis
 	op := operation.NewListIndexes().
 		Session(sess).CommandMonitor(iv.coll.client.monitor).
 		ServerSelector(selector).ClusterClock(iv.coll.client.clock).
+		Retry(retry).RetryOverload(iv.coll.client.retryReads).
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI).
 		Timeout(iv.coll.client.timeout).Crypt(iv.coll.client.cryptFLE).Authenticator(iv.coll.client.authenticator)
@@ -105,12 +111,6 @@ func (iv IndexView) List(ctx context.Context, opts ...options.Lister[options.Lis
 	if rawData, ok := optionsutil.Value(args.Internal, "rawData").(bool); ok {
 		op = op.RawData(rawData)
 	}
-
-	retry := driver.RetryNone
-	if iv.coll.client.retryReads {
-		retry = driver.RetryOncePerCommand
-	}
-	op.Retry(retry)
 
 	err = op.Execute(ctx)
 	if err != nil {
@@ -276,7 +276,7 @@ func (iv IndexView) CreateMany(
 	}
 
 	op := operation.NewCreateIndexes(indexes).
-		Session(sess).WriteConcern(wc).ClusterClock(iv.coll.client.clock).
+		Session(sess).WriteConcern(wc).ClusterClock(iv.coll.client.clock).RetryOverload(iv.coll.client.retryWrites).
 		Database(iv.coll.db.name).Collection(iv.coll.name).CommandMonitor(iv.coll.client.monitor).
 		Deployment(iv.coll.client.deployment).ServerSelector(selector).ServerAPI(iv.coll.client.serverAPI).
 		Timeout(iv.coll.client.timeout).Crypt(iv.coll.client.cryptFLE).Authenticator(iv.coll.client.authenticator)
@@ -420,7 +420,7 @@ func (iv IndexView) drop(ctx context.Context, index any, opts ...options.Lister[
 	selector := makePinnedSelector(sess, iv.coll.writeSelector)
 
 	op := operation.NewDropIndexes(index).Session(sess).WriteConcern(wc).CommandMonitor(iv.coll.client.monitor).
-		ServerSelector(selector).ClusterClock(iv.coll.client.clock).
+		RetryOverload(iv.coll.client.retryWrites).ServerSelector(selector).ClusterClock(iv.coll.client.clock).
 		Database(iv.coll.db.name).Collection(iv.coll.name).
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI).
 		Timeout(iv.coll.client.timeout).Crypt(iv.coll.client.cryptFLE).Authenticator(iv.coll.client.authenticator)

--- a/mongo/insert.go
+++ b/mongo/insert.go
@@ -40,6 +40,7 @@ type insert struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
+	retryOverload            bool
 	result                   insertResult
 	serverAPI                *driver.ServerAPIOptions
 	timeout                  *time.Duration
@@ -97,6 +98,7 @@ func (i *insert) Execute(ctx context.Context) error {
 		ProcessResponseFn: i.processResponse,
 		Batches:           batches,
 		RetryMode:         i.retry,
+		RetryOverload:     i.retryOverload,
 		Type:              driver.Write,
 		Client:            i.session,
 		Clock:             i.clock,

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -33,10 +33,6 @@ var (
 	backoffMax             = 500 * time.Millisecond
 )
 
-var jitter interface {
-	Int63n(int64) int64
-} = randutil.NewLockedRand()
-
 // Session is a MongoDB logical session. Sessions can be used to enable causal
 // consistency for a group of operations or to execute operations in an ACID
 // transaction. A new Session can be created from a Client instance. A Session
@@ -146,7 +142,7 @@ func (s *Session) WithTransaction(
 			if expDur > backoffMax {
 				expDur = backoffMax
 			}
-			backoff := expDur * time.Duration(jitter.Int63n(512)) / 512
+			backoff := expDur * time.Duration(randutil.JitterInt63n(512)) / 512
 			if time.Since(startTime)+backoff > transTimeout {
 				return nil, err
 			}

--- a/mongo/with_transactions_test.go
+++ b/mongo/with_transactions_test.go
@@ -22,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/failpoint"
 	"go.mongodb.org/mongo-driver/v2/internal/integtest"
+	"go.mongodb.org/mongo-driver/v2/internal/randutil"
 	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
@@ -211,11 +212,8 @@ func TestConvenientTransactions(t *testing.T) {
 			},
 		}
 
-		transWithJitter := func(t *testing.T, testJitter *testJitter) time.Duration {
-			j := jitter
-			defer func() { jitter = j }()
-
-			jitter = testJitter
+		transWithJitter := func(t *testing.T, ratio float64) time.Duration {
+			defer randutil.SetJitterForTesting(ratio)()
 
 			err := dbAdmin.RunCommand(bgCtx, fp).Err()
 			require.NoError(t, err, "error setting failpoint: %v", err)
@@ -235,8 +233,8 @@ func TestConvenientTransactions(t *testing.T) {
 			require.NoError(t, err, "WithTransaction error: %v", err)
 			return time.Since(startTime)
 		}
-		noBackoffTime := transWithJitter(t, &testJitter{ratio: 0})
-		withBackoffTime := transWithJitter(t, &testJitter{ratio: 1})
+		noBackoffTime := transWithJitter(t, 0)
+		withBackoffTime := transWithJitter(t, 1)
 		assert.InDelta(
 			t,
 			withBackoffTime, noBackoffTime+1_800*time.Millisecond, float64(500*time.Millisecond),
@@ -672,21 +670,6 @@ func TestConvenientTransactions(t *testing.T) {
 		})
 		assert.Greater(t, count, 1, "expected WithTransaction callback to be retried at least once")
 	})
-}
-
-type testJitter struct {
-	ratio float64
-}
-
-func (j *testJitter) Int63n(n int64) int64 {
-	if j.ratio <= 0 {
-		return 0
-	}
-	if j.ratio >= 1 {
-		return n
-	}
-	val := j.ratio * float64(n)
-	return int64(val)
 }
 
 func setupConvenientTransactions(t *testing.T, extraClientOpts ...*options.ClientOptions) *Client {

--- a/x/mongo/driver/batch_cursor.go
+++ b/x/mongo/driver/batch_cursor.go
@@ -469,6 +469,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		Clock:          bc.clock,
 		Legacy:         LegacyGetMore,
 		CommandMonitor: bc.cmdMonitor,
+		RetryOverload:  bc.clientSession != nil && bc.clientSession.RetryOverload,
 		Crypt:          bc.crypt,
 		ServerAPI:      bc.serverAPI,
 

--- a/x/mongo/driver/mnet/connection.go
+++ b/x/mongo/driver/mnet/connection.go
@@ -9,6 +9,7 @@ package mnet
 import (
 	"context"
 	"io"
+	"sync/atomic"
 
 	"go.mongodb.org/mongo-driver/v2/mongo/address"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
@@ -78,11 +79,26 @@ type Pinner interface {
 
 // Connection represents a connection to a MongoDB server.
 type Connection struct {
+	closed uint32
+
 	ReadWriteCloser
 	Describer
 	Streamer
 	Compressor
 	Pinner
+}
+
+// Close closes the connection.
+func (c *Connection) Close() error {
+	// Logically mark the connection as closed.
+	atomic.StoreUint32(&c.closed, 1)
+
+	return c.ReadWriteCloser.Close()
+}
+
+// Closed returns true if the connection has been logically closed.
+func (c *Connection) Closed() bool {
+	return atomic.LoadUint32(&c.closed) == 1
 }
 
 // NewConnection creates a new Connection with the provided component. This

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -24,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/driverutil"
 	"go.mongodb.org/mongo-driver/v2/internal/handshake"
 	"go.mongodb.org/mongo-driver/v2/internal/logger"
+	"go.mongodb.org/mongo-driver/v2/internal/randutil"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/mongo/address"
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
@@ -35,8 +36,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/wiremessage"
 )
-
-const defaultLocalThreshold = 15 * time.Millisecond
 
 var (
 	// ErrNoDocCommandResponse occurs when the server indicated a response existed, but none was found.
@@ -69,6 +68,10 @@ const (
 	cryptMinWireVersion int32 = 8
 	// minimum wire version necessary to use read snapshots
 	readSnapshotMinWireVersion int32 = 13
+
+	defaultLocalThreshold = 15 * time.Millisecond
+	backoffInitial        = 100 * time.Millisecond
+	backoffMax            = 10_000 * time.Millisecond
 )
 
 // RetryablePoolError is a connection pool error that can be retried while executing an operation.
@@ -307,6 +310,10 @@ type Operation struct {
 	// possible unless RetryNone is used.
 	RetryMode *RetryMode
 
+	// RetryOverload indicates that the driver should retry operations that fail with a server side
+	// overload error.
+	RetryOverload bool
+
 	// Type specifies the kind of operation this is. There is only one mode that enables retry: Write.
 	// For more information about what this mode does, please refer to it's definition. Both Type and
 	// RetryMode must be set for retryability to be enabled.
@@ -493,9 +500,10 @@ func (op Operation) Execute(ctx context.Context) error {
 		if err := op.Client.StartCommand(); err != nil {
 			return err
 		}
+		op.Client.RetryOverload = op.RetryOverload
 	}
 
-	var retries int
+	var defaultRetries int
 	if op.RetryMode != nil {
 		switch op.Type {
 		case Write:
@@ -504,23 +512,23 @@ func (op Operation) Execute(ctx context.Context) error {
 			}
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				retries = 1
+				defaultRetries = 1
 			case RetryContext:
-				retries = -1
+				defaultRetries = -1
 			}
 		case Read:
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				retries = 1
+				defaultRetries = 1
 			case RetryContext:
-				retries = -1
+				defaultRetries = -1
 			}
 		}
 
 		// If context is a Timeout context, automatically set retries to -1 (infinite) if retrying is
 		// enabled.
 		if csot.IsTimeoutContext(ctx) && op.RetryMode.Enabled() {
-			retries = -1
+			defaultRetries = -1
 		}
 	}
 
@@ -530,9 +538,14 @@ func (op Operation) Execute(ctx context.Context) error {
 	var operationErr WriteCommandError
 	var prevErr error
 	var prevIndefiniteErr error
+	var expDur time.Duration
+	var transactionState session.TransactionState
+	var isOverloadedError bool
+	var attempt int
 	retrySupported := false
 	first := true
 	currIndex := 0
+	retries := defaultRetries
 
 	// deprioritizedServers are a running list of servers that should be
 	// deprioritized during server selection. Servers are accumulated across
@@ -541,30 +554,28 @@ func (op Operation) Execute(ctx context.Context) error {
 
 	// resetForRetry records the error that caused the retry, decrements retries, and resets the
 	// retry loop variables to request a new server and a new connection for the next attempt.
-	resetForRetry := func(err error) {
-		retries--
+	resetForRetry := func(err error) error {
+		attempt++
 		prevErr = err
 
-		var isOverloadedError bool
-		// Set the previous indefinite error to be returned in any case where a retryable write error does not have a
-		// NoWritesPerfomed label (the definite case).
+		// If the "prevIndefiniteErr" is nil, then the current error is the first error encountered
+		// during the retry attempt cycle.
+		if prevIndefiniteErr == nil {
+			prevIndefiniteErr = err
+		}
+
+		// Set the previous indefinite error to be returned only if:
+		// 1. The error does not have a NoWritesPerformed label (the definite case).
+		// 2. The error is not a driver exception (e.g. timeouts, network errors).
+		// 3. The error is not a CSOT timeout.
 		if lerr, ok := err.(labeledError); ok {
-			// If the "prevIndefiniteErr" is nil, then the current error is the first error encountered
-			// during the retry attempt cycle. We must persist the first error in the case where all
-			// following errors are labeled "NoWritesPerformed", which would otherwise raise nil as the
-			// error.
-			if prevIndefiniteErr == nil {
-				prevIndefiniteErr = lerr
-			}
-
-			// If the error is not labeled NoWritesPerformed and is retryable, then set the previous
-			// indefinite error to be the current error.
-			if !lerr.HasErrorLabel(NoWritesPerformed) && lerr.HasErrorLabel(RetryableWriteError) {
-				prevIndefiniteErr = err
-			}
-
-			if lerr.HasErrorLabel(ErrSystemOverloadedError) {
-				isOverloadedError = true
+			if !lerr.HasErrorLabel(NoWritesPerformed) {
+				var serverErr Error
+				isDriverException := !errors.As(err, &serverErr) || serverErr.Code == 0
+				isCSOTTimeout := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+				if !isDriverException && !isCSOTTimeout {
+					prevIndefiniteErr = err
+				}
 			}
 		}
 
@@ -577,9 +588,38 @@ func (op Operation) Execute(ctx context.Context) error {
 			conn.Close()
 		}
 
+		// Revert TransactionState as ApplyCommand() advances the state.
+		if op.Client != nil {
+			op.Client.TransactionState = transactionState
+		}
+
 		// Set the server and connection to nil to request a new server and connection.
 		srvr = nil
 		conn = nil
+
+		if isOverloadedError {
+			isOverloadedError = false
+			if expDur == 0 {
+				expDur = backoffInitial
+			} else {
+				expDur *= 2
+				if expDur > backoffMax {
+					expDur = backoffMax
+				}
+			}
+			backoff := expDur * time.Duration(randutil.JitterInt63n(512)) / 512
+			if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < backoff {
+				return err
+			}
+			sleep := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				sleep.Stop()
+				return err
+			case <-sleep.C:
+			}
+		}
+		return nil
 	}
 
 	wm := memoryPool.Get().(*[]byte)
@@ -604,6 +644,9 @@ func (op Operation) Execute(ctx context.Context) error {
 			return prevErr
 		}
 
+		allowedRetries := retries
+		retries = defaultRetries
+
 		requestID := wiremessage.NextRequestID()
 
 		// If the server or connection are nil, try to select a new server and get a new connection.
@@ -613,8 +656,10 @@ func (op Operation) Execute(ctx context.Context) error {
 				// If the returned error is retryable and there are retries remaining (negative
 				// retries means retry indefinitely), then retry the operation. Set the server
 				// and connection to nil to request a new server and connection.
-				if rerr, ok := err.(RetryablePoolError); ok && rerr.Retryable() && retries != 0 {
-					resetForRetry(err)
+				if rerr, ok := err.(RetryablePoolError); ok && rerr.Retryable() && (allowedRetries < 0 || attempt < allowedRetries) {
+					if err = resetForRetry(err); err != nil {
+						return err
+					}
 					continue
 				}
 
@@ -638,6 +683,9 @@ func (op Operation) Execute(ctx context.Context) error {
 					return err
 				}
 			}
+		}
+		if op.Client != nil {
+			transactionState = op.Client.TransactionState
 		}
 
 		// Run steps that must only be run on the first attempt, but not again for retries.
@@ -779,6 +827,11 @@ func (op Operation) Execute(ctx context.Context) error {
 				return ErrUnsupportedStorageEngine
 			}
 
+			isOverloadedError = tt.HasErrorLabel(ErrSystemOverloadedError)
+			if isOverloadedError && op.RetryOverload {
+				retries = 5
+				allowedRetries = retries
+			}
 			connDesc := conn.Description()
 			retryableErr := tt.Retryable(connDesc.Kind, connDesc.WireVersion)
 			preRetryWriteLabelVersion := connDesc.WireVersion != nil && connDesc.WireVersion.Max < 9
@@ -789,17 +842,21 @@ func (op Operation) Execute(ctx context.Context) error {
 			if retryableErr && preRetryWriteLabelVersion && retryEnabled && !inTransaction {
 				tt.Labels = append(tt.Labels, RetryableWriteError)
 			}
+			olRetryErr := tt.HasErrorLabel(ErrRetryableError) && isOverloadedError
+			needRetry := (retrySupported && retryEnabled && retryableErr) || (op.RetryOverload && olRetryErr)
 
 			// If retries are supported for the current operation on the first server description,
 			// the error is considered retryable, and there are retries remaining (negative retries
 			// means retry indefinitely), then retry the operation.
-			if retrySupported && retryEnabled && retryableErr && retries != 0 {
-				if op.Client != nil && op.Client.Committing {
+			if needRetry && (allowedRetries < 0 || attempt < allowedRetries) {
+				if op.Client != nil && op.Client.Committing && !olRetryErr {
 					// Apply majority write concern for retries
 					op.Client.UpdateCommitTransactionWriteConcern()
 					op.WriteConcern = op.Client.CurrentWc
 				}
-				resetForRetry(tt)
+				if err = resetForRetry(tt); err != nil {
+					return err
+				}
 				continue
 			}
 
@@ -879,7 +936,9 @@ func (op Operation) Execute(ctx context.Context) error {
 						op.Client.UpdateCommitTransactionWriteConcern()
 						op.WriteConcern = op.Client.CurrentWc
 					}
-					resetForRetry(tt)
+					if err = resetForRetry(tt); err != nil {
+						return err
+					}
 					continue
 				}
 			}
@@ -893,6 +952,11 @@ func (op Operation) Execute(ctx context.Context) error {
 				return ErrUnsupportedStorageEngine
 			}
 
+			isOverloadedError = tt.HasErrorLabel(ErrSystemOverloadedError)
+			if isOverloadedError && op.RetryOverload {
+				retries = 5
+				allowedRetries = retries
+			}
 			connDesc := conn.Description()
 			var retryableErr bool
 			if op.Type == Write {
@@ -909,17 +973,21 @@ func (op Operation) Execute(ctx context.Context) error {
 			} else {
 				retryableErr = tt.RetryableRead()
 			}
+			olRetryErr := tt.HasErrorLabel(ErrRetryableError) && isOverloadedError
+			needRetry := (retrySupported && retryEnabled && retryableErr) || (op.RetryOverload && olRetryErr)
 
 			// If retries are supported for the current operation on the first server description,
 			// the error is considered retryable, and there are retries remaining (negative retries
 			// means retry indefinitely), then retry the operation.
-			if retrySupported && retryEnabled && retryableErr && retries != 0 {
-				if op.Client != nil && op.Client.Committing {
+			if needRetry && (allowedRetries < 0 || attempt < allowedRetries) {
+				if op.Client != nil && op.Client.Committing && !olRetryErr {
 					// Apply majority write concern for retries
 					op.Client.UpdateCommitTransactionWriteConcern()
 					op.WriteConcern = op.Client.CurrentWc
 				}
-				resetForRetry(tt)
+				if err = resetForRetry(tt); err != nil {
+					return err
+				}
 				continue
 			}
 
@@ -998,6 +1066,9 @@ func (op Operation) Execute(ctx context.Context) error {
 					retries = 1
 				}
 			}
+			isOverloadedError = false
+			expDur = 0
+			attempt = 0
 			currIndex += startedInfo.processedBatches
 			op.Batches.AdvanceBatches(startedInfo.processedBatches)
 			continue

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -571,9 +571,9 @@ func (op Operation) Execute(ctx context.Context) error {
 		if lerr, ok := err.(labeledError); ok {
 			if !lerr.HasErrorLabel(NoWritesPerformed) {
 				var serverErr Error
-				isDriverException := !errors.As(err, &serverErr) || serverErr.Code == 0
+				isDriverException := errors.As(err, &serverErr) && serverErr.Code != 0
 				isCSOTTimeout := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
-				if !isDriverException && !isCSOTTimeout {
+				if isDriverException && !isCSOTTimeout {
 					prevIndefiniteErr = err
 				}
 			}
@@ -649,6 +649,10 @@ func (op Operation) Execute(ctx context.Context) error {
 
 		requestID := wiremessage.NextRequestID()
 
+		if op.Client != nil {
+			transactionState = op.Client.TransactionState
+		}
+
 		// If the server or connection are nil, try to select a new server and get a new connection.
 		if srvr == nil || conn == nil {
 			srvr, conn, err = op.getServerAndConnection(ctx, requestID, deprioritizedServers)
@@ -683,9 +687,6 @@ func (op Operation) Execute(ctx context.Context) error {
 					return err
 				}
 			}
-		}
-		if op.Client != nil {
-			transactionState = op.Client.TransactionState
 		}
 
 		// Run steps that must only be run on the first attempt, but not again for retries.

--- a/x/mongo/driver/operation/abort_transaction.go
+++ b/x/mongo/driver/operation/abort_transaction.go
@@ -61,6 +61,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 		Client:            at.session,
 		Clock:             at.clock,
 		CommandMonitor:    at.monitor,
+		RetryOverload:     at.session != nil && at.session.RetryOverload,
 		Crypt:             at.crypt,
 		Database:          at.database,
 		Deployment:        at.deployment,

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -41,6 +41,7 @@ type Aggregate struct {
 	readConcern              *readconcern.ReadConcern
 	readPreference           *readpref.ReadPref
 	retry                    *driver.RetryMode
+	retryOverload            bool
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	crypt                    driver.Crypt
@@ -105,6 +106,7 @@ func (a *Aggregate) Execute(ctx context.Context) error {
 		ReadPreference:                 a.readPreference,
 		Type:                           driver.Read,
 		RetryMode:                      a.retry,
+		RetryOverload:                  a.retryOverload,
 		Selector:                       a.selector,
 		WriteConcern:                   a.writeConcern,
 		Crypt:                          a.crypt,
@@ -345,6 +347,17 @@ func (a *Aggregate) Retry(retry driver.RetryMode) *Aggregate {
 	}
 
 	a.retry = &retry
+	return a
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (a *Aggregate) RetryOverload(retry bool) *Aggregate {
+	if a == nil {
+		a = new(Aggregate)
+	}
+
+	a.retryOverload = retry
 	return a
 }
 

--- a/x/mongo/driver/operation/aggregate.go
+++ b/x/mongo/driver/operation/aggregate.go
@@ -352,12 +352,12 @@ func (a *Aggregate) Retry(retry driver.RetryMode) *Aggregate {
 
 // RetryOverload indicates that the driver should retry operations that fail with a server
 // side overload error.
-func (a *Aggregate) RetryOverload(retry bool) *Aggregate {
+func (a *Aggregate) RetryOverload(retryOverload bool) *Aggregate {
 	if a == nil {
 		a = new(Aggregate)
 	}
 
-	a.retryOverload = retry
+	a.retryOverload = retryOverload
 	return a
 }
 

--- a/x/mongo/driver/operation/command.go
+++ b/x/mongo/driver/operation/command.go
@@ -33,6 +33,7 @@ type Command struct {
 	monitor        *event.CommandMonitor
 	resultResponse bsoncore.Document
 	resultCursor   *driver.BatchCursor
+	retryOverload  bool
 	crypt          driver.Crypt
 	serverAPI      *driver.ServerAPIOptions
 	createCursor   bool
@@ -108,6 +109,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		Deployment:     c.deployment,
 		ReadPreference: c.readPreference,
 		Selector:       c.selector,
+		RetryOverload:  c.retryOverload,
 		Crypt:          c.crypt,
 		ServerAPI:      c.serverAPI,
 		Timeout:        c.timeout,
@@ -183,6 +185,17 @@ func (c *Command) ServerSelector(selector description.ServerSelector) *Command {
 	}
 
 	c.selector = selector
+	return c
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (c *Command) RetryOverload(retryOverload bool) *Command {
+	if c == nil {
+		c = new(Command)
+	}
+
+	c.retryOverload = retryOverload
 	return c
 }
 

--- a/x/mongo/driver/operation/commit_transaction.go
+++ b/x/mongo/driver/operation/commit_transaction.go
@@ -60,6 +60,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 		Client:            ct.session,
 		Clock:             ct.clock,
 		CommandMonitor:    ct.monitor,
+		RetryOverload:     ct.session != nil && ct.session.RetryOverload,
 		Crypt:             ct.crypt,
 		Database:          ct.database,
 		Deployment:        ct.deployment,

--- a/x/mongo/driver/operation/count.go
+++ b/x/mongo/driver/operation/count.go
@@ -38,6 +38,7 @@ type Count struct {
 	readPreference *readpref.ReadPref
 	selector       description.ServerSelector
 	retry          *driver.RetryMode
+	retryOverload  bool
 	result         CountResult
 	serverAPI      *driver.ServerAPIOptions
 	timeout        *time.Duration
@@ -114,6 +115,7 @@ func (c *Count) Execute(ctx context.Context) error {
 		CommandFn:         c.command,
 		ProcessResponseFn: c.processResponse,
 		RetryMode:         c.retry,
+		RetryOverload:     c.retryOverload,
 		Type:              driver.Read,
 		Client:            c.session,
 		Clock:             c.clock,
@@ -282,6 +284,17 @@ func (c *Count) Retry(retry driver.RetryMode) *Count {
 	}
 
 	c.retry = &retry
+	return c
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (c *Count) RetryOverload(retryOverload bool) *Count {
+	if c == nil {
+		c = new(Count)
+	}
+
+	c.retryOverload = retryOverload
 	return c
 }
 

--- a/x/mongo/driver/operation/create_indexes.go
+++ b/x/mongo/driver/operation/create_indexes.go
@@ -30,6 +30,7 @@ type CreateIndexes struct {
 	clock         *session.ClusterClock
 	collection    string
 	monitor       *event.CommandMonitor
+	retryOverload bool
 	crypt         driver.Crypt
 	database      string
 	deployment    driver.Deployment
@@ -110,6 +111,7 @@ func (ci *CreateIndexes) Execute(ctx context.Context) error {
 		Client:            ci.session,
 		Clock:             ci.clock,
 		CommandMonitor:    ci.monitor,
+		RetryOverload:     ci.retryOverload,
 		Crypt:             ci.crypt,
 		Database:          ci.database,
 		Deployment:        ci.deployment,
@@ -199,6 +201,17 @@ func (ci *CreateIndexes) CommandMonitor(monitor *event.CommandMonitor) *CreateIn
 	}
 
 	ci.monitor = monitor
+	return ci
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (ci *CreateIndexes) RetryOverload(retryOverload bool) *CreateIndexes {
+	if ci == nil {
+		ci = new(CreateIndexes)
+	}
+
+	ci.retryOverload = retryOverload
 	return ci
 }
 

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -38,6 +38,7 @@ type Delete struct {
 	selector      description.ServerSelector
 	writeConcern  *writeconcern.WriteConcern
 	retry         *driver.RetryMode
+	retryOverload bool
 	hint          *bool
 	result        DeleteResult
 	serverAPI     *driver.ServerAPIOptions
@@ -103,6 +104,7 @@ func (d *Delete) Execute(ctx context.Context) error {
 		ProcessResponseFn: d.processResponse,
 		Batches:           batches,
 		RetryMode:         d.retry,
+		RetryOverload:     d.retryOverload,
 		Type:              driver.Write,
 		Client:            d.session,
 		Clock:             d.clock,
@@ -277,6 +279,17 @@ func (d *Delete) Retry(retry driver.RetryMode) *Delete {
 	}
 
 	d.retry = &retry
+	return d
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (d *Delete) RetryOverload(retryOverload bool) *Delete {
+	if d == nil {
+		d = new(Delete)
+	}
+
+	d.retryOverload = retryOverload
 	return d
 }
 

--- a/x/mongo/driver/operation/distinct.go
+++ b/x/mongo/driver/operation/distinct.go
@@ -40,6 +40,7 @@ type Distinct struct {
 	readPreference *readpref.ReadPref
 	selector       description.ServerSelector
 	retry          *driver.RetryMode
+	retryOverload  bool
 	result         DistinctResult
 	serverAPI      *driver.ServerAPIOptions
 	timeout        *time.Duration
@@ -93,6 +94,7 @@ func (d *Distinct) Execute(ctx context.Context) error {
 		CommandFn:         d.command,
 		ProcessResponseFn: d.processResponse,
 		RetryMode:         d.retry,
+		RetryOverload:     d.retryOverload,
 		Type:              driver.Read,
 		Client:            d.session,
 		Clock:             d.clock,
@@ -295,6 +297,17 @@ func (d *Distinct) Retry(retry driver.RetryMode) *Distinct {
 	}
 
 	d.retry = &retry
+	return d
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (d *Distinct) RetryOverload(retryOverload bool) *Distinct {
+	if d == nil {
+		d = new(Distinct)
+	}
+
+	d.retryOverload = retryOverload
 	return d
 }
 

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -29,6 +29,7 @@ type DropIndexes struct {
 	clock         *session.ClusterClock
 	collection    string
 	monitor       *event.CommandMonitor
+	retryOverload bool
 	crypt         driver.Crypt
 	database      string
 	deployment    driver.Deployment
@@ -92,6 +93,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 		Client:            di.session,
 		Clock:             di.clock,
 		CommandMonitor:    di.monitor,
+		RetryOverload:     di.retryOverload,
 		Crypt:             di.crypt,
 		Database:          di.database,
 		Deployment:        di.deployment,
@@ -170,6 +172,17 @@ func (di *DropIndexes) CommandMonitor(monitor *event.CommandMonitor) *DropIndexe
 	}
 
 	di.monitor = monitor
+	return di
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (di *DropIndexes) RetryOverload(retryOverload bool) *DropIndexes {
+	if di == nil {
+		di = new(DropIndexes)
+	}
+
+	di.retryOverload = retryOverload
 	return di
 }
 

--- a/x/mongo/driver/operation/end_sessions.go
+++ b/x/mongo/driver/operation/end_sessions.go
@@ -55,6 +55,7 @@ func (es *EndSessions) Execute(ctx context.Context) error {
 		Client:            es.session,
 		Clock:             es.clock,
 		CommandMonitor:    es.monitor,
+		RetryOverload:     es.session != nil && es.session.RetryOverload,
 		Crypt:             es.crypt,
 		Database:          es.database,
 		Deployment:        es.deployment,

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -58,6 +58,7 @@ type Find struct {
 	readPreference      *readpref.ReadPref
 	selector            description.ServerSelector
 	retry               *driver.RetryMode
+	retryOverload       bool
 	result              driver.CursorResponse
 	serverAPI           *driver.ServerAPIOptions
 	timeout             *time.Duration
@@ -98,6 +99,7 @@ func (f *Find) Execute(ctx context.Context) error {
 		CommandFn:         f.command,
 		ProcessResponseFn: f.processResponse,
 		RetryMode:         f.retry,
+		RetryOverload:     f.retryOverload,
 		Type:              driver.Read,
 		Client:            f.session,
 		Clock:             f.clock,
@@ -527,6 +529,17 @@ func (f *Find) Retry(retry driver.RetryMode) *Find {
 	}
 
 	f.retry = &retry
+	return f
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (f *Find) RetryOverload(retryOverload bool) *Find {
+	if f == nil {
+		f = new(Find)
+	}
+
+	f.retryOverload = retryOverload
 	return f
 }
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -45,6 +45,7 @@ type FindAndModify struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
+	retryOverload            bool
 	crypt                    driver.Crypt
 	hint                     bsoncore.Value
 	serverAPI                *driver.ServerAPIOptions
@@ -132,6 +133,7 @@ func (fam *FindAndModify) Execute(ctx context.Context) error {
 		ProcessResponseFn: fam.processResponse,
 
 		RetryMode:      fam.retry,
+		RetryOverload:  fam.retryOverload,
 		Type:           driver.Write,
 		Client:         fam.session,
 		Clock:          fam.clock,
@@ -418,6 +420,17 @@ func (fam *FindAndModify) Retry(retry driver.RetryMode) *FindAndModify {
 	}
 
 	fam.retry = &retry
+	return fam
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (fam *FindAndModify) RetryOverload(retryOverload bool) *FindAndModify {
+	if fam == nil {
+		fam = new(FindAndModify)
+	}
+
+	fam.retryOverload = retryOverload
 	return fam
 }
 

--- a/x/mongo/driver/operation/hello.go
+++ b/x/mongo/driver/operation/hello.go
@@ -599,6 +599,7 @@ func (h *Hello) command(dst []byte, desc description.SelectedServer) ([]byte, er
 		// loadBalanced=false per the load balancing spec.
 		dst = bsoncore.AppendBooleanElement(dst, "loadBalanced", true)
 	}
+	dst = bsoncore.AppendBooleanElement(dst, "backpressure", true)
 
 	return dst, nil
 }
@@ -635,6 +636,7 @@ func (h *Hello) createOperation() driver.Operation {
 			h.res = resp
 			return nil
 		},
+		RetryOverload: true,
 		ServerAPI:     h.serverAPI,
 		OmitMaxTimeMS: h.omitMaxTimeMS,
 	}

--- a/x/mongo/driver/operation/list_collections.go
+++ b/x/mongo/driver/operation/list_collections.go
@@ -35,6 +35,7 @@ type ListCollections struct {
 	readPreference        *readpref.ReadPref
 	selector              description.ServerSelector
 	retry                 *driver.RetryMode
+	retryOverload         bool
 	result                driver.CursorResponse
 	batchSize             *int32
 	serverAPI             *driver.ServerAPIOptions
@@ -75,6 +76,7 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 		CommandFn:         lc.command,
 		ProcessResponseFn: lc.processResponse,
 		RetryMode:         lc.retry,
+		RetryOverload:     lc.retryOverload,
 		Type:              driver.Read,
 		Client:            lc.session,
 		Clock:             lc.clock,
@@ -237,6 +239,17 @@ func (lc *ListCollections) Retry(retry driver.RetryMode) *ListCollections {
 	}
 
 	lc.retry = &retry
+	return lc
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (lc *ListCollections) RetryOverload(retryOverload bool) *ListCollections {
+	if lc == nil {
+		lc = new(ListCollections)
+	}
+
+	lc.retryOverload = retryOverload
 	return lc
 }
 

--- a/x/mongo/driver/operation/list_databases.go
+++ b/x/mongo/driver/operation/list_databases.go
@@ -35,6 +35,7 @@ type ListDatabases struct {
 	deployment          driver.Deployment
 	readPreference      *readpref.ReadPref
 	retry               *driver.RetryMode
+	retryOverload       bool
 	selector            description.ServerSelector
 	crypt               driver.Crypt
 	serverAPI           *driver.ServerAPIOptions
@@ -159,6 +160,7 @@ func (ld *ListDatabases) Execute(ctx context.Context) error {
 		Deployment:     ld.deployment,
 		ReadPreference: ld.readPreference,
 		RetryMode:      ld.retry,
+		RetryOverload:  ld.retryOverload,
 		Type:           driver.Read,
 		Selector:       ld.selector,
 		Crypt:          ld.crypt,
@@ -292,6 +294,17 @@ func (ld *ListDatabases) Retry(retry driver.RetryMode) *ListDatabases {
 	}
 
 	ld.retry = &retry
+	return ld
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (ld *ListDatabases) RetryOverload(retryOverload bool) *ListDatabases {
+	if ld == nil {
+		ld = new(ListDatabases)
+	}
+
+	ld.retryOverload = retryOverload
 	return ld
 }
 

--- a/x/mongo/driver/operation/list_indexes.go
+++ b/x/mongo/driver/operation/list_indexes.go
@@ -31,6 +31,7 @@ type ListIndexes struct {
 	deployment    driver.Deployment
 	selector      description.ServerSelector
 	retry         *driver.RetryMode
+	retryOverload bool
 	crypt         driver.Crypt
 	serverAPI     *driver.ServerAPIOptions
 	timeout       *time.Duration
@@ -81,6 +82,7 @@ func (li *ListIndexes) Execute(ctx context.Context) error {
 		Crypt:          li.crypt,
 		Legacy:         driver.LegacyListIndexes,
 		RetryMode:      li.retry,
+		RetryOverload:  li.retryOverload,
 		Type:           driver.Read,
 		ServerAPI:      li.serverAPI,
 		Timeout:        li.timeout,
@@ -194,6 +196,17 @@ func (li *ListIndexes) Retry(retry driver.RetryMode) *ListIndexes {
 	}
 
 	li.retry = &retry
+	return li
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (li *ListIndexes) RetryOverload(retryOverload bool) *ListIndexes {
+	if li == nil {
+		li = new(ListIndexes)
+	}
+
+	li.retryOverload = retryOverload
 	return li
 }
 

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -41,6 +41,7 @@ type Update struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
+	retryOverload            bool
 	result                   UpdateResult
 	crypt                    driver.Crypt
 	serverAPI                *driver.ServerAPIOptions
@@ -155,6 +156,7 @@ func (u *Update) Execute(ctx context.Context) error {
 		ProcessResponseFn: u.processResponse,
 		Batches:           batches,
 		RetryMode:         u.retry,
+		RetryOverload:     u.retryOverload,
 		Type:              driver.Write,
 		Client:            u.session,
 		Clock:             u.clock,
@@ -370,6 +372,17 @@ func (u *Update) Retry(retry driver.RetryMode) *Update {
 	}
 
 	u.retry = &retry
+	return u
+}
+
+// RetryOverload indicates that the driver should retry operations that fail with a server
+// side overload error.
+func (u *Update) RetryOverload(retryOverload bool) *Update {
+	if u == nil {
+		u = new(Update)
+	}
+
+	u.retryOverload = retryOverload
 	return u
 }
 

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -101,6 +101,7 @@ type Client struct {
 	Committing     bool
 	Aborting       bool
 	Snapshot       bool
+	RetryOverload  bool
 
 	// SnapshotTime is the atClusterTime value for snapshot reads. This field is
 	// left immutable once set for the lifetime of the session. This guards

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -887,6 +887,9 @@ func (c *Connection) unpin(reason string) error {
 
 // DriverConnectionID returns the driver connection ID.
 func (c *Connection) DriverConnectionID() int64 {
+	if c.connection == nil {
+		return 0
+	}
 	return c.connection.DriverConnectionID()
 }
 


### PR DESCRIPTION
GODRIVER-3658
GODRIVER-3757
GODRIVER-3803 (Not directly related with backpressure)
--- test updates below ---
GODRIVER-3830
GODRIVER-3824
GODRIVER-3831
GODRIVER-3834
GODRIVER-3837
GODRIVER-3850

## Summary
This PR implements backoff for overloaded error.

## Background & Motivation
- New `RetryOverload bool` field on `Operation` struct to opt an operation into overload retries.
- Add a corresponding `RetryOverload` in the client session to preserve the retry state for operations such as `getMore`.
- Address GODRIVER-3803 in "operation.go".
