### PR TITLE
GODRIVER-3863: Add QE prefix and suffix GA

### DIFF
--- a/etc/install-libmongocrypt.sh
+++ b/etc/install-libmongocrypt.sh
@@ -3,7 +3,7 @@
 # This script installs libmongocrypt into an "install" directory.
 set -eux
 
-LIBMONGOCRYPT_TAG="1.19.0"
+LIBMONGOCRYPT_TAG="1.19.1"
 
 # Install libmongocrypt based on OS.
 if [ "Windows_NT" = "${OS:-}" ]; then

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -359,7 +359,7 @@ func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("prefixPreview").
+		SetQueryType("prefix").
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -66,7 +66,7 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 	mt.RunOpts("case 1: can find a document by prefix", prefixSuffixOpts, func(mt *mtest.T) {
 		runCSEProse27Case1(mt, test)
 	})
-	mt.RunOpts("case 2: find a document by suffix", prefixSuffixOpts, func(mt *mtest.T) {
+	mt.RunOpts("case 2: can find a document by suffix", prefixSuffixOpts, func(mt *mtest.T) {
 		runCSEProse27Case2(mt, test)
 	})
 	mt.RunOpts("case 3: assert no document found by prefix", prefixSuffixOpts, func(mt *mtest.T) {
@@ -76,34 +76,38 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 		runCSEProse27Case4(mt, test)
 	})
 
-	const prose27PreviewSkipReason = "TODO(GODRIVER-3863): preview QE text query types removed in libmongocrypt 1.19.0; pending migration to stable names (DRIVERS-3321)"
-	placeholderOpts := mtest.NewOptions()
+	// The substring cases (5, 6, 10, 11) require only the overall case 27
+	// minimums: server 8.2.0+ and libmongocrypt 1.18.1+. Subtests do not inherit
+	// the suite's version gates (mtest rebuilds baseOpts without them), so
+	// declare the requirement explicitly.
+	substringOpts := newQEOpts().MinServerVersion("8.2").MinLibmongocryptVersion("1.18.1")
 
-	mt.Run("case 5: can find a document by substring", func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
+	mt.RunOpts("case 5: can find a document by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case5(mt, test)
 	})
-	mt.Run("case 6: assert no document found by substring", func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
+	mt.RunOpts("case 6: assert no document found by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case6(mt, test)
 	})
-	mt.RunOpts("case 7: assert contentionFactor is required", placeholderOpts, func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
+
+	// Cases 7, 8, and 9 exercise the GA "String" algorithm and stable
+	// prefix/suffix query types, which require server 9.0.0+ and libmongocrypt
+	// 1.19.0+.
+	stableStringOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.19.0")
+
+	mt.RunOpts("case 7: assert contentionFactor is required", stableStringOpts, func(mt *mtest.T) {
 		runCSEProse27Case7(mt, test)
 	})
 
-	optsFor9_0 := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.19.0")
-
-	mt.RunOpts("case 8: can find an auto-encrypted case indexed document by prefix and suffix", optsFor9_0, func(mt *mtest.T) {
+	mt.RunOpts("case 8: can find an auto-encrypted case-insensitively indexed document by prefix and suffix", stableStringOpts, func(mt *mtest.T) {
 		runCSEProse27Case8(mt, test)
 	})
-	mt.RunOpts("case 9: can find an auto-encrypted diacritic-insensitively indexed document by prefix and suffix", optsFor9_0, func(mt *mtest.T) {
+	mt.RunOpts("case 9: can find an auto-encrypted diacritic-insensitively indexed document by prefix and suffix", stableStringOpts, func(mt *mtest.T) {
 		runCSEProse27Case9(mt, test)
 	})
-	mt.Run("case 10: can find an auto-encrypted case-insensitively indexed document by substring", func(mt *mtest.T) {
+	mt.RunOpts("case 10: can find an auto-encrypted case-insensitively indexed document by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case10(mt, test)
 	})
-	mt.Run("case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring", func(mt *mtest.T) {
+	mt.RunOpts("case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case11(mt, test)
 	})
 }

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -135,7 +135,7 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix collection with the following filter:
@@ -149,11 +149,12 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 		}},
 	}}})
 
-	var got struct {
-		EncryptedText string `bson:"encryptedText"`
-	}
-	require.Nil(mt, res.Decode(&got), "error decoding result")
+	var got encryptedTextDoc
+	err = res.Decode(&got)
+	require.NoError(mt, err, "error decoding result: %v", err)
+
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
+	require.True(mt, got.ID.IsZero())
 }
 
 // runCSEProse27Case2 ensures that we can find a document by suffix.
@@ -175,7 +176,7 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix collection with the following filter:
@@ -189,11 +190,12 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 		}},
 	}}})
 
-	var got struct {
-		EncryptedText string `bson:"encryptedText"`
-	}
-	require.Nil(mt, res.Decode(&got), "error decoding result")
+	var got encryptedTextDoc
+	err = res.Decode(&got)
+	require.NoError(mt, err, "error decoding result: %v", err)
+
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
+	require.True(mt, got.ID.IsZero())
 }
 
 // runCSEProse27Case3 asserts that no document is found by prefix.
@@ -215,7 +217,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix collection with the following filter:
@@ -230,7 +232,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 			{Key: "prefix", Value: payload},
 		}},
 	}}}).Raw()
-	assert.ErrorIs(mt, err, mongo.ErrNoDocuments)
+	require.ErrorIs(mt, err, mongo.ErrNoDocuments)
 }
 
 // runCSEProse27Case4 asserts that no document is found by suffix.
@@ -252,7 +254,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix collection with the following filter:
@@ -267,7 +269,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 			{Key: "suffix", Value: payload},
 		}},
 	}}}).Raw()
-	assert.ErrorIs(mt, err, mongo.ErrNoDocuments)
+	require.ErrorIs(mt, err, mongo.ErrNoDocuments)
 }
 
 // runCSEProse27Case5 ensures that we can find a document by substring.
@@ -288,7 +290,7 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), bar, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.substring collection with the following filter:
@@ -302,11 +304,12 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 		}},
 	}}})
 
-	var got struct {
-		EncryptedText string `bson:"encryptedText"`
-	}
-	require.Nil(mt, res.Decode(&got), "error decoding result")
+	var got encryptedTextDoc
+	err = res.Decode(&got)
+	require.NoError(mt, err, "error decoding result: %v", err)
+
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
+	require.True(mt, got.ID.IsZero())
 }
 
 // runCSEProse27Case6 asserts that no document is found by substring.
@@ -327,7 +330,7 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), qux, eo)
-	require.Nil(mt, err, "error in Encrypt: %v", err)
+	require.NoError(mt, err, "error in Encrypt: %v", err)
 
 	// Step 2. Use explicitEncryptedClient to run a "find" operation on the
 	// db.substring collection with the following filter:
@@ -397,7 +400,7 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 	bingPlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bing")}
 
 	bingEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), bingPlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'bing': %v", err)
+	require.NoError(mt, err, "error encrypting 'bing': %v", err)
 
 	// Step 3. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix-ci-di collection with the following filter:
@@ -411,11 +414,11 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 	encColl := test.explicitEncryptClient.Database(dbName).Collection(collName)
 
 	bingCur, err := encColl.Find(context.Background(), bingFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	var results []bson.M
 	err = bingCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "BingQiLin", results[0]["encryptedText"])
@@ -434,7 +437,7 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 	linPlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "lin")}
 
 	linEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), linPlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'lin': %v", err)
+	require.NoError(mt, err, "error encrypting 'lin': %v", err)
 
 	// Step 5. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix-ci-di collection with the following filter:
