### PR TITLE
GODRIVER-4026 Use cmake<4.4 for libmongocrypt build.

### DIFF
--- a/etc/install-libmongocrypt.sh
+++ b/etc/install-libmongocrypt.sh
@@ -39,7 +39,7 @@ if [ "Windows_NT" = "${OS:-}" ]; then
 else
   rm -rf libmongocrypt
   git clone https://github.com/mongodb/libmongocrypt --depth=1 --branch $LIBMONGOCRYPT_TAG 2>/dev/null
-  if ! (./libmongocrypt/.evergreen/compile.sh >|output.txt 2>&1); then
+  if ! (UV_CONSTRAINT=<(echo "cmake<4.4") ./libmongocrypt/.evergreen/compile.sh >|output.txt 2>&1); then
     cat output.txt 1>&2
     exit 1
   fi


### PR DESCRIPTION
[GODRIVER-4026](https://jira.mongodb.org/browse/GODRIVER-4026)

## Summary

Use cmake<4.4 for libmongocrypt build.

## Background & Motivation

The libmongocrypt build is currently broken on CMake 4.4.0, which was just released.
