### PR TITLE
GODRIVER-3912 Add prose test for database.ListCollection routing

### DIFF
--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -624,13 +624,8 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		// command was successful.
 		cur, err := mt.DB.ListCollections(context.Background(), bson.D{})
 
-		if cur != nil {
-			defer func() {
-				require.NoError(t, cur.Close(context.Background()))
-			}()
-		}
-
 		require.NoError(mt, err, "ListCollections error: %v", err)
+		require.NoError(mt, cur.Close(context.Background()))
 
 		mu.Lock()
 		defer mu.Unlock()
@@ -689,16 +684,10 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 
 		// Step 2. Invoke listCollections and assert that it succeeds.
 		cur, err := directClient.Database(mt.DB.Name()).ListCollections(context.Background(), bson.D{})
-
-		if cur != nil {
-			defer func() {
-				require.NoError(mt, cur.Close(context.Background()))
-			}()
-		}
-
 		require.NoError(mt, err,
 			"ListCollections against directly-connected secondary should succeed: %v",
 			err)
+		require.NoError(mt, cur.Close(context.Background()))
 	})
 }
 

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -640,7 +642,27 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		require.Equal(mt, primary.String(), actualHost)
 	})
 
+	// Skip testing auth since it requires building a secondary string with
+	// auth credentials, which is not the point of this test.
 	mt.Run("succeeds when directly connected to a secondary", func(mt *mtest.T) {
+		// This test can only run if the MONGODB_URI contains a username and
+		// password, since we need to authenticate to the secondary.
+		var mongodbURL *url.URL
+		if os.Getenv("MONGODB_URI") != "" {
+			var err error
+			mongodbURL, err = url.Parse(os.Getenv("MONGODB_URI"))
+			require.NoError(mt, err, "error parsing MONGODB_URI: %v", err)
+		} else {
+			mt.Skip("MONGODB_URI must not be set for this test to run")
+		}
+
+		username := mongodbURL.User.Username()
+		require.NotEmpty(mt, username, "MONGODB_URI must contain a username for this test to run")
+
+		password, isSet := mongodbURL.User.Password()
+		require.True(mt, isSet, "MONGODB_URI must contain a password for this test to run")
+		require.NotEmpty(mt, password, "MONGODB_URI must contain a password for this test to run")
+
 		// Step 1. Construct a client whose URI points at a known secondary and sets
 		// directConnection=true.
 		var hello struct {
@@ -666,7 +688,13 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 			mt.Skip("no secondary node available in cluster")
 		}
 
-		directOpts := options.Client().ApplyURI("mongodb://" + secondary).SetDirect(true)
+		// Add auth to secondary.
+		creds := options.Credential{
+			Username: username,
+			Password: password,
+		}
+
+		directOpts := options.Client().ApplyURI("mongodb://" + secondary).SetDirect(true).SetAuth(creds)
 
 		directClient, err := mongo.Connect(directOpts)
 		require.NoError(mt, err, "direct Connect error: %v", err)

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -11,8 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -645,24 +643,9 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 	// Skip testing auth since it requires building a secondary string with
 	// auth credentials, which is not the point of this test.
 	mt.Run("succeeds when directly connected to a secondary", func(mt *mtest.T) {
-		// This test can only run if the MONGODB_URI contains a username and
-		// password, since we need to authenticate to the secondary.
-		var mongodbURL *url.URL
-		if os.Getenv("MONGODB_URI") != "" {
-			var err error
-			mongodbURL, err = url.Parse(os.Getenv("MONGODB_URI"))
-			require.NoError(mt, err, "error parsing MONGODB_URI: %v", err)
-		} else {
-			mt.Skip("MONGODB_URI must not be set for this test to run")
+		if mtest.ClusterConnString().UsernameSet || mtest.SSLEnabled() {
+			mt.Skip("skipping test when auth or SSL is enabled")
 		}
-
-		username := mongodbURL.User.Username()
-		require.NotEmpty(mt, username, "MONGODB_URI must contain a username for this test to run")
-
-		password, isSet := mongodbURL.User.Password()
-		require.True(mt, isSet, "MONGODB_URI must contain a password for this test to run")
-		require.NotEmpty(mt, password, "MONGODB_URI must contain a password for this test to run")
-
 		// Step 1. Construct a client whose URI points at a known secondary and sets
 		// directConnection=true.
 		var hello struct {
@@ -688,13 +671,7 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 			mt.Skip("no secondary node available in cluster")
 		}
 
-		// Add auth to secondary.
-		creds := options.Credential{
-			Username: username,
-			Password: password,
-		}
-
-		directOpts := options.Client().ApplyURI("mongodb://" + secondary).SetDirect(true).SetAuth(creds)
+		directOpts := options.Client().ApplyURI("mongodb://" + secondary).SetDirect(true)
 
 		directClient, err := mongo.Connect(directOpts)
 		require.NoError(mt, err, "direct Connect error: %v", err)

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -672,7 +672,7 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		require.NoError(mt, err, "direct Connect error: %v", err)
 
 		defer func() {
-			require.NoError(t, directClient.Disconnect(context.Background()))
+			require.NoError(mt, directClient.Disconnect(context.Background()))
 		}()
 
 		// Step 2. Invoke listCollections and assert that it succeeds.

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -624,9 +624,11 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		// command was successful.
 		cur, err := mt.DB.ListCollections(context.Background(), bson.D{})
 
-		defer func() {
-			require.NoError(t, cur.Close(context.Background()))
-		}()
+		if cur != nil {
+			defer func() {
+				require.NoError(t, cur.Close(context.Background()))
+			}()
+		}
 
 		require.NoError(mt, err, "ListCollections error: %v", err)
 
@@ -688,9 +690,11 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		// Step 2. Invoke listCollections and assert that it succeeds.
 		cur, err := directClient.Database(mt.DB.Name()).ListCollections(context.Background(), bson.D{})
 
-		defer func() {
-			require.NoError(mt, cur.Close(context.Background()))
-		}()
+		if cur != nil {
+			defer func() {
+				require.NoError(mt, cur.Close(context.Background()))
+			}()
+		}
 
 		require.NoError(mt, err,
 			"ListCollections against directly-connected secondary should succeed: %v",

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -622,7 +622,12 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 
 		// Step 3. Invoke ListCollections against the new client and assert that the
 		// command was successful.
-		_, err := mt.DB.ListCollections(context.Background(), bson.D{})
+		cur, err := mt.DB.ListCollections(context.Background(), bson.D{})
+
+		defer func() {
+			require.NoError(t, cur.Close(context.Background()))
+		}()
+
 		require.NoError(mt, err, "ListCollections error: %v", err)
 
 		mu.Lock()
@@ -644,7 +649,7 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 	// auth credentials, which is not the point of this test.
 	mt.Run("succeeds when directly connected to a secondary", func(mt *mtest.T) {
 		if mtest.ClusterConnString().UsernameSet || mtest.SSLEnabled() {
-			mt.Skip("skipping test when auth or SSL is enabled")
+			mt.Skip("direct URI lacks auth/TLS options; skip when cluster requires them")
 		}
 		// Step 1. Construct a client whose URI points at a known secondary and sets
 		// directConnection=true.
@@ -681,7 +686,12 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 		}()
 
 		// Step 2. Invoke listCollections and assert that it succeeds.
-		_, err = directClient.Database(mt.DB.Name()).ListCollections(context.Background(), bson.D{})
+		cur, err := directClient.Database(mt.DB.Name()).ListCollections(context.Background(), bson.D{})
+
+		defer func() {
+			require.NoError(mt, cur.Close(context.Background()))
+		}()
+
 		require.NoError(mt, err,
 			"ListCollections against directly-connected secondary should succeed: %v",
 			err)

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -608,19 +608,15 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 				if e.CommandName != "listCollections" {
 					return
 				}
-
 				mu.Lock()
 				defer mu.Unlock()
-
 				connIDs = append(connIDs, e.ConnectionID)
 			},
 		}
 
 		// Step 2. Create a new client with the CommandMonitor and read preference
 		// set to secondary.
-		clientOpts := options.Client().
-			SetMonitor(monitor).
-			SetReadPreference(mtest.SecondaryRp)
+		clientOpts := options.Client().SetMonitor(monitor).SetReadPreference(mtest.SecondaryRp)
 
 		mt.ResetClient(clientOpts)
 
@@ -665,22 +661,22 @@ func TestDatabase_ListCollections_Routing(t *testing.T) {
 				break
 			}
 		}
+
 		if secondary == "" {
 			mt.Skip("no secondary node available in cluster")
 		}
 
-		directOpts := options.Client().
-			ApplyURI("mongodb://" + secondary).
-			SetDirect(true)
+		directOpts := options.Client().ApplyURI("mongodb://" + secondary).SetDirect(true)
+
 		directClient, err := mongo.Connect(directOpts)
 		require.NoError(mt, err, "direct Connect error: %v", err)
+
 		defer func() {
-			_ = directClient.Disconnect(context.Background())
+			require.NoError(t, directClient.Disconnect(context.Background()))
 		}()
 
 		// Step 2. Invoke listCollections and assert that it succeeds.
-		_, err = directClient.Database(mt.DB.Name()).
-			ListCollections(context.Background(), bson.D{})
+		_, err = directClient.Database(mt.DB.Name()).ListCollections(context.Background(), bson.D{})
 		require.NoError(mt, err,
 			"ListCollections against directly-connected secondary should succeed: %v",
 			err)

--- a/internal/integration/database_test.go
+++ b/internal/integration/database_test.go
@@ -12,13 +12,17 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/event"
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/failpoint"
 	"go.mongodb.org/mongo-driver/v2/internal/handshake"
 	"go.mongodb.org/mongo-driver/v2/internal/integration/mtest"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
@@ -583,6 +587,103 @@ func TestDatabase(t *testing.T) {
 			collation := collationVal.(bson.M)
 			assert.Equal(mt, locale, collation["locale"], "expected locale %v, got %v", locale, collation["locale"])
 		})
+	})
+}
+
+func TestDatabase_ListCollections_Routing(t *testing.T) {
+	mtOpts := mtest.NewOptions().Topologies(mtest.ReplicaSet).CreateClient(false)
+
+	mt := mtest.New(t, mtOpts)
+
+	mt.Run("routes to primary in replica set", func(mt *mtest.T) {
+		var (
+			mu      sync.Mutex
+			connIDs []string
+		)
+
+		// Step 1. Create a CommandMonitor that captures the ConnectionID of any
+		// command with the name "listCollections".
+		monitor := &event.CommandMonitor{
+			Started: func(_ context.Context, e *event.CommandStartedEvent) {
+				if e.CommandName != "listCollections" {
+					return
+				}
+
+				mu.Lock()
+				defer mu.Unlock()
+
+				connIDs = append(connIDs, e.ConnectionID)
+			},
+		}
+
+		// Step 2. Create a new client with the CommandMonitor and read preference
+		// set to secondary.
+		clientOpts := options.Client().
+			SetMonitor(monitor).
+			SetReadPreference(mtest.SecondaryRp)
+
+		mt.ResetClient(clientOpts)
+
+		// Step 3. Invoke ListCollections against the new client and assert that the
+		// command was successful.
+		_, err := mt.DB.ListCollections(context.Background(), bson.D{})
+		require.NoError(mt, err, "ListCollections error: %v", err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Lenf(mt, connIDs, 1,
+			"expected exactly one listCollections command, got %d", len(connIDs))
+
+		// Step 4. Verify, via the driver's command-monitoring API, that the
+		// operation was issued against the primary node
+		actualHost := strings.SplitN(connIDs[0], "[", 2)[0]
+
+		topo := getTopologyFromClient(mt.Client)
+		primary := getPrimaryAddress(mt, topo, false)
+
+		require.Equal(mt, primary.String(), actualHost)
+	})
+
+	mt.Run("succeeds when directly connected to a secondary", func(mt *mtest.T) {
+		// Step 1. Construct a client whose URI points at a known secondary and sets
+		// directConnection=true.
+		var hello struct {
+			Hosts   []string `bson:"hosts"`
+			Primary string   `bson:"primary"`
+		}
+
+		err := mt.Client.Database("admin").
+			RunCommand(context.Background(), bson.D{{Key: "hello", Value: 1}}).
+			Decode(&hello)
+
+		require.NoError(mt, err, "hello error: %v", err)
+
+		var secondary string
+		for _, h := range hello.Hosts {
+			if h != hello.Primary {
+				secondary = h
+				break
+			}
+		}
+		if secondary == "" {
+			mt.Skip("no secondary node available in cluster")
+		}
+
+		directOpts := options.Client().
+			ApplyURI("mongodb://" + secondary).
+			SetDirect(true)
+		directClient, err := mongo.Connect(directOpts)
+		require.NoError(mt, err, "direct Connect error: %v", err)
+		defer func() {
+			_ = directClient.Disconnect(context.Background())
+		}()
+
+		// Step 2. Invoke listCollections and assert that it succeeds.
+		_, err = directClient.Database(mt.DB.Name()).
+			ListCollections(context.Background(), bson.D{})
+		require.NoError(mt, err,
+			"ListCollections against directly-connected secondary should succeed: %v",
+			err)
 	})
 }
 


### PR DESCRIPTION
GODRIVER-3912

Add prose test for https://github.com/mongodb/specifications/commit/de7fd8d12a7d95db6bc935d7ff1a4780f17911bd

> The server supports running `listCollections` on a secondary node. Drivers MUST however run `listCollections` on the primary node when in a replica set topology, unless directly connected to a secondary node in Single topology.

