### PR TITLE
GODRIVER-4017 Skip withTransaction transaction-options tests.

### DIFF
--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -886,6 +886,15 @@ var skipTests = map[string][]skipCase{
 				"TestUnifiedSpec/transactions-convenient-api/tests/unified/commit.json/withTransaction_commits_after_callback_returns_(second_transaction)",
 			},
 		},
+		{
+			tests: []string{
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_and_no_transaction_options_set",
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_inherits_transaction_options_from_client",
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_inherits_transaction_options_from_defaultTransactionOptions",
+				"TestUnifiedSpec/transactions/tests/unified/client-bulkWrite.json/client_bulkWrite_in_a_transaction",
+			},
+			topologies: []string{"load-balanced"},
+		},
 	},
 
 	"Address CSOT Compliance Issue in Timeout Handling for Cursor Constructors (GODRIVER-3480)": {


### PR DESCRIPTION
GODRIVER-4017

## Summary
Skip the flaky unified test before implementing GODRIVER-3137.

## Background & Motivation
Failure: https://spruce.corp.mongodb.com/task/mongo_go_driver_load_balancer_test__version~6.0_os_ssl_40~rhel87_64_test_load_balancer_noauth_nossl_patch_0e7f82e4071acd4e59abdcafc7a5182cca4414a2_6a4e5958237cfe0007352602_26_07_08_14_06_21/tests?execution=1&sorts=STATUS%3AASC