@@ -446,10 +449,10 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 	}}}}}
 
 	linCur, err := encColl.Find(context.Background(), linFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	err = linCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "BingQiLin", results[0]["encryptedText"])
@@ -486,7 +489,7 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 	cafePlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "cafe")}
 
 	cafeEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), cafePlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'cafe': %v", err)
+	require.NoError(mt, err, "error encrypting 'cafe': %v", err)
 
 	// Step 3. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix-ci-di collection with the following filter:
@@ -500,12 +503,12 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 	encColl := test.explicitEncryptClient.Database(dbName).Collection(collName)
 
 	cafeCur, err := encColl.Find(context.Background(), cafeFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	var results []bson.M
 
 	err = cafeCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "cafébarbäz", results[0]["encryptedText"])
@@ -525,7 +528,7 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 	bazPlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 
 	bazEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), bazPlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'baz': %v", err)
+	require.NoError(mt, err, "error encrypting 'baz': %v", err)
 
 	// Step 5. Use explicitEncryptedClient to run a "find" operation on the
 	// db.prefix-suffix-ci-di collection with the following filter:
@@ -537,10 +540,10 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 	}}}}}
 
 	bazCur, err := encColl.Find(context.Background(), bazFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	err = bazCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "cafébarbäz", results[0]["encryptedText"])
@@ -578,7 +581,7 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 	barPlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bar")}
 
 	barEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), barPlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'bar': %v", err)
+	require.NoError(mt, err, "error encrypting 'bar': %v", err)
 
 	// Step 3. Use explicitEncryptedClient to run a "find" operation on the
 	// db.substring-ci-di collection with the following filter:
@@ -592,12 +595,12 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 	encColl := test.explicitEncryptClient.Database(dbName).Collection(collName)
 
 	barCur, err := encColl.Find(context.Background(), barFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	var results []bson.M
 
 	err = barCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "FooBarBaz", results[0]["encryptedText"])
@@ -635,7 +638,7 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 	cafePlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "cafe")}
 
 	cafeEncSearchToken, err := test.clientEncryption.Encrypt(context.Background(), cafePlaintextSearchToken, encryptOpts)
-	require.Nil(mt, err, "error encrypting 'cafe': %v", err)
+	require.NoError(mt, err, "error encrypting 'cafe': %v", err)
 
 	// Step 3. Use explicitEncryptedClient to run a "find" operation on the
 	// db.substring-ci-di collection with the following filter:
@@ -649,12 +652,12 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 	encColl := test.explicitEncryptClient.Database(dbName).Collection(collName)
 
 	cafeCur, err := encColl.Find(context.Background(), cafeFilter)
-	require.Nil(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
+	require.NoError(mt, err, "error running find on %s.%s: %v", dbName, collName, err)
 
 	var results []bson.M
 
 	err = cafeCur.All(context.Background(), &results)
-	require.Nil(mt, err, "error decoding find results: %v", err)
+	require.NoError(mt, err, "error decoding find results: %v", err)
 
 	require.Len(mt, results, 1, "expected 1 result, got %d", len(results))
 	require.Equal(mt, "foocafébaz", results[0]["encryptedText"])
@@ -664,6 +667,11 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 // Test Runner Helpers
 // =============================================================================
 
+type encryptedTextDoc struct {
+	ID            bson.ObjectID `bson:"_id"`
+	EncryptedText string        `bson:"encryptedText"`
+}
+
 // insertEncryptedText inserts { "encryptedText": <text> } into db.<coll> via
 // the given client with majority write concern.
 func insertEncryptedText(mt *mtest.T, client *mongo.Client, dbName, collName, text string) {
@@ -672,8 +680,20 @@ func insertEncryptedText(mt *mtest.T, client *mongo.Client, dbName, collName, te
 	collOpts := options.Collection().SetWriteConcern(mtest.MajorityWc)
 	coll := client.Database(dbName).Collection(collName, collOpts)
 
-	_, err := coll.InsertOne(context.Background(), bson.D{{Key: "encryptedText", Value: text}})
-	require.Nil(mt, err, "error inserting document into %s.%s: %v", dbName, collName, err)
+	_, err := coll.InsertOne(context.Background(), encryptedTextDoc{ID: bson.NewObjectID(), EncryptedText: text})
+	require.NoError(mt, err, "error inserting document into %s.%s: %v", dbName, collName, err)
+}
+
+// insertEncryptedTextWithNilID inserts { "_id": null, "encryptedText": <text> }
+// into db.<coll> via the given client with majority write concern.
+func insertEncryptedTextWithNilID(mt *mtest.T, client *mongo.Client, dbName, collName, text string) {
+	mt.Helper()
+
+	collOpts := options.Collection().SetWriteConcern(mtest.MajorityWc)
+	coll := client.Database(dbName).Collection(collName, collOpts)
+
+	_, err := coll.InsertOne(context.Background(), encryptedTextDoc{ID: bson.NilObjectID, EncryptedText: text})
+	require.NoError(mt, err, "error inserting document into %s.%s: %v", dbName, collName, err)
 }
 
 // prefixSuffixCollection returns the collection name that cases 1-4 query for
@@ -897,15 +917,15 @@ func setupCSEProse27(mt *mtest.T) *cseProse27Test {
 	// doSetupCSEProse27 registers cleanup for each client as it is created, so a
 	// partial failure still tears down whatever was already connected.
 	test, err := doSetupCSEProse27(mt)
-	require.Nil(mt, err, "failed to set up CSE prose 27: %v", err)
+	require.NoError(mt, err, "failed to set up CSE prose 27: %v", err)
 
 	// Seed the encrypted "foobarbaz" document queried by cases 1-6, inserted
 	// once via the auto-encrypting client. The prefix/suffix document goes into
 	// whichever collection exists for this server version: db.prefix-suffix on
 	// 9.0+ (stable query types) or db.prefix-suffix-preview on pre-9.0 (preview
 	// query types).
-	insertEncryptedText(mt, test.autoEncryptClient, "db", "substring", "foobarbaz")
-	insertEncryptedText(mt, test.autoEncryptClient, "db", prefixSuffixCollection(), "foobarbaz")
+	insertEncryptedTextWithNilID(mt, test.autoEncryptClient, "db", "substring", "foobarbaz")
+	insertEncryptedTextWithNilID(mt, test.autoEncryptClient, "db", prefixSuffixCollection(), "foobarbaz")
 
 	return test
 }

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 type cseProse27Config struct {
+	encryptedFieldsPrefixSuffix     bson.Raw
 	encryptedFieldsPrefixSuffixCIDI bson.Raw
+	encryptedFieldsSubstring        bson.Raw
 	encryptedFieldsSubstringCIDI    bson.Raw
 	key1Document                    bson.Raw
 }
@@ -108,10 +110,6 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
-
 	// Step 1. Use clientEncryption.encrypt() to encrypt "foo" with prefix query
 	// type.
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
@@ -141,21 +139,15 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	}}})
 
 	var got struct {
-		ID            int    `bson:"_id"`
 		EncryptedText string `bson:"encryptedText"`
 	}
 	require.Nil(mt, res.Decode(&got), "error decoding result")
-	require.Equal(mt, 0, got.ID)
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
 }
 
 // runCSEProse27Case2 ensures that we can find a document by suffix.
 func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
-
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "baz" with suffix query
 	// type.
@@ -186,21 +178,15 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	}}})
 
 	var got struct {
-		ID            int    `bson:"_id"`
 		EncryptedText string `bson:"encryptedText"`
 	}
 	require.Nil(mt, res.Decode(&got), "error decoding result")
