### PR TITLE
GODRIVER-3856: Bump maxWireVersion for 9.0 server release

### DIFF
--- a/internal/driverutil/description.go
+++ b/internal/driverutil/description.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	MinWireVersion = 8
-	MaxWireVersion = 25
+	MaxWireVersion = 29
 )
 
 func equalWireVersion(wv1, wv2 *description.VersionRange) bool {


### PR DESCRIPTION
GODRIVER-3856

Bump maxWireVersion for purposes of the [version compatibility check](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md#checking-wire-protocol-compatibility).

