### PR TITLE
GODRIVER-3916 Enable lazy tls reload for new connections

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -1305,6 +1305,50 @@ func addClientCertFromBytes(cfg *tls.Config, data []byte, keyPasswd string) (str
 	return crt.Subject.String(), nil
 }
 
+// BuildTLSReloader returns a callback that re-reads the TLS material specified by the
+// ClientOptions' connection string and returns a fresh *tls.Config. It is used by the
+// driver to recover from TLS handshake failures after on-disk cert rotation.
+//
+// Returns nil when the ClientOptions did not load TLS material from URI-supplied files
+// (e.g., when SetTLSConfig was called directly). In that case the caller should not
+// attempt automatic reload.
+func BuildTLSReloader(opts *ClientOptions) func() (*tls.Config, error) {
+	cs := opts.connString
+	if cs == nil || !cs.SSL {
+		return nil
+	}
+	if !cs.SSLCaFileSet && !cs.SSLClientCertificateKeyFileSet &&
+		!cs.SSLCertificateFileSet && !cs.SSLPrivateKeyFileSet {
+		return nil
+	}
+	return func() (*tls.Config, error) {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		if cs.SSLCaFileSet {
+			if err := addCACertFromFile(cfg, cs.SSLCaFile); err != nil {
+				return nil, err
+			}
+		}
+		if cs.SSLInsecure {
+			cfg.InsecureSkipVerify = true
+		}
+		var keyPasswd string
+		if cs.SSLClientCertificateKeyPasswordSet && cs.SSLClientCertificateKeyPassword != nil {
+			keyPasswd = cs.SSLClientCertificateKeyPassword()
+		}
+		var err error
+		if cs.SSLClientCertificateKeyFileSet {
+			_, err = addClientCertFromConcatenatedFile(cfg, cs.SSLClientCertificateKeyFile, keyPasswd)
+		} else if cs.SSLCertificateFileSet || cs.SSLPrivateKeyFileSet {
+			_, err = addClientCertFromSeparateFiles(cfg, cs.SSLCertificateFile,
+				cs.SSLPrivateKeyFile, keyPasswd)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return cfg, nil
+	}
+}
+
 func stringSliceContains(source []string, target string) bool {
 	for _, str := range source {
 		if str == target {

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -1322,7 +1322,7 @@ func BuildTLSReloader(opts *ClientOptions) func() (*tls.Config, error) {
 		return nil
 	}
 	return func() (*tls.Config, error) {
-		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		cfg := new(tls.Config)
 		if cs.SSLCaFileSet {
 			if err := addCACertFromFile(cfg, cs.SSLCaFile); err != nil {
 				return nil, err

--- a/mongo/options/clientoptions_test.go
+++ b/mongo/options/clientoptions_test.go
@@ -1286,3 +1286,88 @@ func TestApplyURI(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildTLSReloader(t *testing.T) {
+	t.Run("nil when SetTLSConfig used directly", func(t *testing.T) {
+		opts := Client().SetTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12})
+		assert.Nil(t, BuildTLSReloader(opts), "expected nil reloader when no URI sources")
+	})
+
+	t.Run("nil when URI has no TLS file paths", func(t *testing.T) {
+		opts := Client().ApplyURI("mongodb://localhost/?ssl=true&tlsInsecure=true")
+		assert.NoError(t, opts.Validate())
+		assert.Nil(t, BuildTLSReloader(opts), "expected nil reloader when no file sources tracked")
+	})
+
+	t.Run("reloads CA from disk on each call", func(t *testing.T) {
+		dir := t.TempDir()
+		caPath := dir + "/ca.pem"
+		writeFile(t, caPath, readFile(t, "testdata/ca.pem"))
+
+		opts := Client().ApplyURI("mongodb://localhost/?ssl=true&tlsCAFile=" + caPath)
+		assert.NoError(t, opts.Validate())
+
+		reload := BuildTLSReloader(opts)
+		assert.NotNil(t, reload, "expected reloader for tlsCAFile URI option")
+
+		cfg, err := reload()
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg.RootCAs, "expected RootCAs populated")
+		firstSubjects := cfg.RootCAs.Subjects()
+		assert.True(t, len(firstSubjects) > 0, "expected at least one CA subject")
+
+		// Overwrite the CA file with a different valid CA bundle and reload.
+		writeFile(t, caPath, readFile(t, "testdata/ca-with-intermediates.pem"))
+		cfg2, err := reload()
+		assert.NoError(t, err)
+		secondSubjects := cfg2.RootCAs.Subjects()
+		assert.NotEqual(t, len(firstSubjects), len(secondSubjects),
+			"reloaded CA pool should differ in size after file change")
+	})
+
+	t.Run("reloads client cert from disk on each call", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath := dir + "/cert.pem"
+		writeFile(t, certPath, readFile(t, "testdata/nopass/certificate.pem"))
+
+		opts := Client().ApplyURI("mongodb://localhost/?ssl=true&tlsCertificateKeyFile=" + certPath)
+		assert.NoError(t, opts.Validate())
+
+		reload := BuildTLSReloader(opts)
+		assert.NotNil(t, reload, "expected reloader for tlsCertificateKeyFile URI option")
+
+		cfg, err := reload()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(cfg.Certificates), "expected exactly one client cert")
+
+		// Reload again — should still succeed (file unchanged).
+		cfg2, err := reload()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(cfg2.Certificates))
+		assert.False(t, cfg == cfg2, "reloader should return a fresh *tls.Config each call")
+	})
+
+	t.Run("propagates error when file is removed", func(t *testing.T) {
+		dir := t.TempDir()
+		caPath := dir + "/ca.pem"
+		writeFile(t, caPath, readFile(t, "testdata/ca.pem"))
+
+		opts := Client().ApplyURI("mongodb://localhost/?ssl=true&tlsCAFile=" + caPath)
+		assert.NoError(t, opts.Validate())
+
+		reload := BuildTLSReloader(opts)
+		assert.NotNil(t, reload)
+
+		// Remove the underlying file.
+		assert.NoError(t, os.Remove(caPath))
+
+		_, err := reload()
+		assert.Error(t, err, "expected error when CA file is missing")
+	})
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	err := os.WriteFile(path, data, 0o600)
+	assert.NoError(t, err, "WriteFile error for %s: %v", path, err)
+}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -215,6 +215,8 @@ var errTLSReloadNoNewConfig = errors.New("topology: tls cert reload yielded no n
 // newer config while this caller was blocked on the mutex, that one is reused without
 // re-reading from disk. If the published config is identical to what was just tried,
 // errTLSReloadNoNewConfig is returned so the caller does not perform a redundant retry.
+// A reloader that returns (nil, nil) is treated as an error so a nil config is never
+// published.
 func (c *connection) reloadTLSOnce(tried *tls.Config) (*tls.Config, error) {
 	c.config.tlsReloadMu.Lock()
 	if latest := c.config.tlsConfigPtr.Load(); latest != nil {
@@ -229,6 +231,10 @@ func (c *connection) reloadTLSOnce(tried *tls.Config) (*tls.Config, error) {
 		c.config.tlsReloadMu.Unlock()
 		return nil, err
 	}
+	if newCfg == nil {
+		c.config.tlsReloadMu.Unlock()
+		return nil, errors.New("topology: tls reloader returned a nil *tls.Config")
+	}
 	c.config.tlsConfigPtr.Store(newCfg)
 	c.config.tlsReloadMu.Unlock()
 	return newCfg, nil
@@ -236,9 +242,18 @@ func (c *connection) reloadTLSOnce(tried *tls.Config) (*tls.Config, error) {
 
 // handshakeTLS performs the TLS handshake on c.nc. If the initial handshake fails and
 // a reloader is configured, it invokes the reloader once (with single-flight semantics
-// across concurrent failing connections), publishes the fresh config to tlsConfigPtr,
-// and retries the handshake exactly once. The returned error wraps both the original
-// and retry failures so callers can see both root causes.
+// across connections sharing the same option), re-dials a fresh TCP socket (a failed
+// TLS handshake typically leaves the original socket in an unusable state), and retries
+// the handshake exactly once with the reloaded config.
+//
+// On any failure path the returned error wraps origErr via %w — so existing error
+// matching against the underlying TLS / x509 types via errors.Is / errors.As keeps
+// working. The reload, re-dial, or retry-handshake error is included in the message
+// for debuggability but is not unwrappable; AGENTS.md bars errors.Join from non-
+// internal/ packages.
+//
+// On success c.nc is replaced with the fresh socket; on error c.nc may be left pointing
+// at a closed socket which the connect() deferred cleanup tolerates (Close is idempotent).
 func (c *connection) handshakeTLS(ctx context.Context, ocspOpts *ocsp.VerifyOptions) (net.Conn, error) {
 	cfg := c.currentTLSConfig()
 	tlsNc, origErr := configureTLS(ctx, c.config.tlsConnectionSource, c.nc, c.addr, cfg.Clone(), ocspOpts)
@@ -256,6 +271,17 @@ func (c *connection) handshakeTLS(ctx context.Context, ocspOpts *ocsp.VerifyOpti
 		}
 		return nil, fmt.Errorf("%w (tls cert reload also failed: %v)", origErr, reloadErr)
 	}
+
+	// A failed TLS handshake usually leaves the TCP connection unusable — TLS alerts
+	// have been exchanged and the peer typically closes its end. Re-dial a fresh
+	// socket before retrying the handshake.
+	_ = c.nc.Close()
+	freshNc, dialErr := c.config.dialer.DialContext(ctx, c.addr.Network(), c.addr.String())
+	if dialErr != nil {
+		return nil, fmt.Errorf("%w (tls cert reload retry dial failed: %v)", origErr, dialErr)
+	}
+	c.nc = freshNc
+
 	tlsNc, retryErr := configureTLS(ctx, c.config.tlsConnectionSource, c.nc, c.addr, latest.Clone(), ocspOpts)
 	if retryErr != nil {
 		return nil, fmt.Errorf("%w (tls cert reload retry also failed: %v)", origErr, retryErr)

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -191,6 +191,78 @@ func configureTLS(ctx context.Context,
 	return client, nil
 }
 
+// currentTLSConfig returns the *tls.Config the connection should use for its next TLS
+// handshake. It prefers a config previously published via the atomic pointer (set by
+// the reload-on-failure path) and falls back to the static tlsConfig captured when
+// the connection was created.
+func (c *connection) currentTLSConfig() *tls.Config {
+	if c.config.tlsConfigPtr != nil {
+		if cfg := c.config.tlsConfigPtr.Load(); cfg != nil {
+			return cfg
+		}
+	}
+	return c.config.tlsConfig
+}
+
+// errTLSReloadNoNewConfig is returned by reloadTLSOnce when the published TLS config
+// is already the one the caller just attempted with — meaning a sibling goroutine has
+// already reloaded from disk and the result is no help here. The caller should treat
+// this as "no second chance" and surface the original handshake error unchanged.
+var errTLSReloadNoNewConfig = errors.New("topology: tls cert reload yielded no new config")
+
+// reloadTLSOnce returns a *tls.Config newer than tried, calling the registered reloader
+// at most once across concurrent callers. If another goroutine already published a
+// newer config while this caller was blocked on the mutex, that one is reused without
+// re-reading from disk. If the published config is identical to what was just tried,
+// errTLSReloadNoNewConfig is returned so the caller does not perform a redundant retry.
+func (c *connection) reloadTLSOnce(tried *tls.Config) (*tls.Config, error) {
+	c.config.tlsReloadMu.Lock()
+	if latest := c.config.tlsConfigPtr.Load(); latest != nil {
+		c.config.tlsReloadMu.Unlock()
+		if latest == tried {
+			return nil, errTLSReloadNoNewConfig
+		}
+		return latest, nil
+	}
+	newCfg, err := c.config.tlsReloader()
+	if err != nil {
+		c.config.tlsReloadMu.Unlock()
+		return nil, err
+	}
+	c.config.tlsConfigPtr.Store(newCfg)
+	c.config.tlsReloadMu.Unlock()
+	return newCfg, nil
+}
+
+// handshakeTLS performs the TLS handshake on c.nc. If the initial handshake fails and
+// a reloader is configured, it invokes the reloader once (with single-flight semantics
+// across concurrent failing connections), publishes the fresh config to tlsConfigPtr,
+// and retries the handshake exactly once. The returned error wraps both the original
+// and retry failures so callers can see both root causes.
+func (c *connection) handshakeTLS(ctx context.Context, ocspOpts *ocsp.VerifyOptions) (net.Conn, error) {
+	cfg := c.currentTLSConfig()
+	tlsNc, origErr := configureTLS(ctx, c.config.tlsConnectionSource, c.nc, c.addr, cfg.Clone(), ocspOpts)
+	if origErr == nil {
+		return tlsNc, nil
+	}
+	if c.config.tlsReloader == nil {
+		return nil, origErr
+	}
+
+	latest, reloadErr := c.reloadTLSOnce(cfg)
+	if reloadErr != nil {
+		if errors.Is(reloadErr, errTLSReloadNoNewConfig) {
+			return nil, origErr
+		}
+		return nil, fmt.Errorf("%w (tls cert reload also failed: %v)", origErr, reloadErr)
+	}
+	tlsNc, retryErr := configureTLS(ctx, c.config.tlsConnectionSource, c.nc, c.addr, latest.Clone(), ocspOpts)
+	if retryErr != nil {
+		return nil, fmt.Errorf("%w (tls cert reload retry also failed: %v)", origErr, retryErr)
+	}
+	return tlsNc, nil
+}
+
 // connect handles the I/O for a connection. It will dial, configure TLS, and perform initialization
 // handshakes. All errors returned by connect are considered "before the handshake completes" and
 // must be handled by calling the appropriate SDAM handshake error handler.
@@ -241,17 +313,13 @@ func (c *connection) connect(ctx context.Context) (err error) {
 	}
 	c.nc = tempNc
 
-	if c.config.tlsConfig != nil {
-		tlsConfig := c.config.tlsConfig.Clone()
-
-		// store the result of configureTLS in a separate variable than c.nc to avoid overwriting c.nc with nil in
-		// error cases.
+	if c.config.tlsConfig != nil || (c.config.tlsConfigPtr != nil && c.config.tlsConfigPtr.Load() != nil) {
 		ocspOpts := &ocsp.VerifyOptions{
 			Cache:                   c.config.ocspCache,
 			DisableEndpointChecking: c.config.disableOCSPEndpointCheck,
 			HTTPClient:              c.config.httpClient,
 		}
-		tlsNc, err := configureTLS(ctx, c.config.tlsConnectionSource, c.nc, c.addr, tlsConfig, ocspOpts)
+		tlsNc, err := c.handshakeTLS(ctx, ocspOpts)
 		if err != nil {
 			connErr := ConnectionError{Wrapped: err, init: true, message: fmt.Sprintf("failed to configure TLS for %s", c.addr)}
 			return wrapConnectionError(connErr)

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -11,6 +11,8 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -62,6 +64,16 @@ type connectionConfig struct {
 	tlsConnectionSource      tlsConnectionSource
 	loadBalanced             bool
 	getGenerationFn          generationNumberFn
+
+	// tlsReloader, when non-nil, is invoked once after a failed TLS handshake to
+	// produce a fresh *tls.Config (e.g., re-reading rotated cert files). The fresh
+	// config is published via tlsConfigPtr so subsequent connections from the same
+	// pool pick it up without re-reading from disk. tlsReloadMu serializes concurrent
+	// reload attempts so a thundering herd of failing connections only triggers one
+	// disk read.
+	tlsReloader  func() (*tls.Config, error)
+	tlsConfigPtr *atomic.Pointer[tls.Config]
+	tlsReloadMu  *sync.Mutex
 }
 
 func newConnectionConfig(opts ...ConnectionOption) *connectionConfig {
@@ -129,6 +141,22 @@ func WithIdleTimeout(fn func(time.Duration) time.Duration) ConnectionOption {
 func WithTLSConfig(fn func(*tls.Config) *tls.Config) ConnectionOption {
 	return func(c *connectionConfig) {
 		c.tlsConfig = fn(c.tlsConfig)
+	}
+}
+
+// WithTLSReloader registers a callback that the connection layer invokes to obtain a
+// fresh *tls.Config after a TLS handshake failure. It is intended to support recovery
+// from on-disk cert rotation: when a TLS handshake fails, the connection calls the
+// reloader once, atomically publishes the new *tls.Config to other connections in the
+// pool, and retries the handshake. The reloader is invoked at most once per failed
+// connect; pass nil to disable.
+func WithTLSReloader(fn func() (*tls.Config, error)) ConnectionOption {
+	return func(c *connectionConfig) {
+		c.tlsReloader = fn
+		if fn != nil && c.tlsConfigPtr == nil {
+			c.tlsConfigPtr = &atomic.Pointer[tls.Config]{}
+			c.tlsReloadMu = &sync.Mutex{}
+		}
 	}
 }
 

--- a/x/mongo/driver/topology/connection_options.go
+++ b/x/mongo/driver/topology/connection_options.go
@@ -147,16 +147,27 @@ func WithTLSConfig(fn func(*tls.Config) *tls.Config) ConnectionOption {
 // WithTLSReloader registers a callback that the connection layer invokes to obtain a
 // fresh *tls.Config after a TLS handshake failure. It is intended to support recovery
 // from on-disk cert rotation: when a TLS handshake fails, the connection calls the
-// reloader once, atomically publishes the new *tls.Config to other connections in the
-// pool, and retries the handshake. The reloader is invoked at most once per failed
-// connect; pass nil to disable.
+// reloader once, atomically publishes the new *tls.Config to other connections built
+// from the same option, and retries the handshake. Pass nil to disable.
+//
+// The atomic.Pointer and sync.Mutex are allocated once here and captured by the
+// returned closure so that every connectionConfig produced from this option shares the
+// same single-flight state. This is what makes one successful reload visible to all
+// concurrently-failing connections in the pool.
 func WithTLSReloader(fn func() (*tls.Config, error)) ConnectionOption {
+	if fn == nil {
+		return func(c *connectionConfig) {
+			c.tlsReloader = nil
+			c.tlsConfigPtr = nil
+			c.tlsReloadMu = nil
+		}
+	}
+	ptr := &atomic.Pointer[tls.Config]{}
+	mu := &sync.Mutex{}
 	return func(c *connectionConfig) {
 		c.tlsReloader = fn
-		if fn != nil && c.tlsConfigPtr == nil {
-			c.tlsConfigPtr = &atomic.Pointer[tls.Config]{}
-			c.tlsReloadMu = &sync.Mutex{}
-		}
+		c.tlsConfigPtr = ptr
+		c.tlsReloadMu = mu
 	}
 }
 

--- a/x/mongo/driver/topology/tls_reload_test.go
+++ b/x/mongo/driver/topology/tls_reload_test.go
@@ -1,0 +1,208 @@
+// Copyright (C) MongoDB, Inc. 2026-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build go1.17
+
+package topology
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/internal/assert"
+	"go.mongodb.org/mongo-driver/v2/mongo/address"
+)
+
+// fakeTLSConn is a minimal tlsConn stub that returns either an error or success on
+// HandshakeContext, controlled by the parent fakeTLSSource.
+type fakeTLSConn struct {
+	net.Conn
+	handshakeErr error
+}
+
+func (f *fakeTLSConn) HandshakeContext(context.Context) error { return f.handshakeErr }
+func (f *fakeTLSConn) ConnectionState() tls.ConnectionState   { return tls.ConnectionState{} }
+
+// fakeTLSSource records each Client() call and lets a test choose what handshake
+// behavior to return on each call. seenCfgs lets tests verify which *tls.Config was
+// actually used per attempt.
+type fakeTLSSource struct {
+	mu       sync.Mutex
+	calls    int
+	seenCfgs []*tls.Config
+	// errSeq is consulted in order: errSeq[0] for call #1, errSeq[1] for call #2, etc.
+	// Entries past the end of the slice are treated as nil (success).
+	errSeq []error
+}
+
+func (f *fakeTLSSource) Client(nc net.Conn, cfg *tls.Config) tlsConn {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	idx := f.calls
+	f.calls++
+	f.seenCfgs = append(f.seenCfgs, cfg)
+	var err error
+	if idx < len(f.errSeq) {
+		err = f.errSeq[idx]
+	}
+	return &fakeTLSConn{Conn: nc, handshakeErr: err}
+}
+
+func newTestConnectionWithTLS(t *testing.T, src *fakeTLSSource, baseCfg *tls.Config, reloader func() (*tls.Config, error)) *connection {
+	t.Helper()
+	opts := []ConnectionOption{
+		WithDialer(func(Dialer) Dialer {
+			return DialerFunc(func(context.Context, string, string) (net.Conn, error) {
+				return &net.TCPConn{}, nil
+			})
+		}),
+		WithTLSConfig(func(*tls.Config) *tls.Config { return baseCfg }),
+		withTLSConnectionSource(func(tlsConnectionSource) tlsConnectionSource { return src }),
+	}
+	if reloader != nil {
+		opts = append(opts, WithTLSReloader(reloader))
+	}
+	return newConnection(address.Address("localhost:27017"), opts...)
+}
+
+// All test configs set InsecureSkipVerify so the post-handshake OCSP path is bypassed
+// — the fake handshake never produces a real certificate chain to verify.
+
+func TestTLSReload_NoReloaderReturnsOriginalError(t *testing.T) {
+	handshakeErr := errors.New("bad cert")
+	src := &fakeTLSSource{errSeq: []error{handshakeErr}}
+	conn := newTestConnectionWithTLS(t, src, &tls.Config{InsecureSkipVerify: true}, nil)
+
+	err := conn.connect(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, handshakeErr), "expected wrapped handshake error, got %v", err)
+	assert.Equal(t, 1, src.calls, "expected exactly one handshake attempt without a reloader")
+}
+
+func TestTLSReload_SuccessOnRetry(t *testing.T) {
+	handshakeErr := errors.New("expired cert")
+	src := &fakeTLSSource{errSeq: []error{handshakeErr}} // fail #1, succeed #2
+	freshCfg := &tls.Config{ServerName: "fresh", InsecureSkipVerify: true}
+
+	var reloadCalls atomic.Int32
+	reloader := func() (*tls.Config, error) {
+		reloadCalls.Add(1)
+		return freshCfg, nil
+	}
+	conn := newTestConnectionWithTLS(t, src, &tls.Config{ServerName: "stale", InsecureSkipVerify: true}, reloader)
+
+	err := conn.connect(context.Background())
+	assert.NoError(t, err, "expected connect to succeed after reload retry")
+	assert.Equal(t, 2, src.calls, "expected exactly two handshake attempts")
+	assert.Equal(t, int32(1), reloadCalls.Load(), "reloader should be called exactly once")
+	// The second attempt should have used the fresh config (after Clone, ServerName stays).
+	assert.Equal(t, "fresh", src.seenCfgs[1].ServerName, "second handshake should use reloaded config")
+	// The atomic pointer should now hold the fresh config.
+	assert.Equal(t, freshCfg, conn.config.tlsConfigPtr.Load(), "atomic pointer should hold reloaded config")
+}
+
+func TestTLSReload_ReloadErrorPropagated(t *testing.T) {
+	handshakeErr := errors.New("bad cert")
+	reloadErr := errors.New("file vanished")
+	src := &fakeTLSSource{errSeq: []error{handshakeErr}}
+	reloader := func() (*tls.Config, error) { return nil, reloadErr }
+	conn := newTestConnectionWithTLS(t, src, &tls.Config{InsecureSkipVerify: true}, reloader)
+
+	err := conn.connect(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, handshakeErr), "expected original error to be wrapped, got %v", err)
+	// reloadErr is wrapped via %v (not %w) so we match on substring.
+	assert.Contains(t, err.Error(), reloadErr.Error(), "expected reload error in message: %v", err)
+	assert.Equal(t, 1, src.calls, "should not retry handshake when reload fails")
+}
+
+func TestTLSReload_RetryHandshakeAlsoFails(t *testing.T) {
+	handshakeErr := errors.New("bad cert")
+	retryErr := errors.New("still bad")
+	src := &fakeTLSSource{errSeq: []error{handshakeErr, retryErr}}
+
+	var reloadCalls atomic.Int32
+	reloader := func() (*tls.Config, error) {
+		reloadCalls.Add(1)
+		return &tls.Config{ServerName: "fresh", InsecureSkipVerify: true}, nil
+	}
+	conn := newTestConnectionWithTLS(t, src, &tls.Config{InsecureSkipVerify: true}, reloader)
+
+	err := conn.connect(context.Background())
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, handshakeErr), "expected original error to be wrapped, got %v", err)
+	assert.Contains(t, err.Error(), retryErr.Error(), "expected retry error in message: %v", err)
+	assert.Equal(t, 2, src.calls, "expected exactly one retry, no infinite loop")
+	assert.Equal(t, int32(1), reloadCalls.Load(), "reloader should be called exactly once")
+}
+
+func TestTLSReload_ConcurrentSingleFlight(t *testing.T) {
+	// Every handshake fails so each goroutine takes the reload path. The reloader
+	// should be invoked at most once; subsequent callers should reuse the published
+	// pointer.
+	const N = 16
+	src := &fakeTLSSource{} // empty errSeq → first len(errSeq) calls fail (none here)
+	src.errSeq = make([]error, 2*N)
+	failure := errors.New("bad cert")
+	for i := range src.errSeq {
+		src.errSeq[i] = failure
+	}
+
+	var reloadCalls atomic.Int32
+	freshCfg := &tls.Config{ServerName: "fresh", InsecureSkipVerify: true}
+	reloader := func() (*tls.Config, error) {
+		reloadCalls.Add(1)
+		return freshCfg, nil
+	}
+
+	// All connections share the same connectionConfig (same WithTLSReloader) so the
+	// atomic pointer + mutex are shared across them.
+	baseOpts := []ConnectionOption{
+		WithDialer(func(Dialer) Dialer {
+			return DialerFunc(func(context.Context, string, string) (net.Conn, error) {
+				return &net.TCPConn{}, nil
+			})
+		}),
+		WithTLSConfig(func(*tls.Config) *tls.Config { return &tls.Config{ServerName: "stale", InsecureSkipVerify: true} }),
+		withTLSConnectionSource(func(tlsConnectionSource) tlsConnectionSource { return src }),
+		WithTLSReloader(reloader),
+	}
+	// Build N connections sharing the same set of options-derived state by reusing
+	// the SAME tlsConfigPtr across them — done by constructing one config first then
+	// copying its tlsConfigPtr/tlsReloadMu into the others.
+	first := newConnection(address.Address("localhost:27017"), baseOpts...)
+	conns := make([]*connection, N)
+	conns[0] = first
+	for i := 1; i < N; i++ {
+		c := newConnection(address.Address("localhost:27017"), baseOpts...)
+		c.config.tlsConfigPtr = first.config.tlsConfigPtr
+		c.config.tlsReloadMu = first.config.tlsReloadMu
+		conns[i] = c
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			_ = conns[i].connect(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	// Reloader should fire exactly once because once one goroutine published the
+	// fresh config, every later caller picks it up via the atomic pointer.
+	assert.Equal(t, int32(1), reloadCalls.Load(),
+		"expected single-flight reload, got %d invocations", reloadCalls.Load())
+	assert.Equal(t, freshCfg, first.config.tlsConfigPtr.Load(),
+		"expected fresh config published to atomic pointer")
+}

--- a/x/mongo/driver/topology/tls_reload_test.go
+++ b/x/mongo/driver/topology/tls_reload_test.go
@@ -163,8 +163,10 @@ func TestTLSReload_ConcurrentSingleFlight(t *testing.T) {
 		return freshCfg, nil
 	}
 
-	// All connections share the same connectionConfig (same WithTLSReloader) so the
-	// atomic pointer + mutex are shared across them.
+	// WithTLSReloader allocates the atomic pointer + mutex once and captures them in
+	// its returned closure, so every connection built from this same option slice
+	// naturally shares the single-flight state. No manual fixup needed — that
+	// sharing is precisely what this test verifies.
 	baseOpts := []ConnectionOption{
 		WithDialer(func(Dialer) Dialer {
 			return DialerFunc(func(context.Context, string, string) (net.Conn, error) {
@@ -175,17 +177,17 @@ func TestTLSReload_ConcurrentSingleFlight(t *testing.T) {
 		withTLSConnectionSource(func(tlsConnectionSource) tlsConnectionSource { return src }),
 		WithTLSReloader(reloader),
 	}
-	// Build N connections sharing the same set of options-derived state by reusing
-	// the SAME tlsConfigPtr across them — done by constructing one config first then
-	// copying its tlsConfigPtr/tlsReloadMu into the others.
-	first := newConnection(address.Address("localhost:27017"), baseOpts...)
 	conns := make([]*connection, N)
-	conns[0] = first
+	for i := 0; i < N; i++ {
+		conns[i] = newConnection(address.Address("localhost:27017"), baseOpts...)
+	}
+	// Sanity check: pointer and mutex must be the same instance across all
+	// connections, otherwise the single-flight property below is meaningless.
 	for i := 1; i < N; i++ {
-		c := newConnection(address.Address("localhost:27017"), baseOpts...)
-		c.config.tlsConfigPtr = first.config.tlsConfigPtr
-		c.config.tlsReloadMu = first.config.tlsReloadMu
-		conns[i] = c
+		assert.True(t, conns[i].config.tlsConfigPtr == conns[0].config.tlsConfigPtr,
+			"tlsConfigPtr must be shared across connections built from the same option")
+		assert.True(t, conns[i].config.tlsReloadMu == conns[0].config.tlsReloadMu,
+			"tlsReloadMu must be shared across connections built from the same option")
 	}
 
 	var wg sync.WaitGroup
@@ -203,6 +205,6 @@ func TestTLSReload_ConcurrentSingleFlight(t *testing.T) {
 	// fresh config, every later caller picks it up via the atomic pointer.
 	assert.Equal(t, int32(1), reloadCalls.Load(),
 		"expected single-flight reload, got %d invocations", reloadCalls.Load())
-	assert.Equal(t, freshCfg, first.config.tlsConfigPtr.Load(),
+	assert.Equal(t, freshCfg, conns[0].config.tlsConfigPtr.Load(),
 		"expected fresh config published to atomic pointer")
 }

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -431,6 +431,9 @@ func NewAuthenticatorConfig(authenticator driver.Authenticator, clientOpts ...Au
 				return opts.TLSConfig
 			},
 		))
+		if reload := options.BuildTLSReloader(opts); reload != nil {
+			connOpts = append(connOpts, WithTLSReloader(reload))
+		}
 	}
 
 	// HTTP Client


### PR DESCRIPTION
GODRIVER-3916

## Summary

Add lazy TLS cert reload on handshake failure. When a new connection's TLS handshake fails and the *tls.Config was loaded from URI cert files, the driver re-reads those files once, atomically publishes the fresh config to the pool, and retries the handshake exactly once. Existing connections are not touched.



## Background & Motivation

The driver loads tlsCAFile / tlsCertificateKeyFile etc. once at ApplyURI time and caches the resulting *tls.Config. After on-disk cert rotation, every new connection keeps using the stale in-memory cert until process restart. Even though the rotated material is sitting on disk. Operators rotating certs out-of-band currently need to bounce the process or wire up tls.Config.GetClientCertificate themselves. This patch makes rotation transparent: the next failing handshake triggers one reload, and tlsCertificateKeyFile-based clients self-heal on the spot.
