### PR TITLE
GODRIVER-4002: Add substring to QE GA

### DIFF
--- a/etc/install-libmongocrypt.sh
+++ b/etc/install-libmongocrypt.sh
@@ -3,7 +3,7 @@
 # This script installs libmongocrypt into an "install" directory.
 set -eux
 
-LIBMONGOCRYPT_TAG="1.19.1"
+LIBMONGOCRYPT_TAG="1.20.0"
 
 # Install libmongocrypt based on OS.
 if [ "Windows_NT" = "${OS:-}" ]; then

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -575,7 +575,7 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 
 	// Step 2. Use clientEncryption.encrypt() to encrypt "bar" with substring
 	// query type. Substring search is still a preview feature, so the query type
-	// remains "substringPreview" even on libmongocrypt 1.19.0+.
+	// remains "substring" even on libmongocrypt 1.19.0+.
 	encryptOpts := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
@@ -616,8 +616,6 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 
 // runCSEProse27Case11 ensures that we can find an auto-encrypted
 // diacritic-insensitively indexed document by substring.
-//
-// Requires libmongocrypt 1.19.0+.
 func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -630,7 +628,7 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 
 	// Step 2. Use clientEncryption.encrypt() to encrypt "cafe" with substring query
 	// type. Substring search is still a preview feature, so the query type remains
-	// "substringPreview" even on libmongocrypt 1.19.0+.
+	// "substring" even on libmongocrypt 1.19.0+.
 	encryptOpts := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -62,19 +62,33 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 	// These tests are gated on libmongocrypt 1.19.1 so that the preview path is
 	// valid wherever it runs; on a 9.0+ server this is stricter than the spec's
 	// 1.19.0 minimum for the stable path.
-	prefixSuffixOpts := newQEOpts().MinLibmongocryptVersion("1.19.1")
+	prefixSuffixPreviewOpts := newQEOpts().MinServerVersion("8.2").MaxServerVersion("8.99.99").MinLibmongocryptVersion("1.19.1")
 
-	mt.RunOpts("case 1: can find a document by prefix", prefixSuffixOpts, func(mt *mtest.T) {
-		runCSEProse27Case1(mt, test)
+	mt.RunOpts("case 1 (prefixPreview): can find a document by prefix", prefixSuffixPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case1(mt, test, "prefixPreview")
 	})
-	mt.RunOpts("case 2: can find a document by suffix", prefixSuffixOpts, func(mt *mtest.T) {
-		runCSEProse27Case2(mt, test)
+	mt.RunOpts("case 2 (suffixPreview): can find a document by suffix", prefixSuffixPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case2(mt, test, "suffixPreview")
 	})
-	mt.RunOpts("case 3: assert no document found by prefix", prefixSuffixOpts, func(mt *mtest.T) {
-		runCSEProse27Case3(mt, test)
+	mt.RunOpts("case 3 (prefixPreview): assert no document found by prefix", prefixSuffixPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case3(mt, test, "prefixPreview")
 	})
-	mt.RunOpts("case 4: assert no document found by suffix", prefixSuffixOpts, func(mt *mtest.T) {
-		runCSEProse27Case4(mt, test)
+	mt.RunOpts("case 4 (suffixPreview): assert no document found by suffix", prefixSuffixPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case4(mt, test, "suffixPreview")
+	})
+
+	prefixSuffixOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.19.0")
+	mt.RunOpts("case 1 (prefix): can find a document by prefix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case1(mt, test, "prefix")
+	})
+	mt.RunOpts("case 2 (suffix): can find a document by suffix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case2(mt, test, "suffix")
+	})
+	mt.RunOpts("case 3 (prefix): assert no document found by prefix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case3(mt, test, "prefix")
+	})
+	mt.RunOpts("case 4 (suffix): assert no document found by suffix", prefixSuffixOpts, func(mt *mtest.T) {
+		runCSEProse27Case4(mt, test, "suffix")
 	})
 
 	substringPreviewOpts := newQEOpts().MinServerVersion("8.2").MaxServerVersion("8.99.99").MinLibmongocryptVersion("1.18.1")
@@ -123,7 +137,7 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 // =============================================================================
 
 // runCSEProse27Case1 ensures that we can find a document by prefix.
-func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "foo" with prefix query
@@ -131,14 +145,13 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
+		SetQueryType(queryType).
 		SetAlgorithm("String").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
-
-	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -164,7 +177,7 @@ func runCSEProse27Case1(mt *mtest.T, test *cseProse27Test) {
 }
 
 // runCSEProse27Case2 ensures that we can find a document by suffix.
-func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "baz" with suffix query
@@ -172,14 +185,13 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 	baz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
+		SetQueryType(queryType).
 		SetAlgorithm("String").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
-
-	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -205,7 +217,7 @@ func runCSEProse27Case2(mt *mtest.T, test *cseProse27Test) {
 }
 
 // runCSEProse27Case3 asserts that no document is found by prefix.
-func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "baz" with prefix query
@@ -213,14 +225,13 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 	baz := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "baz")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
+		SetQueryType(queryType).
 		SetAlgorithm("String").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetPrefix(options.PrefixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
-
-	eo = setPrefixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), baz, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -242,7 +253,7 @@ func runCSEProse27Case3(mt *mtest.T, test *cseProse27Test) {
 }
 
 // runCSEProse27Case4 asserts that no document is found by suffix.
