### PR TITLE
GODRIVER-3874 Send afterClusterTime on writes in causally-consistent sessions

### DIFF
--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -175,7 +175,10 @@ func executeDropDatabase(ctx context.Context, operation *operation) (*operationR
 	}
 
 	var dbName string
-	elems, _ := operation.Arguments.Elements()
+	elems, err := operation.Arguments.Elements()
+	if err != nil {
+		return nil, err
+	}
 	for _, elem := range elems {
 		key := elem.Key()
 		val := elem.Value()

--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -168,6 +168,33 @@ func executeListDatabases(ctx context.Context, operation *operation, nameOnly bo
 	return newDocumentResult(raw, nil), nil
 }
 
+func executeDropDatabase(ctx context.Context, operation *operation) (*operationResult, error) {
+	client, err := entities(ctx).client(operation.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	var dbName string
+	elems, _ := operation.Arguments.Elements()
+	for _, elem := range elems {
+		key := elem.Key()
+		val := elem.Value()
+
+		switch key {
+		case "database":
+			dbName = val.StringValue()
+		default:
+			return nil, fmt.Errorf("unrecognized dropDatabase option %q", key)
+		}
+	}
+	if dbName == "" {
+		return nil, newMissingArgumentError("database")
+	}
+
+	err = client.Database(dbName).Drop(ctx)
+	return newErrorResult(err), nil
+}
+
 func executeClientBulkWrite(ctx context.Context, operation *operation) (*operationResult, error) {
 	client, err := entities(ctx).client(operation.Object)
 	if err != nil {

--- a/internal/integration/unified/operation.go
+++ b/internal/integration/unified/operation.go
@@ -142,6 +142,8 @@ func (op *operation) run(ctx context.Context, loopDone <-chan struct{}) (*operat
 		return executeListDatabases(ctx, op, false)
 	case "listDatabaseNames":
 		return executeListDatabases(ctx, op, true)
+	case "dropDatabase":
+		return executeDropDatabase(ctx, op)
 	case "clientBulkWrite":
 		return executeClientBulkWrite(ctx, op)
 

--- a/internal/integration/unified/unified_spec_test.go
+++ b/internal/integration/unified/unified_spec_test.go
@@ -39,6 +39,7 @@ var (
 		"mongodb-handshake/tests/unified",
 		"client-backpressure/tests",
 		"transactions/tests/unified",
+		"causal-consistency/tests",
 	}
 	failDirectories = []string{
 		"unified-test-format/tests/valid-fail",

--- a/mongo/client_bulk_write.go
+++ b/mongo/client_bulk_write.go
@@ -91,6 +91,7 @@ func (bw *clientBulkWrite) execute(ctx context.Context) error {
 		Logger:                    bw.client.logger,
 		Authenticator:             bw.client.authenticator,
 		Name:                      driverutil.BulkWriteOp,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 	var exception *ClientBulkWriteException
 

--- a/mongo/insert.go
+++ b/mongo/insert.go
@@ -115,6 +115,7 @@ func (i *insert) Execute(ctx context.Context) error {
 		Logger:                    i.logger,
 		Name:                      driverutil.InsertOp,
 		Authenticator:             i.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -386,6 +386,10 @@ type Operation struct {
 	// required.
 	Authenticator Authenticator
 
+	// SendAfterClusterTime enables sending "readConcern.afterClusterTime" for
+	// operations if they're run in causally-consistent sessions.
+	SendAfterClusterTime bool
+
 	// omitReadPreference is a boolean that indicates whether to omit the
 	// read preference from the command. This omition includes the case
 	// where a default read preference is used when the operation
@@ -1604,6 +1608,15 @@ func (op Operation) addReadConcern(dst []byte, desc description.SelectedServer) 
 
 	// start transaction must append afterclustertime IF causally consistent and operation time exists
 	if rc == nil && client != nil && client.TransactionStarting() && client.Consistent && client.OperationTime != nil {
+		rc = &readconcern.ReadConcern{}
+	}
+
+	// If this is a write operation, then we add an empty read concern so the
+	// following code can set "afterClusterTime". That avoids a data correctness
+	// problem that can happen when there is a network partition in a sharded
+	// cluster. See DRIVERS-3274 for more details.
+	if rc == nil && op.SendAfterClusterTime && client != nil &&
+		client.Consistent && client.OperationTime != nil && !client.TransactionRunning() {
 		rc = &readconcern.ReadConcern{}
 	}
 

--- a/x/mongo/driver/operation/create.go
+++ b/x/mongo/driver/operation/create.go
@@ -68,18 +68,19 @@ func (c *Create) Execute(ctx context.Context) error {
 	}
 
 	return driver.Operation{
-		CommandFn:         c.command,
-		ProcessResponseFn: c.processResponse,
-		Client:            c.session,
-		Clock:             c.clock,
-		CommandMonitor:    c.monitor,
-		Crypt:             c.crypt,
-		Database:          c.database,
-		Deployment:        c.deployment,
-		Selector:          c.selector,
-		WriteConcern:      c.writeConcern,
-		ServerAPI:         c.serverAPI,
-		Authenticator:     c.authenticator,
+		CommandFn:            c.command,
+		ProcessResponseFn:    c.processResponse,
+		Client:               c.session,
+		Clock:                c.clock,
+		CommandMonitor:       c.monitor,
+		Crypt:                c.crypt,
+		Database:             c.database,
+		Deployment:           c.deployment,
+		Selector:             c.selector,
+		WriteConcern:         c.writeConcern,
+		ServerAPI:            c.serverAPI,
+		Authenticator:        c.authenticator,
+		SendAfterClusterTime: true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/create_indexes.go
+++ b/x/mongo/driver/operation/create_indexes.go
@@ -123,6 +123,7 @@ func (ci *CreateIndexes) Execute(ctx context.Context) error {
 		Timeout:                   ci.timeout,
 		Name:                      driverutil.CreateIndexesOp,
 		Authenticator:             ci.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/delete.go
+++ b/x/mongo/driver/operation/delete.go
@@ -121,6 +121,7 @@ func (d *Delete) Execute(ctx context.Context) error {
 		Logger:                    d.logger,
 		Name:                      driverutil.DeleteOp,
 		Authenticator:             d.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/drop_collection.go
+++ b/x/mongo/driver/operation/drop_collection.go
@@ -92,20 +92,21 @@ func (dc *DropCollection) Execute(ctx context.Context) error {
 	}
 
 	return driver.Operation{
-		CommandFn:         dc.command,
-		ProcessResponseFn: dc.processResponse,
-		Client:            dc.session,
-		Clock:             dc.clock,
-		CommandMonitor:    dc.monitor,
-		Crypt:             dc.crypt,
-		Database:          dc.database,
-		Deployment:        dc.deployment,
-		Selector:          dc.selector,
-		WriteConcern:      dc.writeConcern,
-		ServerAPI:         dc.serverAPI,
-		Timeout:           dc.timeout,
-		Name:              driverutil.DropOp,
-		Authenticator:     dc.authenticator,
+		CommandFn:            dc.command,
+		ProcessResponseFn:    dc.processResponse,
+		Client:               dc.session,
+		Clock:                dc.clock,
+		CommandMonitor:       dc.monitor,
+		Crypt:                dc.crypt,
+		Database:             dc.database,
+		Deployment:           dc.deployment,
+		Selector:             dc.selector,
+		WriteConcern:         dc.writeConcern,
+		ServerAPI:            dc.serverAPI,
+		Timeout:              dc.timeout,
+		Name:                 driverutil.DropOp,
+		Authenticator:        dc.authenticator,
+		SendAfterClusterTime: true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/drop_database.go
+++ b/x/mongo/driver/operation/drop_database.go
@@ -45,18 +45,19 @@ func (dd *DropDatabase) Execute(ctx context.Context) error {
 	}
 
 	return driver.Operation{
-		CommandFn:      dd.command,
-		Client:         dd.session,
-		Clock:          dd.clock,
-		CommandMonitor: dd.monitor,
-		Crypt:          dd.crypt,
-		Database:       dd.database,
-		Deployment:     dd.deployment,
-		Selector:       dd.selector,
-		WriteConcern:   dd.writeConcern,
-		ServerAPI:      dd.serverAPI,
-		Name:           driverutil.DropDatabaseOp,
-		Authenticator:  dd.authenticator,
+		CommandFn:            dd.command,
+		Client:               dd.session,
+		Clock:                dd.clock,
+		CommandMonitor:       dd.monitor,
+		Crypt:                dd.crypt,
+		Database:             dd.database,
+		Deployment:           dd.deployment,
+		Selector:             dd.selector,
+		WriteConcern:         dd.writeConcern,
+		ServerAPI:            dd.serverAPI,
+		Name:                 driverutil.DropDatabaseOp,
+		Authenticator:        dd.authenticator,
+		SendAfterClusterTime: true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/drop_indexes.go
+++ b/x/mongo/driver/operation/drop_indexes.go
@@ -105,6 +105,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 		Timeout:                   di.timeout,
 		Name:                      driverutil.DropIndexesOp,
 		Authenticator:             di.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -149,6 +149,7 @@ func (fam *FindAndModify) Execute(ctx context.Context) error {
 		Timeout:                   fam.timeout,
 		Name:                      driverutil.FindAndModifyOp,
 		Authenticator:             fam.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -173,6 +173,7 @@ func (u *Update) Execute(ctx context.Context) error {
 		Logger:                    u.logger,
 		Name:                      driverutil.UpdateOp,
 		Authenticator:             u.authenticator,
+		SendAfterClusterTime:      true,
 	}.Execute(ctx)
 }
 


### PR DESCRIPTION
[GODRIVER-3874](https://jira.mongodb.org/browse/GODRIVER-3874)

## Summary

  Send afterClusterTime in the readConcern of write commands when executing them in a causally-consistent session. Affected write operations: insert, update, delete,
  findAndModify, create, createIndexes, dropCollection, dropDatabase, dropIndexes, and clientBulkWrite.

  Also adds dropDatabase support to the unified spec test runner and enables the causal-consistency unified test suite.

## Background & Motivation
See [DRIVERS-3274](https://jira.mongodb.org/browse/DRIVERS-3274)