### PR TITLE
GODRIVER-4006: Skip markdown-link-check in precommit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
+        env:
+          SKIP: markdown-lint-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,3 @@ jobs:
         with:
           go-version: "stable"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
-        env:
-          SKIP: markdown-lint-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,12 @@ repos:
     hooks:
       - id: markdown-link-check
         exclude: ^(vendor)
-        # If the endpoint returns HTTP 429 (Too Many Requests), consider it a
-        # successful check.
-        args: ["-a 200,206,429"]
+        # Override the entrypoint to catch failures and exit with 0
+        entry: bash -c 'markdown-link-check "$@" || true' --
+        # Split args into separate string elements
+        args: ["-a", "200,206,429"]
+        # TODO(GODRIVER-4005): Print the output even when the hook technically passes
+        verbose: true
   - repo: local
     hooks:
       - id: executable-shell


### PR DESCRIPTION
GODRIVER-4006

https://goreportcard.com is down and this is blocking from merging due to dead link pre-commit check. We should skip until we find a better solution.