### PR TITLE
GODRIVER-4050 Skip tests that fail due to SERVER-128517

### DIFF
--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -1046,6 +1046,17 @@ var skipTests = map[string][]skipCase{
 			minServerVersion: "9.0",
 		},
 	},
+
+	// TODO(GODRIVER-4049) Figure out how to set a 500ms maxAwaitTimeMS on
+	// hello.
+	"SERVER-128517 forces a min maxAwaitTimeMS of 10s, which conflicts with the test timeouts": {
+		{
+			tests: []string{
+				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Network_timeout_on_Monitor_check",
+				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Driver_extends_timeout_while_streaming",
+			},
+		},
+	},
 }
 
 type options struct {


### PR DESCRIPTION
[GODRIVER-4050](https://jira.mongodb.org/browse/GODRIVER-4050)

## Summary

Skip tests that fail due to SERVER-128517.

## Background & Motivation

<!--- Rationale for the pull request. -->
