### PR TITLE
GODRIVER-3963 Update client backpressure with baseBackoffMS.

### DIFF
--- a/internal/handshake/operation/hello.go
+++ b/internal/handshake/operation/hello.go
@@ -599,7 +599,7 @@ func (h *Hello) command(dst []byte, desc description.SelectedServer) ([]byte, er
 		// loadBalanced=false per the load balancing spec.
 		dst = bsoncore.AppendBooleanElement(dst, "loadBalanced", true)
 	}
-	dst = bsoncore.AppendBooleanElement(dst, "backpressure", true)
+	dst = bsoncore.AppendStringElement(dst, "backpressure", "2")
 
 	return dst, nil
 }

--- a/internal/integration/backpressure_prose_test.go
+++ b/internal/integration/backpressure_prose_test.go
@@ -51,7 +51,7 @@ func TestBackpressureProse(t *testing.T) {
 		withBackoffTime := transWithJitter(mt, 1)
 		assert.InDelta(
 			mt,
-			withBackoffTime, noBackoffTime+300*time.Millisecond, float64(300*time.Millisecond),
+			withBackoffTime, noBackoffTime+600*time.Millisecond, float64(600*time.Millisecond),
 			"with backoff time: %v, no backoff time: %v", withBackoffTime, noBackoffTime,
 		)
 	})
@@ -110,5 +110,59 @@ func TestBackpressureProse(t *testing.T) {
 		assert.True(mt, cmdErr.HasErrorLabel("RetryableError"), `expected error has "RetryableError" label`)
 		assert.True(mt, cmdErr.HasErrorLabel("SystemOverloadedError"), `expected error has "SystemOverloadedError" label`)
 		assert.Equalf(mt, 2, opsCnt, "expected 2 attempts (1 original + 1 retry), got %d", opsCnt)
+	})
+	mt.RunOpts("5. Overload Errors with baseBackoffMS override base backoff", mtest.NewOptions().MinServerVersion("9.0"), func(mt *mtest.T) {
+		mt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode:               failpoint.ModeAlwaysOn,
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorCode:    462,
+				ErrorLabels:  &[]string{"SystemOverloadedError", "RetryableError"},
+			},
+		})
+
+		mt.ResetClient(options.Client())
+
+		setExternalClientBaseBackoffMS := func(ms int) {
+			err := mt.Client.Database("admin").RunCommand(context.Background(), bson.D{
+				{"setParameter", 1},
+				{"externalClientBaseBackoffMS", ms},
+			}).Err()
+			require.NoError(mt, err, "setParameter externalClientBaseBackoffMS=%d error: %v", ms, err)
+		}
+
+		insertWithJitter := func() (time.Duration, mongo.CommandError) {
+			defer randutil.SetJitterForTesting(func() float64 { return 1 })()
+
+			startTime := time.Now()
+			_, err := mt.Coll.InsertOne(context.Background(), bson.D{{"a", 1}})
+			duration := time.Since(startTime)
+
+			var cmdErr mongo.CommandError
+			require.Truef(mt, errors.As(err, &cmdErr), "expected a CommandError, got %T: %v", err, err)
+			return duration, cmdErr
+		}
+
+		exponentialTime, exponentialErr := insertWithJitter()
+		_, err := exponentialErr.Raw.LookupErr("baseBackoffMS")
+		require.Error(mt, err, "expected no baseBackoffMS on the error before setting externalClientBaseBackoffMS")
+
+		setExternalClientBaseBackoffMS(50)
+		defer setExternalClientBaseBackoffMS(0)
+
+		baseBackoffTime, baseBackoffErr := insertWithJitter()
+		baseBackoffMS, err := baseBackoffErr.Raw.LookupErr("baseBackoffMS")
+		require.NoError(mt, err, "expected the server to attach baseBackoffMS to the error")
+		baseBackoffMSVal, ok := baseBackoffMS.AsInt64OK()
+		require.True(mt, ok, "expected baseBackoffMS to be numeric, got %v", baseBackoffMS.Type)
+		require.Equal(mt, int64(50), baseBackoffMSVal, "expected baseBackoffMS to be 50")
+
+		assert.GreaterOrEqual(mt, exponentialTime, 600*time.Millisecond,
+			"expected the default backoff run to take at least 600ms, took %v", exponentialTime)
+		assert.GreaterOrEqual(mt, baseBackoffTime, 300*time.Millisecond,
+			"expected the baseBackoffMS run to take at least 300ms, took %v", baseBackoffTime)
+		assert.Less(mt, baseBackoffTime, 600*time.Millisecond,
+			"expected the baseBackoffMS run to take less than 600ms, took %v", baseBackoffTime)
 	})
 }

