### PR TITLE
GODRIVER-3961 Update explicit encryption prose test 12 with contention factor.

### DIFF
--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1632,6 +1632,7 @@ func TestClientSideEncryptionProse_12_explicit_encryption(t *testing.T) {
 
 	// Test Setup ... begin
 	encryptedFields := readJSONFile(mt, "encrypted-fields.json")
+	encryptedFieldsC10 := readJSONFile(mt, "encryptedFields-c10.json")
 	key1Document := readJSONFile(mt, "key1-document.json")
 	var key1ID bson.Binary
 	{
@@ -1641,9 +1642,19 @@ func TestClientSideEncryptionProse_12_explicit_encryption(t *testing.T) {
 
 	testSetup := func() (*mongo.Client, *mongo.ClientEncryption) {
 		mtest.DropEncryptedCollection(mt, mt.Client.Database("db").Collection("explicit_encryption"), encryptedFields)
-		cco := options.CreateCollection().SetEncryptedFields(encryptedFields)
-		err := mt.Client.Database("db").CreateCollection(context.Background(), "explicit_encryption", cco)
+		err := mt.Client.Database("db").CreateCollection(
+			context.Background(),
+			"explicit_encryption",
+			options.CreateCollection().SetEncryptedFields(encryptedFields))
 		assert.Nil(mt, err, "error on CreateCollection: %v", err)
+
+		mtest.DropEncryptedCollection(mt, mt.Client.Database("db").Collection("explicit_encryption_c10"), encryptedFieldsC10)
+		err = mt.Client.Database("db").CreateCollection(
+			context.Background(),
+			"explicit_encryption_c10",
+			options.CreateCollection().SetEncryptedFields(encryptedFieldsC10))
+		assert.Nil(mt, err, "error on CreateCollection: %v", err)
+
 		err = mt.Client.Database("keyvault").Collection("datakeys").Drop(context.Background())
 		assert.Nil(mt, err, "error on Drop: %v", err)
 		opts := options.Client().ApplyURI(mtest.ClusterURI())
@@ -1702,15 +1713,6 @@ func TestClientSideEncryptionProse_12_explicit_encryption(t *testing.T) {
 		assert.Equal(mt, gotValue.StringValue(), valueToEncrypt, "expected %q, got %q", valueToEncrypt, gotValue.StringValue())
 	})
 	mt.Run("case 2: can insert encrypted indexed and find with non-zero contention", func(mt *mtest.T) {
-		// TODO(GODRIVER-3961): The latest server (SERVER-91887) enforces that the
-		// explicit-encryption contentionFactor must match the collection's
-		// configured contention. This test inserts with contentionFactor 10 but
-		// the collection is configured with contention 0, and finds with both
-		// contentionFactor 0 and 10, which is unsatisfiable under the new
-		// enforcement. Skip until the prose test and encrypted-fields contention
-		// config are synced with the DRIVERS-3547 spec update.
-		mt.Skip("skipping pending GODRIVER-3961: QE contention enforcement (SERVER-91887)")
-
 		encryptedClient, clientEncryption := testSetup()
 		defer clientEncryption.Close(context.Background())
 		defer encryptedClient.Disconnect(context.Background())

--- a/internal/integration/client_side_encryption_prose_test.go
+++ b/internal/integration/client_side_encryption_prose_test.go
@@ -1717,7 +1717,7 @@ func TestClientSideEncryptionProse_12_explicit_encryption(t *testing.T) {
 		defer clientEncryption.Close(context.Background())
 		defer encryptedClient.Disconnect(context.Background())
 
-		coll := encryptedClient.Database("db").Collection("explicit_encryption")
+		coll := encryptedClient.Database("db").Collection("explicit_encryption_c10")
 		valueToEncrypt := "encrypted indexed value"
 		rawVal := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, valueToEncrypt)}
 

--- a/testdata/client-side-encryption-prose/encryptedFields-c10.json
+++ b/testdata/client-side-encryption-prose/encryptedFields-c10.json
@@ -1,0 +1,30 @@
+{
+  "fields": [
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedIndexed",
+      "bsonType": "string",
+      "queries": {
+        "queryType": "equality",
+        "contention": {
+          "$numberLong": "10"
+        }
+      }
+    },
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "q83vqxI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedUnindexed",
+      "bsonType": "string"
+    }
+  ]
+}


### PR DESCRIPTION
[GODRIVER-3961](https://jira.mongodb.org/browse/GODRIVER-3961)

## Summary

* Update explicit [encryption prose test 12 case 2](https://github.com/mongodb/mongo-go-driver/blob/60fc66d150ad8dd3f83240efe3519ee546e52256/internal/integration/client_side_encryption_prose_test.go#L1704) to use the new encrypted fields config with specified contention factor `encryptedFields-c10.json`
* Unskip the updated test case.

## Background & Motivation

The latest MongoDB server version requires the collection contention factor and query contention factor to match.
