### PR TITLE
GODRIVER-3917 Replace curl | sh with go install in etc/golangci-lint.sh

### DIFF
--- a/etc/golangci-lint.sh
+++ b/etc/golangci-lint.sh
@@ -17,7 +17,7 @@ GOROOT="$(go${GO_VERSION} env GOROOT)"
 PATH="$GOROOT/bin:$PATH"
 export PATH
 export GOROOT
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v${GOLANGCI_LINT_VERSION}
+GOBIN="$(go env GOPATH)/bin" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}
 
 export GOOS=$GOOS_ORIG
 export GOARCH=$GOARCH_ORIG


### PR DESCRIPTION
GODRIVER-3917

etc/golangci-lint.sh installs golangci-lint via curl|sh, a known supply-chain attack vector that is also blocked by endpoint-security tooling on MongoDB-issued machines, preventing `task lint` from running locally.