--- a/internal/integration/handshake_test.go
+++ b/internal/integration/handshake_test.go
@@ -1252,7 +1252,7 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 	}
 }
 
-// Test 9: Handshake documents include backpressure: true
+// Test 9: Handshake documents include backpressure: "2"
 func TestHandshakeProse_Handshake_Documents(t *testing.T) {
 	mt := mtest.New(t,
 		mtest.NewOptions().CreateCollection(false).ClientType(mtest.Proxy),
@@ -1268,7 +1268,9 @@ func TestHandshakeProse_Handshake_Documents(t *testing.T) {
 
 	v, err := firstMessage.Sent.Command.LookupErr("backpressure")
 	require.NoError(mt, err, "expected backpressure field in handshake command document")
-	require.True(mt, v.Boolean(), "expected backpressure field to be true")
+	str, ok := v.StringValueOK()
+	require.True(mt, ok, "expected backpressure field to be a string, got %v", v.Type)
+	require.Equal(mt, "2", str, `expected backpressure field to be "2"`)
 }
 
 // mustMarshalBSON marshals a value to BSON. It panics if any error occurs.

--- a/internal/integration/transactions_convenient_api_prose_test.go
+++ b/internal/integration/transactions_convenient_api_prose_test.go
@@ -57,7 +57,7 @@ func TestTransactionConvenientApiProse(t *testing.T) {
 		withBackoffTime := transWithJitter(mt, 1)
 		assert.InDelta(
 			t,
-			withBackoffTime, noBackoffTime+1_800*time.Millisecond, float64(500*time.Millisecond),
+			withBackoffTime, noBackoffTime+2_300*time.Millisecond, float64(500*time.Millisecond),
 			"with backoff time: %v, no backoff time: %v", withBackoffTime, noBackoffTime,
 		)
 	})

--- a/mongo/session.go
+++ b/mongo/session.go
@@ -138,6 +138,7 @@ func (s *Session) WithTransaction(
 		if expDur == 0 {
 			expDur = backoffInitial
 		} else {
+			expDur += expDur / 2
 			if expDur > backoffMax {
 				expDur = backoffMax
 			}
@@ -151,9 +152,6 @@ func (s *Session) WithTransaction(
 				sleep.Stop()
 				return nil, timeoutError{Wrapped: err}
 			case <-sleep.C:
-			}
-			if expDur < backoffMax {
-				expDur += expDur / 2
 			}
 		}
 

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/internal/driverutil"
@@ -122,7 +123,7 @@ type WriteCommandError struct {
 	WriteErrors       WriteErrors
 	Labels            []string
 	Raw               bsoncore.Document
-	BaseBackoffMS     int64
+	BaseBackoff       time.Duration
 }
 
 // UnsupportedStorageEngine returns whether or not the WriteCommandError comes from a retryable write being attempted
@@ -279,7 +280,7 @@ type Error struct {
 	Wrapped         error
 	TopologyVersion *description.TopologyVersion
 	Raw             bsoncore.Document
-	BaseBackoffMS   int64
+	BaseBackoff     time.Duration
 }
 
 // UnsupportedStorageEngine returns whether e came as a result of an unsupported storage engine
@@ -404,7 +405,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 	var errmsg, codeName string
 	var code int32
 	var labels []string
-	var baseBackoffMS int64
+	var baseBackoff time.Duration
 	var ok bool
 	var tv *description.TopologyVersion
 	var wcError WriteCommandError
@@ -448,7 +449,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 			}
 		case "baseBackoffMS":
 			if ms, okay := elem.Value().AsInt64OK(); okay {
-				baseBackoffMS = ms
+				baseBackoff = time.Duration(ms) * time.Millisecond
 			}
 		case "errorLabels":
 			if arr, okay := elem.Value().ArrayOK(); okay {
@@ -514,8 +515,8 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 				wcError.WriteConcernError.Details = make([]byte, len(info))
 				copy(wcError.WriteConcernError.Details, info)
 			}
-			if ms, exists := doc.Lookup("baseBackoffMS").AsInt64OK(); exists && baseBackoffMS == 0 {
-				baseBackoffMS = ms
+			if ms, exists := doc.Lookup("baseBackoffMS").AsInt64OK(); exists && baseBackoff == 0 {
+				baseBackoff = time.Duration(ms) * time.Millisecond
 			}
 			if errLabels, exists := doc.Lookup("errorLabels").ArrayOK(); exists {
 				vals, err := errLabels.Values()
@@ -552,7 +553,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 			Labels:          labels,
 			TopologyVersion: tv,
 			Raw:             doc,
-			BaseBackoffMS:   baseBackoffMS,
+			BaseBackoff:     baseBackoff,
 		}
 
 		// If we get a MaxTimeMSExpired error, assume that the error was caused
@@ -576,7 +577,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 			wcError.WriteConcernError.TopologyVersion = tv
 		}
 		wcError.Raw = doc
-		wcError.BaseBackoffMS = baseBackoffMS
+		wcError.BaseBackoff = baseBackoff
 		return wcError
 	}
 

