### PR TITLE
GODRIVER-3623 Deprecate AggregateOptions Custom functionality as internal-only.

### DIFF
--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -163,8 +163,7 @@ func (ao *AggregateOptionsBuilder) SetLet(let any) *AggregateOptionsBuilder {
 // with non-custom options, and custom options bypass client-side validation. Prefer using non-custom
 // options where possible.
 //
-// Deprecated: SetCustom is for internal use only and should not be set. It may be changed or removed
-// in any release.
+// Deprecated: SetCustom is for internal use only. It may be changed or removed in any release.
 func (ao *AggregateOptionsBuilder) SetCustom(c bson.M) *AggregateOptionsBuilder {
 	ao.Opts = append(ao.Opts, func(opts *AggregateOptions) error {
 		opts.Custom = c

--- a/mongo/options/aggregateoptions.go
+++ b/mongo/options/aggregateoptions.go
@@ -26,7 +26,10 @@ type AggregateOptions struct {
 	Comment                  any
 	Hint                     any
 	Let                      any
-	Custom                   bson.M
+
+	// Deprecated: Custom is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Custom bson.M
 
 	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
 	// release.
@@ -159,6 +162,9 @@ func (ao *AggregateOptionsBuilder) SetLet(let any) *AggregateOptionsBuilder {
 // with desired option names and values. Values must be Marshalable. Custom options may conflict
 // with non-custom options, and custom options bypass client-side validation. Prefer using non-custom
 // options where possible.
+//
+// Deprecated: SetCustom is for internal use only and should not be set. It may be changed or removed
+// in any release.
 func (ao *AggregateOptionsBuilder) SetCustom(c bson.M) *AggregateOptionsBuilder {
 	ao.Opts = append(ao.Opts, func(opts *AggregateOptions) error {
 		opts.Custom = c


### PR DESCRIPTION
GODRIVER-3623

## Summary

Mark the AggregateOptions.Custom struct field and the AggregateOptionsBuilder.SetCustom method as deprecated.

## Background & Motivation

GODRIVER-2337 added the Custom field to AggregateOptions specifically for an internal use-case. It appears users are trying to use this field to set maxTimeMS.