### PR TITLE
GODRIVER-3931 Fix bson.Raw.Validate panic on zero-length BSON document

### DIFF
--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -405,6 +405,9 @@ func (d Document) Validate() error {
 	if int(length) > len(d) {
 		return NewDocumentLengthError(int(length), len(d))
 	}
+	if length < 5 {
+		return ErrInvalidLength
+	}
 	if d[length-1] != 0x00 {
 		return ErrMissingNull
 	}

--- a/x/bsonx/bsoncore/document_test.go
+++ b/x/bsonx/bsoncore/document_test.go
@@ -53,6 +53,13 @@ func TestDocument(t *testing.T) {
 				t.Errorf("Did not get expected error. got %v; want %v", got, want)
 			}
 		})
+		t.Run("ZeroLength", func(t *testing.T) {
+			want := ErrInvalidLength
+			got := Document{0x00, 0x00, 0x00, 0x00}.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
 		t.Run("Invalid Element", func(t *testing.T) {
 			want := NewInsufficientBytesError(nil, nil)
 			r := make(Document, 9)


### PR DESCRIPTION
GODRIVER-3931

## Summary

Adds a minimum length check in bsoncore.Document.Validate() to prevent a panic on a BSON document with a declared length of zero. Returns ErrInvalidLength if the declared length is less than 5 (the BSON minimum) before indexing into the document. Includes a corresponding test case in document_test.go.

## Background & Motivation

bson.Raw.Validate panics on a malformed four-byte input whose declared length is zero. The existing guards in bsoncore.Document.Validate() reject negative and oversized lengths but miss zero, causing d[length-1] to evaluate as d[-1] and produce a runtime index-out-of-range panic.
