### PR TITLE
GODRIVER-3937 Deprecate x/mongo/driver/session package.

### DIFF
--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -46,6 +46,9 @@ var ErrUnackWCUnsupported = errors.New("transactions do not support unacknowledg
 var ErrSnapshotTransaction = errors.New("transactions are not supported in snapshot sessions")
 
 // TransactionState indicates the state of the transactions FSM.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type TransactionState uint8
 
 // Client Session states
@@ -82,6 +85,9 @@ var _ mnet.Pinner = (LoadBalancedTransactionConnection)(nil)
 // LoadBalancedTransactionConnection represents a connection that's pinned by a ClientSession because it's being used
 // to execute a transaction when running against a load balancer. This interface is a copy of driver.PinnedConnection
 // and exists to be able to pin transactions to a connection without causing an import cycle.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type LoadBalancedTransactionConnection interface {
 	mnet.ReadWriteCloser
 	mnet.Describer
@@ -89,6 +95,9 @@ type LoadBalancedTransactionConnection interface {
 }
 
 // Client is a session for clients to run commands.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type Client struct {
 	*Server
 	ClientID       uuid.UUID
@@ -147,6 +156,9 @@ func getClusterTime(clusterTime bson.Raw) (uint32, uint32) {
 }
 
 // MaxClusterTime compares 2 clusterTime documents and returns the document representing the highest cluster time.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 func MaxClusterTime(ct1, ct2 bson.Raw) bson.Raw {
 	epoch1, ord1 := getClusterTime(ct1)
 	epoch2, ord2 := getClusterTime(ct2)

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -22,33 +22,58 @@ import (
 )
 
 // ErrSessionEnded is returned when a client session is used after a call to endSession().
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrSessionEnded = errors.New("ended session was used")
 
 // ErrNoTransactStarted is returned if a transaction operation is called when no transaction has started.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrNoTransactStarted = errors.New("no transaction started")
 
 // ErrTransactInProgress is returned if startTransaction() is called when a transaction is in progress.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrTransactInProgress = errors.New("transaction already in progress")
 
 // ErrAbortAfterCommit is returned when abort is called after a commit.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrAbortAfterCommit = errors.New("cannot call abortTransaction after calling commitTransaction")
 
 // ErrAbortTwice is returned if abort is called after transaction is already aborted.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrAbortTwice = errors.New("cannot call abortTransaction twice")
 
 // ErrCommitAfterAbort is returned if commit is called after an abort.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrCommitAfterAbort = errors.New("cannot call commitTransaction after calling abortTransaction")
 
 // ErrUnackWCUnsupported is returned if an unacknowledged write concern is supported for a transaction.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrUnackWCUnsupported = errors.New("transactions do not support unacknowledged write concerns")
 
 // ErrSnapshotTransaction is returned if an transaction is started on a snapshot session.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 var ErrSnapshotTransaction = errors.New("transactions are not supported in snapshot sessions")
 
 // TransactionState indicates the state of the transactions FSM.
 //
 // Deprecated: For internal use only, do not use. May be changed or removed in
-// any release.
+// any release. To check whether a transaction is active, call
+// [go.mongodb.org/mongo-driver/v2/mongo.Session.TransactionRunning].
 type TransactionState uint8
 
 // Client Session states
@@ -97,7 +122,8 @@ type LoadBalancedTransactionConnection interface {
 // Client is a session for clients to run commands.
 //
 // Deprecated: For internal use only, do not use. May be changed or removed in
-// any release.
+// any release. Use [go.mongodb.org/mongo-driver/v2/mongo.Client.StartSession]
+// to create a new session.
 type Client struct {
 	*Server
 	ClientID       uuid.UUID
@@ -178,6 +204,10 @@ func MaxClusterTime(ct1, ct2 bson.Raw) bson.Raw {
 }
 
 // NewImplicitClientSession creates a new implicit client-side session.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release. Use [go.mongodb.org/mongo-driver/v2/mongo.Client.StartSession]
+// to create a new session.
 func NewImplicitClientSession(pool *Pool, clientID uuid.UUID) *Client {
 	// Server-side session checkout for implicit sessions is deferred until after checking out a
 	// connection, so don't check out a server-side session right now. This will limit the number of
@@ -191,6 +221,10 @@ func NewImplicitClientSession(pool *Pool, clientID uuid.UUID) *Client {
 }
 
 // NewClientSession creates a new explicit client-side session.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release. Use [go.mongodb.org/mongo-driver/v2/mongo.Client.StartSession]
+// to create a new session.
 func NewClientSession(pool *Pool, clientID uuid.UUID, opts ...*ClientOptions) (*Client, error) {
 	c := &Client{
 		pool:     pool,
@@ -391,6 +425,10 @@ func (c *Client) TransactionStarting() bool {
 
 // TransactionRunning returns true if the client session has started the transaction
 // and it hasn't been committed or aborted
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release. To check whether a transaction is active, call
+// [go.mongodb.org/mongo-driver/v2/mongo.Session.TransactionRunning].
 func (c *Client) TransactionRunning() bool {
 	return c != nil && (c.TransactionState == Starting || c.TransactionState == InProgress)
 }

--- a/x/mongo/driver/session/cluster_clock.go
+++ b/x/mongo/driver/session/cluster_clock.go
@@ -13,6 +13,9 @@ import (
 )
 
 // ClusterClock represents a logical clock for keeping track of cluster time.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type ClusterClock struct {
 	clusterTime bson.Raw
 	lock        sync.Mutex

--- a/x/mongo/driver/session/doc.go
+++ b/x/mongo/driver/session/doc.go
@@ -11,4 +11,7 @@
 //
 // WARNING: THIS PACKAGE IS EXPERIMENTAL AND MAY BE MODIFIED OR REMOVED WITHOUT
 // NOTICE! USE WITH EXTREME CAUTION!
+//
+// Deprecated: Package session is for internal use only and should not be used.
+// It may be changed or removed in any release.
 package session

--- a/x/mongo/driver/session/options.go
+++ b/x/mongo/driver/session/options.go
@@ -14,6 +14,9 @@ import (
 )
 
 // ClientOptions represents all possible options for creating a client session.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type ClientOptions struct {
 	CausalConsistency     *bool
 	DefaultReadConcern    *readconcern.ReadConcern
@@ -24,6 +27,9 @@ type ClientOptions struct {
 }
 
 // TransactionOptions represents all possible options for starting a transaction in a session.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type TransactionOptions struct {
 	ReadConcern    *readconcern.ReadConcern
 	WriteConcern   *writeconcern.WriteConcern

--- a/x/mongo/driver/session/server_session.go
+++ b/x/mongo/driver/session/server_session.go
@@ -15,6 +15,9 @@ import (
 )
 
 // Server is an open session with the server.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type Server struct {
 	SessionID bsoncore.Document
 	TxnNumber int64

--- a/x/mongo/driver/session/session_pool.go
+++ b/x/mongo/driver/session/session_pool.go
@@ -57,6 +57,9 @@ func (p *Pool) createServerSession() (*Server, error) {
 }
 
 // NewPool creates a new server session pool
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 func NewPool(descChan <-chan description.Topology) *Pool {
 	p := &Pool{
 		descChan: descChan,

--- a/x/mongo/driver/session/session_pool.go
+++ b/x/mongo/driver/session/session_pool.go
@@ -15,6 +15,9 @@ import (
 )
 
 // Node represents a server session in a linked list
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type Node struct {
 	*Server
 	next *Node
@@ -29,6 +32,9 @@ type topologyDescription struct {
 }
 
 // Pool is a pool of server sessions that can be reused.
+//
+// Deprecated: For internal use only, do not use. May be changed or removed in
+// any release.
 type Pool struct {
 	// number of sessions checked out of pool (accessed atomically)
 	checkedOut int64


### PR DESCRIPTION
[GODRIVER-3937](https://jira.mongodb.org/browse/GODRIVER-3937)

## Summary

* Deprecate the "x/mongo/driver/session" package.
* Deprecate all types and functions in the "x/mongo/driver/session" package.

## Background & Motivation

We're planning to move the "x/mongo/driver/session" package to an "/internal" directory in an upcoming release, so start by deprecating the package to give notice to any people using it. The package is already documented as experimental.
