### PR TITLE
GODRIVER-4066 Fix unused imports.

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -27,7 +27,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
-	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/operation"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 )
 


### PR DESCRIPTION
GODRIVER-4066

## Summary
Fix the unused imports caused by https://github.com/mongodb/mongo-go-driver/pull/2515.

## Background & Motivation

<!--- Rationale for the pull request. -->