### PR TITLE
GODRIVER-3858 Split write batches by wire-message size, not document payload (Marge up from release/2.6).

### DIFF
--- a/internal/integration/crud_prose_test.go
+++ b/internal/integration/crud_prose_test.go
@@ -1017,3 +1017,45 @@ func TestClientBulkWriteProse(t *testing.T) {
 		assert.Equal(mt, num, int(n), "expected %d documents, got: %d", num, n)
 	})
 }
+
+func TestInsertManySplitsBatchesByWireMessageSize(t *testing.T) {
+	ctx := context.Background()
+
+	mt := mtest.New(t)
+	mt.Setup()
+
+	var hello struct {
+		MaxBsonObjectSize   int
+		MaxMessageSizeBytes int
+	}
+	err := mt.DB.RunCommand(ctx, bson.D{{"hello", 1}}).Decode(&hello)
+	require.NoError(mt, err, "Hello error: %v", err)
+
+	// Per-document overhead the driver adds when marshalling a
+	// bson.D{{"x", <string>}}: 13 bytes for the BSON envelope (length,
+	// type, key, terminators) plus 17 bytes for the _id ObjectID the
+	// driver auto-injects.
+	const perDocOverhead = 30
+
+	// Three documents whose BSON sizes sum to just under
+	// maxMessageSizeBytes: two near-max, one filling the rest. The 100-
+	// byte budget margin reserves room for the 30-byte-per-doc overhead
+	// across the three documents (90 bytes) plus a 10-byte slack, so
+	// sum_of_docs lands ~10 bytes under 48,000,000. The remaining ~200
+	// bytes of command body framing then push the actual OP_MSG over
+	// the limit.
+	const totalBudgetMargin = 100
+
+	bigStrLen := hello.MaxBsonObjectSize - perDocOverhead
+	smallStrLen := hello.MaxMessageSizeBytes - totalBudgetMargin - 2*bigStrLen
+
+	bigStr := strings.Repeat("a", bigStrLen)
+	smallStr := strings.Repeat("a", smallStrLen)
+	docs := []any{
+		bson.D{{Key: "x", Value: bigStr}},
+		bson.D{{Key: "x", Value: bigStr}},
+		bson.D{{Key: "x", Value: smallStr}},
+	}
+	_, err = mt.Coll.InsertMany(ctx, docs)
+	require.NoError(mt, err, "InsertMany error: %v", err)
+}

--- a/x/mongo/driver/batches.go
+++ b/x/mongo/driver/batches.go
@@ -39,7 +39,7 @@ func (b *Batches) AppendBatchSequence(dst []byte, maxCount, totalSize int) (int,
 	idx, dst = bsoncore.ReserveLength(dst)
 	dst = append(dst, b.Identifier...)
 	dst = append(dst, 0x00)
-	var size int
+	size := len(dst)
 	var n int
 	for i := b.offset; i < len(b.Documents); i++ {
 		if n == maxCount {
@@ -69,7 +69,7 @@ func (b *Batches) AppendBatchArray(dst []byte, maxCount, totalSize int) (int, []
 	}
 	l := len(dst)
 	aidx, dst := bsoncore.AppendArrayElementStart(dst, b.Identifier)
-	var size int
+	size := len(dst)
 	var n int
 	for i := b.offset; i < len(b.Documents); i++ {
 		if n == maxCount {

--- a/x/mongo/driver/batches_test.go
+++ b/x/mongo/driver/batches_test.go
@@ -36,9 +36,10 @@ func TestAppendBatchSequence(t *testing.T) {
 	batches := newTestBatches(t)
 
 	got := []byte{42}
+	sizeLimit := len(batches.Documents[0]) + len(batches.Documents[1])
 	var n int
 	var err error
-	n, got, err = batches.AppendBatchSequence(got, 2, len(batches.Documents[0]))
+	n, got, err = batches.AppendBatchSequence(got, 2, sizeLimit)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n)
 
@@ -57,9 +58,10 @@ func TestAppendBatchArray(t *testing.T) {
 	batches := newTestBatches(t)
 
 	got := []byte{42}
+	sizeLimit := len(batches.Documents[0]) + len(batches.Documents[1])
 	var n int
 	var err error
-	n, got, err = batches.AppendBatchArray(got, 2, len(batches.Documents[0]))
+	n, got, err = batches.AppendBatchArray(got, 2, sizeLimit)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n)
 


### PR DESCRIPTION
GODRIVER-3858

## Summary
Marge up from release/2.6

## Background & Motivation
Split write batches by wire-message size, not document payload