--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -122,6 +122,7 @@ type WriteCommandError struct {
 	WriteErrors       WriteErrors
 	Labels            []string
 	Raw               bsoncore.Document
+	BaseBackoffMS     int64
 }
 
 // UnsupportedStorageEngine returns whether or not the WriteCommandError comes from a retryable write being attempted
@@ -278,6 +279,7 @@ type Error struct {
 	Wrapped         error
 	TopologyVersion *description.TopologyVersion
 	Raw             bsoncore.Document
+	BaseBackoffMS   int64
 }
 
 // UnsupportedStorageEngine returns whether e came as a result of an unsupported storage engine
@@ -402,6 +404,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 	var errmsg, codeName string
 	var code int32
 	var labels []string
+	var baseBackoffMS int64
 	var ok bool
 	var tv *description.TopologyVersion
 	var wcError WriteCommandError
@@ -442,6 +445,10 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 		case "code":
 			if c, okay := elem.Value().Int32OK(); okay {
 				code = c
+			}
+		case "baseBackoffMS":
+			if ms, okay := elem.Value().AsInt64OK(); okay {
+				baseBackoffMS = ms
 			}
 		case "errorLabels":
 			if arr, okay := elem.Value().ArrayOK(); okay {
@@ -507,6 +514,9 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 				wcError.WriteConcernError.Details = make([]byte, len(info))
 				copy(wcError.WriteConcernError.Details, info)
 			}
+			if ms, exists := doc.Lookup("baseBackoffMS").AsInt64OK(); exists && baseBackoffMS == 0 {
+				baseBackoffMS = ms
+			}
 			if errLabels, exists := doc.Lookup("errorLabels").ArrayOK(); exists {
 				vals, err := errLabels.Values()
 				if err != nil {
@@ -542,6 +552,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 			Labels:          labels,
 			TopologyVersion: tv,
 			Raw:             doc,
+			BaseBackoffMS:   baseBackoffMS,
 		}
 
 		// If we get a MaxTimeMSExpired error, assume that the error was caused
@@ -565,6 +576,7 @@ func ExtractErrorFromServerResponse(doc bsoncore.Document) error {
 			wcError.WriteConcernError.TopologyVersion = tv
 		}
 		wcError.Raw = doc
+		wcError.BaseBackoffMS = baseBackoffMS
 		return wcError
 	}
 

