### PR TITLE
GODRIVER-3568 Add support for regional STS endpoints

### DIFF
--- a/internal/credproviders/assume_role_provider.go
+++ b/internal/credproviders/assume_role_provider.go
@@ -23,7 +23,8 @@ const (
 	// assumeRoleProviderName provides a name of assume role provider
 	assumeRoleProviderName = "AssumeRoleProvider"
 
-	stsURI = `https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&RoleSessionName=%s&RoleArn=%s&WebIdentityToken=%s&Version=2011-06-15`
+	stsURI       = `https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&RoleSessionName=%s&RoleArn=%s&WebIdentityToken=%s&Version=2011-06-15`
+	stsRegionURI = `https://sts.%s.amazonaws.com/?Action=AssumeRoleWithWebIdentity&RoleSessionName=%s&RoleArn=%s&WebIdentityToken=%s&Version=2011-06-15`
 )
 
 // An AssumeRoleProvider retrieves credentials for assume role with web identity.
@@ -31,6 +32,7 @@ type AssumeRoleProvider struct {
 	AwsRoleArnEnv              EnvVar
 	AwsWebIdentityTokenFileEnv EnvVar
 	AwsRoleSessionNameEnv      EnvVar
+	AwsRegionEnv               EnvVar
 
 	httpClient *http.Client
 	expiration time.Time
@@ -52,8 +54,10 @@ func NewAssumeRoleProvider(httpClient *http.Client, expiryWindow time.Duration) 
 		AwsWebIdentityTokenFileEnv: EnvVar("AWS_WEB_IDENTITY_TOKEN_FILE"),
 		// AwsRoleSessionNameEnv is the environment variable for AWS_ROLE_SESSION_NAME
 		AwsRoleSessionNameEnv: EnvVar("AWS_ROLE_SESSION_NAME"),
-		httpClient:            httpClient,
-		expiryWindow:          expiryWindow,
+		// AwsRegionEnv is the environment variable for AWS_REGION
+		AwsRegionEnv: EnvVar("AWS_REGION"),
+		httpClient:   httpClient,
+		expiryWindow: expiryWindow,
 	}
 }
 
@@ -89,7 +93,14 @@ func (a *AssumeRoleProvider) RetrieveWithContext(ctx context.Context) (credentia
 		sessionName = id.String()
 	}
 
-	fullURI := fmt.Sprintf(stsURI, sessionName, roleArn, string(token))
+	// If the region is not set, use the default STS URI. Otherwise, use the region-specific STS URI.
+	region := a.AwsRegionEnv.Get()
+	fullURI := ""
+	if region == "" {
+		fullURI = fmt.Sprintf(stsURI, sessionName, roleArn, string(token))
+	} else {
+		fullURI = fmt.Sprintf(stsRegionURI, region, sessionName, roleArn, string(token))
+	}
 
 	req, err := http.NewRequest(http.MethodPost, fullURI, nil)
 	if err != nil {

--- a/internal/credproviders/assume_role_provider.go
+++ b/internal/credproviders/assume_role_provider.go
@@ -33,6 +33,7 @@ type AssumeRoleProvider struct {
 	AwsWebIdentityTokenFileEnv EnvVar
 	AwsRoleSessionNameEnv      EnvVar
 	AwsRegionEnv               EnvVar
+	AwsStsRegionalEndpointsEnv EnvVar
 
 	httpClient *http.Client
 	expiration time.Time
@@ -56,8 +57,10 @@ func NewAssumeRoleProvider(httpClient *http.Client, expiryWindow time.Duration) 
 		AwsRoleSessionNameEnv: EnvVar("AWS_ROLE_SESSION_NAME"),
 		// AwsRegionEnv is the environment variable for AWS_REGION
 		AwsRegionEnv: EnvVar("AWS_REGION"),
-		httpClient:   httpClient,
-		expiryWindow: expiryWindow,
+		// AwsStsRegionalEndpointsEnv is the environment variable for AWS_STS_REGIONAL_ENDPOINTS
+		AwsStsRegionalEndpointsEnv: EnvVar("AWS_STS_REGIONAL_ENDPOINTS"),
+		httpClient:                 httpClient,
+		expiryWindow:               expiryWindow,
 	}
 }
 
