### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/internal/assert/assertion_compare.go
+++ b/internal/assert/assertion_compare.go
@@ -43,7 +43,7 @@ var (
 	bytesType = reflect.TypeOf([]byte{})
 )
 
-func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
+func compare(obj1, obj2 any, kind reflect.Kind) (CompareType, bool) {
 	obj1Value := reflect.ValueOf(obj1)
 	obj2Value := reflect.ValueOf(obj2)
 
@@ -360,7 +360,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 //	assert.Greater(t, 2, 1)
 //	assert.Greater(t, float64(2), float64(1))
 //	assert.Greater(t, "b", "a")
-func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func Greater(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -373,7 +373,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	assert.GreaterOrEqual(t, 2, 2)
 //	assert.GreaterOrEqual(t, "b", "a")
 //	assert.GreaterOrEqual(t, "b", "b")
-func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func GreaterOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -385,7 +385,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	assert.Less(t, 1, 2)
 //	assert.Less(t, float64(1), float64(2))
 //	assert.Less(t, "a", "b")
-func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func Less(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -398,7 +398,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	assert.LessOrEqual(t, 2, 2)
 //	assert.LessOrEqual(t, "a", "b")
 //	assert.LessOrEqual(t, "b", "b")
-func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func LessOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -409,7 +409,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //
 //	assert.Positive(t, 1)
 //	assert.Positive(t, 1.23)
-func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+func Positive(t TestingT, e any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -421,7 +421,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 //
 //	assert.Negative(t, -1)
 //	assert.Negative(t, -1.23)
-func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+func Negative(t TestingT, e any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -429,7 +429,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
-func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+func compareTwoValues(t TestingT, e1 any, e2 any, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/internal/assert/assertion_compare_go1.17_test.go
+++ b/internal/assert/assertion_compare_go1.17_test.go
@@ -20,8 +20,8 @@ func TestCompare17(t *testing.T) {
 	type customTime time.Time
 	type customBytes []byte
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		cType   string
 	}{
 		{less: time.Now(), greater: time.Now().Add(time.Hour), cType: "time.Time"},
@@ -76,8 +76,8 @@ func TestGreater17(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: []byte{1, 1}, greater: []byte{1, 2}, msg: `"[1 1]" is not greater than "[1 2]"`},
@@ -107,8 +107,8 @@ func TestGreaterOrEqual17(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: []byte{1, 1}, greater: []byte{1, 2}, msg: `"[1 1]" is not greater than or equal to "[1 2]"`},
@@ -138,8 +138,8 @@ func TestLess17(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: []byte{1, 1}, greater: []byte{1, 2}, msg: `"[1 2]" is not less than "[1 1]"`},
@@ -169,8 +169,8 @@ func TestLessOrEqual17(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: []byte{1, 1}, greater: []byte{1, 2}, msg: `"[1 2]" is not less than or equal to "[1 1]"`},

--- a/internal/assert/assertion_compare_test.go
+++ b/internal/assert/assertion_compare_test.go
@@ -29,8 +29,8 @@ func TestCompare(t *testing.T) {
 	type customFloat64 float64
 	type customString string
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		cType   string
 	}{
 		{less: customString("a"), greater: customString("b"), cType: "string"},
@@ -95,7 +95,7 @@ type outputT struct {
 }
 
 // Implements TestingT
-func (t *outputT) Errorf(format string, args ...interface{}) {
+func (t *outputT) Errorf(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	t.buf.WriteString(s)
 }
@@ -138,8 +138,8 @@ func TestGreater(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"a" is not greater than "b"`},
@@ -179,8 +179,8 @@ func TestGreaterOrEqual(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"a" is not greater than or equal to "b"`},
@@ -220,8 +220,8 @@ func TestLess(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"b" is not less than "a"`},
@@ -261,8 +261,8 @@ func TestLessOrEqual(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"b" is not less than or equal to "a"`},
@@ -306,7 +306,7 @@ func TestPositive(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		e   interface{}
+		e   any
 		msg string
 	}{
 		{e: int(-1), msg: `"-1" is not positive`},
@@ -345,7 +345,7 @@ func TestNegative(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		e   interface{}
+		e   any
 		msg string
 	}{
 		{e: int(1), msg: `"1" is not negative`},
@@ -367,8 +367,8 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
-		v1            interface{}
-		v2            interface{}
+		v1            any
+		v2            any
 		compareResult bool
 	}{
 		{v1: 123, v2: "abc"},
@@ -387,8 +387,8 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 	type CompareStruct struct{}
 
 	for _, currCase := range []struct {
-		v1 interface{}
-		v2 interface{}
+		v1 any
+		v2 any
 	}{
 		{v1: CompareStruct{}, v2: CompareStruct{}},
 		{v1: map[string]int{}, v2: map[string]int{}},
@@ -403,8 +403,8 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
-		v1           interface{}
-		v2           interface{}
+		v1           any
+		v2           any
 		compareTypes []CompareType
 	}{
 		{v1: 1, v2: 2, compareTypes: []CompareType{compareLess}},
@@ -436,7 +436,7 @@ func Test_containsValue(t *testing.T) {
 }
 
 func TestComparingMsgAndArgsForwarding(t *testing.T) {
-	msgAndArgs := []interface{}{"format %s %x", "this", 0xc001}
+	msgAndArgs := []any{"format %s %x", "this", 0xc001}
 	expectedOutput := "format this c001\n"
 	funcs := []func(t TestingT){
 		func(t TestingT) { Greater(t, 1, 2, msgAndArgs...) },

--- a/internal/assert/assertion_format.go
+++ b/internal/assert/assertion_format.go
@@ -16,11 +16,11 @@ import (
 //	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func Containsf(t TestingT, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Contains(t, s, contains, append([]interface{}{msg}, args...)...)
+	return Contains(t, s, contains, append([]any{msg}, args...)...)
 }
 
 // ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
@@ -28,11 +28,11 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+func ElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return ElementsMatch(t, listA, listB, append([]interface{}{msg}, args...)...)
+	return ElementsMatch(t, listA, listB, append([]any{msg}, args...)...)
 }
 
 // Equalf asserts that two objects are equal.
@@ -42,11 +42,11 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func Equalf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Equal(t, expected, actual, append([]interface{}{msg}, args...)...)
+	return Equal(t, expected, actual, append([]any{msg}, args...)...)
 }
 
 // EqualErrorf asserts that a function returned an error (i.e. not `nil`)
@@ -54,22 +54,22 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return EqualError(t, theError, errString, append([]interface{}{msg}, args...)...)
+	return EqualError(t, theError, errString, append([]any{msg}, args...)...)
 }
 
 // EqualValuesf asserts that two objects are equal or convertible to the same types
 // and equal.
 //
 //	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
-func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func EqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return EqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
+	return EqualValues(t, expected, actual, append([]any{msg}, args...)...)
 }
 
 // Errorf asserts that a function returned an error (i.e. not `nil`).
@@ -78,11 +78,11 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 //	  if assert.Errorf(t, err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedErrorf, err)
 //	  }
-func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
+func Errorf(t TestingT, err error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Error(t, err, append([]interface{}{msg}, args...)...)
+	return Error(t, err, append([]any{msg}, args...)...)
 }
 
 // ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
@@ -90,48 +90,48 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
-func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return ErrorContains(t, theError, contains, append([]interface{}{msg}, args...)...)
+	return ErrorContains(t, theError, contains, append([]any{msg}, args...)...)
 }
 
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Eventually(t, condition, waitFor, tick, append([]interface{}{msg}, args...)...)
+	return Eventually(t, condition, waitFor, tick, append([]any{msg}, args...)...)
 }
 
 // Failf reports a failure through
-func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+func Failf(t TestingT, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Fail(t, failureMessage, append([]interface{}{msg}, args...)...)
+	return Fail(t, failureMessage, append([]any{msg}, args...)...)
 }
 
 // FailNowf fails test
-func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+func FailNowf(t TestingT, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return FailNow(t, failureMessage, append([]interface{}{msg}, args...)...)
+	return FailNow(t, failureMessage, append([]any{msg}, args...)...)
 }
 
 // Falsef asserts that the specified value is false.
 //
 //	assert.Falsef(t, myBool, "error message %s", "formatted")
-func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
+func Falsef(t TestingT, value bool, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return False(t, value, append([]interface{}{msg}, args...)...)
+	return False(t, value, append([]any{msg}, args...)...)
 }
 
 // Greaterf asserts that the first element is greater than the second
@@ -139,11 +139,11 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 //	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
 //	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
-func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func Greaterf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Greater(t, e1, e2, append([]interface{}{msg}, args...)...)
+	return Greater(t, e1, e2, append([]any{msg}, args...)...)
 }
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
@@ -152,40 +152,40 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 //	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
-func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func GreaterOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return GreaterOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
+	return GreaterOrEqual(t, e1, e2, append([]any{msg}, args...)...)
 }
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func InDeltaf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return InDelta(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+	return InDelta(t, expected, actual, delta, append([]any{msg}, args...)...)
 }
 
 // IsTypef asserts that the specified objects are of the same type.
-func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+func IsTypef(t TestingT, expectedType any, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return IsType(t, expectedType, object, append([]interface{}{msg}, args...)...)
+	return IsType(t, expectedType, object, append([]any{msg}, args...)...)
 }
 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
+func Lenf(t TestingT, object any, length int, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Len(t, object, length, append([]interface{}{msg}, args...)...)
+	return Len(t, object, length, append([]any{msg}, args...)...)
 }
 
 // Lessf asserts that the first element is less than the second
@@ -193,11 +193,11 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	assert.Lessf(t, 1, 2, "error message %s", "formatted")
 //	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	assert.Lessf(t, "a", "b", "error message %s", "formatted")
-func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func Lessf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Less(t, e1, e2, append([]interface{}{msg}, args...)...)
+	return Less(t, e1, e2, append([]any{msg}, args...)...)
 }
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
@@ -206,32 +206,32 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
-func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func LessOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return LessOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
+	return LessOrEqual(t, e1, e2, append([]any{msg}, args...)...)
 }
 
 // Negativef asserts that the specified element is negative
 //
 //	assert.Negativef(t, -1, "error message %s", "formatted")
 //	assert.Negativef(t, -1.23, "error message %s", "formatted")
-func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+func Negativef(t TestingT, e any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Negative(t, e, append([]interface{}{msg}, args...)...)
+	return Negative(t, e, append([]any{msg}, args...)...)
 }
 
 // Nilf asserts that the specified object is nil.
 //
 //	assert.Nilf(t, err, "error message %s", "formatted")
-func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func Nilf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Nil(t, object, append([]interface{}{msg}, args...)...)
+	return Nil(t, object, append([]any{msg}, args...)...)
 }
 
 // NoErrorf asserts that a function returned no error (i.e. `nil`).
@@ -240,11 +240,11 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool 
 //	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
+func NoErrorf(t TestingT, err error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NoError(t, err, append([]interface{}{msg}, args...)...)
+	return NoError(t, err, append([]any{msg}, args...)...)
 }
 
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
@@ -253,11 +253,11 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 //	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func NotContainsf(t TestingT, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NotContains(t, s, contains, append([]interface{}{msg}, args...)...)
+	return NotContains(t, s, contains, append([]any{msg}, args...)...)
 }
 
 // NotEqualf asserts that the specified values are NOT equal.
@@ -266,60 +266,60 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func NotEqualf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NotEqual(t, expected, actual, append([]interface{}{msg}, args...)...)
+	return NotEqual(t, expected, actual, append([]any{msg}, args...)...)
 }
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
-func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func NotEqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
+	return NotEqualValues(t, expected, actual, append([]any{msg}, args...)...)
 }
 
 // NotNilf asserts that the specified object is not nil.
 //
 //	assert.NotNilf(t, err, "error message %s", "formatted")
