### PR TITLE
GODRIVER-3832: Fix mongo.ErrorCodes() with ClientBulkWriteException

### DIFF
--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -801,16 +802,26 @@ type ClientBulkWriteException struct {
 
 // ErrorCodes returns a list of error codes returned by the server.
 func (bwe ClientBulkWriteException) ErrorCodes() []int {
-	var codes []int
+	codes := []int{}
+
 	if bwe.WriteError != nil {
 		codes = append(codes, bwe.WriteError.Code)
 	}
 	for _, wce := range bwe.WriteConcernErrors {
 		codes = append(codes, wce.Code)
 	}
-	for _, we := range bwe.WriteErrors {
-		codes = append(codes, we.Code)
+
+	// We iterate over the WriteErrors in index order to ensure deterministic
+	// error messages, so we sort the WriteErrors map's keys before iterating.
+	keys := make([]int, 0, len(bwe.WriteErrors))
+	for k := range bwe.WriteErrors {
+		keys = append(keys, k)
 	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		codes = append(codes, bwe.WriteErrors[k].Code)
+	}
+
 	return codes
 }
 

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -381,6 +381,7 @@ var (
 )
 
 var _ error = ClientBulkWriteException{}
+var _ errorCoder = ClientBulkWriteException{}
 
 // CommandError represents a server error during execution of a command. This can be returned by any operation.
 type CommandError struct {

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"sort"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -810,16 +809,8 @@ func (bwe ClientBulkWriteException) ErrorCodes() []int {
 	for _, wce := range bwe.WriteConcernErrors {
 		codes = append(codes, wce.Code)
 	}
-
-	// We iterate over the WriteErrors in index order to ensure deterministic
-	// error messages, so we sort the WriteErrors map's keys before iterating.
-	keys := make([]int, 0, len(bwe.WriteErrors))
-	for k := range bwe.WriteErrors {
-		keys = append(keys, k)
-	}
-	sort.Ints(keys)
-	for _, k := range keys {
-		codes = append(codes, bwe.WriteErrors[k].Code)
+	for _, we := range bwe.WriteErrors {
+		codes = append(codes, we.Code)
 	}
 
 	return codes

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -799,6 +799,21 @@ type ClientBulkWriteException struct {
 	PartialResult *ClientBulkWriteResult
 }
 
+// ErrorCodes returns a list of error codes returned by the server.
+func (bwe ClientBulkWriteException) ErrorCodes() []int {
+	var codes []int
+	if bwe.WriteError != nil {
+		codes = append(codes, bwe.WriteError.Code)
+	}
+	for _, wce := range bwe.WriteConcernErrors {
+		codes = append(codes, wce.Code)
+	}
+	for _, we := range bwe.WriteErrors {
+		codes = append(codes, we.Code)
+	}
+	return codes
+}
+
 // Error implements the error interface.
 func (bwe ClientBulkWriteException) Error() string {
 	causes := make([]string, 0, 4)

--- a/mongo/errors.go
+++ b/mongo/errors.go
@@ -380,8 +380,10 @@ var (
 	_ ServerError = BulkWriteException{}
 )
 
-var _ error = ClientBulkWriteException{}
-var _ errorCoder = ClientBulkWriteException{}
+var (
+	_ error      = ClientBulkWriteException{}
+	_ errorCoder = ClientBulkWriteException{}
+)
 
 // CommandError represents a server error during execution of a command. This can be returned by any operation.
 type CommandError struct {

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -956,32 +956,32 @@ func TestErrorCodes(t *testing.T) {
 func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
 	tests := []struct {
 		name  string
-		error ClientBulkWriteException
+		input ClientBulkWriteException
 		want  []int
 	}{
 		{
 			name:  "empty",
-			error: ClientBulkWriteException{},
-			want:  nil,
+			input: ClientBulkWriteException{},
+			want:  []int{},
 		},
 		{
 			name:  "top-level write error",
-			error: ClientBulkWriteException{WriteError: &WriteError{Code: 1}},
+			input: ClientBulkWriteException{WriteError: &WriteError{Code: 1}},
 			want:  []int{1},
 		},
 		{
 			name:  "write concern errors",
-			error: ClientBulkWriteException{WriteConcernErrors: []WriteConcernError{{Code: 2}, {Code: 3}}},
+			input: ClientBulkWriteException{WriteConcernErrors: []WriteConcernError{{Code: 2}, {Code: 3}}},
 			want:  []int{2, 3},
 		},
 		{
 			name:  "write errors (map)",
-			error: ClientBulkWriteException{WriteErrors: map[int]WriteError{0: {Code: 4}, 1: {Code: 5}}},
+			input: ClientBulkWriteException{WriteErrors: map[int]WriteError{0: {Code: 4}, 1: {Code: 5}}},
 			want:  []int{4, 5},
 		},
 		{
 			name: "all sources combined",
-			error: ClientBulkWriteException{
+			input: ClientBulkWriteException{
 				WriteError:         &WriteError{Code: 10},
 				WriteConcernErrors: []WriteConcernError{{Code: 11}},
 				WriteErrors:        map[int]WriteError{0: {Code: 12}},
@@ -992,8 +992,8 @@ func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.want, tt.error.ErrorCodes())
-			assert.ElementsMatch(t, tt.want, ErrorCodes(tt.error))
+			assert.Equal(t, tt.want, tt.input.ErrorCodes())
+			assert.Equal(t, tt.want, ErrorCodes(tt.input))
 		})
 	}
 }

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -992,8 +992,21 @@ func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.input.ErrorCodes())
-			assert.Equal(t, tt.want, ErrorCodes(tt.input))
+			assert.ElementsMatch(
+				t,
+				tt.want,
+				tt.input.ErrorCodes(),
+				"%T.ErrorCodes method",
+				tt.input,
+			)
+
+			assert.ElementsMatch(
+				t,
+				tt.want,
+				ErrorCodes(tt.input),
+				"mongo.ErrorCodes(%T)",
+				tt.input,
+			)
 		})
 	}
 }

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -929,11 +929,71 @@ func TestErrorCodes(t *testing.T) {
 			input: topology.ErrTopologyClosed,
 			want:  []int{},
 		},
+		{
+			name:  "ClientBulkWriteException single write error",
+			input: ClientBulkWriteException{WriteErrors: map[int]WriteError{0: {Code: 7}}},
+			want:  []int{7},
+		},
+		{
+			name:  "ClientBulkWriteException single write concern error",
+			input: ClientBulkWriteException{WriteConcernErrors: []WriteConcernError{{Code: 8}}},
+			want:  []int{8},
+		},
+		{
+			name:  "ClientBulkWriteException top-level write error only",
+			input: ClientBulkWriteException{WriteError: &WriteError{Code: 9}},
+			want:  []int{9},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, ErrorCodes(tt.input))
+		})
+	}
+}
+
+func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
+	tests := []struct {
+		name  string
+		error ClientBulkWriteException
+		want  []int
+	}{
+		{
+			name:  "empty",
+			error: ClientBulkWriteException{},
+			want:  nil,
+		},
+		{
+			name:  "top-level write error",
+			error: ClientBulkWriteException{WriteError: &WriteError{Code: 1}},
+			want:  []int{1},
+		},
+		{
+			name:  "write concern errors",
+			error: ClientBulkWriteException{WriteConcernErrors: []WriteConcernError{{Code: 2}, {Code: 3}}},
+			want:  []int{2, 3},
+		},
+		{
+			name:  "write errors (map)",
+			error: ClientBulkWriteException{WriteErrors: map[int]WriteError{0: {Code: 4}, 1: {Code: 5}}},
+			want:  []int{4, 5},
+		},
+		{
+			name: "all sources combined",
+			error: ClientBulkWriteException{
+				WriteError:         &WriteError{Code: 10},
+				WriteConcernErrors: []WriteConcernError{{Code: 11}},
+				WriteErrors:        map[int]WriteError{0: {Code: 12}},
+			},
+			want: []int{10, 11, 12},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, tt.error.ErrorCodes())
+			assert.ElementsMatch(t, tt.want, ErrorCodes(tt.error))
 		})
 	}
 }

--- a/mongo/errors_test.go
+++ b/mongo/errors_test.go
@@ -992,7 +992,7 @@ func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(
+			require.ElementsMatch(
 				t,
 				tt.want,
 				tt.input.ErrorCodes(),
@@ -1000,7 +1000,7 @@ func TestClientBulkWriteException_ErrorCodes(t *testing.T) {
 				tt.input,
 			)
 
-			assert.ElementsMatch(
+			require.ElementsMatch(
 				t,
 				tt.want,
 				ErrorCodes(tt.input),


### PR DESCRIPTION
GODRIVER-3832

## Summary

This makes mongo.ErrorCodes return a nonempty list when given a ClientBulkWriteException.

## Background & Motivation

Presently this function returns an empty list when given a ClientBulkWriteException, which allows errors from Client.BulkWrite to pass by undetected.