--- a/x/mongo/driver/errors_test.go
+++ b/x/mongo/driver/errors_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) MongoDB, Inc. 2026-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package driver
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
+)
+
+func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
+	t.Parallel()
+
+	marshal := func(t *testing.T, doc bson.D) bsoncore.Document {
+		t.Helper()
+
+		raw, err := bson.Marshal(doc)
+		require.NoError(t, err)
+
+		return bsoncore.Document(raw)
+	}
+
+	t.Run("command error", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			doc  bson.D
+			want int64
+		}{
+			{
+				name: "absent",
+				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}},
+				want: 0,
+			},
+			{
+				name: "int32",
+				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", int32(50)}},
+				want: 50,
+			},
+			{
+				name: "int64",
+				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", int64(50)}},
+				want: 50,
+			},
+			{
+				name: "double",
+				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", 50.0}},
+				want: 50,
+			},
+		}
+
+		for _, test := range tests {
+			test := test
+
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				err := ExtractErrorFromServerResponse(marshal(t, test.doc))
+
+				cerr, ok := err.(Error)
+				require.Truef(t, ok, "expected an Error, got %T: %v", err, err)
+				require.Equal(t, test.want, cerr.BaseBackoffMS)
+			})
+		}
+	})
+
+	t.Run("write command error", func(t *testing.T) {
+		t.Parallel()
+
+		doc := bson.D{
+			{"ok", 1},
+			{"baseBackoffMS", int32(50)},
+			{"writeErrors", bson.A{bson.D{{"index", 0}, {"code", 462}, {"errmsg", "overloaded"}}}},
+		}
+
+		err := ExtractErrorFromServerResponse(marshal(t, doc))
+
+		wce, ok := err.(WriteCommandError)
+		require.Truef(t, ok, "expected a WriteCommandError, got %T: %v", err, err)
+		require.Equal(t, int64(50), wce.BaseBackoffMS)
+	})
+
+	t.Run("write concern error", func(t *testing.T) {
+		t.Parallel()
+
+		doc := bson.D{
+			{"ok", 1},
+			{"writeConcernError", bson.D{
+				{"code", 462},
+				{"errmsg", "overloaded"},
+				{"baseBackoffMS", int32(50)},
+			}},
+		}
+
+		err := ExtractErrorFromServerResponse(marshal(t, doc))
+
+		wce, ok := err.(WriteCommandError)
+		require.Truef(t, ok, "expected a WriteCommandError, got %T: %v", err, err)
+		require.Equal(t, int64(50), wce.BaseBackoffMS)
+	})
+}

--- a/x/mongo/driver/errors_test.go
+++ b/x/mongo/driver/errors_test.go
@@ -8,6 +8,7 @@ package driver
 
 import (
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/internal/require"
@@ -32,7 +33,7 @@ func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
 		tests := []struct {
 			name string
 			doc  bson.D
-			want int64
+			want time.Duration
 		}{
 			{
 				name: "absent",
@@ -42,17 +43,17 @@ func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
 			{
 				name: "int32",
 				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", int32(50)}},
-				want: 50,
+				want: 50 * time.Millisecond,
 			},
 			{
 				name: "int64",
 				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", int64(50)}},
-				want: 50,
+				want: 50 * time.Millisecond,
 			},
 			{
 				name: "double",
 				doc:  bson.D{{"ok", 0}, {"code", 462}, {"errmsg", "overloaded"}, {"baseBackoffMS", 50.0}},
-				want: 50,
+				want: 50 * time.Millisecond,
 			},
 		}
 
@@ -66,7 +67,7 @@ func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
 
 				cerr, ok := err.(Error)
 				require.Truef(t, ok, "expected an Error, got %T: %v", err, err)
-				require.Equal(t, test.want, cerr.BaseBackoffMS)
+				require.Equal(t, test.want, cerr.BaseBackoff)
 			})
 		}
 	})