-func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "foo" with suffix query
@@ -250,14 +261,13 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 	foo := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "foo")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
+		SetQueryType(queryType).
 		SetAlgorithm("String").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
 			SetSuffix(options.SuffixOptions{StrMaxQueryLength: 10, StrMinQueryLength: 2}))
-
-	eo = setSuffixQueryTypeForVersion(eo)
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), foo, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -714,30 +724,6 @@ func substringCollection() string {
 		return "substring-preview"
 	}
 	return "substring"
-}
-
-// setPrefixQueryTypeForVersion returns an EncryptOptionsBuilder with the query
-// type set to:
-//
-//   - prefixPreview for server versions < 9.0
-//   - prefix for server versions >= 9.0
-func setPrefixQueryTypeForVersion(opts *options.EncryptOptionsBuilder) *options.EncryptOptionsBuilder {
-	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
-		return opts.SetQueryType("prefixPreview")
-	}
-	return opts.SetQueryType("prefix")
-}
-
-// setSuffixQueryTypeForVersion returns an EncryptOptionsBuilder with the query
-// type set to:
-//
-//   - suffixPreview for server versions < 9.0
-//   - suffix for server versions >= 9.0
-func setSuffixQueryTypeForVersion(opts *options.EncryptOptionsBuilder) *options.EncryptOptionsBuilder {
-	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
-		return opts.SetQueryType("suffixPreview")
-	}
-	return opts.SetQueryType("suffix")
 }
 
 // =============================================================================

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -31,6 +31,7 @@ type cseProse27Config struct {
 	encryptedFieldsPrefixSuffixPreview bson.Raw
 	encryptedFieldsSubstring           bson.Raw
 	encryptedFieldsSubstringCIDI       bson.Raw
+	encryptedFieldsSubstringPreview    bson.Raw
 	key1Document                       bson.Raw
 }
 
@@ -76,15 +77,20 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 		runCSEProse27Case4(mt, test)
 	})
 
-	// The substring cases 5 and 6 require only the overall case 27
-	// minimums: server 8.2.0+ and libmongocrypt 1.18.1+.
-	substringOpts := newQEOpts().MaxServerVersion("8.99.99")
-
-	mt.RunOpts("case 5: can find a document by substring", substringOpts, func(mt *mtest.T) {
-		runCSEProse27Case5(mt, test)
+	substringPreviewOpts := newQEOpts().MinServerVersion("8.2").MaxServerVersion("8.99.99").MinLibmongocryptVersion("1.18.1")
+	mt.RunOpts("case 5 (substringPreview): can find a document by substring", substringPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case5(mt, test, "substringPreview")
 	})
-	mt.RunOpts("case 6: assert no document found by substring", substringOpts, func(mt *mtest.T) {
-		runCSEProse27Case6(mt, test)
+	mt.RunOpts("case 6 (substringPreview): assert no document found by substring", substringPreviewOpts, func(mt *mtest.T) {
+		runCSEProse27Case6(mt, test, "substringPreview")
+	})
+
+	substringOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.20.0")
+	mt.RunOpts("case 5 (substring): can find a document by substring", substringOpts, func(mt *mtest.T) {
+		runCSEProse27Case5(mt, test, "substring")
+	})
+	mt.RunOpts("case 6 (substring): assert no document found by substring", substringOpts, func(mt *mtest.T) {
+		runCSEProse27Case6(mt, test, "substring")
 	})
 
 	// Cases 7, 8, and 9 exercise the GA "String" algorithm and stable
@@ -273,7 +279,7 @@ func runCSEProse27Case4(mt *mtest.T, test *cseProse27Test) {
 }
 
 // runCSEProse27Case5 ensures that we can find a document by substring.
-func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "bar" with substring
@@ -281,13 +287,13 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 	bar := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bar")}
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
+		SetQueryType(queryType).
 		SetAlgorithm("String").
-		SetQueryType("substringPreview").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
-			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 6, StrMinQueryLength: 2}))
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), bar, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -296,7 +302,7 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 	// db.substring collection with the following filter:
 	//
 	// { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
