### PR TITLE
GODRIVER-4053 Add "Client Side Encryption Tests" variants to PR builds.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2051,6 +2051,7 @@ buildvariants:
     tasks:
       - name: ".versioned-api"
   - matrix_name: "client-side-encryption-test"
+    tags: ["pullrequest"]
     matrix_spec: {version: ["latest", "rapid"], os-ssl-40: ["rhel87-64"]}
     display_name: "Client Side Encryption Tests ${version} ${os-ssl-40}"
     tasks:


### PR DESCRIPTION
[GODRIVER-4053](https://jira.mongodb.org/browse/GODRIVER-4053)

## Summary
Add `tags: ["pullrequest"]` to the "client-side-encryption-test" matrix in ".evergreen/config.yml" to enable it for PR builds.

## Background & Motivation

<!--- Rationale for the pull request. -->