-func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func NotNilf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NotNil(t, object, append([]interface{}{msg}, args...)...)
+	return NotNil(t, object, append([]any{msg}, args...)...)
 }
 
 // Positivef asserts that the specified element is positive
 //
 //	assert.Positivef(t, 1, "error message %s", "formatted")
 //	assert.Positivef(t, 1.23, "error message %s", "formatted")
-func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+func Positivef(t TestingT, e any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Positive(t, e, append([]interface{}{msg}, args...)...)
+	return Positive(t, e, append([]any{msg}, args...)...)
 }
 
 // Truef asserts that the specified value is true.
 //
 //	assert.Truef(t, myBool, "error message %s", "formatted")
-func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
+func Truef(t TestingT, value bool, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return True(t, value, append([]interface{}{msg}, args...)...)
+	return True(t, value, append([]any{msg}, args...)...)
 }
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+	return WithinDuration(t, expected, actual, delta, append([]any{msg}, args...)...)
 }

--- a/internal/assert/assertions.go
+++ b/internal/assert/assertions.go
@@ -24,13 +24,13 @@ import (
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 }
 
 // ObjectsAreEqual determines if two objects are considered equal.
 //
 // This function does no assertion of any kind.
-func ObjectsAreEqual(expected, actual interface{}) bool {
+func ObjectsAreEqual(expected, actual any) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
@@ -52,7 +52,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 
 // ObjectsAreEqualValues gets whether two objects are equal, or if their
 // values are equal.
-func ObjectsAreEqualValues(expected, actual interface{}) bool {
+func ObjectsAreEqualValues(expected, actual any) bool {
 	if ObjectsAreEqual(expected, actual) {
 		return true
 	}
@@ -151,7 +151,7 @@ func isTest(name, prefix string) bool {
 	return !unicode.IsLower(r)
 }
 
-func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+func messageFromMsgAndArgs(msgAndArgs ...any) string {
 	if len(msgAndArgs) == 0 || msgAndArgs == nil {
 		return ""
 	}
@@ -192,7 +192,7 @@ type failNower interface {
 }
 
 // FailNow fails test
-func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -213,7 +213,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool 
 }
 
 // Fail reports a failure through
-func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+func Fail(t TestingT, failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -268,7 +268,7 @@ func labeledOutput(content ...labeledContent) string {
 }
 
 // IsType asserts that the specified objects are of the same type.
-func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func IsType(t TestingT, expectedType any, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -287,7 +287,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func Equal(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -309,7 +309,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 // validateEqualArgs checks whether provided arguments can be safely used in the
 // Equal/NotEqual functions.
-func validateEqualArgs(expected, actual interface{}) error {
+func validateEqualArgs(expected, actual any) error {
 	if expected == nil && actual == nil {
 		return nil
 	}
@@ -326,7 +326,7 @@ func validateEqualArgs(expected, actual interface{}) error {
 // If the values are not of like type, the returned strings will be prefixed
 // with the type name, and the value will be enclosed in parenthesis similar
 // to a type conversion in the Go grammar.
-func formatUnequalValues(expected, actual interface{}) (e string, a string) {
+func formatUnequalValues(expected, actual any) (e string, a string) {
 	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
 		return fmt.Sprintf("%T(%s)", expected, truncatingFormat(expected)),
 			fmt.Sprintf("%T(%s)", actual, truncatingFormat(actual))
@@ -342,7 +342,7 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 //
 // This helps keep formatted error messages lines from exceeding the
 // bufio.MaxScanTokenSize max line length that the go testing framework imposes.
-func truncatingFormat(data interface{}) string {
+func truncatingFormat(data any) string {
 	value := fmt.Sprintf("%#v", data)
 	max := bufio.MaxScanTokenSize - 100 // Give us some space the type info too if needed.
 	if len(value) > max {
@@ -355,7 +355,7 @@ func truncatingFormat(data interface{}) string {
 // and equal.
 //
 //	assert.EqualValues(t, uint32(123), int32(123))
-func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func EqualValues(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -374,7 +374,7 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 // NotNil asserts that the specified object is not nil.
 //
 //	assert.NotNil(t, err)
-func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func NotNil(t TestingT, object any, msgAndArgs ...any) bool {
 	if !isNil(object) {
 		return true
 	}
@@ -396,7 +396,7 @@ func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
 }
 
 // isNil checks if a specified object is nil or not, without Failing.
-func isNil(object interface{}) bool {
+func isNil(object any) bool {
 	if object == nil {
 		return true
 	}
@@ -421,7 +421,7 @@ func isNil(object interface{}) bool {
 // Nil asserts that the specified object is nil.
 //
 //	assert.Nil(t, err)
-func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Nil(t TestingT, object any, msgAndArgs ...any) bool {
 	if isNil(object) {
 		return true
 	}
@@ -433,7 +433,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 // getLen try to get length of object.
 // return (false, 0) if impossible.
-func getLen(x interface{}) (ok bool, length int) {
+func getLen(x any) (ok bool, length int) {
 	v := reflect.ValueOf(x)
 	defer func() {
 		if e := recover(); e != nil {
@@ -447,7 +447,7 @@ func getLen(x interface{}) (ok bool, length int) {
 // Len also fails if the object has a type that len() not accept.
 //
 //	assert.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+func Len(t TestingT, object any, length int, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -465,7 +465,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // True asserts that the specified value is true.
 //
 //	assert.True(t, myBool)
-func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+func True(t TestingT, value bool, msgAndArgs ...any) bool {
 	if !value {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -479,7 +479,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // False asserts that the specified value is false.
 //
 //	assert.False(t, myBool)
-func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+func False(t TestingT, value bool, msgAndArgs ...any) bool {
 	if value {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -496,7 +496,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotEqual(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -515,7 +515,7 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValues(t, obj1, obj2)
-func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotEqualValues(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -531,7 +531,7 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (false, false) if impossible.
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
-func containsElement(list interface{}, element interface{}) (ok, found bool) {
+func containsElement(list any, element any) (ok, found bool) {
 	listValue := reflect.ValueOf(list)
 	listType := reflect.TypeOf(list)
 	if listType == nil {
@@ -574,7 +574,7 @@ func containsElement(list interface{}, element interface{}) (ok, found bool) {
 //	assert.Contains(t, "Hello World", "World")
 //	assert.Contains(t, ["Hello", "World"], "World")
 //	assert.Contains(t, {"Hello": "World"}, "Hello")
-func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+func Contains(t TestingT, s, contains any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -596,7 +596,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 //	assert.NotContains(t, "Hello World", "Earth")
 //	assert.NotContains(t, ["Hello", "World"], "Earth")
 //	assert.NotContains(t, {"Hello": "World"}, "Earth")
-func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+func NotContains(t TestingT, s, contains any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -613,7 +613,7 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 }
 
 // isEmpty gets whether the specified object is considered empty or not.
-func isEmpty(object interface{}) bool {
+func isEmpty(object any) bool {
 	// get nil case out of the way
 	if object == nil {
 		return true
@@ -645,7 +645,7 @@ func isEmpty(object interface{}) bool {
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+func ElementsMatch(t TestingT, listA, listB any, msgAndArgs ...any) (ok bool) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -667,7 +667,7 @@ func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface
 }
 
 // isList checks that the provided value is array or slice.
-func isList(t TestingT, list interface{}, msgAndArgs ...interface{}) (ok bool) {
+func isList(t TestingT, list any, msgAndArgs ...any) (ok bool) {
 	kind := reflect.TypeOf(list).Kind()
 	if kind != reflect.Array && kind != reflect.Slice {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s, expecting array or slice", list, kind),
@@ -679,8 +679,8 @@ func isList(t TestingT, list interface{}, msgAndArgs ...interface{}) (ok bool) {
 // diffLists diffs two arrays/slices and returns slices of elements that are only in A and only in B.
 // If some element is present multiple times, each instance is counted separately (e.g. if something is 2x in A and
 // 5x in B, it will be 0x in extraA and 3x in extraB). The order of items in both lists is ignored.
-func diffLists(listA, listB interface{}) ([]interface{}, []interface{}) {
-	var extraA, extraB []interface{}
+func diffLists(listA, listB any) ([]any, []any) {
+	var extraA, extraB []any
 
 	aValue := reflect.ValueOf(listA)
 	bValue := reflect.ValueOf(listB)
@@ -718,7 +718,7 @@ func diffLists(listA, listB interface{}) ([]interface{}, []interface{}) {
 	return extraA, extraB
 }
 
-func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) string {
+func formatListDiff(listA, listB any, extraA, extraB []any) string {
 	var msg bytes.Buffer
 
 	msg.WriteString("elements differ")
@@ -741,7 +741,7 @@ func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) stri
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -754,7 +754,7 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	return true
 }
 
-func toFloat(x interface{}) (float64, bool) {
+func toFloat(x any) (float64, bool) {
 	var xf float64
 	xok := true
 
@@ -795,7 +795,7 @@ func toFloat(x interface{}) (float64, bool) {
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
-func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func InDelta(t TestingT, expected, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -837,7 +837,7 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 //	  if assert.NoError(t, err) {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
+func NoError(t TestingT, err error, msgAndArgs ...any) bool {
 	if err != nil {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -854,7 +854,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //	  if assert.Error(t, err) {
 //		   assert.Equal(t, expectedError, err)
 //	  }
-func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
+func Error(t TestingT, err error, msgAndArgs ...any) bool {
 	if err == nil {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -870,7 +870,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -890,7 +890,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+func ErrorIs(t TestingT, err, target error, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -916,7 +916,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContains(t, err,  expectedErrorSubString)
-func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -932,7 +932,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 	return true
 }
 
-func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+func typeAndKind(v any) (reflect.Type, reflect.Kind) {
 	t := reflect.TypeOf(v)
 	k := t.Kind()
 
@@ -945,7 +945,7 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 
 // diff returns a diff of both values as long as both are of the same type and
 // are a struct, map, slice, array or string. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
+func diff(expected any, actual any) string {
 	if expected == nil || actual == nil {
 		return ""
 	}
@@ -988,7 +988,7 @@ func diff(expected interface{}, actual interface{}) string {
 	return "\n\nDiff:\n" + diff
 }
 
-func isFunction(arg interface{}) bool {
+func isFunction(arg any) bool {
 	if arg == nil {
 		return false
 	}
@@ -1020,7 +1020,7 @@ type tHelper interface {
 // periodically checking target function each tick.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
-func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1068,7 +1068,7 @@ func buildErrorChainString(err error) string {
 //	if assert.NotEmpty(t, obj) {
 //	  assert.Equal(t, "two", obj[1])
 //	}
-func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func NotEmpty(t TestingT, object any, msgAndArgs ...any) bool {
 	pass := !isEmpty(object)
 	if !pass {
 		if h, ok := t.(tHelper); ok {
@@ -1093,7 +1093,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 //	assert.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Empty(t TestingT, object any, msgAndArgs ...any) bool {
 	pass := isEmpty(object)
 	if !pass {
 		if h, ok := t.(tHelper); ok {

--- a/internal/assert/assertions_test.go
+++ b/internal/assert/assertions_test.go
@@ -35,8 +35,8 @@ type AssertionTesterNonConformingObject struct{}
 
 func TestObjectsAreEqual(t *testing.T) {
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// cases that are expected to be equal
@@ -94,11 +94,11 @@ func TestEqual(t *testing.T) {
 	type myType string
 
 	mockT := new(testing.T)
-	var m map[string]interface{}
+	var m map[string]any
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 		remark   string
 	}{
@@ -137,7 +137,7 @@ type bufferT struct {
 	buf bytes.Buffer
 }
 
-func (t *bufferT) Errorf(format string, args ...interface{}) {
+func (t *bufferT) Errorf(format string, args ...any) {
 	// implementation of decorate is copied from testing.T
 	decorate := func(s string) string {
 		_, file, line, ok := runtime.Caller(3) // decorate + log + public function.
@@ -177,7 +177,7 @@ func TestStringEqual(_ *testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
-		msgAndArgs []interface{}
+		msgAndArgs []any
 		want       string
 	}{
 		{equalWant: "hi, \nmy name is", equalGot: "what,\nmy name is", want: "\tassertions.go:\\d+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"hi, \\\\nmy name is\"\n\\s+actual\\s+: \"what,\\\\nmy name is\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1,2 \\+1,2 @@\n\\s+-hi, \n\\s+\\+what,\n\\s+my name is"},
@@ -191,13 +191,13 @@ func TestEqualFormatting(_ *testing.T) {
 	for _, currCase := range []struct {
 		equalWant  string
 		equalGot   string
-		msgAndArgs []interface{}
+		msgAndArgs []any
 		want       string
 	}{
 		{equalWant: "want", equalGot: "got", want: "\tassertions.go:\\d+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{"hello, %v!", "world"}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+hello, world!\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{123}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+123\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{struct{ a string }{"hello"}}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+{a:hello}\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{"hello, %v!", "world"}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+hello, world!\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{123}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+123\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{struct{ a string }{"hello"}}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+{a:hello}\n"},
 	} {
 		mockT := &bufferT{}
 		Equal(mockT, currCase.equalWant, currCase.equalGot, currCase.msgAndArgs...)
@@ -284,8 +284,8 @@ func TestNotEqual(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// cases that are expected not to match
@@ -323,8 +323,8 @@ func TestNotEqualValues(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// cases that are expected not to match
@@ -374,12 +374,12 @@ func TestContainsNotContains(t *testing.T) {
 		{"g", "h"},
 		{"j", "k"},
 	}
-	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
-	var zeroMap map[interface{}]interface{}
+	simpleMap := map[any]any{"Foo": "Bar"}
+	var zeroMap map[any]any
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		{"Hello World", "Hello", true},
@@ -455,7 +455,7 @@ func TestContainsNotContainsOnNilValue(t *testing.T) {
 func Test_containsElement(t *testing.T) {
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
-	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
+	simpleMap := map[any]any{"Foo": "Bar"}
 
 	ok, found := containsElement("Hello World", "World")
 	True(t, ok)
@@ -506,8 +506,8 @@ func TestElementsMatch(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// matching
@@ -546,10 +546,10 @@ func TestElementsMatch(t *testing.T) {
 func TestDiffLists(t *testing.T) {
 	tests := []struct {
 		name   string
-		listA  interface{}
-		listB  interface{}
-		extraA []interface{}
-		extraB []interface{}
+		listA  any
+		listB  any
+		extraA []any
+		extraB []any
 	}{
 		{
 			name:   "equal empty",
@@ -576,14 +576,14 @@ func TestDiffLists(t *testing.T) {
 			name:   "extra A",
 			listA:  []string{"hello", "hello", "world"},
 			listB:  []string{"hello", "world"},
-			extraA: []interface{}{"hello"},
+			extraA: []any{"hello"},
 			extraB: nil,
 		},
 		{
 			name:   "extra A twice",
 			listA:  []string{"hello", "hello", "hello", "world"},
 			listB:  []string{"hello", "world"},
-			extraA: []interface{}{"hello", "hello"},
+			extraA: []any{"hello", "hello"},
 			extraB: nil,
 		},
 		{
@@ -591,14 +591,14 @@ func TestDiffLists(t *testing.T) {
 			listA:  []string{"hello", "world"},
 			listB:  []string{"hello", "hello", "world"},
 			extraA: nil,
-			extraB: []interface{}{"hello"},
+			extraB: []any{"hello"},
 		},
 		{
 			name:   "extra B twice",
 			listA:  []string{"hello", "world"},
 			listB:  []string{"hello", "hello", "world", "hello"},
 			extraA: nil,
-			extraB: []interface{}{"hello", "hello"},
+			extraB: []any{"hello", "hello"},
 		},
 		{
 			name:   "integers 1",
@@ -611,8 +611,8 @@ func TestDiffLists(t *testing.T) {
 			name:   "integers 2",
 			listA:  []int{1, 2, 1, 2, 1},
 			listB:  []int{2, 1, 2, 1, 2},
-			extraA: []interface{}{1},
-			extraB: []interface{}{2},
+			extraA: []any{1},
+			extraB: []any{2},
 		},
 	}
 	for _, test := range tests {
@@ -747,7 +747,7 @@ func Test_isEmpty(t *testing.T) {
 }
 
 func Test_getLen(t *testing.T) {
-	falseCases := []interface{}{
+	falseCases := []any{
 		nil,
 		0,
 		true,
@@ -766,7 +766,7 @@ func Test_getLen(t *testing.T) {
 	ch <- 2
 	ch <- 3
 	trueCases := []struct {
-		v interface{}
+		v any
 		l int
 	}{
 		{[]int{1, 2, 3}, 3},
@@ -807,7 +807,7 @@ func TestLen(t *testing.T) {
 	ch <- 3
 
 	cases := []struct {
-		v interface{}
+		v any
 		l int
 	}{
 		{[]int{1, 2, 3}, 3},
@@ -830,7 +830,7 @@ func TestLen(t *testing.T) {
 	}
 
 	cases = []struct {
-		v interface{}
+		v any
 		l int
 	}{
 		{[]int{1, 2, 3}, 4},
@@ -885,7 +885,7 @@ func TestInDelta(t *testing.T) {
 	True(t, InDelta(mockT, math.NaN(), math.NaN(), 0.01), "Expected NaN for both to pass")
 
 	cases := []struct {
-		a, b  interface{}
+		a, b  any
 		delta float64
 	}{
 		{uint(2), uint(1), 1},
@@ -1103,21 +1103,21 @@ func TestDiffRace(t *testing.T) {
 
 type mockTestingT struct {
 	errorFmt string
-	args     []interface{}
+	args     []any
 }
 
 func (m *mockTestingT) errorString() string {
 	return fmt.Sprintf(m.errorFmt, m.args...)
 }
 
-func (m *mockTestingT) Errorf(format string, args ...interface{}) {
+func (m *mockTestingT) Errorf(format string, args ...any) {
 	m.errorFmt = format
 	m.args = args
 }
 
 type mockFailNowTestingT struct{}
 
-func (m *mockFailNowTestingT) Errorf(string, ...interface{}) {}
+func (m *mockFailNowTestingT) Errorf(string, ...any) {}
 
 func (m *mockFailNowTestingT) FailNow() {}
 

--- a/internal/assert/difflib.go
+++ b/internal/assert/difflib.go
@@ -555,7 +555,7 @@ type UnifiedDiff struct {
 func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
-	wf := func(format string, args ...interface{}) error {
+	wf := func(format string, args ...any) error {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
 		return err
 	}
@@ -671,7 +671,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
 	var diffErr error
-	wf := func(format string, args ...interface{}) {
+	wf := func(format string, args ...any) {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
 		if diffErr == nil && err != nil {
 			diffErr = err

--- a/internal/assert/difflib_test.go
+++ b/internal/assert/difflib_test.go
@@ -20,7 +20,7 @@ func assertAlmostEqual(t *testing.T, a, b float64, places int) {
 	}
 }
 
-func assertEqual(t *testing.T, a, b interface{}) {
+func assertEqual(t *testing.T, a, b any) {
 	if !reflect.DeepEqual(a, b) {
 		t.Errorf("%v != %v", a, b)
 	}

--- a/internal/aws/credentials/credentials.go
+++ b/internal/aws/credentials/credentials.go
@@ -123,7 +123,7 @@ func (c *Credentials) GetWithContext(ctx context.Context) (Value, error) {
 	// Cannot pass context down to the actual retrieve, because the first
 	// context would cancel the whole group when there is not direct
 	// association of items in the group.
-	resCh := c.sf.DoChan("", func() (interface{}, error) {
+	resCh := c.sf.DoChan("", func() (any, error) {
 		return c.singleRetrieve(&suppressedContext{ctx})
 	})
 	select {
@@ -135,7 +135,7 @@ func (c *Credentials) GetWithContext(ctx context.Context) (Value, error) {
 	}
 }
 
-func (c *Credentials) singleRetrieve(ctx context.Context) (interface{}, error) {
+func (c *Credentials) singleRetrieve(ctx context.Context) (any, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -176,7 +176,7 @@ func (c *Credentials) asyncIsExpired() <-chan Value {
 }
 
 // isExpiredLocked helper method wrapping the definition of expired credentials.
-func (c *Credentials) isExpiredLocked(creds interface{}) bool {
+func (c *Credentials) isExpiredLocked(creds any) bool {
 	return creds == nil || creds.(Value) == Value{} || c.provider.IsExpired()
 }
 

--- a/internal/integration/client_test.go
+++ b/internal/integration/client_test.go
@@ -869,7 +869,7 @@ func TestClient_BulkWrite_AddCommandFields(t *testing.T) {
 		return opts
 	}
 
-	marshalValue := func(val interface{}) bson.RawValue {
+	marshalValue := func(val any) bson.RawValue {
 		t.Helper()
 
 		valType, data, err := bson.MarshalValue(val)

--- a/internal/integration/collection_test.go
+++ b/internal/integration/collection_test.go
@@ -2032,7 +2032,7 @@ func TestCollection(t *testing.T) {
 func TestBypassEmptyTsReplacement(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().CreateClient(false).MinServerVersion("5.0"))
 
-	marshalValue := func(val interface{}) bson.RawValue {
+	marshalValue := func(val any) bson.RawValue {
 		t.Helper()
 
 		valType, data, err := bson.MarshalValue(val)
@@ -2085,7 +2085,7 @@ func TestBypassEmptyTsReplacement(t *testing.T) {
 		}
 	})
 	mt.Run("insert many", func(mt *mtest.T) {
-		docs := []interface{}{
+		docs := []any{
 			bson.D{{"x", 42}},
 			bson.D{{"y", "foo"}},
 		}

--- a/internal/integration/handshake_test.go
+++ b/internal/integration/handshake_test.go
@@ -1272,7 +1272,7 @@ func TestHandshakeProse_Handshake_Documents(t *testing.T) {
 }
 
 // mustMarshalBSON marshals a value to BSON. It panics if any error occurs.
-func mustMarshalBSON(val interface{}) []byte {
+func mustMarshalBSON(val any) []byte {
 	bytes, err := bson.Marshal(val)
 	if err != nil {
 		panic(err)

--- a/internal/rand/example_test.go
+++ b/internal/rand/example_test.go
@@ -57,7 +57,7 @@ func Example_rand() {
 	// The tabwriter here helps us generate aligned output.
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
 	defer w.Flush()
-	show := func(name string, v1, v2, v3 interface{}) {
+	show := func(name string, v1, v2, v3 any) {
 		fmt.Fprintf(w, "%s\t%v\t%v\t%v\n", name, v1, v2, v3)
 	}
 

--- a/internal/rand/regress_test.go
+++ b/internal/rand/regress_test.go
@@ -80,7 +80,7 @@ func TestRegress(t *testing.T) {
 	n := rv.NumMethod()
 	p := 0
 	if *printgolden {
-		fmt.Printf("var regressGolden = []interface{}{\n")
+		fmt.Printf("var regressGolden = []any{\n")
 	}
 	for i := 0; i < n; i++ {
 		m := rv.Type().Method(i)
@@ -97,7 +97,7 @@ func TestRegress(t *testing.T) {
 			var args []reflect.Value
 			var argstr string
 			if mt.NumIn() == 1 {
-				var x interface{}
+				var x any
 				switch mt.In(0).Kind() {
 				default:
 					t.Fatalf("unexpected argument type for r.%s", m.Name)
@@ -137,7 +137,7 @@ func TestRegress(t *testing.T) {
 				args = append(args, reflect.ValueOf(x))
 			}
 
-			var out interface{}
+			var out any
 			out = mv.Call(args)[0].Interface()
 			if m.Name == "Int" || m.Name == "Intn" {
 				out = int64(out.(int))
@@ -174,7 +174,7 @@ func TestRegress(t *testing.T) {
 	}
 }
 
-var regressGolden = []interface{}{
+var regressGolden = []any{
 	float64(0.6279600685109523),   // ExpFloat64()
 	float64(0.16198826513357806),  // ExpFloat64()
 	float64(0.007880404652650552), // ExpFloat64()

--- a/internal/require/require.go
+++ b/internal/require/require.go
@@ -14,7 +14,7 @@ import (
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	FailNow()
 }
 
@@ -28,7 +28,7 @@ type tHelper interface {
 //	assert.Contains(t, "Hello World", "World")
 //	assert.Contains(t, ["Hello", "World"], "World")
 //	assert.Contains(t, {"Hello": "World"}, "Hello")
-func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func Contains(t TestingT, s any, contains any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -44,7 +44,7 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+func Containsf(t TestingT, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -59,7 +59,7 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+func ElementsMatch(t TestingT, listA any, listB any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -74,7 +74,7 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+func ElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -91,7 +91,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func Equal(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -106,7 +106,7 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -121,7 +121,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -135,7 +135,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // and equal.
 //
 //	assert.EqualValues(t, uint32(123), int32(123))
-func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func EqualValues(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -149,7 +149,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // and equal.
 //
 //	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
-func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func EqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -166,7 +166,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func Equalf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -182,7 +182,7 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //	  if assert.Error(t, err) {
 //		   assert.Equal(t, expectedError, err)
 //	  }
-func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+func Error(t TestingT, err error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -197,7 +197,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContains(t, err,  expectedErrorSubString)
-func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -212,7 +212,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
-func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -228,7 +228,7 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 //	  if assert.Errorf(t, err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedErrorf, err)
 //	  }
-func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+func Errorf(t TestingT, err error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -242,7 +242,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
-func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -256,7 +256,7 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 // periodically checking target function each tick.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -267,7 +267,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 }
 
 // Fail reports a failure through
-func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+func Fail(t TestingT, failureMessage string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -278,7 +278,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
-func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -289,7 +289,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
-func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+func FailNowf(t TestingT, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -300,7 +300,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 }
 
 // Failf reports a failure through
-func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+func Failf(t TestingT, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -313,7 +313,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 // False asserts that the specified value is false.
 //
 //	assert.False(t, myBool)
-func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+func False(t TestingT, value bool, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -326,7 +326,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //	assert.Falsef(t, myBool, "error message %s", "formatted")
-func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+func Falsef(t TestingT, value bool, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -341,7 +341,7 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 //	assert.Greater(t, 2, 1)
 //	assert.Greater(t, float64(2), float64(1))
 //	assert.Greater(t, "b", "a")
-func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func Greater(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -357,7 +357,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	assert.GreaterOrEqual(t, 2, 2)
 //	assert.GreaterOrEqual(t, "b", "a")
 //	assert.GreaterOrEqual(t, "b", "b")
-func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func GreaterOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -373,7 +373,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
-func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func GreaterOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -388,7 +388,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 //	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
 //	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
-func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func Greaterf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -401,7 +401,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
-func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func InDelta(t TestingT, expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -414,7 +414,7 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func InDeltaf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -425,7 +425,7 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // IsType asserts that the specified objects are of the same type.
-func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+func IsType(t TestingT, expectedType any, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -436,7 +436,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 }
 
 // IsTypef asserts that the specified objects are of the same type.
-func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+func IsTypef(t TestingT, expectedType any, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -450,7 +450,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // Len also fails if the object has a type that len() not accept.
 //
 //	assert.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+func Len(t TestingT, object any, length int, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -464,7 +464,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+func Lenf(t TestingT, object any, length int, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -479,7 +479,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	assert.Less(t, 1, 2)
 //	assert.Less(t, float64(1), float64(2))
 //	assert.Less(t, "a", "b")
-func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func Less(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -495,7 +495,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	assert.LessOrEqual(t, 2, 2)
 //	assert.LessOrEqual(t, "a", "b")
 //	assert.LessOrEqual(t, "b", "b")
-func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func LessOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -511,7 +511,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
-func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func LessOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -526,7 +526,7 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 //	assert.Lessf(t, 1, 2, "error message %s", "formatted")
 //	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	assert.Lessf(t, "a", "b", "error message %s", "formatted")
-func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func Lessf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -540,7 +540,7 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //
 //	assert.Negative(t, -1)
 //	assert.Negative(t, -1.23)
-func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+func Negative(t TestingT, e any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -554,7 +554,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	assert.Negativef(t, -1, "error message %s", "formatted")
 //	assert.Negativef(t, -1.23, "error message %s", "formatted")
-func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+func Negativef(t TestingT, e any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -567,7 +567,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Nil asserts that the specified object is nil.
 //
 //	assert.Nil(t, err)
-func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func Nil(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -580,7 +580,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //	assert.Nilf(t, err, "error message %s", "formatted")
-func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func Nilf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -596,7 +596,7 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //	  if assert.NoError(t, err) {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+func NoError(t TestingT, err error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -612,7 +612,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+func NoErrorf(t TestingT, err error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -628,7 +628,7 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 //	assert.NotContains(t, "Hello World", "Earth")
 //	assert.NotContains(t, ["Hello", "World"], "Earth")
 //	assert.NotContains(t, {"Hello": "World"}, "Earth")
-func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func NotContains(t TestingT, s any, contains any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -644,7 +644,7 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+func NotContainsf(t TestingT, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -660,7 +660,7 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func NotEqual(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -673,7 +673,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValues(t, obj1, obj2)
-func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func NotEqualValues(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -686,7 +686,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
-func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func NotEqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -702,7 +702,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func NotEqualf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -715,7 +715,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 // NotNil asserts that the specified object is not nil.
 //
 //	assert.NotNil(t, err)
-func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func NotNil(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -728,7 +728,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //	assert.NotNilf(t, err, "error message %s", "formatted")
-func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func NotNilf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -742,7 +742,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //
 //	assert.Positive(t, 1)
 //	assert.Positive(t, 1.23)
-func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+func Positive(t TestingT, e any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -756,7 +756,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	assert.Positivef(t, 1, "error message %s", "formatted")
 //	assert.Positivef(t, 1.23, "error message %s", "formatted")
-func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+func Positivef(t TestingT, e any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -769,7 +769,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // True asserts that the specified value is true.
 //
 //	assert.True(t, myBool)
-func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+func True(t TestingT, value bool, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -782,7 +782,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //	assert.Truef(t, myBool, "error message %s", "formatted")
-func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+func Truef(t TestingT, value bool, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -795,7 +795,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -808,7 +808,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -823,7 +823,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 //	if require.NotEmpty(t, obj) {
 //	  require.Equal(t, "two", obj[1])
 //	}
-func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func NotEmpty(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -846,7 +846,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func Empty(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/internal/testutil/reflect.go
+++ b/internal/testutil/reflect.go
@@ -12,7 +12,7 @@ import (
 )
 
 // getUnexportedField uses reflection and unsafe to read an unexported field
-// named fieldName from a struct pointer v, and returns it as interface{}.
+// named fieldName from a struct pointer v, and returns it as any.
 func getUnexportedField(v any, fieldName string) any {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {


### PR DESCRIPTION
Replaces all occurrences of `interface{}` with `any` (the Go 1.18+ alias) across 16 files in the `internal/` directory. This is a mechanical refactor with no functional changes — `any` is semantically identical to `interface{}` and is now the idiomatic Go style for projects targeting Go 1.18+.

Changes: 253 insertions, 253 deletions across 16 files.