-	coll := test.explicitEncryptClient.Database("db").Collection("substring")
+	coll := test.explicitEncryptClient.Database("db").Collection(substringCollection())
 	res := coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrContains", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -313,7 +319,7 @@ func runCSEProse27Case5(mt *mtest.T, test *cseProse27Test) {
 }
 
 // runCSEProse27Case6 asserts that no document is found by substring.
-func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
+func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test, queryType string) {
 	mt.Helper()
 
 	// Step 1. Use clientEncryption.encrypt() to encrypt "qux" with substring
@@ -322,12 +328,12 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 	eo := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("substringPreview").
+		SetQueryType(queryType).
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(true).
 			SetDiacriticSensitive(true).
-			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 10, StrMinQueryLength: 2}))
+			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMaxQueryLength: 6, StrMinQueryLength: 2}))
 
 	payload, err := test.clientEncryption.Encrypt(context.Background(), qux, eo)
 	require.NoError(mt, err, "error in Encrypt: %v", err)
@@ -338,7 +344,7 @@ func runCSEProse27Case6(mt *mtest.T, test *cseProse27Test) {
 	// { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'qux'>} } }
 	//
 	// Assert that no documents are returned.
-	coll := test.explicitEncryptClient.Database("db").Collection("substring")
+	coll := test.explicitEncryptClient.Database("db").Collection(substringCollection())
 	_, err = coll.FindOne(context.Background(), bson.D{{Key: "$expr", Value: bson.D{
 		{Key: "$encStrContains", Value: bson.D{
 			{Key: "input", Value: "$encryptedText"},
@@ -700,6 +706,18 @@ func prefixSuffixCollection() string {
 	return "prefix-suffix"
 }
 
+// substringCollection returns the collection name that cases 5-6 query for
+// the current server version:
+//
+//   - substring-preview for server versions < 9.0 (preview query types)
+//   - substring for server versions >= 9.0 (stable query types)
+func substringCollection() string {
+	if mtest.CompareServerVersions(mtest.ServerVersion(), "9.0") < 0 {
+		return "substring-preview"
+	}
+	return "substring"
+}
+
 // setPrefixQueryTypeForVersion returns an EncryptOptionsBuilder with the query
 // type set to:
 //
@@ -752,6 +770,7 @@ func loadCSEProse27Config() (cseProse27Config, error) {
 		{filepath.Join(cseSpecDataDir, "encryptedFields-prefix-suffix-preview.json"), &cfg.encryptedFieldsPrefixSuffixPreview},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-substring.json"), &cfg.encryptedFieldsSubstring},
 		{filepath.Join(cseSpecDataDir, "encryptedFields-substring-ci-di.json"), &cfg.encryptedFieldsSubstringCIDI},
+		{filepath.Join(cseSpecDataDir, "encryptedFields-substring-preview.json"), &cfg.encryptedFieldsSubstringPreview},
 		{filepath.Join(cseSpecDataDir, "keys", "key1-document.json"), &cfg.key1Document},
 	}
 
@@ -793,8 +812,9 @@ func doSetupCSEProse27(mt *mtest.T) (*cseProse27Test, error) {
 		// The preview prefix/suffix query types are used on pre-9.0 servers.
 		{"prefix-suffix-preview", cfg.encryptedFieldsPrefixSuffixPreview, "", "9.0"},
 
-		{"substring", cfg.encryptedFieldsSubstring, "", "8.99.99"},
-		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, "", "8.99.99"},
+		{"substring", cfg.encryptedFieldsSubstring, "9.0", ""},
+		{"substring-ci-di", cfg.encryptedFieldsSubstringCIDI, "9.0", ""},
+		{"substring-preview", cfg.encryptedFieldsSubstringPreview, "", "8.99.99"},
 	}
 	for _, c := range encryptedColls {
 		// Always drop to ensure a clean state from any previous run.
@@ -917,7 +937,7 @@ func setupCSEProse27(mt *mtest.T) *cseProse27Test {
 	// whichever collection exists for this server version: db.prefix-suffix on
 	// 9.0+ (stable query types) or db.prefix-suffix-preview on pre-9.0 (preview
 	// query types).
-	insertEncryptedTextWithNilID(mt, test.autoEncryptClient, "db", "substring", "foobarbaz")
+	insertEncryptedTextWithNilID(mt, test.autoEncryptClient, "db", substringCollection(), "foobarbaz")
 	insertEncryptedTextWithNilID(mt, test.autoEncryptClient, "db", prefixSuffixCollection(), "foobarbaz")
 
 	return test

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -109,7 +109,7 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 		runCSEProse27Case9(mt, test)
 	})
 
-	stableSubstringOpts := newQEOpts().MaxServerVersion("8.99.99").MinLibmongocryptVersion("1.19.0")
+	stableSubstringOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.18.1")
 	mt.RunOpts("case 10: can find an auto-encrypted case-insensitively indexed document by substring", stableSubstringOpts, func(mt *mtest.T) {
 		runCSEProse27Case10(mt, test)
 	})
@@ -553,8 +553,6 @@ func runCSEProse27Case9(mt *mtest.T, test *cseProse27Test) {
 
 // runCSEProse27Case10 ensures that we can find an auto-encrypted
 // case-insensitively indexed document by substring.
-//
-// Requires libmongocrypt 1.19.0+.
 func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 	mt.Helper()
 
@@ -571,12 +569,12 @@ func runCSEProse27Case10(mt *mtest.T, test *cseProse27Test) {
 	encryptOpts := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("substringPreview").
+		SetQueryType("substring").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
-			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 10}))
+			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 6}))
 
 	barPlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "bar")}
 
