### PR TITLE
GODRIVER-3921 retro backpressure cleanup

### DIFF
--- a/internal/integration/backpressure_prose_test.go
+++ b/internal/integration/backpressure_prose_test.go
@@ -40,16 +40,7 @@ func TestBackpressureProse(t *testing.T) {
 		mt.ResetClient(options.Client())
 
 		transWithJitter := func(t *mtest.T, ratio float64) time.Duration {
-			defer randutil.SetJitterForTesting(func(n int64) int64 {
-				val := int64(ratio * float64(n))
-				if val < 0 {
-					return 0
-				}
-				if val > n {
-					return n
-				}
-				return val
-			})()
+			defer randutil.SetJitterForTesting(func() float64 { return ratio })()
 
 			startTime := time.Now()
 			_, err := t.Coll.InsertOne(context.Background(), bson.D{{"a", 1}})

--- a/internal/integration/retryable_reads_prose_test.go
+++ b/internal/integration/retryable_reads_prose_test.go
@@ -360,7 +360,7 @@ func TestRetryableReadsProse(t *testing.T) {
 			},
 		}
 
-		defer randutil.SetJitterForTesting(func(int64) int64 {
+		defer randutil.SetJitterForTesting(func() float64 {
 			ops[len(ops)-1] = true
 			return 0
 		})()

--- a/internal/integration/retryable_writes_prose_test.go
+++ b/internal/integration/retryable_writes_prose_test.go
@@ -596,7 +596,7 @@ func TestErrorPropagationAfterEncounteringMultipleErrors(t *testing.T) {
 			},
 		}
 
-		defer randutil.SetJitterForTesting(func(int64) int64 {
+		defer randutil.SetJitterForTesting(func() float64 {
 			ops[len(ops)-1] = true
 			return 0
 		})()

--- a/internal/integration/transactions_convenient_api_prose_test.go
+++ b/internal/integration/transactions_convenient_api_prose_test.go
@@ -35,16 +35,7 @@ func TestTransactionConvenientApiProse(t *testing.T) {
 		}
 
 		transWithJitter := func(t *mtest.T, ratio float64) time.Duration {
-			defer randutil.SetJitterForTesting(func(n int64) int64 {
-				val := int64(ratio * float64(n))
-				if val < 0 {
-					return 0
-				}
-				if val > n {
-					return n
-				}
-				return val
-			})()
+			defer randutil.SetJitterForTesting(func() float64 { return ratio })()
 
 			mt.SetFailPoint(fp)
 

--- a/internal/randutil/jitter.go
+++ b/internal/randutil/jitter.go
@@ -8,21 +8,28 @@ package randutil
 
 var globalRand = NewLockedRand()
 
-var jitterInt63n func(int64) int64 = globalRand.Int63n
+// jitter is the function used by Jitter. Production code uses
+// globalRand.Float64; tests may swap it via SetJitterForTesting.
+var jitter func() float64 = globalRand.Float64
 
-// JitterInt63n returns, as an int64, a non-negative pseudo-random number in
-// the half-open interval [0,n). It panics if n <= 0.
+// Jitter returns a pseudo-random ratio in [0.0, 1.0) for use in backoff
+// calculations per the client-backpressure spec:
 //
-// If a test jitter function is set by calling SetJitterForTesting, JitterInt63n
-// returns the value from the custom function.
-func JitterInt63n(n int64) int64 {
-	return jitterInt63n(n)
+//	backoff = Jitter() * min(MAX_BACKOFF, BASE_BACKOFF * 2.0^(attempt - 1.0))
+//
+// If a test jitter function is set by calling SetJitterForTesting, Jitter
+// returns the value from that custom function.
+func Jitter() float64 {
+	return jitter()
 }
 
-// SetJitterForTesting sets a custom jitter function for testing and returns a restore function.
-func SetJitterForTesting(f func(int64) int64) func() {
-	jitterInt63n = f
+// SetJitterForTesting sets a custom jitter function for testing and returns
+// a restore function. The function should return a ratio in [0.0, 1.0); values
+// outside that range are not validated and will produce backoffs outside
+// the spec-defined range.
+func SetJitterForTesting(f func() float64) func() {
+	jitter = f
 	return func() {
-		jitterInt63n = globalRand.Int63n
+		jitter = globalRand.Float64
 	}
 }

--- a/internal/randutil/jitter.go
+++ b/internal/randutil/jitter.go
@@ -6,21 +6,21 @@
 
 package randutil
 
+import "time"
+
 var globalRand = NewLockedRand()
 
 // jitter is the function used by Jitter. Production code uses
 // globalRand.Float64; tests may swap it via SetJitterForTesting.
 var jitter func() float64 = globalRand.Float64
 
-// Jitter returns a pseudo-random ratio in [0.0, 1.0) for use in backoff
-// calculations per the client-backpressure spec:
+// JitterDuration returns the input duration weighted by a pseudo-random ratio
+// in [0.0, 1.0).
 //
-//	backoff = Jitter() * min(MAX_BACKOFF, BASE_BACKOFF * 2.0^(attempt - 1.0))
-//
-// If a test jitter function is set by calling SetJitterForTesting, Jitter
-// returns the value from that custom function.
-func Jitter() float64 {
-	return jitter()
+// If a test jitter function is set by calling SetJitterForTesting,
+// JitterDuration returns the value from that custom function.
+func JitterDuration(d time.Duration) time.Duration {
+	return time.Duration(float64(d) * jitter())
 }
 
 // SetJitterForTesting sets a custom jitter function for testing and returns

--- a/mongo/change_stream_deployment.go
+++ b/mongo/change_stream_deployment.go
@@ -40,6 +40,20 @@ func (c *changeStreamDeployment) Kind() description.TopologyKind {
 
 func (c *changeStreamDeployment) Connection(context.Context) (*mnet.Connection, error) {
 	var err error
+	// TODO(GODRIVER-3905): replace c.conn.Closed() with c.conn.IsAlive()
+	// once the bufio.Reader infrastructure from GODRIVER-3603 lands.
+	// The post-3603 form will be:
+	//
+	//     if c.conn == nil || !c.conn.IsAlive() {
+	//         err = c.reset()
+	//     }
+	//
+	// IsAlive performs a non-destructive Peek under a short read deadline,
+	// catching the silent-death cases this Closed() check currently misses
+	// (server-side close, peer RST, network drop already noticed by the
+	// kernel, TLS abort). The narrow "did we call Close?" semantics of the
+	// current flag aren't useful here — we want to know whether the cached
+	// connection is reusable, not who terminated it.
 	if c.conn == nil || c.conn.Closed() {
 		err = c.reset()
 	}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -142,7 +142,7 @@ func (s *Session) WithTransaction(
 			if expDur > backoffMax {
 				expDur = backoffMax
 			}
-			backoff := expDur * time.Duration(randutil.JitterInt63n(512)) / 512
+			backoff := time.Duration(randutil.Jitter() * float64(expDur))
 			if time.Since(startTime)+backoff > transTimeout {
 				return nil, timeoutError{Wrapped: err}
 			}

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -142,7 +142,7 @@ func (s *Session) WithTransaction(
 			if expDur > backoffMax {
 				expDur = backoffMax
 			}
-			backoff := time.Duration(randutil.Jitter() * float64(expDur))
+			backoff := randutil.JitterDuration(expDur)
 			if time.Since(startTime)+backoff > transTimeout {
 				return nil, timeoutError{Wrapped: err}
 			}

--- a/x/mongo/driver/mnet/connection.go
+++ b/x/mongo/driver/mnet/connection.go
@@ -79,6 +79,13 @@ type Pinner interface {
 
 // Connection represents a connection to a MongoDB server.
 type Connection struct {
+	// closed is a shadow of the underlying ReadWriteCloser's state. It only
+	// reflects intentional closes performed via Connection.Close(); it does
+	// not catch silent underlying death (network drop, server-side close,
+	// pool eviction, etc.).
+	//
+	// TODO(GODRIVER-3905): remove this field along with Close()/Closed()
+	// once IsAlive() lands on the topology connection.
 	closed uint32
 
 	ReadWriteCloser
@@ -89,6 +96,14 @@ type Connection struct {
 }
 
 // Close closes the connection.
+//
+// TODO(GODRIVER-3905): remove this override. Once GODRIVER-3603 lands
+// the bufio.Reader on topology.connection, the "is this connection
+// still usable?" question (the only reason this override exists, via
+// the Closed flag) will be answered by a new IsAlive method that runs
+// a peek-based liveness probe. Callers then get Close from the embedded
+// ReadWriteCloser directly via interface promotion. See
+// change_stream_deployment.Connection for the consumer that drives this.
 func (c *Connection) Close() error {
 	// Logically mark the connection as closed.
 	atomic.StoreUint32(&c.closed, 1)
@@ -97,6 +112,13 @@ func (c *Connection) Close() error {
 }
 
 // Closed returns true if the connection has been logically closed.
+//
+// TODO(GODRIVER-3905): remove in favor of an IsAlive method on the
+// topology connection. Closed answers "did our code call
+// Connection.Close()?": a strict subset of "is this connection
+// usable?". A bufio.Reader-backed Peek probe with a short read deadline
+// catches the silent-death cases (peer FIN, RST, TLS abort, network
+// drop already noticed by the kernel) and returns the broader answer.
 func (c *Connection) Closed() bool {
 	return atomic.LoadUint32(&c.closed) == 1
 }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -104,7 +104,7 @@ func (b retryBudget) allows(attempt uint) bool {
 func capped(n uint) retryBudget { return retryBudget{finite: true, max: n} }
 
 // unlimited is the zero-valued, uncapped retry budget.
-var unlimited retryBudget
+func unlimitedBudget() retryBudget { return retryBudget{} }
 
 // InvalidOperationError is returned from Validate and indicates that a required field is missing
 // from an instance of Operation.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -612,7 +612,7 @@ func (op Operation) Execute(ctx context.Context) error {
 					expDur = backoffMax
 				}
 			}
-			backoff := expDur * time.Duration(randutil.JitterInt63n(512)) / 512
+			backoff := time.Duration(randutil.Jitter() * float64(expDur))
 			if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < backoff {
 				return err
 			}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -24,7 +24,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/driverutil"
 	"go.mongodb.org/mongo-driver/v2/internal/handshake"
 	"go.mongodb.org/mongo-driver/v2/internal/logger"
-	"go.mongodb.org/mongo-driver/v2/internal/ptrutil"
 	"go.mongodb.org/mongo-driver/v2/internal/randutil"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/mongo/address"
@@ -85,6 +84,27 @@ type labeledError interface {
 	error
 	HasErrorLabel(string) bool
 }
+
+// retryBudget is a retry cap for an operation's retry loop. The zero value
+// is "unlimited" (no cap). Use capped(n) to construct a finite budget of n.
+//
+// TODO(GODRIVER-3650): Consider using the internal Optional type for this
+// instead of a custom struct.
+type retryBudget struct {
+	finite bool
+	max    uint
+}
+
+// allows reports whether the given retry attempt is within the budget.
+func (b retryBudget) allows(attempt uint) bool {
+	return !b.finite || attempt < b.max
+}
+
+// capped returns a retry budget of n attempts.
+func capped(n uint) retryBudget { return retryBudget{finite: true, max: n} }
+
+// unlimited is the zero-valued, uncapped retry budget.
+var unlimited retryBudget
 
 // InvalidOperationError is returned from Validate and indicates that a required field is missing
 // from an instance of Operation.
@@ -507,7 +527,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		}
 	}
 
-	defaultRetries := ptrutil.Ptr(uint(0))
+	defaultBudget := capped(0)
 	if op.RetryMode != nil {
 		switch op.Type {
 		case Write:
@@ -516,23 +536,23 @@ func (op Operation) Execute(ctx context.Context) error {
 			}
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				defaultRetries = ptrutil.Ptr(uint(1))
+				defaultBudget = capped(1)
 			case RetryContext:
-				defaultRetries = nil
+				defaultBudget = unlimited
 			}
 		case Read:
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				defaultRetries = ptrutil.Ptr(uint(1))
+				defaultBudget = capped(1)
 			case RetryContext:
-				defaultRetries = nil
+				defaultBudget = unlimited
 			}
 		}
 
-		// If context is a Timeout context, automatically set retries to infinite (nil) if retrying is
-		// enabled.
+		// If context is a Timeout context, automatically set retries to
+		// unlimited if retrying is enabled.
 		if csot.IsTimeoutContext(ctx) && op.RetryMode.Enabled() {
-			defaultRetries = nil
+			defaultBudget = unlimited
 		}
 	}
 
@@ -549,7 +569,7 @@ func (op Operation) Execute(ctx context.Context) error {
 	retrySupported := false
 	first := true
 	currIndex := 0
-	retries := defaultRetries
+	nextBudget := defaultBudget
 
 	// deprioritizedServers are a running list of servers that should be
 	// deprioritized during server selection. Servers are accumulated across
@@ -649,8 +669,8 @@ func (op Operation) Execute(ctx context.Context) error {
 			return prevErr
 		}
 
-		allowedRetries := retries
-		retries = defaultRetries
+		currentBudget := nextBudget
+		nextBudget = defaultBudget
 
 		requestID := wiremessage.NextRequestID()
 
@@ -662,10 +682,10 @@ func (op Operation) Execute(ctx context.Context) error {
 		if srvr == nil || conn == nil {
 			srvr, conn, err = op.getServerAndConnection(ctx, requestID, deprioritizedServers)
 			if err != nil {
-				// If the returned error is retryable and there are retries remaining (nil
-				// means retry indefinitely), then retry the operation. Set the server and
-				// connection to nil to request a new server and connection.
-				if rerr, ok := err.(RetryablePoolError); ok && rerr.Retryable() && (allowedRetries == nil || attempt < *allowedRetries) {
+				// If the returned error is retryable and the budget allows another
+				// attempt, retry the operation. Set the server and connection to
+				// nil to request a new server and connection.
+				if rerr, ok := err.(RetryablePoolError); ok && rerr.Retryable() && currentBudget.allows(attempt) {
 					if err = resetForRetry(err); err != nil {
 						return err
 					}
@@ -835,8 +855,10 @@ func (op Operation) Execute(ctx context.Context) error {
 
 			isOverloadedError = tt.HasErrorLabel(ErrSystemOverloadedError)
 			if isOverloadedError && op.MaxAdaptiveRetries != 0 {
-				retries = ptrutil.Ptr(op.MaxAdaptiveRetries)
-				allowedRetries = ptrutil.Ptr(op.MaxAdaptiveRetries)
+				// If maxAdaptiveRetries is set, we want to retry overload errors until
+				// we hit that max.
+				nextBudget = capped(op.MaxAdaptiveRetries)
+				currentBudget = nextBudget
 			}
 			connDesc := conn.Description()
 			retryableErr := tt.Retryable(connDesc.Kind, connDesc.WireVersion)
@@ -852,9 +874,9 @@ func (op Operation) Execute(ctx context.Context) error {
 			needRetry := (retrySupported && retryEnabled && retryableErr) || (op.MaxAdaptiveRetries != 0 && olRetryErr)
 
 			// If retries are supported for the current operation on the first server description,
-			// the error is considered retryable, and there are retries remaining (nil means retry
-			// indefinitely), then retry the operation.
-			if needRetry && (allowedRetries == nil || attempt < *allowedRetries) {
+			// the error is considered retryable, and the budget allows another
+			// attempt, retry the operation.
+			if needRetry && currentBudget.allows(attempt) {
 				if op.Client != nil && op.Client.Committing && !olRetryErr {
 					// Apply majority write concern for retries
 					op.Client.UpdateCommitTransactionWriteConcern()
@@ -960,8 +982,10 @@ func (op Operation) Execute(ctx context.Context) error {
 
 			isOverloadedError = tt.HasErrorLabel(ErrSystemOverloadedError)
 			if isOverloadedError && op.MaxAdaptiveRetries != 0 {
-				retries = ptrutil.Ptr(op.MaxAdaptiveRetries)
-				allowedRetries = ptrutil.Ptr(op.MaxAdaptiveRetries)
+				// If maxAdaptiveRetries is set, we want to retry overload errors until
+				// we hit that max.
+				nextBudget = capped(op.MaxAdaptiveRetries)
+				currentBudget = nextBudget
 			}
 			connDesc := conn.Description()
 			var retryableErr bool
@@ -983,9 +1007,9 @@ func (op Operation) Execute(ctx context.Context) error {
 			needRetry := (retrySupported && retryEnabled && retryableErr) || (op.MaxAdaptiveRetries != 0 && olRetryErr)
 
 			// If retries are supported for the current operation on the first server description,
-			// the error is considered retryable, and there are retries remaining (nil means retry
-			// indefinitely), then retry the operation.
-			if needRetry && (allowedRetries == nil || attempt < *allowedRetries) {
+			// the error is considered retryable, and the budget allows another
+			// attempt, retry the operation.
+			if needRetry && currentBudget.allows(attempt) {
 				if op.Client != nil && op.Client.Committing && !olRetryErr {
 					// Apply majority write concern for retries
 					op.Client.UpdateCommitTransactionWriteConcern()
@@ -1069,7 +1093,7 @@ func (op Operation) Execute(ctx context.Context) error {
 				// Reset the retries number for RetryOncePerCommand unless context is a Timeout context, in
 				// which case retries should remain as nil (as many times as possible).
 				if *op.RetryMode == RetryOncePerCommand && !csot.IsTimeoutContext(ctx) {
-					retries = ptrutil.Ptr(uint(1))
+					nextBudget = capped(1)
 				}
 			}
 			isOverloadedError = false

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -538,21 +538,21 @@ func (op Operation) Execute(ctx context.Context) error {
 			case RetryOnce, RetryOncePerCommand:
 				defaultBudget = capped(1)
 			case RetryContext:
-				defaultBudget = unlimited
+				defaultBudget = unlimitedBudget()
 			}
 		case Read:
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
 				defaultBudget = capped(1)
 			case RetryContext:
-				defaultBudget = unlimited
+				defaultBudget = unlimitedBudget()
 			}
 		}
 
 		// If context is a Timeout context, automatically set retries to
 		// unlimited if retrying is enabled.
 		if csot.IsTimeoutContext(ctx) && op.RetryMode.Enabled() {
-			defaultBudget = unlimited
+			defaultBudget = unlimitedBudget()
 		}
 	}
 
@@ -632,7 +632,7 @@ func (op Operation) Execute(ctx context.Context) error {
 					expDur = backoffMax
 				}
 			}
-			backoff := time.Duration(randutil.Jitter() * float64(expDur))
+			backoff := randutil.JitterDuration(expDur)
 			if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < backoff {
 				return err
 			}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -100,11 +100,11 @@ func (b retryBudget) allows(attempt uint) bool {
 	return !b.finite || attempt < b.max
 }
 
-// capped returns a retry budget of n attempts.
-func capped(n uint) retryBudget { return retryBudget{finite: true, max: n} }
+// cappedRetryBudget returns a retry budget of n attempts.
+func cappedRetryBudget(n uint) retryBudget { return retryBudget{finite: true, max: n} }
 
-// unlimited is the zero-valued, uncapped retry budget.
-func unlimitedBudget() retryBudget { return retryBudget{} }
+// unlimitedRetryBudget is the zero-valued, uncapped retry budget.
+func unlimitedRetryBudget() retryBudget { return retryBudget{} }
 
 // InvalidOperationError is returned from Validate and indicates that a required field is missing
 // from an instance of Operation.
@@ -527,7 +527,7 @@ func (op Operation) Execute(ctx context.Context) error {
 		}
 	}
 
-	defaultBudget := capped(0)
+	defaultBudget := cappedRetryBudget(0)
 	if op.RetryMode != nil {
 		switch op.Type {
 		case Write:
@@ -536,23 +536,23 @@ func (op Operation) Execute(ctx context.Context) error {
 			}
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				defaultBudget = capped(1)
+				defaultBudget = cappedRetryBudget(1)
 			case RetryContext:
-				defaultBudget = unlimitedBudget()
+				defaultBudget = unlimitedRetryBudget()
 			}
 		case Read:
 			switch *op.RetryMode {
 			case RetryOnce, RetryOncePerCommand:
-				defaultBudget = capped(1)
+				defaultBudget = cappedRetryBudget(1)
 			case RetryContext:
-				defaultBudget = unlimitedBudget()
+				defaultBudget = unlimitedRetryBudget()
 			}
 		}
 
 		// If context is a Timeout context, automatically set retries to
 		// unlimited if retrying is enabled.
 		if csot.IsTimeoutContext(ctx) && op.RetryMode.Enabled() {
-			defaultBudget = unlimitedBudget()
+			defaultBudget = unlimitedRetryBudget()
 		}
 	}
 
@@ -857,7 +857,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			if isOverloadedError && op.MaxAdaptiveRetries != 0 {
 				// If maxAdaptiveRetries is set, we want to retry overload errors until
 				// we hit that max.
-				nextBudget = capped(op.MaxAdaptiveRetries)
+				nextBudget = cappedRetryBudget(op.MaxAdaptiveRetries)
 				currentBudget = nextBudget
 			}
 			connDesc := conn.Description()
@@ -984,7 +984,7 @@ func (op Operation) Execute(ctx context.Context) error {
 			if isOverloadedError && op.MaxAdaptiveRetries != 0 {
 				// If maxAdaptiveRetries is set, we want to retry overload errors until
 				// we hit that max.
-				nextBudget = capped(op.MaxAdaptiveRetries)
+				nextBudget = cappedRetryBudget(op.MaxAdaptiveRetries)
 				currentBudget = nextBudget
 			}
 			connDesc := conn.Description()
@@ -1093,7 +1093,7 @@ func (op Operation) Execute(ctx context.Context) error {
 				// Reset the retries number for RetryOncePerCommand unless context is a Timeout context, in
 				// which case retries should remain as nil (as many times as possible).
 				if *op.RetryMode == RetryOncePerCommand && !csot.IsTimeoutContext(ctx) {
-					nextBudget = capped(1)
+					nextBudget = cappedRetryBudget(1)
 				}
 			}
 			isOverloadedError = false

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -810,6 +810,9 @@ func (c *Connection) ServerConnectionID() *int64 {
 func (c *Connection) Stale() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	if c.connection == nil {
+		return true
+	}
 	return c.connection.pool.stale(c.connection)
 }
 

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -838,19 +838,28 @@ func (c *Connection) LocalAddress() address.Address {
 
 // PinToCursor updates this connection to reflect that it is pinned to a cursor.
 func (c *Connection) PinToCursor() error {
-	return c.pin("cursor", c.connection.pool.pinConnectionToCursor, c.connection.pool.unpinConnectionFromCursor)
+	return c.pin("cursor",
+		func() { c.connection.pool.pinConnectionToCursor() },
+		func() { c.connection.pool.unpinConnectionFromCursor() })
 }
 
 // PinToTransaction updates this connection to reflect that it is pinned to a transaction.
 func (c *Connection) PinToTransaction() error {
-	return c.pin("transaction", c.connection.pool.pinConnectionToTransaction, c.connection.pool.unpinConnectionFromTransaction)
+	return c.pin("transaction",
+		func() { c.connection.pool.pinConnectionToTransaction() },
+		func() { c.connection.pool.unpinConnectionFromTransaction() })
 }
 
 func (c *Connection) pin(reason string, updatePoolFn, cleanupPoolFn func()) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if c.connection == nil {
 		return fmt.Errorf("attempted to pin a connection for a %s, but the connection has already been returned to the pool", reason)
+	}
+
+	if c.connection.pool == nil {
+		return fmt.Errorf("attempted to pin a connection for a %s, but the connection is not associated with a pool", reason)
 	}
 
 	// Only use the provided callbacks for the first reference to avoid double-counting pinned connection statistics


### PR DESCRIPTION
GODRIVER-3921

Retrospective cleanups to the retry/backoff code that shipped with the backpressure feature. No behavior changes. These address rough edges noticed after the release: a leaky jitter abstraction, a semantically awkward *uint for retry budgets, missing documentation of known limitations in the connection liveness API, and a latent nil-panic in Stale().