-	require.Equal(mt, 0, got.ID)
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
 }
 
 // runCSEProse27Case3 asserts that no document is found by prefix.
 func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
-
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "baz" with prefix query
 	// type.
@@ -238,10 +224,6 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
-
 	// Step 1. Use clientEncryption.encrypt() to encrypt "foo" with suffix query
 	// type.
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
@@ -278,10 +260,6 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
-
 	// Step 1. Use clientEncryption.encrypt() to encrypt "bar" with substring
 	// query type.
 	bar := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bar")}
@@ -311,21 +289,15 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 	}}})
 
 	var got struct {
-		ID            int    `bson:"_id"`
 		EncryptedText string `bson:"encryptedText"`
 	}
 	require.Nil(mt, res.Decode(&got), "error decoding result")
-	require.Equal(mt, 0, got.ID)
 	require.Equal(mt, "foobarbaz", got.EncryptedText)
 }
 
 // runCSEProse27Case6 asserts that no document is found by substring.
 func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
-
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "qux" with substring
 	// query type.
@@ -362,10 +334,6 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 // runCSEProse27Case7 asserts that a contention factor is required.
 func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
-
-	// Create the preview prefix-suffix/substring collections and seed the
-	// encrypted "foobarbaz" document.
-	seedCSEProse27PreviewCollections(mt, test)
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "baz" with prefix query
 	// type but no contention factor, and expect an error that a contention
@@ -682,74 +650,6 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 // Test Runner Helpers
 // =============================================================================
 
-// seedCSEProse27PreviewCollections drops and creates the case- and
-// diacritic-sensitive "prefix-suffix" and "substring" collections used by the
-// preview cases (1-7) and seeds each with an explicitly encrypted "foobarbaz"
-// document. It reuses the shared clientEncryption and explicitEncryptClient.
-//
-// The prefix-suffix collection is only created on servers < 9.0; on 9.0+ the
-// stable ci-di collections (cases 8-11) are used instead.
-//
-// Preview query types; only invoked by the skipped cases 1-7 pending DRIVERS-3321.
-func seedCSEProse27PreviewCollections(mt *mtest.T, test *cseProse27Test) {
-	mt.Helper()
-
-	cols := []struct {
-		name       string
-		fields     bson.Raw
-		stringOpts *options.StringOptionsBuilder
-	}{
-		{
-			name:   "prefix-suffix",
-			fields: readJSONFile(mt, "encryptedFields-prefix-suffix.json"),
-			stringOpts: options.String().
-				SetCaseSensitive(true).
-				SetDiacriticSensitive(true).
-				SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}).
-				SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}),
-		},
-		{
-			name:   "substring",
-			fields: readJSONFile(mt, "encryptedFields-substring.json"),
-			stringOpts: options.String().
-				SetCaseSensitive(true).
-				SetDiacriticSensitive(true).
-				SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}),
-		},
-	}
-
-	foobarbaz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foobarbaz")}
-	adminDB := mt.Client.Database("db")
-
-	for _, c := range cols {
-		// Always drop to ensure a clean state from any previous run.
-		mtest.DropEncryptedCollection(mt, adminDB.Collection(c.name), c.fields)
-
-		if c.name == "prefix-suffix" && mtest.CompareServerVersions(mtest.ServerVersion(), "9.0.0") >= 0 {
-			continue
-		}
-
-		cco := options.CreateCollection().SetEncryptedFields(c.fields)
-		err := adminDB.CreateCollection(context.Background(), c.name, cco)
-		require.Nil(mt, err, "error creating db.%s: %v", c.name, err)
-
-		eo := options.Encrypt().
-			SetKeyID(test.key1ID).
-			SetAlgorithm("TextPreview").
-			SetContentionFactor(0).
-			SetStringOptions(c.stringOpts)
-
-		payload, err := test.clientEncryption.Encrypt(context.Background(), foobarbaz, eo)
-		require.Nil(mt, err, "error encrypting seed for db.%s: %v", c.name, err)
-
-		collOpts := options.Collection().SetWriteConcern(mtest.MajorityWc)
-		coll := test.explicitEncryptClient.Database("db").Collection(c.name, collOpts)
-
-		_, err = coll.InsertOne(context.Background(), bson.D{{Key: "_id", Value: 0}, {Key: "encryptedText", Value: payload}})
-		require.Nil(mt, err, "error inserting seed into db.%s: %v", c.name, err)
-	}
-}
-
 // insertEncryptedText inserts { "encryptedText": <text> } into db.<coll> via
 // the given client with majority write concern.
 func insertEncryptedText(mt *mtest.T, client *mongo.Client, dbName, collName, text string) {
@@ -785,7 +685,9 @@ func loadCSEProse27Config() (cseProse27Config, error) {
 		path string
 		dest *bson.Raw
 	}{
+		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix.json"), &cfg.encryptedFieldsPrefixSuffix},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix-ci-di.json"), &cfg.encryptedFieldsPrefixSuffixCIDI},
+		{filepath.Join(cseSpecDataDir, "encryptedFields-substring.json"), &cfg.encryptedFieldsSubstring},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-substring-ci-di.json"), &cfg.encryptedFieldsSubstringCIDI},
 		{filepath.Join(cseSpecDataDir, "keys", "key1-document.json"), &cfg.key1Document},
 	}
@@ -810,8 +712,7 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 	test := &cseProse27Test{}
 
 	// Using QE CreateCollection() and Collection.Drop(), drop and create the
