### PR TITLE
GODRIVER-3960 fix: format Arguments swapping

### DIFF
--- a/x/mongo/driver/dns/dns.go
+++ b/x/mongo/driver/dns/dns.go
@@ -114,7 +114,7 @@ func validateSRVResult(recordFromSRV, inputHostName string) error {
 	separatedInputDomain := strings.Split(strings.ToLower(inputHostName), ".")
 	separatedRecord := strings.Split(strings.ToLower(recordFromSRV), ".")
 	if l := len(separatedInputDomain); l < 3 && len(separatedRecord) <= l {
-		return fmt.Errorf("server record (%d levels) should have more domain levels than parent URI (%d levels)", l, len(separatedRecord))
+		return fmt.Errorf("server record (%d levels) should have more domain levels than parent URI (%d levels)", len(separatedRecord), l)
 	}
 	if len(separatedRecord) < len(separatedInputDomain) {
 		return errors.New("domain suffix from SRV record not matched input domain")


### PR DESCRIPTION
[GODRIVER-3960](https://jira.mongodb.org/browse/GODRIVER-3960)

## Summary

The error message in `validateSRVResult` (`x/mongo/driver/dns/dns.go`) had its  format arguments swapped — `len(separatedInputDomain)` was labeled as "server record" and `len(separatedRecord)` was labeled as "parent URI", which is the opposite of what each variable represents.   

<!--- A summary of the changes proposed by this pull request. -->

### Background & Motivation                                                                                                    

In `validateSRVResult`, the `fmt.Errorf` format arguments were swapped:
`len(separatedInputDomain)` (parent URI) was printed as "server record", and `len(separatedRecord)` (SRV record) was printed as "parent URI".
This would cause confusing/misleading error messages when SRV validation fails. 

<!--- Rationale for the pull request. -->

## Note on tests                                                                                                              

There are currently no unit tests for `validateSRVResult` (`x/mongo/driver/dns/` has no test file). 
Adding a `dns_test.go` is recommended to cover this function, but is left for a follow-up to keep this PR focused on the bug fix. 

Happy to add tests here if reviewers prefer.