### PR TITLE
Add CLAUDE.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ perf-report.txt
 secrets-expansion.yml
 secrets-export.sh
 .test.env
+
+# Ignore Claude configs
+CLAUDE.local.md


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->

## Summary

Add `CLAUDE.local.md` to .gitignore.

## Background & Motivation

`CLAUDE.local.md` is intended to be local-only additions to `CLAUDE.md` (see [here](https://code.claude.com/docs/en/memory#choose-where-to-put-claude-md-files)). Add it to .gitignore so we don't commit it.