-	// test collections with majority write concern. Only the case- and
-	// diacritic-insensitive (ci-di) collections are needed by cases 8-11.
+	// test collections with majority write concern.
 	db := mt.Client.Database("db")
 	encryptedColls := []struct {
 		name         string
@@ -819,7 +720,9 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 		minServerVer string
 	}{
 		// prefix and suffix query types require server 9.0+.
+		{"prefix-suffix", cfg.encryptedFieldsPrefixSuffix, "9.0"},
 		{"prefix-suffix-ci-di", cfg.encryptedFieldsPrefixSuffixCIDI, "9.0"},
+		{"substring", cfg.encryptedFieldsSubstring, ""},
 		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, ""},
 	}
 	for _, c := range encryptedColls {
@@ -932,6 +835,14 @@ func setupCSEProse27(mt *mtest.T) *cseProse27Test {
 	// partial failure still tears down whatever was already connected.
 	test, err := doSetupCSEProse27(mt)
 	require.Nil(mt, err, "failed to set up CSE prose 27: %v", err)
+
+	// Seed the encrypted "foobarbaz" document queried by cases 1-6, inserted
+	// once via the auto-encrypting client. The prefix-suffix collection only
+	// exists on server 9.0+.
+	insertEncryptedText(mt, test.autoEncryptClient, "db", "substring", "foobarbaz")
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0.0") >= 0 {
+		insertEncryptedText(mt, test.autoEncryptClient, "db", "prefix-suffix", "foobarbaz")
+	}
 
 	return test
 }

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -120,7 +120,7 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -165,7 +165,7 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -210,7 +210,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -250,7 +250,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -290,7 +290,7 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -335,7 +335,7 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("TextPreview").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -375,7 +375,7 @@ func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 		SetKeyID(test.key1ID).
 		SetAlgorithm("TextPreview").
 		SetQueryType("prefixPreview").
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
@@ -407,7 +407,7 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("prefix").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetPrefix(options.PrefixOptions{StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -444,7 +444,7 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("suffix").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetSuffix(options.SuffixOptions{StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -496,7 +496,7 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("prefix").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetPrefix(options.PrefixOptions{StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -535,7 +535,7 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("suffix").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetSuffix(options.SuffixOptions{StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -588,7 +588,7 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -645,7 +645,7 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 		SetAlgorithm("String").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
-		SetTextOptions(options.Text().
+		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
 			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 10}))
@@ -695,14 +695,14 @@ func seedCSEProse27PreviewCollections(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
 	cols := []struct {
-		name     string
-		fields   bson.Raw
-		textOpts *options.TextOptionsBuilder
+		name       string
+		fields     bson.Raw
+		stringOpts *options.StringOptionsBuilder
 	}{
 		{
 			name:   "prefix-suffix",
 			fields: readJSONFile(mt, "encryptedFields-prefix-suffix.json"),
-			textOpts: options.Text().
+			stringOpts: options.String().
 				SetCaseSensitive(true).
 				SetDiacriticSensitive(true).
 				SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}).
@@ -711,7 +711,7 @@ func seedCSEProse27PreviewCollections(mt *mtest.T, test *cseProse27Test) {
 		{
 			name:   "substring",
 			fields: readJSONFile(mt, "encryptedFields-substring.json"),
-			textOpts: options.Text().
+			stringOpts: options.String().
 				SetCaseSensitive(true).
 				SetDiacriticSensitive(true).
 				SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}),
@@ -737,7 +737,7 @@ func seedCSEProse27PreviewCollections(mt *mtest.T, test *cseProse27Test) {
 			SetKeyID(test.key1ID).
 			SetAlgorithm("TextPreview").
 			SetContentionFactor(0).
-			SetTextOptions(c.textOpts)
+			SetStringOptions(c.stringOpts)
 
 		payload, err := test.clientEncryption.Encrypt(context.Background(), foobarbaz, eo)
 		require.Nil(mt, err, "error encrypting seed for db.%s: %v", c.name, err)

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -115,7 +115,7 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -154,7 +154,7 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	baz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -193,7 +193,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	baz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -229,7 +229,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -265,7 +265,7 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 	bar := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bar")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -304,7 +304,7 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 	qux := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "qux")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("substringPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
@@ -341,7 +341,7 @@ func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 	baz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
-		SetAlgorithm("TextPreview").
+		SetAlgorithm("String").
 		SetQueryType("prefixPreview").
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
@@ -349,7 +349,7 @@ func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
 
 	_, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
-	require.ErrorContains(mt, err, "contention factor is required for textPreview algorithm")
+	require.ErrorContains(mt, err, "contention factor is required for string algorithm")
 }
 
 // runCSEProse27Case8 ensures that we can find an auto-encrypted case indexed

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -80,7 +80,7 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 	// minimums: server 8.2.0+ and libmongocrypt 1.18.1+. Subtests do not inherit
 	// the suite's version gates (mtest rebuilds baseOpts without them), so
 	// declare the requirement explicitly.
-	substringOpts := newQEOpts().MinServerVersion("8.2").MinLibmongocryptVersion("1.18.1")
+	substringOpts := newQEOpts().MinServerVersion("8.2").MinLibmongocryptVersion("1.18.1").MaxServerVersion("8.99.99")
 
 	mt.RunOpts("case 5: can find a document by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case5(mt, test)
@@ -104,10 +104,12 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 	mt.RunOpts("case 9: can find an auto-encrypted diacritic-insensitively indexed document by prefix and suffix", stableStringOpts, func(mt *mtest.T) {
 		runCSEProse27Case9(mt, test)
 	})
-	mt.RunOpts("case 10: can find an auto-encrypted case-insensitively indexed document by substring", substringOpts, func(mt *mtest.T) {
+
+	stableSubstringOpts := newQEOpts().MaxServerVersion("8.99.99").MinLibmongocryptVersion("1.19.0")
+	mt.RunOpts("case 10: can find an auto-encrypted case-insensitively indexed document by substring", stableSubstringOpts, func(mt *mtest.T) {
 		runCSEProse27Case10(mt, test)
 	})
-	mt.RunOpts("case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring", substringOpts, func(mt *mtest.T) {
+	mt.RunOpts("case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring", stableSubstringOpts, func(mt *mtest.T) {
 		runCSEProse27Case11(mt, test)
 	})
 }
@@ -373,8 +375,6 @@ func runCSEProse27Case7(mt *mtest.T, test *cseProse27Test) {
 // document by prefix and suffix.
 //
 // Requires server 9.0+ and libmongocrypt 1.19.0+.
-//
-// TODO(GODRIVER-3943): Add 1.19.0 min guards.
 func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -462,8 +462,6 @@ func runCSEProse27Case8(mt *mtest.T, test *cseProse27Test) {
 // diacritic-insensitively indexed document by prefix and suffix.
 //
 // Requires server 9.0+ and libmongocrypt 1.19.0+.
-//
-// TODO(GODRIVER-3943): Add 1.19.0 min guards.
 func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -553,8 +551,6 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 // case-insensitively indexed document by substring.
 //
 // Requires libmongocrypt 1.19.0+.
-//
-// TODO(GODRIVER-3943): Add 1.19.0 min guards.
 func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -610,8 +606,6 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 // diacritic-insensitively indexed document by substring.
 //
 // Requires libmongocrypt 1.19.0+.
-//
-// TODO(GODRIVER-3943): Add 1.19.0 min guards.
 func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -800,8 +794,9 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 		{"prefix-suffix-ci-di", cfg.encryptedFieldsPrefixSuffixCIDI, "9.0", ""},
 		// The preview prefix/suffix query types are used on pre-9.0 servers.
 		{"prefix-suffix-preview", cfg.encryptedFieldsPrefixSuffixPreview, "", "9.0"},
-		{"substring", cfg.encryptedFieldsSubstring, "", ""},
-		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, "", ""},
+
+		{"substring", cfg.encryptedFieldsSubstring, "", "8.99.99"},
+		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, "", "8.99.99"},
 	}
 	for _, c := range encryptedColls {
 		// Always drop to ensure a clean state from any previous run.

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -45,7 +45,7 @@ type cseProse27Test struct {
 const cseSpecDataDir = "../../testdata/specifications/source/client-side-encryption/etc/data"
 
 func TestClientSideEncryptionProse_27(t *testing.T) {
-	mt := newCSE_T(t, newQEOpts().MinServerVersion("8.2"))
+	mt := newCSE_T(t, newQEOpts().MinServerVersion("8.2").MinLibmongocryptVersion("1.18.1"))
 	mt.Setup()
 
 	test := setupCSEProse27(mt)
@@ -76,11 +76,9 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 		runCSEProse27Case4(mt, test)
 	})
 
-	// The substring cases (5, 6, 10, 11) require only the overall case 27
-	// minimums: server 8.2.0+ and libmongocrypt 1.18.1+. Subtests do not inherit
-	// the suite's version gates (mtest rebuilds baseOpts without them), so
-	// declare the requirement explicitly.
-	substringOpts := newQEOpts().MinServerVersion("8.2").MinLibmongocryptVersion("1.18.1").MaxServerVersion("8.99.99")
+	// The substring cases 5 and 6 require only the overall case 27
+	// minimums: server 8.2.0+ and libmongocrypt 1.18.1+.
+	substringOpts := newQEOpts().MaxServerVersion("8.99.99")
 
 	mt.RunOpts("case 5: can find a document by substring", substringOpts, func(mt *mtest.T) {
 		runCSEProse27Case5(mt, test)

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -26,11 +26,12 @@ import (
 )
 
 type cseProse27Config struct {
-	encryptedFieldsPrefixSuffix     bson.Raw
-	encryptedFieldsPrefixSuffixCIDI bson.Raw
-	encryptedFieldsSubstring        bson.Raw
-	encryptedFieldsSubstringCIDI    bson.Raw
-	key1Document                    bson.Raw
+	encryptedFieldsPrefixSuffix        bson.Raw
+	encryptedFieldsPrefixSuffixCIDI    bson.Raw
+	encryptedFieldsPrefixSuffixPreview bson.Raw
+	encryptedFieldsSubstring           bson.Raw
+	encryptedFieldsSubstringCIDI       bson.Raw
+	key1Document                       bson.Raw
 }
 
 type cseProse27Test struct {
@@ -49,30 +50,35 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 
 	test := setupCSEProse27(mt)
 
-	// TODO(GODRIVER-3863): Cases 1-7 exercise the preview QE text query types
-	// removed in libmongocrypt 1.19.0. They are migrated to this pattern but
-	// remain skipped (via prose27PreviewSkipReason) until updated to the stable
-	// names under DRIVERS-3321. The MaxServerVersion guards from the original
-	// tests are preserved.
+	// Cases 1-4 exercise prefix/suffix string queries and run against either:
+	//
+	//   - a 9.0+ server using the stable "prefix"/"suffix" query types and the
+	//     db.prefix-suffix collection (requires libmongocrypt 1.19.0+), or
+	//   - a pre-9.0 server using the "prefixPreview"/"suffixPreview" query types
+	//     and the db.prefix-suffix-preview collection (requires libmongocrypt
+	//     1.19.1+).
+	//
+	// These tests are gated on libmongocrypt 1.19.1 so that the preview path is
+	// valid wherever it runs; on a 9.0+ server this is stricter than the spec's
+	// 1.19.0 minimum for the stable path.
+	prefixSuffixOpts := newQEOpts().MinLibmongocryptVersion("1.19.1")
+
+	mt.RunOpts("case 1: can find a document by prefix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case1(mt, test)
+	})
+	mt.RunOpts("case 2: find a document by suffix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case2(mt, test)
+	})
+	mt.RunOpts("case 3: assert no document found by prefix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case3(mt, test)
+	})
+	mt.RunOpts("case 4: assert no document found by suffix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case4(mt, test)
+	})
+
 	const prose27PreviewSkipReason = "TODO(GODRIVER-3863): preview QE text query types removed in libmongocrypt 1.19.0; pending migration to stable names (DRIVERS-3321)"
 	placeholderOpts := mtest.NewOptions()
 
-	mt.RunOpts("case 1: can find a document by prefix", placeholderOpts, func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
-		runCSEProse27Case1(mt, test)
-	})
-	mt.RunOpts("case 2: find a document by suffix", placeholderOpts, func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
-		runCSEProse27Case2(mt, test)
-	})
-	mt.RunOpts("case 3: assert no document found by prefix", placeholderOpts, func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
-		runCSEProse27Case3(mt, test)
-	})
-	mt.RunOpts("case 4: assert no document found by suffix", placeholderOpts, func(mt *mtest.T) {
-		mt.Skip(prose27PreviewSkipReason)
-		runCSEProse27Case4(mt, test)
-	})
 	mt.Run("case 5: can find a document by substring", func(mt *mtest.T) {
 		mt.Skip(prose27PreviewSkipReason)
 		runCSEProse27Case5(mt, test)
@@ -116,12 +122,13 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+
+	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
 	require.Nil(mt, err, "error in Encrypt: %v", err)
@@ -130,7 +137,7 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	// db.prefix-suffix collection with the following filter:
 	//
 	// { $expr: { $encStrStartsWith: {input: '$encryptedText', prefix: <encrypted 'foo'>} } }
-	coll := test.explicitEncryptClient.Database("db").Collection("prefix-suffix")
+	coll := test.explicitEncryptClient.Database("db").Collection(prefixSuffixCollection())
 	res := coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrStartsWith", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -155,12 +162,13 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+
+	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
 	require.Nil(mt, err, "error in Encrypt: %v", err)
@@ -169,7 +177,7 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	// db.prefix-suffix collection with the following filter:
 	//
 	// { $expr: { $encStrEndsWith: {input: '$encryptedText', suffix: <encrypted 'baz'>} } }
-	coll := test.explicitEncryptClient.Database("db").Collection("prefix-suffix")
+	coll := test.explicitEncryptClient.Database("db").Collection(prefixSuffixCollection())
 	res := coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrEndsWith", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -194,12 +202,13 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("prefixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+
+	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
 	require.Nil(mt, err, "error in Encrypt: %v", err)
@@ -210,7 +219,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	// { $expr: { $encStrStartsWith: {input: '$encryptedText', prefix: <encrypted 'baz'>} } }
 	//
 	// Assert that no documents are returned.
-	coll := test.explicitEncryptClient.Database("db").Collection("prefix-suffix")
+	coll := test.explicitEncryptClient.Database("db").Collection(prefixSuffixCollection())
 	_, err = coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrStartsWith", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -230,12 +239,13 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("suffixPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+
+	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
 	require.Nil(mt, err, "error in Encrypt: %v", err)
@@ -246,7 +256,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	// { $expr: { $encStrEndsWith: {input: '$encryptedText', suffix: <encrypted 'foo'>} } }
 	//
 	// Assert that no documents are returned.
-	coll := test.explicitEncryptClient.Database("db").Collection("prefix-suffix")
+	coll := test.explicitEncryptClient.Database("db").Collection(prefixSuffixCollection())
 	_, err = coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrEndsWith", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -662,6 +672,42 @@ func insertEncryptedText(mt *mtest.T, client *mongo.Client, dbName, collName, te
 	require.Nil(mt, err, "error inserting document into %s.%s: %v", dbName, collName, err)
 }
 
+// prefixSuffixCollection returns the collection name that cases 1-4 query for
+// the current server version:
+//
+//   - prefix-suffix-preview for server versions < 9.0 (preview query types)
+//   - prefix-suffix for server versions >= 9.0 (stable query types)
+func prefixSuffixCollection() string {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
+		return "prefix-suffix-preview"
+	}
+	return "prefix-suffix"
+}
+
+// setPrefixQueryTypeForVersion returns an EncryptOptionsBuilder with the query
+// type set to:
+//
+//   - prefixPreview for server versions < 9.0
+//   - prefix for server versions >= 9.0
+func setPrefixQueryTypeForVersion(opts *options.EncryptOptionsBuilder) *options.EncryptOptionsBuilder {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
+		return opts.SetQueryType("prefixPreview")
+	}
+	return opts.SetQueryType("prefix")
+}
+
+// setSuffixQueryTypeForVersion returns an EncryptOptionsBuilder with the query
+// type set to:
+//
+//   - suffixPreview for server versions < 9.0
+//   - suffix for server versions >= 9.0
+func setSuffixQueryTypeForVersion(opts *options.EncryptOptionsBuilder) *options.EncryptOptionsBuilder {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
+		return opts.SetQueryType("suffixPreview")
+	}
+	return opts.SetQueryType("suffix")
+}
+
 // =============================================================================
 // Setup
 // =============================================================================
@@ -687,6 +733,7 @@ func loadCSEProse27Config() (cseProse27Config, error) {
 	}{
 		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix.json"), &cfg.encryptedFieldsPrefixSuffix},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix-ci-di.json"), &cfg.encryptedFieldsPrefixSuffixCIDI},
+		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix-preview.json"), &cfg.encryptedFieldsPrefixSuffixPreview},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-substring.json"), &cfg.encryptedFieldsSubstring},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-substring-ci-di.json"), &cfg.encryptedFieldsSubstringCIDI},
 		{filepath.Join(cseSpecDataDir, "keys", "key1-document.json"), &cfg.key1Document},
@@ -715,15 +762,22 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 	// test collections with majority write concern.
 	db := mt.Client.Database("db")
 	encryptedColls := []struct {
-		name         string
-		fields       bson.Raw
+		name   string
+		fields bson.Raw
+		// minServerVer, if set, only creates the collection when the server
+		// version is >= minServerVer.
 		minServerVer string
+		// maxServerVer, if set, only creates the collection when the server
+		// version is < maxServerVer.
+		maxServerVer string
 	}{
-		// prefix and suffix query types require server 9.0+.
-		{"prefix-suffix", cfg.encryptedFieldsPrefixSuffix, "9.0"},
-		{"prefix-suffix-ci-di", cfg.encryptedFieldsPrefixSuffixCIDI, "9.0"},
-		{"substring", cfg.encryptedFieldsSubstring, ""},
-		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, ""},
+		// The stable prefix and suffix query types require server 9.0+.
+		{"prefix-suffix", cfg.encryptedFieldsPrefixSuffix, "9.0", ""},
+		{"prefix-suffix-ci-di", cfg.encryptedFieldsPrefixSuffixCIDI, "9.0", ""},
+		// The preview prefix/suffix query types are used on pre-9.0 servers.
+		{"prefix-suffix-preview", cfg.encryptedFieldsPrefixSuffixPreview, "", "9.0"},
+		{"substring", cfg.encryptedFieldsSubstring, "", ""},
+		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, "", ""},
 	}
 	for _, c := range encryptedColls {
 		// Always drop to ensure a clean state from any previous run.
@@ -731,6 +785,11 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 
 		// Skip creating collections that require a higher server version.
 		if c.minServerVer != "" && mtest.CompareServerVersions(mtest.ServerVersion(), c.minServerVer) < 0 {
+			continue
+		}
+
+		// Skip creating collections that require a lower (pre-release) server version.
+		if c.maxServerVer != "" && mtest.CompareServerVersions(mtest.ServerVersion(), c.maxServerVer) >= 0 {
 			continue
 		}
 
@@ -837,12 +896,12 @@ func setupCSEProse27(mt *mtest.T) *cseProse27Test {
 	require.Nil(mt, err, "failed to set up CSE prose 27: %v", err)
 
 	// Seed the encrypted "foobarbaz" document queried by cases 1-6, inserted
-	// once via the auto-encrypting client. The prefix-suffix collection only
-	// exists on server 9.0+.
+	// once via the auto-encrypting client. The prefix/suffix document goes into
+	// whichever collection exists for this server version: db.prefix-suffix on
+	// 9.0+ (stable query types) or db.prefix-suffix-preview on pre-9.0 (preview
+	// query types).
 	insertEncryptedText(mt, test.autoEncryptClient, "db", "substring", "foobarbaz")
-	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0.0") >= 0 {
-		insertEncryptedText(mt, test.autoEncryptClient, "db", "prefix-suffix", "foobarbaz")
-	}
+	insertEncryptedText(mt, test.autoEncryptClient, "db", prefixSuffixCollection(), "foobarbaz")
 
 	return test
 }

