### PR TITLE
GODRIVER-3943: Add libmongocrypt version constraints to mtest

### DIFF
--- a/internal/integration/mtest/libmongocrypt_version_enabled.go
+++ b/internal/integration/mtest/libmongocrypt_version_enabled.go
@@ -1,0 +1,32 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build cse
+
+package mtest
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/mongocrypt"
+)
+
+// verifyLibmongocryptVersionConstraints returns an error if the loaded
+// libmongocrypt version is not in the range [min, max]. Bounds are only
+// checked when non-empty.
+func verifyLibmongocryptVersionConstraints(min, max string) error {
+	if min == "" && max == "" {
+		return nil
+	}
+	version := mongocrypt.Version()
+	if min != "" && CompareServerVersions(version, min) < 0 {
+		return fmt.Errorf("libmongocrypt version %q is lower than min required version %q", version, min)
+	}
+	if max != "" && CompareServerVersions(version, max) > 0 {
+		return fmt.Errorf("libmongocrypt version %q is higher than max version %q", version, max)
+	}
+	return nil
+}

--- a/internal/integration/mtest/libmongocrypt_version_not_enabled.go
+++ b/internal/integration/mtest/libmongocrypt_version_not_enabled.go
@@ -1,0 +1,22 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build !cse
+
+package mtest
+
+import "fmt"
+
+// verifyLibmongocryptVersionConstraints returns an error when a non-empty
+// version constraint is requested but the driver was not built with the cse
+// tag (and therefore has no access to libmongocrypt). When both bounds are
+// empty there is nothing to check and nil is returned.
+func verifyLibmongocryptVersionConstraints(min, max string) error {
+	if min == "" && max == "" {
+		return nil
+	}
+	return fmt.Errorf("libmongocrypt version constraints require the cse build tag")
+}

--- a/internal/integration/mtest/mongotest.go
+++ b/internal/integration/mtest/mongotest.go
@@ -60,23 +60,25 @@ type T struct {
 	*testing.T
 
 	// members for only this T instance
-	createClient      *bool
-	createCollection  *bool
-	runOn             []RunOnBlock
-	mockDeployment    *drivertest.MockDeployment // nil if the test is not being run against a mock
-	mockResponses     []bson.D
-	createdColls      []*Collection // collections created in this test
-	proxyDialer       *proxyDialer
-	dbName, collName  string
-	failPointNames    []string
-	minServerVersion  string
-	maxServerVersion  string
-	validTopologies   []TopologyKind
-	auth              *bool
-	enterprise        *bool
-	ssl               *bool
-	collCreateOpts    *options.CreateCollectionOptionsBuilder
-	requireAPIVersion *bool
+	createClient            *bool
+	createCollection        *bool
+	runOn                   []RunOnBlock
+	mockDeployment          *drivertest.MockDeployment // nil if the test is not being run against a mock
+	mockResponses           []bson.D
+	createdColls            []*Collection // collections created in this test
+	proxyDialer             *proxyDialer
+	dbName, collName        string
+	failPointNames          []string
+	minServerVersion        string
+	maxServerVersion        string
+	minLibmongocryptVersion string
+	maxLibmongocryptVersion string
+	validTopologies         []TopologyKind
+	auth                    *bool
+	enterprise              *bool
+	ssl                     *bool
+	collCreateOpts          *options.CreateCollectionOptionsBuilder
+	requireAPIVersion       *bool
 
 	// options copied to sub-tests
 	clientType               ClientType
@@ -822,6 +824,11 @@ func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 		if err := verifyVersionConstraints("4.2", ""); err != nil {
 			return err
 		}
+		if rob.CSFLE.Options != nil {
+			if err := verifyLibmongocryptVersionConstraints(rob.CSFLE.Options.MinVer, ""); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -831,6 +838,9 @@ func verifyRunOnBlockConstraint(rob RunOnBlock) error {
 func (t *T) verifyConstraints() error {
 	// Check constraints not specified as runOn blocks
 	if err := verifyVersionConstraints(t.minServerVersion, t.maxServerVersion); err != nil {
+		return err
+	}
+	if err := verifyLibmongocryptVersionConstraints(t.minLibmongocryptVersion, t.maxLibmongocryptVersion); err != nil {
 		return err
 	}
 	if err := verifyTopologyConstraints(t.validTopologies); err != nil {

--- a/internal/integration/mtest/options.go
+++ b/internal/integration/mtest/options.go
@@ -331,3 +331,19 @@ func (op *Options) AllowFailPointsOnSharded() *Options {
 	})
 	return op
 }
+
+// MinLibmongocryptVersion specifies the minimum libmongocrypt version required for the test to run.
+func (op *Options) MinLibmongocryptVersion(version string) *Options {
+	op.optFuncs = append(op.optFuncs, func(t *T) {
+		t.minLibmongocryptVersion = version
+	})
+	return op
+}
+
+// MaxLibmongocryptVersion specifies the maximum libmongocrypt version allowed for the test to run.
+func (op *Options) MaxLibmongocryptVersion(version string) *Options {
+	op.optFuncs = append(op.optFuncs, func(t *T) {
+		t.maxLibmongocryptVersion = version
+	})
+	return op
+}


### PR DESCRIPTION
[GODRIVER-3943](https://jira.mongodb.org/browse/GODRIVER-3943)

## Summary

Implements libmongocrypt version constraint enforcement in the `mtest` package, required by the [Unified Test Format spec](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md) which added a `csfle.minLibmongocryptVersion` field to `runOnRequirements`.

- **2 new files** (`libmongocrypt_version_enabled.go` / `libmongocrypt_version_not_enabled.go`): build-tag-guarded implementations of `verifyLibmongocryptVersionConstraints`. The `cse`-enabled file calls `mongocrypt.Version()` and compares using the existing `CompareServerVersions` utility; the `!cse` stub skips any test that specifies a bound (since the version cannot be verified without libmongocrypt).
- **`mongotest.go`**: `verifyConstraints()` now enforces `MinLibmongocryptVersion`/`MaxLibmongocryptVersion` set directly on `mtest.Options`; `verifyRunOnBlockConstraint()` now checks `csfle.minLibmongocryptVersion` from Unified Test Format `runOnRequirements`.
- **`options.go`**: Doc comments added to `MinLibmongocryptVersion` and `MaxLibmongocryptVersion` setters (fields and setters were added in an earlier commit on this branch).

## Background & Motivation
