### PR TITLE
GODRIVER-3920 Add prose test for pool clearing behavior during minPoolSize population.

### DIFF
--- a/internal/integration/sdam_error_handling_test.go
+++ b/internal/integration/sdam_error_handling_test.go
@@ -325,6 +325,9 @@ func TestSDAMErrorHandling(t *testing.T) {
 			appName := "authErrorTest"
 
 			var once sync.Once
+			// heartbeatDone is intended to block the "ConnectionPoolReady" event in pool.ready(),
+			// so a successful heartbeat is guaranteed before signaling maintain() to start creating
+			// connections.
 			heartbeatDone := make(chan struct{})
 			serverMonitor := &event.ServerMonitor{
 				ServerHeartbeatSucceeded: func(_ *event.ServerHeartbeatSucceededEvent) {
@@ -358,7 +361,6 @@ func TestSDAMErrorHandling(t *testing.T) {
 			}
 
 			mt.ResetClient(options.Client().
-				ApplyURI(mtest.ClusterURI()).
 				SetAppName(appName).
 				SetPoolMonitor(poolMonitor).
 				SetServerMonitor(serverMonitor).

--- a/internal/integration/sdam_error_handling_test.go
+++ b/internal/integration/sdam_error_handling_test.go
@@ -16,10 +16,12 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/event"
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/eventtest"
 	"go.mongodb.org/mongo-driver/v2/internal/failpoint"
 	"go.mongodb.org/mongo-driver/v2/internal/integration/mtest"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
@@ -311,6 +313,72 @@ func TestSDAMErrorHandling(t *testing.T) {
 			}
 		})
 	})
