### PR TITLE
GODRIVER-3906 Exclude tls.RecordHeaderError from backpressure labels 

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -65,6 +65,12 @@ func wrapConnectionError(connErr ConnectionError) error {
 	if errors.As(connErr.Wrapped, &unknownCAErr) {
 		return connErr
 	}
+	// tls.RecordHeaderError is a non-I/O TLS error per the CMAP spec: the peer sent
+	// bytes that don't form a valid TLS record. This cannot indicate server overload.
+	var tlsRecordHeaderErr tls.RecordHeaderError
+	if errors.As(connErr.Wrapped, &tlsRecordHeaderErr) {
+		return connErr
+	}
 	return driver.Error{
 		Labels:  []string{driver.ErrSystemOverloadedError, driver.ErrRetryableError, driver.NetworkError},
 		Wrapped: connErr,

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -65,8 +65,12 @@ func wrapConnectionError(connErr ConnectionError) error {
 	if errors.As(connErr.Wrapped, &unknownCAErr) {
 		return connErr
 	}
-	// tls.RecordHeaderError is a non-I/O TLS error per the CMAP spec: the peer sent
-	// bytes that don't form a valid TLS record. This cannot indicate server overload.
+	// tls.RecordHeaderError is a non-I/O TLS error per the CMAP spec: the peer
+	// sent bytes that don't form a valid TLS record. This cannot indicate
+	// server overload.
+	//
+	// TODO(GODRIVER-3956): Make the TLS record header error check and test work
+	// on Windows.
 	var tlsRecordHeaderErr tls.RecordHeaderError
 	if errors.As(connErr.Wrapped, &tlsRecordHeaderErr) {
 		return connErr

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -123,6 +123,41 @@ func TestConnection(t *testing.T) {
 				assert.True(t, errors.As(connErr.Wrapped, &hostErr),
 					"expected x509.HostnameError, got %T: %v", connErr.Wrapped, connErr.Wrapped)
 			})
+			t.Run("TLS record header error does not get backpressure labels", func(t *testing.T) {
+				// Start a local server that sends non-TLS data. The TLS client will
+				// fail with tls.RecordHeaderError because the first bytes aren't a
+				// valid TLS record.
+				ln, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err)
+				defer ln.Close()
+
+				go func() {
+					c, aErr := ln.Accept()
+					if aErr != nil {
+						return
+					}
+					defer c.Close()
+					_, _ = c.Write([]byte("not a TLS server"))
+				}()
+
+				conn := newConnection(address.Address(ln.Addr().String()),
+					WithTLSConfig(func(_ *tls.Config) *tls.Config {
+						return &tls.Config{InsecureSkipVerify: true}
+					}),
+				)
+				err = conn.connect(context.Background())
+
+				var de driver.Error
+				assert.False(t, errors.As(err, &de),
+					"tls.RecordHeaderError should not get backpressure labels, got: %v", err)
+				var connErr ConnectionError
+				require.True(t, errors.As(err, &connErr),
+					"expected ConnectionError, got %T: %v", err, err)
+				var recordHeaderErr tls.RecordHeaderError
+				assert.True(t, errors.As(connErr.Wrapped, &recordHeaderErr),
+					"expected tls.RecordHeaderError inside ConnectionError, got %T: %v",
+					connErr.Wrapped, connErr.Wrapped)
+			})
 			t.Run("handshaker error", func(t *testing.T) {
 				err := errors.New("handshaker error")
 				var want error = ConnectionError{Wrapped: err, init: true}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"math/rand"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -124,39 +125,48 @@ func TestConnection(t *testing.T) {
 					"expected x509.HostnameError, got %T: %v", connErr.Wrapped, connErr.Wrapped)
 			})
 			t.Run("TLS record header error does not get backpressure labels", func(t *testing.T) {
-				// Start a local server that sends non-TLS data. The TLS client will
-				// fail with tls.RecordHeaderError because the first bytes aren't a
-				// valid TLS record.
-				ln, err := net.Listen("tcp", "127.0.0.1:0")
-				require.NoError(t, err)
-				defer ln.Close()
+				// Windows doesn't return a wrapped tls.RecordHeaderError, but
+				// returns
+				//
+				//   *net.OpError: read tcp 127.0.0.1:46242->127.0.0.1:46241: wsarecv: An established connection was aborted by the software in your host machine.
+				//
+				// Skip the test on Windows.
+				if runtime.GOOS == "windows" {
+					t.Skip("Skipping this test on Windows because it doesn't return tls.RecordHeaderError")
+				}
 
-				go func() {
-					c, aErr := ln.Accept()
-					if aErr != nil {
-						return
-					}
+				// Create a conn that responds with non-TLS data. The TLS client
+				// will fail with tls.RecordHeaderError because the first bytes
+				// aren't a valid TLS record.
+				addr := bootstrapConnections(t, 1, func(c net.Conn) {
 					defer c.Close()
 					_, _ = c.Write([]byte("not a TLS server"))
-				}()
+				})
 
-				conn := newConnection(address.Address(ln.Addr().String()),
-					WithTLSConfig(func(_ *tls.Config) *tls.Config {
+				conn := newConnection(address.Address(addr.String()),
+					WithTLSConfig(func(*tls.Config) *tls.Config {
 						return &tls.Config{InsecureSkipVerify: true}
 					}),
 				)
-				err = conn.connect(context.Background())
+				err := conn.connect(context.Background())
 
 				var de driver.Error
-				assert.False(t, errors.As(err, &de),
-					"tls.RecordHeaderError should not get backpressure labels, got: %v", err)
+				assert.False(t,
+					errors.As(err, &de),
+					"tls.RecordHeaderError should not be wrapped by driver.Error, but it is: %v",
+					err)
+
 				var connErr ConnectionError
-				require.True(t, errors.As(err, &connErr),
-					"expected ConnectionError, got %T: %v", err, err)
+				require.True(t,
+					errors.As(err, &connErr),
+					"expected a ConnectionError, but got %[1]T: %[1]v",
+					err)
+
 				var recordHeaderErr tls.RecordHeaderError
-				assert.True(t, errors.As(connErr.Wrapped, &recordHeaderErr),
-					"expected tls.RecordHeaderError inside ConnectionError, got %T: %v",
-					connErr.Wrapped, connErr.Wrapped)
+				assert.True(t,
+					errors.As(connErr.Wrapped, &recordHeaderErr),
+					"expected a tls.RecordHeaderError wrapped by a ConnectionError, but got %[1]T: %[1]v",
+					connErr.Wrapped)
 			})
 			t.Run("handshaker error", func(t *testing.T) {
 				err := errors.New("handshaker error")

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -131,8 +131,11 @@ func TestConnection(t *testing.T) {
 				//   *net.OpError: read tcp 127.0.0.1:46242->127.0.0.1:46241: wsarecv: An established connection was aborted by the software in your host machine.
 				//
 				// Skip the test on Windows.
+				//
+				// TODO(GODRIVER-3956): Make the TLS record header error check
+				// and test work on Windows.
 				if runtime.GOOS == "windows" {
-					t.Skip("Skipping this test on Windows because it doesn't return tls.RecordHeaderError")
+					t.Skip("Skipping this test on Windows because tls.Conn.HandshakeContext doesn't return tls.RecordHeaderError on Windows")
 				}
 
 				// Create a conn that responds with non-TLS data. The TLS client
@@ -151,7 +154,7 @@ func TestConnection(t *testing.T) {
 				err := conn.connect(context.Background())
 
 				var de driver.Error
-				assert.False(t,
+				require.False(t,
 					errors.As(err, &de),
 					"tls.RecordHeaderError should not be wrapped by driver.Error, but it is: %v",
 					err)
@@ -163,7 +166,7 @@ func TestConnection(t *testing.T) {
 					err)
 
 				var recordHeaderErr tls.RecordHeaderError
-				assert.True(t,
+				require.True(t,
 					errors.As(connErr.Wrapped, &recordHeaderErr),
 					"expected a tls.RecordHeaderError wrapped by a ConnectionError, but got %[1]T: %[1]v",
 					connErr.Wrapped)


### PR DESCRIPTION
[GODRIVER-3906](https://jira.mongodb.org/browse/GODRIVER-3906)

## Summary

Add `tls.RecordHeaderError` to the `wrapConnectionError` deny-list so that protocol-level TLS handshake rejections are not incorrectly labeled as server-overload errors.

## Background & Motivation

`wrapConnectionError` (added in [GODRIVER-3646](https://jira.mongodb.org/browse/GODRIVER-3646) / [#2330](https://github.com/mongodb/mongo-go-driver/pull/2330)) labels connection-establishment errors with `SystemOverloadedError` and `RetryableError` to support client-side backpressure. The deny-list already excludes DNS errors and three x509 cert-verification types. The CMAP spec is broader:

> "For errors that the driver can distinguish as never occurring due to server overload, such as DNS lookup failures, **non-I/O TLS errors** (e.g., certificate validation or hostname-mismatch failures), …, the driver MUST NOT add backpressure error labels for these error types."

`tls.RecordHeaderError` — returned when the peer sends bytes that don't form a valid TLS record (e.g., a plain-text server responding to a TLS `ClientHello`) — is a non-I/O TLS error. Before this fix, it was incorrectly labeled as a potential overload signal, causing `Server.ProcessHandshakeError` to skip pool-clearing when the server is genuinely misconfigured.