@@ -93,13 +96,16 @@ func (a *AssumeRoleProvider) RetrieveWithContext(ctx context.Context) (credentia
 		sessionName = id.String()
 	}
 
-	// If the region is not set, use the default STS URI. Otherwise, use the region-specific STS URI.
+	// Use the regional STS endpoint only when AWS_STS_REGIONAL_ENDPOINTS is
+	// set to "regional" and AWS_REGION is non-empty. Otherwise, fall back to
+	// the global STS endpoint.
 	region := a.AwsRegionEnv.Get()
+	useRegional := a.AwsStsRegionalEndpointsEnv.Get() == "regional"
 	fullURI := ""
-	if region == "" {
-		fullURI = fmt.Sprintf(stsURI, sessionName, roleArn, string(token))
-	} else {
+	if useRegional && region != "" {
 		fullURI = fmt.Sprintf(stsRegionURI, region, sessionName, roleArn, string(token))
+	} else {
+		fullURI = fmt.Sprintf(stsURI, sessionName, roleArn, string(token))
 	}
 
 	req, err := http.NewRequest(http.MethodPost, fullURI, nil)

--- a/internal/credproviders/env_provider.go
+++ b/internal/credproviders/env_provider.go
@@ -29,6 +29,7 @@ type EnvProvider struct {
 	AwsAccessKeyIDEnv     EnvVar
 	AwsSecretAccessKeyEnv EnvVar
 	AwsSessionTokenEnv    EnvVar
+	AwsRegionEnv          EnvVar
 
 	retrieved bool
 }
@@ -42,6 +43,8 @@ func NewEnvProvider() *EnvProvider {
 		AwsSecretAccessKeyEnv: EnvVar("AWS_SECRET_ACCESS_KEY"),
 		// AwsSessionTokenEnv is the environment variable for AWS_SESSION_TOKEN
 		AwsSessionTokenEnv: EnvVar("AWS_SESSION_TOKEN"),
+		// AwsRegionEnv is the environment variable for AWS_REGION
+		AwsRegionEnv: EnvVar("AWS_REGION"),
 	}
 }
 

--- a/internal/credproviders/env_provider.go
+++ b/internal/credproviders/env_provider.go
@@ -29,7 +29,6 @@ type EnvProvider struct {
 	AwsAccessKeyIDEnv     EnvVar
 	AwsSecretAccessKeyEnv EnvVar
 	AwsSessionTokenEnv    EnvVar
-	AwsRegionEnv          EnvVar
 
 	retrieved bool
 }
@@ -43,8 +42,6 @@ func NewEnvProvider() *EnvProvider {
 		AwsSecretAccessKeyEnv: EnvVar("AWS_SECRET_ACCESS_KEY"),
 		// AwsSessionTokenEnv is the environment variable for AWS_SESSION_TOKEN
 		AwsSessionTokenEnv: EnvVar("AWS_SESSION_TOKEN"),
-		// AwsRegionEnv is the environment variable for AWS_REGION
-		AwsRegionEnv: EnvVar("AWS_REGION"),
 	}
 }
 


### PR DESCRIPTION
[GODRIVER-3568](https://jira.mongodb.org/browse/GODRIVER-3568)

The default STS endpoint `sts.amazonaws.com` does not work in AWS Gov cloud, as stated in the documentation https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-iam.html:
> - In the AWS GovCloud (US) Regions, there is no AWS STS global endpoint. AWS provides Regional AWS STS endpoints.
> - When using the IAM or AWS STS service in AWS GovCloud (US), you must use [AWS GovCloud (US)IAM/AWS STS endpoints](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html). Use SSL (HTTPS) when you make calls to the IAM or AWS STS service in AWS GovCloud (US) Regions.

Since the driver was hardcoding the global sts endpoint, this driver wouldn't work when using IAM with IRSA (in EKS pods).

Also adding the option to enable/disable the feature with and environmental variable as per the documentation https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html

For this new code to have effect, these environmental variables need to be set
```
AWS_STS_REGIONAL_ENDPOINTS=regional
AWS_REGION='your region'
```