@@ -84,7 +85,7 @@ func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
 
 		wce, ok := err.(WriteCommandError)
 		require.Truef(t, ok, "expected a WriteCommandError, got %T: %v", err, err)
-		require.Equal(t, int64(50), wce.BaseBackoffMS)
+		require.Equal(t, 50*time.Millisecond, wce.BaseBackoff)
 	})
 
 	t.Run("write concern error", func(t *testing.T) {
@@ -103,6 +104,6 @@ func TestExtractErrorFromServerResponse_BaseBackoffMS(t *testing.T) {
 
 		wce, ok := err.(WriteCommandError)
 		require.Truef(t, ok, "expected a WriteCommandError, got %T: %v", err, err)
-		require.Equal(t, int64(50), wce.BaseBackoffMS)
+		require.Equal(t, 50*time.Millisecond, wce.BaseBackoff)
 	})
 }

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -566,7 +566,7 @@ func (op Operation) Execute(ctx context.Context) error {
 	var operationErr WriteCommandError
 	var prevErr error
 	var prevIndefiniteErr error
-	var expDur time.Duration
+	var overloadAttempt uint
 	var transactionState session.TransactionState
 	var isOverloadedError bool
 	var attempt uint
@@ -628,15 +628,16 @@ func (op Operation) Execute(ctx context.Context) error {
 
 		if isOverloadedError {
 			isOverloadedError = false
-			if expDur == 0 {
-				expDur = backoffInitial
-			} else {
-				expDur *= 2
-				if expDur > backoffMax {
-					expDur = backoffMax
-				}
+			overloadAttempt++
+
+			// A positive "baseBackoffMS" on the error is a server-supplied base
+			// backoff that replaces the driver's default.
+			base := backoffInitial
+			if serverBase := serverBaseBackoff(err); serverBase > 0 {
+				base = serverBase
 			}
-			backoff := randutil.JitterDuration(expDur)
+
+			backoff := randutil.JitterDuration(overloadBackoff(base, overloadAttempt))
 			if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) < backoff {
 				return err
 			}
@@ -1101,7 +1102,7 @@ func (op Operation) Execute(ctx context.Context) error {
 				}
 			}
 			isOverloadedError = false
-			expDur = 0
+			overloadAttempt = 0
 			attempt = 0
 			currIndex += startedInfo.processedBatches
 			op.Batches.AdvanceBatches(startedInfo.processedBatches)
@@ -2284,6 +2285,30 @@ func (op Operation) publishFinishedEvent(ctx context.Context, info finishedInfor
 		CommandFinishedEvent: finished,
 	}
 	op.CommandMonitor.Failed(ctx, failedEvent)
+}
+
+// overloadBackoff returns the exponential backoff duration for the given overload retry attempt.
+func overloadBackoff(base time.Duration, attempt uint) time.Duration {
+	d := base
+	for i := uint(0); i < attempt && d < backoffMax; i++ {
+		d *= 2
+	}
+	if d > backoffMax {
+		d = backoffMax
+	}
+	return d
+}
+
+// serverBaseBackoff returns the server-supplied base backoff attached to err.
+func serverBaseBackoff(err error) time.Duration {
+	switch e := err.(type) {
+	case Error:
+		return time.Duration(e.BaseBackoffMS) * time.Millisecond
+	case WriteCommandError:
+		return time.Duration(e.BaseBackoffMS) * time.Millisecond
+	default:
+		return 0
+	}
 }
 
 // sessionsSupported returns true of the given server version indicates that it supports sessions.

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -2301,14 +2301,17 @@ func overloadBackoff(base time.Duration, attempt uint) time.Duration {
 
 // serverBaseBackoff returns the server-supplied base backoff attached to err.
 func serverBaseBackoff(err error) time.Duration {
-	switch e := err.(type) {
-	case Error:
-		return time.Duration(e.BaseBackoffMS) * time.Millisecond
-	case WriteCommandError:
-		return time.Duration(e.BaseBackoffMS) * time.Millisecond
-	default:
-		return 0
+	var cerr Error
+	if errors.As(err, &cerr) {
+		return cerr.BaseBackoff
 	}
+
+	var wce WriteCommandError
+	if errors.As(err, &wce) {
+		return wce.BaseBackoff
+	}
+
+	return 0
 }
 
 // sessionsSupported returns true of the given server version indicates that it supports sessions.

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -1049,7 +1050,12 @@ func TestServerBaseBackoff(t *testing.T) {
 		},
 		{
 			name: "command error with baseBackoffMS",
-			err:  Error{BaseBackoffMS: 50},
+			err:  Error{BaseBackoff: 50 * time.Millisecond},
+			want: 50 * time.Millisecond,
+		},
+		{
+			name: "wrapped command error with baseBackoffMS",
+			err:  fmt.Errorf("wrapped: %w", Error{BaseBackoff: 50 * time.Millisecond}),
 			want: 50 * time.Millisecond,
 		},
 		{
@@ -1059,7 +1065,7 @@ func TestServerBaseBackoff(t *testing.T) {
 		},
 		{
 			name: "write command error with baseBackoffMS",
-			err:  WriteCommandError{BaseBackoffMS: 50},
+			err:  WriteCommandError{BaseBackoff: 50 * time.Millisecond},
 			want: 50 * time.Millisecond,
 		},
 	}

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -19,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/csot"
 	"go.mongodb.org/mongo-driver/v2/internal/handshake"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/internal/uuid"
 	"go.mongodb.org/mongo-driver/v2/mongo/address"
@@ -967,6 +968,109 @@ func BenchmarkRedactStartedInformationCmd(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				redactStartedInformationCmd(info)
 			}
+		})
+	}
+}
+
+func TestOverloadBackoff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		base    time.Duration
+		attempt uint
+		want    time.Duration
+	}{
+		{
+			name:    "first retry",
+			base:    100 * time.Millisecond,
+			attempt: 1,
+			want:    200 * time.Millisecond,
+		},
+		{
+			name:    "second retry",
+			base:    100 * time.Millisecond,
+			attempt: 2,
+			want:    400 * time.Millisecond,
+		},
+		{
+			name:    "third retry",
+			base:    100 * time.Millisecond,
+			attempt: 3,
+			want:    800 * time.Millisecond,
+		},
+		{
+			name:    "capped at backoffMax",
+			base:    100 * time.Millisecond,
+			attempt: 7,
+			want:    backoffMax,
+		},
+		{
+			name:    "no overflow for large attempts",
+			base:    100 * time.Millisecond,
+			attempt: 1000,
+			want:    backoffMax,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.want, overloadBackoff(test.base, test.attempt))
+		})
+	}
+}
+
+func TestServerBaseBackoff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: 0,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("foo"),
+			want: 0,
+		},
+		{
+			name: "command error without baseBackoffMS",
+			err:  Error{},
+			want: 0,
+		},
+		{
+			name: "command error with baseBackoffMS",
+			err:  Error{BaseBackoffMS: 50},
+			want: 50 * time.Millisecond,
+		},
+		{
+			name: "write command error without baseBackoffMS",
+			err:  WriteCommandError{},
+			want: 0,
+		},
+		{
+			name: "write command error with baseBackoffMS",
+			err:  WriteCommandError{BaseBackoffMS: 50},
+			want: 50 * time.Millisecond,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.want, serverBaseBackoff(test.err))
 		})
 	}
 }


### PR DESCRIPTION
GODRIVER-3963
GODRIVER-4045

## Summary
Update client backpressure with baseBackoffMS.

Example code will be updated along with GODRIVER-4062.

## Background & Motivation
Spec updates at: https://github.com/mongodb/specifications/commit/d6fc118bd1dd6854fa72f9be0ff5d6a57e8f68e1
And the followup correction: https://github.com/mongodb/specifications/commit/615e0f9ca5f554614636c098225fbbf1be55565d