### PR TITLE
GODRIVER-4024 fix: validate UncompressedSize before allocation in DecompressPayload

### DIFF
--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -167,7 +167,7 @@ func DecompressPayload(in []byte, opts CompressionOpts) ([]byte, error) {
 	// malicious OP_COMPRESSED frame cannot drive an unbounded allocation
 	// (out of memory) or a make([]byte, negative) panic.
 	if opts.UncompressedSize < 0 || opts.UncompressedSize > maxDecompressedSize {
-		return nil, fmt.Errorf("invalid uncompressed size: %d", opts.UncompressedSize)
+		return nil, fmt.Errorf("invalid uncompressed size %d: must be between 0 and %d", opts.UncompressedSize, maxDecompressedSize)
 	}
 
 	switch opts.Compressor {

--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -153,8 +153,23 @@ var zstdReaderPool = sync.Pool{
 	},
 }
 
+// maxDecompressedSize is the largest UncompressedSize that DecompressPayload
+// will honor. It matches the MongoDB wire protocol maximum message size
+// (defaultMaxMessageSize in x/mongo/driver/topology/connection.go, 48000000
+// bytes / ~48MB): a legitimate uncompressed message can never exceed it.
+const maxDecompressedSize = 48000000
+
 // DecompressPayload takes a byte slice that has been compressed and undoes it according to the options passed
 func DecompressPayload(in []byte, opts CompressionOpts) ([]byte, error) {
+	// UncompressedSize is read directly off the wire (see
+	// wiremessage.ReadCompressedUncompressedSize) and is used below as an
+	// allocation size. Validate it before allocating so a malformed or
+	// malicious OP_COMPRESSED frame cannot drive an unbounded allocation
+	// (out of memory) or a make([]byte, negative) panic.
+	if opts.UncompressedSize < 0 || opts.UncompressedSize > maxDecompressedSize {
+		return nil, fmt.Errorf("invalid uncompressed size: %d", opts.UncompressedSize)
+	}
+
 	switch opts.Compressor {
 	case wiremessage.CompressorNoOp:
 		return in, nil

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -102,6 +102,40 @@ func TestDecompressFailures(t *testing.T) {
 		_, err = DecompressPayload(compressedData, opts)
 		assert.Error(t, err)
 	})
+
+	// UncompressedSize is attacker-controlled (read straight off the wire in
+	// Operation.decompressWireMessage). An out-of-range value must be rejected
+	// with an error before it is used as an allocation size, otherwise a
+	// malicious server can drive an unbounded allocation (OOM) or a
+	// make([]byte, negative) panic.
+	validZlibEmptyBody := []byte{0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01}
+
+	oversized := []struct {
+		name       string
+		compressor wiremessage.CompressorID
+		in         []byte
+		size       int32
+	}{
+		{"zlib oversized size", wiremessage.CompressorZLib, validZlibEmptyBody, 2147483647},
+		{"zlib negative size", wiremessage.CompressorZLib, validZlibEmptyBody, -1},
+		{"zstd oversized size", wiremessage.CompressorZstd, []byte{}, 2147483647},
+		{"zstd negative size", wiremessage.CompressorZstd, []byte{}, -1},
+		{"snappy negative size", wiremessage.CompressorSnappy, []byte{}, -1},
+	}
+	for _, tc := range oversized {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := CompressionOpts{
+				Compressor:       tc.compressor,
+				UncompressedSize: tc.size,
+			}
+			// Must return an error rather than allocating tc.size bytes or panicking.
+			_, err := DecompressPayload(tc.in, opts)
+			assert.Error(t, err)
+		})
+	}
 }
 
 var (

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -120,6 +120,7 @@ func TestDecompressFailures(t *testing.T) {
 		{"zlib negative size", wiremessage.CompressorZLib, validZlibEmptyBody, -1},
 		{"zstd oversized size", wiremessage.CompressorZstd, []byte{}, 2147483647},
 		{"zstd negative size", wiremessage.CompressorZstd, []byte{}, -1},
+		{"snappy oversized size", wiremessage.CompressorSnappy, []byte{}, 2147483647},
 		{"snappy negative size", wiremessage.CompressorSnappy, []byte{}, -1},
 	}
 	for _, tc := range oversized {


### PR DESCRIPTION
[GODRIVER-4024](https://jira.mongodb.org/browse/GODRIVER-4024)

`DecompressPayload` uses `opts.UncompressedSize` directly as an allocation size without validating it first. That value is read straight off the wire and is fully controlled by the server, so a malformed or malicious `OP_COMPRESSED` frame can force the driver into an unbounded allocation or a runtime panic. This PR adds a bounds check before any allocation occurs.

## Root Cause

The size flows unvalidated from the wire all the way to the allocation site:

```
wiremessage.ReadCompressedUncompressedSize()   raw int32, no bounds check
  → Operation.decompressWireMessage()           x/mongo/driver/operation.go
  → DecompressPayload()                         x/mongo/driver/compression.go
```

Inside `DecompressPayload`, the server-controlled value is used directly as an allocation size with no validation on any of the three compressor paths:

```go
// zlib path
out := make([]byte, opts.UncompressedSize)

// zstd path
buf := make([]byte, 0, opts.UncompressedSize)

// snappy path
out := make([]byte, opts.UncompressedSize)
```

The existing wire-level `maxMessageSize` check (48 MB, enforced in `topology/connection.go`) applies to the size of the compressed message on the wire, not to the declared uncompressed size. A server can therefore send a small, valid compressed message that passes the wire-size check while claiming an arbitrarily large uncompressed size, and the driver will attempt the allocation before decompressing a single byte.

## Impact

A server, or an on-path attacker on a connection where compression is negotiated, can send an `OP_COMPRESSED` message with a crafted `UncompressedSize` field and trigger one of two outcomes:

**Unbounded allocation / OOM.** A large positive value, up to `math.MaxInt32` (2,147,483,647), drives a roughly 2 GB allocation from a few bytes of compressed input. The subsequent read fails because the actual data does not fill the buffer, but the allocation has already happened and the client process is killed by the OS out-of-memory handler before it can return an error.

**Panic / client crash.** A negative value, for example wire bytes `0xFFFFFFFF`, causes `make([]byte, negative)` to panic with `makeslice: len out of range`. This panic is unrecovered in the message-read path and terminates the client process.

Impact is availability only. There is no memory disclosure and no path to remote code execution. The `int32` type caps a single allocation at approximately 2 GB. This is a robustness and hardening fix.

## Fix

Reject out-of-range sizes at the top of `DecompressPayload`, before any allocation occurs on the zlib, zstd, or snappy paths:

```go
const maxDecompressedSize int32 = 48_000_000

if opts.UncompressedSize < 0 || opts.UncompressedSize > maxDecompressedSize {
    return nil, fmt.Errorf(
        "invalid uncompressed size %d: must be between 0 and %d",
        opts.UncompressedSize, maxDecompressedSize,
    )
}
```

`maxDecompressedSize` is set to 48,000,000 bytes, matching `defaultMaxMessageSize` already established in `x/mongo/driver/topology/connection.go`. A legitimate uncompressed message can never exceed 48 MB under the MongoDB wire protocol, so no valid traffic is rejected by this check.

## Testing

Added regression cases to `TestDecompressFailures` covering oversized and negative `UncompressedSize` for all three compressor paths: zlib, zstd, and snappy. Each case now returns a clean error instead of allocating or panicking. Existing round-trip tests (`TestCompression`, `TestCompressionLevels`) continue to pass unchanged.

## Backward Compatibility

No public API change. The signatures of `DecompressPayload` and `CompressionOpts` are unchanged. The behavior change is limited to previously-invalid inputs, specifically sizes below zero or above 48 MB, which now return an error instead of triggering an unbounded allocation or a runtime panic.