### PR TITLE
GODRIVER-3965 fix: misleading error message type info in rewrap function

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -457,7 +457,7 @@ func setRewrapManyDataKeyWriteModels(rewrappedDocuments []bsoncore.Document, wri
 
 		idSubtype, idData, ok := id.BinaryOK()
 		if !ok {
-			return fmt.Errorf("expected to assert %q as binary, got type 0x%02x", idKey, id.Type())
+			return fmt.Errorf("expected to assert %q as binary, got type %s", idKey, id.Type)
 		}
 		binaryID := bson.Binary{Subtype: idSubtype, Data: idData}
 

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -457,7 +457,7 @@ func setRewrapManyDataKeyWriteModels(rewrappedDocuments []bsoncore.Document, wri
 
 		idSubtype, idData, ok := id.BinaryOK()
 		if !ok {
-			return fmt.Errorf("expected to assert %q as binary, got type %T", idKey, id)
+			return fmt.Errorf("expected to assert %q as binary, got type 0x%02x", idKey, id.Type())
 		}
 		binaryID := bson.Binary{Subtype: idSubtype, Data: idData}
 


### PR DESCRIPTION
GODRIVER-3965

## Summary

### Problem

Error message uses `%T` format verb with `bsoncore.Value`, which always displays `bsoncore.Value` regardless of actual BSON type present.

Before:
`expected to assert "_id" as binary, got type bsoncore.Value`

After:
`expected to assert "_id" as binary, got type string`

### What I have changed

Use `id.Type.String()` to display the actual BSON type code instead of using the Go type name in the error msg.

<!--- A summary of the changes proposed by this pull request. -->

## Background & Motivation

When `BinaryOK()` fails, it's hard to tell what BSON type is actually in the document. 
The current error msg just says `bsoncore.Value`, which doesn't help. 
Showing the BSON type code makes debugging easier.
<!--- Rationale for the pull request. -->
