### PR TITLE
GODRIVER-3962 fix: change stream set batch size nil cursor

### DIFF
--- a/internal/assert/assertions.go
+++ b/internal/assert/assertions.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"time"
 	"unicode"
@@ -927,6 +928,43 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 	actual := theError.Error()
 	if !strings.Contains(actual, contains) {
 		return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, contains), msgAndArgs...)
+	}
+
+	return true
+}
+
+// PanicTestFunc defines a func that should be passed to the assert.Panics and assert.NotPanics
+// methods, and represents a simple func that takes no arguments, and returns nothing.
+type PanicTestFunc func()
+
+// didPanic returns true if the function passed to it panics. Otherwise, it returns false.
+func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string) {
+	didPanic = true
+
+	defer func() {
+		message = recover()
+		if didPanic {
+			stack = string(debug.Stack())
+		}
+	}()
+
+	// call the target function
+	f()
+	didPanic = false
+
+	return
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	assert.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if funcDidPanic, panicValue, panickedStack := didPanic(f); funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should not panic\n\tPanic value:\t%v\n\tPanic stack:\t%s", f, panicValue, panickedStack), msgAndArgs...)
 	}
 
 	return true

--- a/mongo/change_stream.go
+++ b/mongo/change_stream.go
@@ -566,6 +566,9 @@ func (cs *ChangeStream) SetBatchSize(size int32) {
 	// Set batch size on the cursor options also so any "resumed" change stream
 	// cursors will pick up the latest batch size setting.
 	cs.cursorOptions.BatchSize = size
+	if cs.cursor == nil {
+		return
+	}
 	cs.cursor.SetBatchSize(size)
 }
 

--- a/mongo/change_stream_test.go
+++ b/mongo/change_stream_test.go
@@ -25,5 +25,6 @@ func TestChangeStream(t *testing.T) {
 		assert.Nil(t, err, "change stream error: %v", err)
 		err = cs.Close(bgCtx)
 		assert.Nil(t, err, "Close error: %v", err)
+		assert.NotPanics(t, func() { cs.SetBatchSize(2) }, "SetBatchSize should not panic with nil cursor")
 	})
 }


### PR DESCRIPTION
GODRIVER-3962

## Summary

### Content
`SetBatchSize` does not check if `cs.cursor` is nil before calling `cs.cursor.SetBatchSize(size)`, which causes a panic when the cursor is nil.

Other methods such as `Decode` already handle this case by checking for a nilcursor. 
This change applies the same guard to `SetBatchSize`.

### What I have changed 
- Added a nil check for `cs.cursor` in `SetBatchSize`
- `cs.cursorOptions.BatchSize` is still updated so that resumed cursors pick up the latest batch size setting.

### Tests
Added a nil cursor case to the existing `TestChangeStream` into unit test.

<!--- A summary of the changes proposed by this pull request. -->

### Background & Motivation
`SetBatchSize` does not guard against a nil `cs.cursor`, which causes a panic if called on a ChangeStream that has not been initialized or has already been closed. 
Other methods such as `Decode` already handle this case explicitly.

<!--- Rationale for the pull request. -->
