### PR TITLE
GODRIVER-3995: Add IWM 9.0+ comments

### DIFF
--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -971,7 +971,7 @@ func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 // server side overload error. MaxAdaptiveRetries can also be set through the "maxAdaptiveRetries" URI option
 // (e.g. "maxAdaptiveRetries=5").
 //
-// This option works with MongoDB Server Version 9.0 and above.
+// This option works with mongodb atlas server version 9.0 and above.
 func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 	c.MaxAdaptiveRetries = &n
 
@@ -982,7 +982,7 @@ func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 // with a server side overload error. EnableOverloadRetargeting can also be set through the "enableOverloadRetargeting"
 // URI option (e.g. "enableOverloadRetargeting=true").
 //
-// This option works with MongoDB Atlas Server Version 9.0 and above.
+// This option works with mongodb atlas server version 9.0 and above.
 func (c *ClientOptions) SetEnableOverloadRetargeting(b bool) *ClientOptions {
 	c.EnableOverloadRetargeting = &b
 

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -982,7 +982,7 @@ func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 // with a server side overload error. EnableOverloadRetargeting can also be set through the "enableOverloadRetargeting"
 // URI option (e.g. "enableOverloadRetargeting=true").
 //
-// This option works with MongoDB Server Version 9.0 and above.
+// This option works with MongoDB Atlas Server Version 9.0 and above.
 func (c *ClientOptions) SetEnableOverloadRetargeting(b bool) *ClientOptions {
 	c.EnableOverloadRetargeting = &b
 

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -971,7 +971,7 @@ func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 // server side overload error. MaxAdaptiveRetries can also be set through the "maxAdaptiveRetries" URI option
 // (e.g. "maxAdaptiveRetries=5").
 //
-// This option works with mongodb atlas server version 9.0 and above.
+// This option works with MongoDB Atlas Server Version 9.0 and above.
 func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 	c.MaxAdaptiveRetries = &n
 
@@ -982,7 +982,7 @@ func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 // with a server side overload error. EnableOverloadRetargeting can also be set through the "enableOverloadRetargeting"
 // URI option (e.g. "enableOverloadRetargeting=true").
 //
-// This option works with mongodb atlas server version 9.0 and above.
+// This option works with MongoDB Atlas Server Version 9.0 and above.
 func (c *ClientOptions) SetEnableOverloadRetargeting(b bool) *ClientOptions {
 	c.EnableOverloadRetargeting = &b
 

--- a/mongo/options/clientoptions.go
+++ b/mongo/options/clientoptions.go
@@ -970,6 +970,8 @@ func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
 // SetMaxAdaptiveRetries specifies the maximum number of times the driver should retry operations that fail with a
 // server side overload error. MaxAdaptiveRetries can also be set through the "maxAdaptiveRetries" URI option
 // (e.g. "maxAdaptiveRetries=5").
+//
+// This option works with MongoDB Server Version 9.0 and above.
 func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 	c.MaxAdaptiveRetries = &n
 
@@ -979,6 +981,8 @@ func (c *ClientOptions) SetMaxAdaptiveRetries(n uint) *ClientOptions {
 // SetEnableOverloadRetargeting specifies whether the driver should enable overload retargeting for operations that fail
 // with a server side overload error. EnableOverloadRetargeting can also be set through the "enableOverloadRetargeting"
 // URI option (e.g. "enableOverloadRetargeting=true").
+//
+// This option works with MongoDB Server Version 9.0 and above.
 func (c *ClientOptions) SetEnableOverloadRetargeting(b bool) *ClientOptions {
 	c.EnableOverloadRetargeting = &b
 


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-3995

## Summary

Add inline doc note: "This option works with MongoDB Atlas Server Version 9.0 and above."

## Background & Motivation

Drivers shipped client-side overload handling in support of MongoDB IWM in the most recent driver releases (see release notes for each driver). The release notes recommended upgrade and introduced new public API surface.

A revised implementation is planned for a future driver release. The revised implementation may change the URI options, error types, and/or retry semantics shipped in the initial release.


