### PR TITLE
GODRIVER-4088 Return the server error when the first attempt fails with NoWritesPerformed.

### DIFF
--- a/internal/integration/no_writes_performed_test.go
+++ b/internal/integration/no_writes_performed_test.go
@@ -29,38 +29,77 @@ func TestNoWritesPerformedLabel(t *testing.T) {
 	// Sharded topologies are excluded because a failpoint is applied to only a single mongoS.
 	mtOpts := mtest.NewOptions().MinServerVersion("4.4").Topologies(mtest.ReplicaSet)
 
-	mt.RunOpts("RunCommand returns the server error on the first attempt", mtOpts, func(mt *mtest.T) {
-		const errorCode int32 = 262 // ExceededTimeLimit
+	const errorCode int32 = 262 // ExceededTimeLimit
 
-		mt.SetFailPoint(failpoint.FailPoint{
-			ConfigureFailPoint: "failCommand",
-			Mode: failpoint.Mode{
-				Times: 1,
+	testCases := []struct {
+		name        string
+		failCommand string
+		setup       func(mt *mtest.T) // nil when the test needs no seed data
+		execute     func(mt *mtest.T) *mongo.SingleResult
+	}{
+		{
+			name:        "RunCommand returns the server error on the first attempt",
+			failCommand: "insert",
+			execute: func(mt *mtest.T) *mongo.SingleResult {
+				return mt.DB.RunCommand(context.Background(), bson.D{
+					{Key: "insert", Value: mt.Coll.Name()},
+					{Key: "documents", Value: bson.A{bson.D{{Key: "x", Value: 1}}}},
+				})
 			},
-			Data: failpoint.Data{
-				FailCommands: []string{"insert"},
-				ErrorCode:    errorCode,
-				ErrorLabels:  &[]string{"SystemOverloadedError", "NoWritesPerformed"},
+		},
+		{
+			// GODRIVER-4098: findAndModify reports its result in the "value" field. A discarded
+			// error leaves the SingleResult reading that field from the server's error response,
+			// where it does not exist, so a matching document is reported as no document at all.
+			name:        "FindOneAndUpdate returns the server error on the first attempt",
+			failCommand: "findAndModify",
+			setup: func(mt *mtest.T) {
+				_, err := mt.Coll.InsertOne(context.Background(), bson.D{{Key: "x", Value: 1}})
+				require.NoError(mt, err, "InsertOne error: %v", err)
 			},
+			execute: func(mt *mtest.T) *mongo.SingleResult {
+				return mt.Coll.FindOneAndUpdate(context.Background(),
+					bson.D{{Key: "x", Value: 1}},
+					bson.D{{Key: "$set", Value: bson.D{{Key: "y", Value: 2}}}})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		mt.RunOpts(tc.name, mtOpts, func(mt *mtest.T) {
+			if tc.setup != nil {
+				tc.setup(mt)
+			}
+
+			mt.SetFailPoint(failpoint.FailPoint{
+				ConfigureFailPoint: "failCommand",
+				Mode: failpoint.Mode{
+					Times: 1,
+				},
+				Data: failpoint.Data{
+					FailCommands: []string{tc.failCommand},
+					ErrorCode:    errorCode,
+					ErrorLabels:  &[]string{"SystemOverloadedError", "NoWritesPerformed"},
+				},
+			})
+
+			res := tc.execute(mt)
+
+			err := res.Err()
+			require.Error(mt, err, "expected an error from %s, got nil", tc.failCommand)
+			require.False(mt, errors.Is(err, mongo.ErrNoDocuments),
+				"expected the server error, got ErrNoDocuments")
+
+			var cerr mongo.CommandError
+			require.True(mt, errors.As(err, &cerr), "expected a mongo.CommandError, got %v", err)
+			require.Equal(mt, errorCode, cerr.Code, "expected error code 262")
+			require.True(mt, cerr.HasErrorLabel("NoWritesPerformed"),
+				"expected the error to have the NoWritesPerformed label")
+
+			// Decode must report the error rather than handing back the server's
+			// error-response document as a result.
+			var raw bson.Raw
+			require.Error(mt, res.Decode(&raw), "expected an error from Decode, got nil and document %v", raw)
 		})
-
-		res := mt.DB.RunCommand(context.Background(), bson.D{
-			{Key: "insert", Value: mt.Coll.Name()},
-			{Key: "documents", Value: bson.A{bson.D{{Key: "x", Value: 1}}}},
-		})
-
-		err := res.Err()
-		require.Error(mt, err, "expected an error from RunCommand, got nil")
-
-		var cerr mongo.CommandError
-		require.True(mt, errors.As(err, &cerr), "expected a mongo.CommandError, got %v", err)
-		require.Equal(mt, errorCode, cerr.Code, "expected error code 262")
-		require.True(mt, cerr.HasErrorLabel("NoWritesPerformed"),
-			"expected the error to have the NoWritesPerformed label")
-
-		// Decode must report the error rather than handing back the server's
-		// error-response document as a result.
-		var raw bson.Raw
-		require.Error(mt, res.Decode(&raw), "expected an error from Decode, got nil and document %v", raw)
-	})
+	}
 }

--- a/internal/integration/no_writes_performed_test.go
+++ b/internal/integration/no_writes_performed_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) MongoDB, Inc. 2026-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/internal/failpoint"
+	"go.mongodb.org/mongo-driver/v2/internal/integration/mtest"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// TestNoWritesPerformedLabel asserts that an operation which fails on its first
+// and only attempt with the "NoWritesPerformed" label surfaces the server
+// error. The label instructs the driver to return the error from the previous
+// attempt, so when there is no previous attempt the current error must be
+// returned rather than substituted with a nil error.
+func TestNoWritesPerformedLabel(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().CreateClient(false))
+
+	// Sharded topologies are excluded because a failpoint is applied to only a single mongoS.
+	mtOpts := mtest.NewOptions().MinServerVersion("4.4").Topologies(mtest.ReplicaSet)
+
+	mt.RunOpts("RunCommand returns the server error on the first attempt", mtOpts, func(mt *mtest.T) {
+		const errorCode int32 = 262 // ExceededTimeLimit
+
+		mt.SetFailPoint(failpoint.FailPoint{
+			ConfigureFailPoint: "failCommand",
+			Mode: failpoint.Mode{
+				Times: 1,
+			},
+			Data: failpoint.Data{
+				FailCommands: []string{"insert"},
+				ErrorCode:    errorCode,
+				ErrorLabels:  &[]string{"SystemOverloadedError", "NoWritesPerformed"},
+			},
+		})
+
+		res := mt.DB.RunCommand(context.Background(), bson.D{
+			{Key: "insert", Value: mt.Coll.Name()},
+			{Key: "documents", Value: bson.A{bson.D{{Key: "x", Value: 1}}}},
+		})
+
+		err := res.Err()
+		require.Error(mt, err, "expected an error from RunCommand, got nil")
+
+		var cerr mongo.CommandError
+		require.True(mt, errors.As(err, &cerr), "expected a mongo.CommandError, got %v", err)
+		require.Equal(mt, errorCode, cerr.Code, "expected error code 262")
+		require.True(mt, cerr.HasErrorLabel("NoWritesPerformed"),
+			"expected the error to have the NoWritesPerformed label")
+
+		// Decode must report the error rather than handing back the server's
+		// error-response document as a result.
+		var raw bson.Raw
+		require.Error(mt, res.Decode(&raw), "expected an error from Decode, got nil and document %v", raw)
+	})
+}

--- a/x/mongo/driver/operation.go
+++ b/x/mongo/driver/operation.go
@@ -894,8 +894,9 @@ func (op Operation) Execute(ctx context.Context) error {
 
 			// If the error is no longer retryable and has the NoWritesPerformed label, then we should
 			// set the error to the "previous indefinite error" unless the current error is already the
-			// "previous indefinite error". After resetting, repeat the error check.
-			if tt.HasErrorLabel(NoWritesPerformed) && !prevIndefiniteErrIsSet {
+			// "previous indefinite error" or no previous attempt was made. After resetting, repeat the
+			// error check.
+			if tt.HasErrorLabel(NoWritesPerformed) && !prevIndefiniteErrIsSet && prevIndefiniteErr != nil {
 				err = prevIndefiniteErr
 				prevIndefiniteErrIsSet = true
 
@@ -1027,8 +1028,9 @@ func (op Operation) Execute(ctx context.Context) error {
 
 			// If the error is no longer retryable and has the NoWritesPerformed label, then we should
 			// set the error to the "previous indefinite error" unless the current error is already the
-			// "previous indefinite error". After resetting, repeat the error check.
-			if tt.HasErrorLabel(NoWritesPerformed) && !prevIndefiniteErrIsSet {
+			// "previous indefinite error" or no previous attempt was made. After resetting, repeat the
+			// error check.
+			if tt.HasErrorLabel(NoWritesPerformed) && !prevIndefiniteErrIsSet && prevIndefiniteErr != nil {
 				err = prevIndefiniteErr
 				prevIndefiniteErrIsSet = true
 

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -19,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/assert"
 	"go.mongodb.org/mongo-driver/v2/internal/csot"
 	"go.mongodb.org/mongo-driver/v2/internal/handshake"
+	"go.mongodb.org/mongo-driver/v2/internal/require"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/internal/uuid"
 	"go.mongodb.org/mongo-driver/v2/mongo/address"
@@ -672,6 +673,67 @@ func TestOperation(t *testing.T) {
 
 		assert.ErrorIs(t, err, ErrDeadlineWouldBeExceeded)
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+	t.Run("NoWritesPerformed on the first attempt returns the current error", func(t *testing.T) {
+		labels := bson.A{"SystemOverloadedError", "NoWritesPerformed"}
+		const errorCode int32 = 262 // ExceededTimeLimit
+
+		executeInsert := func(t *testing.T, response bson.D) error {
+			t.Helper()
+
+			doc, err := bson.Marshal(response)
+			require.NoError(t, err, "Marshal error: %v", err)
+
+			conn := &mockConnection{rReadWM: createExhaustServerResponse(doc, false)}
+			op := Operation{
+				CommandFn: func(dst []byte, _ description.SelectedServer) ([]byte, error) {
+					return bsoncore.AppendInt32Element(dst, "insert", 1), nil
+				},
+				Database:   "foobar",
+				Deployment: SingleConnectionDeployment{C: mnet.NewConnection(conn)},
+				Type:       Write,
+			}
+
+			return op.Execute(context.Background())
+		}
+
+		t.Run("command error", func(t *testing.T) {
+			err := executeInsert(t, bson.D{
+				{Key: "ok", Value: 0},
+				{Key: "code", Value: errorCode},
+				{Key: "codeName", Value: "ExceededTimeLimit"},
+				{Key: "errmsg", Value: "operation was interrupted"},
+				{Key: "errorLabels", Value: labels},
+			})
+
+			require.Error(t, err, "expected an error from Execute(), got nil")
+
+			var cerr Error
+			require.True(t, errors.As(err, &cerr), "expected an Error, got %v", err)
+			require.Equal(t, errorCode, cerr.Code, "expected error code 262")
+			require.True(t, cerr.HasErrorLabel(NoWritesPerformed),
+				"expected the error to have the NoWritesPerformed label")
+		})
+		t.Run("write concern error", func(t *testing.T) {
+			err := executeInsert(t, bson.D{
+				{Key: "ok", Value: 1},
+				{Key: "n", Value: 0},
+				{Key: "writeConcernError", Value: bson.D{
+					{Key: "code", Value: errorCode},
+					{Key: "codeName", Value: "ExceededTimeLimit"},
+					{Key: "errmsg", Value: "operation was interrupted"},
+					{Key: "errorLabels", Value: labels},
+				}},
+			})
+
+			require.Error(t, err, "expected an error from Execute(), got nil")
+
+			var wce WriteCommandError
+			require.True(t, errors.As(err, &wce), "expected a WriteCommandError, got %v", err)
+			require.NotNil(t, wce.WriteConcernError, "expected a write concern error")
+			require.True(t, wce.HasErrorLabel(NoWritesPerformed),
+				"expected the error to have the NoWritesPerformed label")
+		})
 	})
 }
 


### PR DESCRIPTION
GODRIVER-4088
GODRIVER-4098

## Summary
This PR adds a `prevIndefiniteErr != nil` guard to both the command error and write concern error branches in `Operation.Execute`, so the real server error is returned when there is no previous attempt to fall back to. Behavior after a retry is unchanged.

## Background & Motivation
Previously, retryability was decided purely by labels. The server attaches `NoWritesPerformed` as a companion to a retryable write failure: it means "this retry attempt performed no writes, so prefer the earlier error." Therefore, the label always came bundled with `RetryableWriteError`.

That bundling made the nil case unreachable on the normal path:
1. First attempt fails with `[RetryableWriteError, NoWritesPerformed]` -> `needRetry` is true -> `resetForRetry` runs -> `prevIndefiniteErr` gets set
2. Only a later attempt reaches the substitution branch, and by then there's a real previous error to substitute.

The branch was written assuming step 1 always happens first.

When SystemOverloadedError is introduced, it can hit any command on its very first attempt. The label set in this ticket is `[SystemOverloadedError, NoWritesPerformed]` without `RetryableWriteError`. In "operation.go":
``` go
needRetry := (retrySupported && retryEnabled && retryableErr) || (op.MaxAdaptiveRetries != 0 && olRetryErr)
```
- `retryableErr` is false because of no `RetryableWriteError`.
- `olRetryErr` is also false due to not being a `RetryableError`.

So control falls into the NoWritesPerformed branch with prevIndefiniteErr still nil.

## Notes
This patch will be merged to v2.8 branch.