--- a/internal/require/require.go
+++ b/internal/require/require.go
@@ -855,3 +855,15 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	}
 	t.FailNow()
 }
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -245,29 +245,29 @@ func transformExplicitEncryptionOptions(opts ...options.Lister[options.EncryptOp
 		}
 		transformed.RangeOptions = &transformedRange
 	}
-	if args.TextOptions != nil {
-		textArgs, err := mongoutil.NewOptions[options.TextOptions](args.TextOptions)
+	if args.StringOptions != nil {
+		stringArgs, err := mongoutil.NewOptions[options.StringOptions](args.StringOptions)
 		if err != nil {
 			return nil, err
 		}
 
-		transformedText := mcopts.ExplicitTextOptions{
-			CaseSensitive:      textArgs.CaseSensitive,
-			DiacriticSensitive: textArgs.DiacriticSensitive,
+		transformedString := mcopts.ExplicitStringOptions{
+			CaseSensitive:      stringArgs.CaseSensitive,
+			DiacriticSensitive: stringArgs.DiacriticSensitive,
 		}
-		if textArgs.Substring != nil {
-			substringOpts := mcopts.SubstringOptions(*textArgs.Substring)
-			transformedText.Substring = &substringOpts
+		if stringArgs.Substring != nil {
+			substringOpts := mcopts.SubstringOptions(*stringArgs.Substring)
+			transformedString.Substring = &substringOpts
 		}
-		if textArgs.Prefix != nil {
-			prefixOpts := mcopts.PrefixOptions(*textArgs.Prefix)
-			transformedText.Prefix = &prefixOpts
+		if stringArgs.Prefix != nil {
+			prefixOpts := mcopts.PrefixOptions(*stringArgs.Prefix)
+			transformedString.Prefix = &prefixOpts
 		}
-		if textArgs.Suffix != nil {
-			suffixOpts := mcopts.SuffixOptions(*textArgs.Suffix)
-			transformedText.Suffix = &suffixOpts
+		if stringArgs.Suffix != nil {
+			suffixOpts := mcopts.SuffixOptions(*stringArgs.Suffix)
+			transformedString.Suffix = &suffixOpts
 		}
-		transformed.SetTextOptions(transformedText)
+		transformed.SetStringOptions(transformedString)
 	}
 	return transformed, nil
 }

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -99,14 +99,18 @@ func (ro *RangeOptionsBuilder) SetPrecision(precision int32) *RangeOptionsBuilde
 	return ro
 }
 
-// TextOptions specifies index options for a Queryable Encryption field supporting "text" queries.
+// StringOptions specifies index options for a Queryable Encryption field
+// supporting prefix, suffix, and substring queries.
 //
 // See corresponding setter methods for documentation.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-type TextOptions struct {
-	Substring          *SubstringOptions
+type StringOptions struct {
+	// Substring specifies options to support substring queries.
+	//
+	// Beta: This is a preview feature and should only be used for experimental
+	// workloads. It is not intended for public use. It is subject to breaking
+	// changes.
+	Substring *SubstringOptions
+
 	Prefix             *PrefixOptions
 	Suffix             *SuffixOptions
 	CaseSensitive      bool
@@ -115,8 +119,9 @@ type TextOptions struct {
 
 // SubstringOptions specifies options to support substring queries.
 //
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
+// Beta: This is a preview feature and should only be used for experimental
+// workloads. It is not intended for public use. It is subject to breaking
+// changes.
 type SubstringOptions struct {
 	StrMaxLength      int32
 	StrMinQueryLength int32
@@ -124,114 +129,91 @@ type SubstringOptions struct {
 }
 
 // PrefixOptions specifies options to support prefix queries.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
 type PrefixOptions struct {
 	StrMinQueryLength int32
 	StrMaxQueryLength int32
 }
 
 // SuffixOptions specifies options to support suffix queries.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
 type SuffixOptions struct {
 	StrMinQueryLength int32
 	StrMaxQueryLength int32
 }
 
-// TextOptionsBuilder contains options to configure TextOptions for queryable
-// encryption. Each option can be set through setter functions. See
+// StringOptionsBuilder contains options to configure StringOptions for
+// queryable encryption. Each option can be set through setter functions. See
 // documentation for each setter function for an explanation of the option.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-type TextOptionsBuilder struct {
-	Opts []func(*TextOptions) error
+type StringOptionsBuilder struct {
+	Opts []func(*StringOptions) error
 }
 
-// Text creates a new TextOptions instance.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func Text() *TextOptionsBuilder {
-	return &TextOptionsBuilder{}
+// String creates a new StringOptions instance.
+func String() *StringOptionsBuilder {
+	return &StringOptionsBuilder{}
 }
 
-// List returns a list of TextOptions setter functions.
-func (to *TextOptionsBuilder) List() []func(*TextOptions) error {
-	return to.Opts
+// List returns a list of StringOptions setter functions.
+func (so *StringOptionsBuilder) List() []func(*StringOptions) error {
+	return so.Opts
 }
 
-// SetSubstring sets the text index substring value.
+// SetSubstring sets the string index substring value.
 //
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (to *TextOptionsBuilder) SetSubstring(substring SubstringOptions) *TextOptionsBuilder {
-	to.Opts = append(to.Opts, func(opts *TextOptions) error {
+// Beta: This is a preview feature and should only be used for experimental
+// workloads. It is not intended for public use. It is subject to breaking
+// changes.
+func (so *StringOptionsBuilder) SetSubstring(substring SubstringOptions) *StringOptionsBuilder {
+	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.Substring = &substring
 
 		return nil
 	})
 
-	return to
+	return so
 }
 
-// SetPrefix sets the text index prefix value.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (to *TextOptionsBuilder) SetPrefix(prefix PrefixOptions) *TextOptionsBuilder {
-	to.Opts = append(to.Opts, func(opts *TextOptions) error {
+// SetPrefix sets the string index prefix value.
+func (so *StringOptionsBuilder) SetPrefix(prefix PrefixOptions) *StringOptionsBuilder {
+	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.Prefix = &prefix
 
 		return nil
 	})
 
-	return to
+	return so
 }
 
-// SetSuffix sets the text index suffix value.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (to *TextOptionsBuilder) SetSuffix(suffix SuffixOptions) *TextOptionsBuilder {
-	to.Opts = append(to.Opts, func(opts *TextOptions) error {
+// SetSuffix sets the string index suffix value.
+func (so *StringOptionsBuilder) SetSuffix(suffix SuffixOptions) *StringOptionsBuilder {
+	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.Suffix = &suffix
 
 		return nil
 	})
 
-	return to
+	return so
 }
 
-// SetCaseSensitive sets the text index caseSensitive value.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (to *TextOptionsBuilder) SetCaseSensitive(caseSensitive bool) *TextOptionsBuilder {
-	to.Opts = append(to.Opts, func(opts *TextOptions) error {
+// SetCaseSensitive sets the string index caseSensitive value.
+func (so *StringOptionsBuilder) SetCaseSensitive(caseSensitive bool) *StringOptionsBuilder {
+	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.CaseSensitive = caseSensitive
 
 		return nil
 	})
 
-	return to
+	return so
 }
 
-// SetDiacriticSensitive sets the text index diacriticSensitive value.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (to *TextOptionsBuilder) SetDiacriticSensitive(diacriticSensitive bool) *TextOptionsBuilder {
-	to.Opts = append(to.Opts, func(opts *TextOptions) error {
+// SetDiacriticSensitive sets the string index diacriticSensitive value.
+func (so *StringOptionsBuilder) SetDiacriticSensitive(diacriticSensitive bool) *StringOptionsBuilder {
+	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.DiacriticSensitive = diacriticSensitive
 
 		return nil
 	})
 
-	return to
+	return so
 }
 
 // EncryptOptions represents arguments to explicitly encrypt a value.
@@ -244,7 +226,7 @@ type EncryptOptions struct {
 	QueryType        string
 	ContentionFactor *int64
 	RangeOptions     *RangeOptionsBuilder
-	TextOptions      *TextOptionsBuilder
+	StringOptions    *StringOptionsBuilder
 }
 
 // EncryptOptionsBuilder contains options to configure Encryptopts for
@@ -285,14 +267,19 @@ func (e *EncryptOptionsBuilder) SetKeyAltName(keyAltName string) *EncryptOptions
 	return e
 }
 
-// SetAlgorithm specifies an algorithm to use for encryption. This should be one of the following:
-// - AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic
-// - AEAD_AES_256_CBC_HMAC_SHA_512-Random
-// - Indexed
-// - Unindexed
-// - Range
+// SetAlgorithm specifies an algorithm to use for encryption. This should be one
+// of the following:
+//
+//   - AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic
+//   - AEAD_AES_256_CBC_HMAC_SHA_512-Random
+//   - Indexed
+//   - Unindexed
+//   - Range
+//   - String
+//
 // This is required.
-// Indexed and Unindexed are used for Queryable Encryption.
+//
+// Indexed, Range, and String are used for Queryable Encryption.
 func (e *EncryptOptionsBuilder) SetAlgorithm(algorithm string) *EncryptOptionsBuilder {
 	e.Opts = append(e.Opts, func(opts *EncryptOptions) error {
 		opts.Algorithm = algorithm
@@ -303,10 +290,21 @@ func (e *EncryptOptionsBuilder) SetAlgorithm(algorithm string) *EncryptOptionsBu
 	return e
 }
 
-// SetQueryType specifies the intended query type. It is only valid to set if algorithm is "Indexed".
-// This should be one of the following:
-// - equality
+// SetQueryType specifies the intended query type. It is only valid to set when
+// algorithm is "Indexed", "Range", or "String". This should be one of the
+// following:
+//
+//   - equality
+//   - range
+//   - prefix / prefixPreview (used for the $encStrStartsWith operator)
+//   - suffix / suffixPreview (used for the $encStrEndsWith operator)
+//   - substringPreview (used for the $encStrContains operator)
+//
 // QueryType is used for Queryable Encryption.
+//
+// Beta: "prefixPreview", "suffixPreview", and "substringPreview" are preview
+// features and should only be used for experimental workloads. They are not
+// intended for public use and are subject to breaking changes.
 func (e *EncryptOptionsBuilder) SetQueryType(queryType string) *EncryptOptionsBuilder {
 	e.Opts = append(e.Opts, func(opts *EncryptOptions) error {
 		opts.QueryType = queryType
@@ -340,13 +338,10 @@ func (e *EncryptOptionsBuilder) SetRangeOptions(ro *RangeOptionsBuilder) *Encryp
 	return e
 }
 
-// SetTextOptions specifies the options to use for text queries.
-//
-// Beta: This is a preview feature and should only be used for experimental workloads.
-// It is not intended for public use. It is subject to breaking changes.
-func (e *EncryptOptionsBuilder) SetTextOptions(to *TextOptionsBuilder) *EncryptOptionsBuilder {
+// SetStringOptions specifies the options to use for string queries.
+func (e *EncryptOptionsBuilder) SetStringOptions(so *StringOptionsBuilder) *EncryptOptionsBuilder {
 	e.Opts = append(e.Opts, func(opts *EncryptOptions) error {
-		opts.TextOptions = to
+		opts.StringOptions = so
 
 		return nil
 	})

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -349,14 +349,14 @@ func (m *MongoCrypt) createExplicitEncryptionContext(opts *options.ExplicitEncry
 
 		mongocryptDoc, err := bsoncore.AppendDocumentEnd(mongocryptDoc, idx)
 		if err != nil {
-			return nil, fmt.Errorf("error building text options doc: %w", err)
+			return nil, fmt.Errorf("error building string options doc: %w", err)
 		}
 
 		mongocryptBinary := newBinaryFromBytes(mongocryptDoc)
 		defer mongocryptBinary.close()
 
 		if ok := C.mongocrypt_ctx_setopt_algorithm_text(ctx.wrapped, mongocryptBinary.wrapped); !ok {
-			return nil, fmt.Errorf("error setting text algorithm option: %w", ctx.createErrorFromStatus())
+			return nil, fmt.Errorf("error setting string algorithm option: %w", ctx.createErrorFromStatus())
 		}
 	}
 

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -311,41 +311,41 @@ func (m *MongoCrypt) createExplicitEncryptionContext(opts *options.ExplicitEncry
 		}
 	}
 
-	if opts.TextOptions != nil {
+	if opts.StringOptions != nil {
 		idx, mongocryptDoc := bsoncore.AppendDocumentStart(nil)
-		if opts.TextOptions.Substring != nil {
+		if opts.StringOptions.Substring != nil {
 			substringIdx, substringDoc := bsoncore.AppendDocumentStart(nil)
-			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMaxLength", opts.TextOptions.Substring.StrMaxLength)
-			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMinQueryLength", opts.TextOptions.Substring.StrMinQueryLength)
-			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMaxQueryLength", opts.TextOptions.Substring.StrMaxQueryLength)
+			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMaxLength", opts.StringOptions.Substring.StrMaxLength)
+			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMinQueryLength", opts.StringOptions.Substring.StrMinQueryLength)
+			substringDoc = bsoncore.AppendInt32Element(substringDoc, "strMaxQueryLength", opts.StringOptions.Substring.StrMaxQueryLength)
 			substringDoc, err := bsoncore.AppendDocumentEnd(substringDoc, substringIdx)
 			if err != nil {
 				return nil, fmt.Errorf("error building substring doc: %w", err)
 			}
 			mongocryptDoc = bsoncore.AppendDocumentElement(mongocryptDoc, "substring", substringDoc)
 		}
-		if opts.TextOptions.Prefix != nil {
+		if opts.StringOptions.Prefix != nil {
 			prefixIdx, prefixDoc := bsoncore.AppendDocumentStart(nil)
-			prefixDoc = bsoncore.AppendInt32Element(prefixDoc, "strMinQueryLength", opts.TextOptions.Prefix.StrMinQueryLength)
-			prefixDoc = bsoncore.AppendInt32Element(prefixDoc, "strMaxQueryLength", opts.TextOptions.Prefix.StrMaxQueryLength)
+			prefixDoc = bsoncore.AppendInt32Element(prefixDoc, "strMinQueryLength", opts.StringOptions.Prefix.StrMinQueryLength)
+			prefixDoc = bsoncore.AppendInt32Element(prefixDoc, "strMaxQueryLength", opts.StringOptions.Prefix.StrMaxQueryLength)
 			prefixDoc, err := bsoncore.AppendDocumentEnd(prefixDoc, prefixIdx)
 			if err != nil {
 				return nil, fmt.Errorf("error building prefix doc: %w", err)
 			}
 			mongocryptDoc = bsoncore.AppendDocumentElement(mongocryptDoc, "prefix", prefixDoc)
 		}
-		if opts.TextOptions.Suffix != nil {
+		if opts.StringOptions.Suffix != nil {
 			suffixIdx, suffixDoc := bsoncore.AppendDocumentStart(nil)
-			suffixDoc = bsoncore.AppendInt32Element(suffixDoc, "strMinQueryLength", opts.TextOptions.Suffix.StrMinQueryLength)
-			suffixDoc = bsoncore.AppendInt32Element(suffixDoc, "strMaxQueryLength", opts.TextOptions.Suffix.StrMaxQueryLength)
+			suffixDoc = bsoncore.AppendInt32Element(suffixDoc, "strMinQueryLength", opts.StringOptions.Suffix.StrMinQueryLength)
+			suffixDoc = bsoncore.AppendInt32Element(suffixDoc, "strMaxQueryLength", opts.StringOptions.Suffix.StrMaxQueryLength)
 			suffixDoc, err := bsoncore.AppendDocumentEnd(suffixDoc, suffixIdx)
 			if err != nil {
 				return nil, fmt.Errorf("error building suffix doc: %w", err)
 			}
 			mongocryptDoc = bsoncore.AppendDocumentElement(mongocryptDoc, "suffix", suffixDoc)
 		}
-		mongocryptDoc = bsoncore.AppendBooleanElement(mongocryptDoc, "caseSensitive", opts.TextOptions.CaseSensitive)
-		mongocryptDoc = bsoncore.AppendBooleanElement(mongocryptDoc, "diacriticSensitive", opts.TextOptions.DiacriticSensitive)
+		mongocryptDoc = bsoncore.AppendBooleanElement(mongocryptDoc, "caseSensitive", opts.StringOptions.CaseSensitive)
+		mongocryptDoc = bsoncore.AppendBooleanElement(mongocryptDoc, "diacriticSensitive", opts.StringOptions.DiacriticSensitive)
 
 		mongocryptDoc, err := bsoncore.AppendDocumentEnd(mongocryptDoc, idx)
 		if err != nil {

--- a/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
+++ b/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
@@ -34,7 +34,7 @@ type ExplicitEncryptionOptions struct {
 	QueryType        string
 	ContentionFactor *int64
 	RangeOptions     *ExplicitRangeOptions
-	TextOptions      *ExplicitTextOptions
+	StringOptions    *ExplicitStringOptions
 }
 
 // ExplicitRangeOptions specifies options for the range index.
@@ -46,8 +46,8 @@ type ExplicitRangeOptions struct {
 	Precision  *int32
 }
 
-// ExplicitTextOptions specifies options for the text query.
-type ExplicitTextOptions struct {
+// ExplicitStringOptions specifies options for the string query.
+type ExplicitStringOptions struct {
 	Substring          *SubstringOptions
 	Prefix             *PrefixOptions
 	Suffix             *SuffixOptions
@@ -115,9 +115,9 @@ func (eeo *ExplicitEncryptionOptions) SetRangeOptions(ro ExplicitRangeOptions) *
 	return eeo
 }
 
-// SetTextOptions specifies the text options.
-func (eeo *ExplicitEncryptionOptions) SetTextOptions(to ExplicitTextOptions) *ExplicitEncryptionOptions {
-	eeo.TextOptions = &to
+// SetStringOptions specifies the string options.
+func (eeo *ExplicitEncryptionOptions) SetStringOptions(to ExplicitStringOptions) *ExplicitEncryptionOptions {
+	eeo.StringOptions = &to
 	return eeo
 }
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3863

## Breaking Changes

The changes here break previously-Beta QE APIs and are acceptable tin a minor release (2.8.0) since those APIs were documented as unstable and subject to backwards-breaking changes.

### `mongo/options` (semver-covered):

- Renamed `TextOptions` to `StringOptions` and `TextOptionsBuilder` to `StringOptionsBuilder`
- Renamed constructor `Text()` to `String()`
- Renamed `EncryptOptions.TextOptions` field to `StringOptions`
- Renamed `EncryptOptionsBuilder.SetTextOptions()` to `SetStringOptions()` which now takes `*StringOptionsBuilder`
- All `StringOptionsBuilder` setters / `List()` now operate on `*StringOptionsBuilder`

### Behavioral 

- Encryption algorithm value "TextPreview" was renamed to "String"

### `x/mongo/driver/mongocrypt/options` (not semver-covered, flagged per policy)

- `ExplicitTextOptions` renamed to `ExplicitStringOptions`; `ExplicitEncryptionOptions.TextOptions` field and `SetTextOptions()` renamed to `String`-prefixed equivalents.

### Promoted from Beta to GA (non-breaking)

`prefix`/`suffix` query types and `PrefixOptions`/`SuffixOptions`. `substring`/`*Preview` query types remain Beta.

## Background & Motivation

Queryable Encryption's prefix and suffix string-query support is graduating from experimental preview to GA (per upstream DRIVERS-3321), so the river renames the unstable `Text*` API to `String*` and the `"TextPreview"` algorithm to `"String"` to align with the finalized, stable naming. 
