### PR TITLE
GODRIVER-3968 Set dry_run on the golang/pre-publish release action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           version: ${{ inputs.version }}
           push_changes: ${{ inputs.push_changes }}
           ignored_branches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
-          dry_run: ${{ inputs.push_changes != 'true' }}
+          dry_run: ${{ !inputs.push_changes }}
   static-scan:
     needs: [pre-publish]
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           version: ${{ inputs.version }}
           push_changes: ${{ inputs.push_changes }}
           ignored_branches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
+          dry_run: ${{ inputs.push_changes != 'true' }}
   static-scan:
     needs: [pre-publish]
     permissions:


### PR DESCRIPTION
[GODRIVER-3968](https://jira.mongodb.org/browse/GODRIVER-3968)

## Summary

Set `dry_run` on the golang/pre-publish release action based on the `push_changes` toggle value.

## Background & Motivation

As of https://github.com/mongodb-labs/drivers-github-tools/commit/9e807b432a5ccde822da073302ac26d414bf36a8, the `golang/pre-publish` action now requires users to set `dry_run`.