+	mt.RunOpts("pool is not cleared on handshake error during minPoolSize population",
+		mtest.NewOptions().MinServerVersion("4.4").Topologies(mtest.Single), func(mt *mtest.T) {
+			// This is a prose test to replace TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/
+			// pool-clear-min-pool-size-error.json/Pool_is_not_cleared_on_handshake_error_during_minPoolSize_population
+			// The failpoint is set after the monitor's first heartbeat succeeds,
+			// so the monitor is unaffected. Pool connections' hello failures carry
+			// ErrSystemOverloadedError and must not trigger pool.clear().
+			appName := "authErrorTest"
+
+			heartbeatDone := make(chan struct{}, 1)
+			serverMonitor := &event.ServerMonitor{
+				ServerHeartbeatSucceeded: func(_ *event.ServerHeartbeatSucceededEvent) {
+					select {
+					case heartbeatDone <- struct{}{}:
+					default:
+					}
+				},
+			}
+
+			tpm := eventtest.NewTestPoolMonitor()
+			mt.ResetClient(options.Client().
+				ApplyURI(mtest.ClusterURI()).
+				SetAppName(appName).
+				SetPoolMonitor(tpm.PoolMonitor).
+				SetServerMonitor(serverMonitor).
+				SetMinPoolSize(5).
+				SetMaxConnecting(1).
+				SetServerMonitoringMode(options.ServerMonitoringModePoll).
+				SetHeartbeatInterval(1_000_000 * time.Millisecond))
+
+			timer := time.NewTimer(10 * time.Second)
+			defer timer.Stop()
+			select {
+			case <-heartbeatDone:
+			case <-timer.C:
+				mt.Fatal("timed out waiting for first server heartbeat")
+			}
+
+			// The failpoint uses skip:1 so the first pool connection's hello succeeds;
+			// subsequent pool hellos will be closed by the server, triggering
+			// ProcessHandshakeError. Setting the failpoint after heartbeatDone
+			// ensures the monitor's hello is already past and is unaffected.
+			mt.SetFailPoint(failpoint.FailPoint{
+				ConfigureFailPoint: "failCommand",
+				Mode:               failpoint.Mode{Skip: 1},
+				Data: failpoint.Data{
+					FailCommands:    []string{"hello", "isMaster"},
+					CloseConnection: true,
+					AppName:         appName,
+				},
+			})
+
+			require.Eventually(mt, func() bool {
+				return len(tpm.Events(func(e *event.PoolEvent) bool {
+					return e.Type == event.ConnectionClosed
+				})) > 0
+			}, 10*time.Second, 100*time.Millisecond,
+				"expected ConnectionClosed event within 10s")
+
+			require.False(mt, tpm.IsPoolCleared(),
+				"pool should not be cleared on handshake error during minPoolSize population")
+
+			require.Len(mt, tpm.Events(func(e *event.PoolEvent) bool {
+				return e.Type == event.ConnectionPoolReady
+			}), 1, "expected exactly 1 ConnectionPoolReady event (pool was not cleared and re-readied)")
+		})
 }
 
 func runServerErrorsTest(mt *mtest.T, isShutdownError bool, tpm *eventtest.TestPoolMonitor) {

--- a/internal/integration/sdam_error_handling_test.go
+++ b/internal/integration/sdam_error_handling_test.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -322,42 +324,51 @@ func TestSDAMErrorHandling(t *testing.T) {
 			// ErrSystemOverloadedError and must not trigger pool.clear().
 			appName := "authErrorTest"
 
-			heartbeatDone := make(chan struct{}, 1)
+			var once sync.Once
+			heartbeatDone := make(chan struct{})
 			serverMonitor := &event.ServerMonitor{
 				ServerHeartbeatSucceeded: func(_ *event.ServerHeartbeatSucceededEvent) {
-					select {
-					case heartbeatDone <- struct{}{}:
-					default:
+					once.Do(func() {
+						close(heartbeatDone)
+					})
+				},
+			}
+
+			var poolReadyCnt atomic.Uint32
+			var poolClearedCnt atomic.Uint32
+			var connClosedCnt atomic.Uint32
+			poolMonitor := &event.PoolMonitor{
+				Event: func(e *event.PoolEvent) {
+					switch e.Type {
+					case event.ConnectionClosed:
+						connClosedCnt.Add(1)
+					case event.ConnectionPoolReady:
+						<-heartbeatDone
+						poolReadyCnt.Add(1)
+					case event.ConnectionPoolCleared:
+						poolClearedCnt.Add(1)
 					}
 				},
 			}
 
-			tpm := eventtest.NewTestPoolMonitor()
 			mt.ResetClient(options.Client().
 				ApplyURI(mtest.ClusterURI()).
 				SetAppName(appName).
-				SetPoolMonitor(tpm.PoolMonitor).
+				SetPoolMonitor(poolMonitor).
 				SetServerMonitor(serverMonitor).
 				SetMinPoolSize(5).
 				SetMaxConnecting(1).
 				SetServerMonitoringMode(options.ServerMonitoringModePoll).
 				SetHeartbeatInterval(1_000_000 * time.Millisecond))
 
-			timer := time.NewTimer(10 * time.Second)
-			defer timer.Stop()
-			select {
-			case <-heartbeatDone:
-			case <-timer.C:
-				mt.Fatal("timed out waiting for first server heartbeat")
-			}
-
-			// The failpoint uses skip:1 so the first pool connection's hello succeeds;
-			// subsequent pool hellos will be closed by the server, triggering
-			// ProcessHandshakeError. Setting the failpoint after heartbeatDone
-			// ensures the monitor's hello is already past and is unaffected.
+			// Close every pool connection's hello. mt.ResetClient() returns only after
+			// the first heartbeat fires (pool.ready() blocks on <-heartbeatDone), so
+			// the monitor's hello is already past and the failpoint only affects pool
+			// connections. Their hello failures carry ErrSystemOverloadedError and must
+			// not trigger pool.clear().
 			mt.SetFailPoint(failpoint.FailPoint{
 				ConfigureFailPoint: "failCommand",
-				Mode:               failpoint.Mode{Skip: 1},
+				Mode:               failpoint.ModeAlwaysOn,
 				Data: failpoint.Data{
 					FailCommands:    []string{"hello", "isMaster"},
 					CloseConnection: true,
@@ -366,18 +377,15 @@ func TestSDAMErrorHandling(t *testing.T) {
 			})
 
 			require.Eventually(mt, func() bool {
-				return len(tpm.Events(func(e *event.PoolEvent) bool {
-					return e.Type == event.ConnectionClosed
-				})) > 0
+				return connClosedCnt.Load() > 0
 			}, 10*time.Second, 100*time.Millisecond,
 				"expected ConnectionClosed event within 10s")
 
-			require.False(mt, tpm.IsPoolCleared(),
-				"pool should not be cleared on handshake error during minPoolSize population")
+			require.Equal(mt, uint32(1), poolReadyCnt.Load(),
+				"expected exactly 1 ConnectionPoolReady event (pool was not cleared and re-readied)")
 
-			require.Len(mt, tpm.Events(func(e *event.PoolEvent) bool {
-				return e.Type == event.ConnectionPoolReady
-			}), 1, "expected exactly 1 ConnectionPoolReady event (pool was not cleared and re-readied)")
+			require.Equal(mt, uint32(0), poolClearedCnt.Load(),
+				"pool should not be cleared on handshake error during minPoolSize population")
 		})
 }
 

--- a/internal/integration/sdam_error_handling_test.go
+++ b/internal/integration/sdam_error_handling_test.go
@@ -337,14 +337,20 @@ func TestSDAMErrorHandling(t *testing.T) {
 			var poolReadyCnt atomic.Uint32
 			var poolClearedCnt atomic.Uint32
 			var connClosedCnt atomic.Uint32
+			timer := time.NewTimer(10 * time.Second)
+			defer timer.Stop()
 			poolMonitor := &event.PoolMonitor{
 				Event: func(e *event.PoolEvent) {
 					switch e.Type {
 					case event.ConnectionClosed:
 						connClosedCnt.Add(1)
 					case event.ConnectionPoolReady:
-						<-heartbeatDone
-						poolReadyCnt.Add(1)
+						select {
+						case <-heartbeatDone:
+							poolReadyCnt.Add(1)
+						case <-timer.C:
+							mt.Fatalf("timeout waiting for first server heartbeat")
+						}
 					case event.ConnectionPoolCleared:
 						poolClearedCnt.Add(1)
 					}

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -764,7 +764,8 @@ var skipTests = map[string][]string{
 		"TestSDAMSpec/errors/pre-42-ShutdownInProgress.json",
 	},
 
-	// TODO(GODRIVER-1826): Race condition between monitor and pool causes pool to be cleared.
+	// TODO(GODRIVER-3828): Race condition between monitor and pool causes pool to be cleared in the current implementation.
+	// The current implementation is covered by TestSDAMErrorHandling/pool_is_not_cleared_on_handshake_error_during_minPoolSize_population
 	"Backpressure SDAM test 'pool-clear-min-pool-size-error.yml' fails on standalone deployments": {
 		"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json/Pool_is_not_cleared_on_handshake_error_during_minPoolSize_population",
 	},


### PR DESCRIPTION
GODRIVER-3920

## Summary
This PR proposes an alternative prose test to "TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json/Pool_is_not_cleared_on_handshake_error_during_minPoolSize_population", but matches the current Go driver implementation, particularly for the `Pool.ready()` in `Server.Connect()`.

## Background & Motivation
The TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json/Pool_is_not_cleared_on_handshake_error_during_minPoolSize_population fails due to a race condition between the server monitor's first heartbeat and the pool's `minPoolSize` maintenance.

Root cause: `Server.Connect()` in server.go#L288 calls `s.pool.ready()` immediately before the monitoring goroutine has run its first heartbeat. `pool.ready()` transitions the pool to the `poolReady` state and signals `p.maintainReady`, causing `maintain()` to start creating `minPoolSize` connections right away. These connections race with and can steal the server monitor's failpoint "skip: 1" allowance.

The race:
1. The `pool.ready()` in `Server.Connect()` fires `poolReadyEvent` &rarr; `maintainReady` signaled.
2. `maintain()` wakes up and begins creating connections.
3. One pool connection's `hello` reaches the server before the monitor's `hello`, consuming "skip: 1".
4. Monitor's first heartbeat from `setupHeartbeatConnection` then fails because connection is closed.
5. `check()` returns `description.Server{LastError: err}` &rarr; Monitor loop calls `pool.clear()` &rarr; `poolClearedEvent` fires &rarr; assertion fails

The backpressure logic added in GODRIVER-3646 correctly prevents pool clearing for pool connections, but the monitor is the one calling `pool.clear()` because a pool connection stole the monitor's skip allowance.

However, the motivation for a proactive `pool.ready()` in `Connect()` exists. It makes the driver usable immediately and degrades gracefully on bad servers. Strictly following the spec makes startup behavior worse for any server that doesn't respond to the first heartbeat instantly.

Therefore, this PR simply replaces the unified test with a prose test to better cover the logic changes introduced by GODRIVER-3646. Pool initialization modifications can be made in a different ticket, such as GODRIVER-3828.

The prose test waits for the first server heartbeat to succeed before setting the failpoint.
