### PR TITLE
GODRIVER-4064: Bump spec tests to 93a77b5

### DIFF
--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -886,6 +886,15 @@ var skipTests = map[string][]skipCase{
 				"TestUnifiedSpec/transactions-convenient-api/tests/unified/commit.json/withTransaction_commits_after_callback_returns_(second_transaction)",
 			},
 		},
+		{
+			tests: []string{
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_and_no_transaction_options_set",
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_inherits_transaction_options_from_client",
+				"TestUnifiedSpec/transactions-convenient-api/tests/unified/transaction-options.json/withTransaction_inherits_transaction_options_from_defaultTransactionOptions",
+				"TestUnifiedSpec/transactions/tests/unified/client-bulkWrite.json/client_bulkWrite_in_a_transaction",
+			},
+			topologies: []string{"load-balanced"},
+		},
 	},
 
 	"Address CSOT Compliance Issue in Timeout Handling for Cursor Constructors (GODRIVER-3480)": {

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -1046,6 +1046,17 @@ var skipTests = map[string][]skipCase{
 			minServerVersion: "9.0",
 		},
 	},
+
+	// TODO(GODRIVER-4049) Figure out how to set a 500ms maxAwaitTimeMS on
+	// hello.
+	"SERVER-128517 forces a min maxAwaitTimeMS of 10s, which conflicts with the test timeouts": {
+		{
+			tests: []string{
+				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Network_timeout_on_Monitor_check",
+				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Driver_extends_timeout_while_streaming",
+			},
+		},
+	},
 }
 
 type options struct {

--- a/internal/spectest/skip.go
+++ b/internal/spectest/skip.go
@@ -1046,17 +1046,6 @@ var skipTests = map[string][]skipCase{
 			minServerVersion: "9.0",
 		},
 	},
-
-	// TODO(GODRIVER-4049) Figure out how to set a 500ms maxAwaitTimeMS on
-	// hello.
-	"SERVER-128517 forces a min maxAwaitTimeMS of 10s, which conflicts with the test timeouts": {
-		{
-			tests: []string{
-				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Network_timeout_on_Monitor_check",
-				"TestUnifiedSpec/server-discovery-and-monitoring/tests/unified/hello-timeout.json/Driver_extends_timeout_while_streaming",
-			},
-		},
-	},
 }
 
 type options struct {


### PR DESCRIPTION
GODRIVER-4064

Bump release/2.8 spec tests to https://github.com/mongodb/specifications/commit/93a77b53d0160f7f1914826551aa1d322ec53fe9 