### PR TITLE
GODRIVER-4102: reject int32 length overflow in bsoncore valueLength

### DIFF
--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -688,6 +688,13 @@ func valueLength(src []byte, t Type) (int32, bool) {
 		ok = false
 	}
 
+	// Adding a type's fixed overhead to a length read from src can overflow
+	// int32 and wrap negative, which would slip past the len(src) checks in
+	// readValue and ReadElement. Reject any negative result as malformed.
+	if length < 0 {
+		ok = false
+	}
+
 	return length, ok
 }
 

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -972,3 +972,31 @@ func TestInvalidBytes(t *testing.T) {
 		assert.Equal(t, 4, len(src), "expected src to contain the size parameter still")
 	})
 }
+
+func TestValueLengthOverflow(t *testing.T) {
+	t.Parallel()
+
+	// A length field that, combined with a type's fixed overhead, overflows
+	// int32 must be rejected instead of wrapping negative and slipping past the
+	// len(src) bounds checks in readValue and ReadElement. See valueLength.
+	t.Run("binary element in a document", func(t *testing.T) {
+		t.Parallel()
+
+		doc := Document{
+			0x0d, 0x00, 0x00, 0x00, // document length = 13
+			0x05,       // type = binary
+			0x61, 0x00, // key "a"
+			0xff, 0xff, 0xff, 0x7f, // payload length = math.MaxInt32
+			0x00, // subtype
+			0x00, // document terminator
+		}
+		assert.Error(t, doc.Validate(), "expected an error validating an overflowing element length")
+	})
+
+	t.Run("string value", func(t *testing.T) {
+		t.Parallel()
+
+		v := Value{Type: TypeString, Data: []byte{0xff, 0xff, 0xff, 0x7f}}
+		assert.Error(t, v.Validate(), "expected an error validating an overflowing string length")
+	})
+}

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 )
 
 func compareErrors(err1, err2 error) bool {
@@ -974,14 +975,77 @@ func TestInvalidBytes(t *testing.T) {
 }
 
 func TestValueLengthOverflow(t *testing.T) {
-	t.Parallel()
+	// maxInt32 is a length field holding math.MaxInt32. Adding any type's fixed
+	// overhead to it wraps int32 negative.
+	maxInt32 := []byte{0xff, 0xff, 0xff, 0x7f}
 
-	// A length field that, combined with a type's fixed overhead, overflows
-	// int32 must be rejected instead of wrapping negative and slipping past the
-	// len(src) bounds checks in readValue and ReadElement. See valueLength.
+	tests := []struct {
+		name       string
+		t          Type
+		src        []byte
+		wantOK     bool
+		wantLength int32
+	}{
+		{
+			name:   "binary overflows",
+			t:      TypeBinary,
+			src:    maxInt32,
+			wantOK: false,
+		},
+		{
+			name:   "string overflows",
+			t:      TypeString,
+			src:    maxInt32,
+			wantOK: false,
+		},
+		{
+			name:   "javascript overflows",
+			t:      TypeJavaScript,
+			src:    maxInt32,
+			wantOK: false,
+		},
+		{
+			name:   "symbol overflows",
+			t:      TypeSymbol,
+			src:    maxInt32,
+			wantOK: false,
+		},
+		{
+			name:   "dbpointer overflows",
+			t:      TypeDBPointer,
+			src:    maxInt32,
+			wantOK: false,
+		},
+		{
+			// math.MaxInt32-5 plus binary's five bytes of overhead is exactly
+			// math.MaxInt32, so it must not be rejected as an overflow. Lengths
+			// that fit are still caught downstream by the len(src) checks in
+			// readValue and ReadElement.
+			name:       "binary at the largest length that does not overflow",
+			t:          TypeBinary,
+			src:        []byte{0xfa, 0xff, 0xff, 0x7f},
+			wantOK:     true,
+			wantLength: math.MaxInt32,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			length, ok := valueLength(test.src, test.t)
+			require.Equal(t, test.wantOK, ok, "expected valueLength to report ok=%v", test.wantOK)
+			if test.wantOK {
+				require.Equal(t, test.wantLength, length, "expected length %d", test.wantLength)
+			}
+		})
+	}
+}
+
+// TestValueLengthOverflowNoPanic asserts that an overflowing length is reported
+// as an error at the exported boundaries rather than panicking. A negative
+// length slips past the len(src) checks in readValue and ReadElement, so before
+// valueLength rejected it these calls panicked on a negative slice bound.
+func TestValueLengthOverflowNoPanic(t *testing.T) {
 	t.Run("binary element in a document", func(t *testing.T) {
-		t.Parallel()
-
 		doc := Document{
 			0x0d, 0x00, 0x00, 0x00, // document length = 13
 			0x05,       // type = binary
@@ -990,13 +1054,14 @@ func TestValueLengthOverflow(t *testing.T) {
 			0x00, // subtype
 			0x00, // document terminator
 		}
-		assert.Error(t, doc.Validate(), "expected an error validating an overflowing element length")
+		require.Error(t, doc.Validate(), "expected an error validating an overflowing element length")
+
+		_, err := doc.Elements()
+		require.Error(t, err, "expected an error reading elements with an overflowing element length")
 	})
 
 	t.Run("string value", func(t *testing.T) {
-		t.Parallel()
-
 		v := Value{Type: TypeString, Data: []byte{0xff, 0xff, 0xff, 0x7f}}
-		assert.Error(t, v.Validate(), "expected an error validating an overflowing string length")
+		require.Error(t, v.Validate(), "expected an error validating an overflowing string length")
 	})
 }


### PR DESCRIPTION
GODRIVER-4102

## Summary

`valueLength` adds a fixed per-type overhead to a length it reads from the value bytes but keeps the result in an `int32`, so a binary, string, or DBPointer element declaring a length near `math.MaxInt32` wraps the sum negative. That negative length slips past the `int(length) > len(src)` guards in `readValue` and `ReadElement`, so `src[:length]` panics. This rejects a negative result in `valueLength`, the single point every caller funnels through, matching the `int64`-widened arithmetic the `TypeRegex` arm already uses a few lines down.

## Background & Motivation

The raw-BSON entry points exist to vet untrusted bytes, yet `bson.Raw.Validate`, `Raw.Elements`, and `RawValue.Validate` all crash on a 13-byte document whose one binary element declares a payload length of `0x7FFFFFFF`. The same value path decodes replies read straight off the connection, since batch cursors call `Elements` on the server's raw response, so a malformed or hostile reply can take down the caller's goroutine. Added a regression test covering both the document and value forms.
