### PR TITLE
GODRIVER-2962 Unexport all command type methods.

### DIFF
--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -209,7 +209,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (inser
 	if bw.comment != nil {
 		comment, err := marshalValue(bw.comment, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {
-			return op.Result(), err
+			return op.result(), err
 		}
 		op.comment = comment
 	}
@@ -233,9 +233,9 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (inser
 		op.additionalCmd = bw.additionalCmd
 	}
 
-	err := op.Execute(ctx)
+	err := op.execute(ctx)
 
-	return op.Result(), err
+	return op.result(), err
 }
 
 func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (operation.DeleteResult, error) {
@@ -255,7 +255,8 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 				converted.Hint,
 				true,
 				bw.collection.bsonOpts,
-				bw.collection.registry)
+				bw.collection.registry,
+			)
 			hasHint = hasHint || (converted.Hint != nil)
 		case *DeleteManyModel:
 			doc, err = createDeleteDoc(
@@ -264,7 +265,8 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 				converted.Hint,
 				false,
 				bw.collection.bsonOpts,
-				bw.collection.registry)
+				bw.collection.registry,
+			)
 			hasHint = hasHint || (converted.Hint != nil)
 		}
 
@@ -444,7 +446,7 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (updat
 	if bw.comment != nil {
 		comment, err := marshalValue(bw.comment, bw.collection.bsonOpts, bw.collection.registry)
 		if err != nil {
-			return op.Result(), err
+			return op.result(), err
 		}
 		op.comment = comment
 	}
@@ -468,9 +470,9 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (updat
 		op.additionalCmd = bw.additionalCmd
 	}
 
-	err := op.Execute(ctx)
+	err := op.execute(ctx)
 
-	return op.Result(), err
+	return op.result(), err
 }
 
 type updateDoc struct {

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -362,7 +362,7 @@ func (coll *Collection) insert(
 	}
 	op.retry = &retry
 
-	err = op.Execute(ctx)
+	err = op.execute(ctx)
 	var wce driver.WriteCommandError
 	if !errors.As(err, &wce) {
 		return result, err
@@ -763,14 +763,14 @@ func (coll *Collection) updateOrReplace(
 	if additionalCmd, ok := optionsutil.Value(args.Internal, "addCommandFields").(bson.D); ok {
 		op.additionalCmd = additionalCmd
 	}
-	err = op.Execute(ctx)
+	err = op.execute(ctx)
 
 	rr, err := processWriteError(err)
 	if rr&expectedRr == 0 {
 		return nil, err
 	}
 
-	opRes := op.Result()
+	opRes := op.result()
 	res := &UpdateResult{
 		MatchedCount:  opRes.N,
 		ModifiedCount: opRes.NModified,

--- a/mongo/op_insert.go
+++ b/mongo/op_insert.go
@@ -42,7 +42,7 @@ type insertOp struct {
 	retry                     *driver.RetryMode
 	maxAdaptiveRetries        uint
 	enableOverloadRetargeting bool
-	result                    insertResult
+	res                       insertResult
 	serverAPI                 *driver.ServerAPIOptions
 	timeout                   *time.Duration
 	rawData                   *bool
@@ -74,19 +74,19 @@ func buildInsertResult(response bsoncore.Document) (insertResult, error) {
 	return ir, nil
 }
 
-// Result returns the result of executing this operation.
-func (i *insertOp) Result() insertResult { return i.result }
+// result returns the result of executing this operation.
+func (i *insertOp) result() insertResult { return i.res }
 
 func (i *insertOp) processResponse(_ context.Context, resp bsoncore.Document, _ driver.ResponseInfo) error {
 	ir, err := buildInsertResult(resp)
-	i.result.N += ir.N
+	i.res.N += ir.N
 	return err
 }
 
-// Execute runs this operations and returns an error if the operation did not execute successfully.
-func (i *insertOp) Execute(ctx context.Context) error {
+// execute runs this operations and returns an error if the operation did not execute successfully.
+func (i *insertOp) execute(ctx context.Context) error {
 	if i.deployment == nil {
-		return errors.New("the Insert operation must have a Deployment set before Execute can be called")
+		return errors.New("the insert operation must have a Deployment set before execute can be called")
 	}
 	batches := &driver.Batches{
 		Identifier: "documents",

--- a/mongo/op_update.go
+++ b/mongo/op_update.go
@@ -45,7 +45,7 @@ type updateOp struct {
 	retry                     *driver.RetryMode
 	maxAdaptiveRetries        uint
 	enableOverloadRetargeting bool
-	result                    updateResult
+	res                       updateResult
 	crypt                     driver.Crypt
 	serverAPI                 *driver.ServerAPIOptions
 	let                       bsoncore.Document
@@ -115,27 +115,27 @@ func buildUpdateResult(response bsoncore.Document) (updateResult, error) {
 	return ur, nil
 }
 
-// Result returns the result of executing this operation.
-func (u *updateOp) Result() updateResult { return u.result }
+// result returns the result of executing this operation.
+func (u *updateOp) result() updateResult { return u.res }
 
 func (u *updateOp) processResponse(_ context.Context, resp bsoncore.Document, info driver.ResponseInfo) error {
 	ur, err := buildUpdateResult(resp)
 
-	u.result.N += ur.N
-	u.result.NModified += ur.NModified
+	u.res.N += ur.N
+	u.res.NModified += ur.NModified
 	if info.CurrentIndex > 0 {
 		for ind := range ur.Upserted {
 			ur.Upserted[ind].Index += int64(info.CurrentIndex)
 		}
 	}
-	u.result.Upserted = append(u.result.Upserted, ur.Upserted...)
+	u.res.Upserted = append(u.res.Upserted, ur.Upserted...)
 	return err
 }
 
-// Execute runs this operation and returns an error if the operation did not execute successfully.
-func (u *updateOp) Execute(ctx context.Context) error {
+// execute runs this operation and returns an error if the operation did not execute successfully.
+func (u *updateOp) execute(ctx context.Context) error {
 	if u.deployment == nil {
-		return errors.New("the update operation must have a Deployment set before Execute can be called")
+		return errors.New("the update operation must have a Deployment set before execute can be called")
 	}
 	batches := &driver.Batches{
 		Identifier: "updates",


### PR DESCRIPTION
[GODRIVER-2962](https://jira.mongodb.org/browse/GODRIVER-2962)

## Summary

Unexport all methods for types `mongo.updateOp` and `mongo.insertOp`.

## Background & Motivation

The recently merged PRs from epic [GODRIVER-2962](https://jira.mongodb.org/browse/GODRIVER-2962) (https://github.com/mongodb/mongo-go-driver/pull/2483, https://github.com/mongodb/mongo-go-driver/pull/2478, and https://github.com/mongodb/mongo-go-driver/pull/2473) all unexport the command type methods. Apply that same pattern to the previously merged PRs for `updateOp` and `insertOp`.