### PR TITLE
GODRIVER-3862: Collection.Clone propegates BSONOptions

### DIFF
--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -1179,31 +1179,39 @@ func TestClient_BSONOptions(t *testing.T) {
 		opts := mtest.NewOptions().ClientOptions(
 			options.Client().SetBSONOptions(tc.bsonOpts))
 		mt.RunOpts(tc.name, opts, func(mt *mtest.T) {
-			// Cloned Collection should inherent BSONOptions
-			clonedCol := mt.Coll.Clone()
-			res, err := clonedCol.InsertOne(context.Background(), tc.doc)
-			require.NoError(mt, err, "InsertOne error")
+			for _, collName := range []string{"default", "cloned"} {
+				collName := collName
+				mt.Run(collName, func(mt *mtest.T) {
+					coll := mt.Coll
+					if collName == "cloned" {
+						coll = mt.Coll.Clone()
+					}
 
-			sr := mt.Coll.FindOne(
-				context.Background(),
-				bson.D{{Key: "_id", Value: res.InsertedID}},
-				// Exclude the auto-generated "_id" field so we can make simple
-				// assertions on the return value.
-				options.FindOne().SetProjection(bson.D{{Key: "_id", Value: 0}}))
+					res, err := coll.InsertOne(context.Background(), tc.doc)
+					require.NoError(mt, err, "InsertOne error")
 
-			if tc.want != nil {
-				got := tc.decodeInto()
-				err := sr.Decode(got)
-				require.NoError(mt, err, "Decode error")
+					// Exclude the auto-generated "_id" field so we can make
+					// simple assertions on the return value.
+					sr := coll.FindOne(
+						context.Background(),
+						bson.D{{Key: "_id", Value: res.InsertedID}},
+						options.FindOne().SetProjection(bson.D{{Key: "_id", Value: 0}}))
 
-				assert.Equal(mt, tc.want, got, "expected and actual decoded result are different")
-			}
+					if tc.want != nil {
+						got := tc.decodeInto()
+						err := sr.Decode(got)
+						require.NoError(mt, err, "Decode error")
 
-			if tc.wantRaw != nil {
-				got, err := sr.Raw()
-				require.NoError(mt, err, "Raw error")
+						assert.Equal(mt, tc.want, got, "expected and actual decoded result are different")
+					}
 
-				assertbson.EqualDocument(mt, tc.wantRaw, got)
+					if tc.wantRaw != nil {
+						got, err := sr.Raw()
+						require.NoError(mt, err, "Raw error")
+
+						assertbson.EqualDocument(mt, tc.wantRaw, got)
+					}
+				})
 			}
 		})
 	}
@@ -1213,28 +1221,38 @@ func TestClient_BSONOptions(t *testing.T) {
 			ObjectIDAsHexString: true,
 		}))
 	mt.RunOpts("ObjectIDAsHexString", opts, func(mt *mtest.T) {
-		res, err := mt.Coll.InsertOne(context.Background(), bson.D{{"x", 42}})
-		require.NoError(mt, err, "InsertOne error")
+		for _, collName := range []string{"default", "cloned"} {
+			collName := collName
+			mt.Run(collName, func(mt *mtest.T) {
+				coll := mt.Coll
+				if collName == "cloned" {
+					coll = mt.Coll.Clone()
+				}
 
-		sr := mt.Coll.FindOne(
-			context.Background(),
-			bson.D{{Key: "_id", Value: res.InsertedID}},
-		)
+				res, err := coll.InsertOne(context.Background(), bson.D{{"x", 42}})
+				require.NoError(mt, err, "InsertOne error")
 
-		type data struct {
-			ID string `bson:"_id"`
-			X  int    `bson:"x"`
+				sr := coll.FindOne(
+					context.Background(),
+					bson.D{{Key: "_id", Value: res.InsertedID}},
+				)
+
+				type data struct {
+					ID string `bson:"_id"`
+					X  int    `bson:"x"`
+				}
+				var got data
+
+				err = sr.Decode(&got)
+				require.NoError(mt, err, "Decode error")
+
+				want := data{
+					ID: res.InsertedID.(bson.ObjectID).Hex(),
+					X:  42,
+				}
+				assert.Equal(mt, want, got, "expected and actual decoded result are different")
+			})
 		}
-		var got data
-
-		err = sr.Decode(&got)
-		require.NoError(mt, err, "Decode error")
-
-		want := data{
-			ID: res.InsertedID.(bson.ObjectID).Hex(),
-			X:  42,
-		}
-		assert.Equal(mt, want, got, "expected and actual decoded result are different")
 	})
 
 	opts = mtest.NewOptions().ClientOptions(
@@ -1251,13 +1269,23 @@ func TestClient_BSONOptions(t *testing.T) {
 			B *inlineDupInner `bson:"b,inline"`
 		}
 
-		_, err := mt.Coll.InsertOne(context.Background(), inlineDupOuter{
-			A: "outer",
-			B: &inlineDupInner{
-				A: "inner",
-			},
-		})
-		require.Error(mt, err, "expected InsertOne to return an error")
+		for _, collName := range []string{"default", "cloned"} {
+			collName := collName
+			mt.Run(collName, func(mt *mtest.T) {
+				coll := mt.Coll
+				if collName == "cloned" {
+					coll = mt.Coll.Clone()
+				}
+
+				_, err := coll.InsertOne(context.Background(), inlineDupOuter{
+					A: "outer",
+					B: &inlineDupInner{
+						A: "inner",
+					},
+				})
+				require.Error(mt, err, "expected InsertOne to return an error")
+			})
+		}
 	})
 }
 

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -955,6 +955,8 @@ func TestClient_BSONOptions(t *testing.T) {
 		A string
 		B string `json:"x"`
 		C string `json:"y" bson:"3"`
+		D string `json:"oe,omitempty"`
+		E string `json:"oz,omitzero"`
 	}
 
 	type omitemptyTest struct {
@@ -999,6 +1001,7 @@ func TestClient_BSONOptions(t *testing.T) {
 				AppendString("a", "apple").
 				AppendString("x", "banana").
 				AppendString("3", "carrot").
+				AppendString("oz", ""). // driver does not yet respect json omitzero tags
 				Build()),
 		},
 		{
@@ -1176,7 +1179,9 @@ func TestClient_BSONOptions(t *testing.T) {
 		opts := mtest.NewOptions().ClientOptions(
 			options.Client().SetBSONOptions(tc.bsonOpts))
 		mt.RunOpts(tc.name, opts, func(mt *mtest.T) {
-			res, err := mt.Coll.InsertOne(context.Background(), tc.doc)
+			// Cloned Collection should inherent BSONOptions
+			clonedCol := mt.Coll.Clone()
+			res, err := clonedCol.InsertOne(context.Background(), tc.doc)
 			require.NoError(mt, err, "InsertOne error")
 
 			sr := mt.Coll.FindOne(

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -136,6 +136,7 @@ func (coll *Collection) copy() *Collection {
 		readPreference: coll.readPreference,
 		readSelector:   coll.readSelector,
 		writeSelector:  coll.writeSelector,
+		bsonOpts:       coll.bsonOpts,
 		registry:       coll.registry,
 	}
 }
@@ -162,6 +163,10 @@ func (coll *Collection) Clone(opts ...options.Lister[options.CollectionOptions])
 
 	if args.Registry != nil {
 		copyColl.registry = args.Registry
+	}
+
+	if args.BSONOptions != nil {
+		copyColl.bsonOpts = args.BSONOptions
 	}
 
 	copyColl.readSelector = &serverselector.Composite{


### PR DESCRIPTION
GODRIVER-3862

It's not uncommon to clone a collection to set different read preference on a read path or write preference on a write path. In my cause I was storing and reading a third party struct which has json struct tags but no bson tags. I found the drivers BSONOptions.UseJSONStructTags worked up until I cloned a collection. 

The issue is that the driver does not copy this setting when Cloning collections and additionally ignores it when passed as an option to collection.Clone. This pull addresses both issues