@@ -626,12 +624,12 @@ func runCSEProse27Case11(mt *mtest.T, test *cseProse27Test) {
 	encryptOpts := options.Encrypt().
 		SetKeyID(test.key1ID).
 		SetAlgorithm("String").
-		SetQueryType("substringPreview").
+		SetQueryType("substring").
 		SetContentionFactor(0).
 		SetStringOptions(options.String().
 			SetCaseSensitive(false).
 			SetDiacriticSensitive(false).
-			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 10}))
+			SetSubstring(options.SubstringOptions{StrMaxLength: 10, StrMinQueryLength: 2, StrMaxQueryLength: 6}))
 
 	cafePlaintextSearchToken := bson.RawValue{Type: bson.TypeString, Value: bsoncore.AppendString(nil, "cafe")}
 

--- a/internal/integration/client_side_encryption_prose_27_test.go
+++ b/internal/integration/client_side_encryption_prose_27_test.go
@@ -123,7 +123,7 @@ func TestClientSideEncryptionProse_27(t *testing.T) {
 		runCSEProse27Case9(mt, test)
 	})
 
-	stableSubstringOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.18.1")
+	stableSubstringOpts := newQEOpts().MinServerVersion("9.0").MinLibmongocryptVersion("1.20.0")
 	mt.RunOpts("case 10: can find an auto-encrypted case-insensitively indexed document by substring", stableSubstringOpts, func(mt *mtest.T) {
 		runCSEProse27Case10(mt, test)
 	})

--- a/mongo/options/encryptoptions.go
+++ b/mongo/options/encryptoptions.go
@@ -105,10 +105,6 @@ func (ro *RangeOptionsBuilder) SetPrecision(precision int32) *RangeOptionsBuilde
 // See corresponding setter methods for documentation.
 type StringOptions struct {
 	// Substring specifies options to support substring queries.
-	//
-	// Beta: This is a preview feature and should only be used for experimental
-	// workloads. It is not intended for public use. It is subject to breaking
-	// changes.
 	Substring *SubstringOptions
 
 	Prefix             *PrefixOptions
@@ -118,10 +114,6 @@ type StringOptions struct {
 }
 
 // SubstringOptions specifies options to support substring queries.
-//
-// Beta: This is a preview feature and should only be used for experimental
-// workloads. It is not intended for public use. It is subject to breaking
-// changes.
 type SubstringOptions struct {
 	StrMaxLength      int32
 	StrMinQueryLength int32
@@ -158,10 +150,6 @@ func (so *StringOptionsBuilder) List() []func(*StringOptions) error {
 }
 
 // SetSubstring sets the string index substring value.
-//
-// Beta: This is a preview feature and should only be used for experimental
-// workloads. It is not intended for public use. It is subject to breaking
-// changes.
 func (so *StringOptionsBuilder) SetSubstring(substring SubstringOptions) *StringOptionsBuilder {
 	so.Opts = append(so.Opts, func(opts *StringOptions) error {
 		opts.Substring = &substring
@@ -298,7 +286,7 @@ func (e *EncryptOptionsBuilder) SetAlgorithm(algorithm string) *EncryptOptionsBu
 //   - range
 //   - prefix / prefixPreview (used for the $encStrStartsWith operator)
 //   - suffix / suffixPreview (used for the $encStrEndsWith operator)
-//   - substringPreview (used for the $encStrContains operator)
+//   - substring / substringPreview (used for the $encStrContains operator)
 //
 // QueryType is used for Queryable Encryption.
 //


### PR DESCRIPTION
<!--- If applicable, issue number goes here, e.g. GODRIVER-ABCD -->
GODRIVER-4002

## Summary

Add the QE query type "substring" and document as GA.

## Background & Motivation

The "substringPreview" query type is currently documented as experimental, but is planned to go GA
