### PR TITLE
GODRIVER-4068 Bump Go version in vulncheck.

### DIFF
--- a/etc/govulncheck.sh
+++ b/etc/govulncheck.sh
@@ -7,7 +7,7 @@ set -ex
 # Note: this needs to be updated if the listed Go version has vulnerabilities
 # discovered because they will show up in the scan results along with Go Driver
 # and dependency vulnerabilities.
-VERSION_REGEX='1\\.25\\.[0-9]+'
+VERSION_REGEX='1\\.26\\.[0-9]+'
 JQ_FILTER="first(.[] \
 | select(.stable == true and (.version | test(\"^go${VERSION_REGEX}$\"))) \
 | .version)"


### PR DESCRIPTION
GODRIVER-4068

## Summary
Bump the Go version to 1.26 in vulncheck in ‎etc/govulncheck.sh.

## Background & Motivation
We need to bump the Go version in vulncheck since we have updated to Go 1.26 in CI in GODRIVER-3882