### PR TITLE
GODRIVER-4097: Preserve version-to-name mapping in client metadata

### DIFF
--- a/internal/handshake/operation/hello.go
+++ b/internal/handshake/operation/hello.go
@@ -27,6 +27,10 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/session"
 )
 
+// metadataDelimiter separates the entries contributed by the driver and each
+// wrapping library within a client metadata field.
+const metadataDelimiter = "|"
+
 // maxClientMetadataSize is the maximum size of the client metadata document
 // that can be sent to the server. Note that the maximum document size on
 // standalone and replica servers is 1024, but the maximum document size on
@@ -50,10 +54,15 @@ type Hello struct {
 	loadBalanced       bool
 	omitMaxTimeMS      bool
 
-	// Fields provided by a library that wraps the Go Driver.
+	// Fields provided by a library that wraps the Go Driver. Each is a
+	// delimited list with one entry per wrapping library, positionally
+	// corresponding across the three fields. outerLibrarySet distinguishes "no
+	// wrapping library" from a wrapping library that reported an empty value,
+	// which is a meaningful entry and must still be delimited.
 	outerLibraryName     string
 	outerLibraryVersion  string
 	outerLibraryPlatform string
+	outerLibrarySet      bool
 
 	res bsoncore.Document
 }
@@ -147,6 +156,15 @@ func (h *Hello) OuterLibraryVersion(version string) *Hello {
 // Driver.
 func (h *Hello) OuterLibraryPlatform(platform string) *Hello {
 	h.outerLibraryPlatform = platform
+
+	return h
+}
+
+// OuterLibrarySet specifies whether any library wraps the Go Driver. It must be
+// set for the outer library values to be appended, because an empty value is a
+// meaningful entry and cannot be distinguished from an absent one.
+func (h *Hello) OuterLibrarySet(set bool) *Hello {
+	h.outerLibrarySet = set
 
 	return h
 }
@@ -275,18 +293,19 @@ func appendClientAppName(dst []byte, name string) ([]byte, error) {
 // appendClientDriver appends the driver metadata to dst. It is the
 // responsibility of the caller to check that this appending does not cause dst
 // to exceed any size limitations.
-func appendClientDriver(dst []byte, outerLibraryName, outerLibraryVersion string) ([]byte, error) {
+func appendClientDriver(dst []byte, outerLibraryName, outerLibraryVersion string, outerLibrarySet bool) ([]byte, error) {
 	var idx int32
 	idx, dst = bsoncore.AppendDocumentElementStart(dst, "driver")
 
+	// The driver occupies the first entry, so the delimiter is appended
+	// unconditionally when a wrapping library is present. An empty outer value
+	// yields an empty entry, which keeps name and version aligned by index.
 	name := driverName
-	if outerLibraryName != "" {
-		name = name + "|" + outerLibraryName
-	}
-
 	version := version.Driver
-	if outerLibraryVersion != "" {
-		version = version + "|" + outerLibraryVersion
+
+	if outerLibrarySet {
+		name = name + metadataDelimiter + outerLibraryName
+		version = version + metadataDelimiter + outerLibraryVersion
 	}
 
 	dst = bsoncore.AppendStringElement(dst, "name", name)
@@ -413,9 +432,11 @@ func appendClientOS(dst []byte, omitNonType bool) ([]byte, error) {
 // responsibility of the caller to check that this appending does not cause dst
 // to exceed any size limitations.
 func appendClientPlatform(dst []byte, outerLibraryPlatform string) []byte {
+	// Unlike name and version, platform is not positional: a wrapping library
+	// that reports no platform contributes nothing rather than an empty entry.
 	platform := runtime.Version()
 	if outerLibraryPlatform != "" {
-		platform = platform + "|" + outerLibraryPlatform
+		platform = platform + metadataDelimiter + outerLibraryPlatform
 	}
 
 	return bsoncore.AppendStringElement(dst, "platform", platform)
@@ -474,7 +495,7 @@ retry:
 		return nil, err
 	}
 
-	dst, err = appendClientDriver(dst, h.outerLibraryName, h.outerLibraryVersion)
+	dst, err = appendClientDriver(dst, h.outerLibraryName, h.outerLibraryVersion, h.outerLibrarySet)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handshake/operation/hello_test.go
+++ b/internal/handshake/operation/hello_test.go
@@ -115,6 +115,7 @@ func TestAppendClientDriver(t *testing.T) {
 		name                string
 		outerLibraryName    string
 		outerLibraryVersion string
+		outerLibrarySet     bool
 		want                []byte // Extend JSON
 	}{
 		{
@@ -127,7 +128,33 @@ func TestAppendClientDriver(t *testing.T) {
 			name:                "with outer library data",
 			outerLibraryName:    "outer-library-name",
 			outerLibraryVersion: "outer-library-version",
+			outerLibrarySet:     true,
 			want:                []byte(fmt.Sprintf(`{"driver":{"name": "%s|outer-library-name", "version": "%s|outer-library-version"}}`, driverName, version.Driver)),
+		},
+		{
+			// An outer library that reports no version contributes an empty
+			// entry, so the trailing delimiter is significant.
+			name:                "outer library without a version",
+			outerLibraryName:    "outer-library-name",
+			outerLibraryVersion: "",
+			outerLibrarySet:     true,
+			want:                []byte(fmt.Sprintf(`{"driver":{"name": "%s|outer-library-name", "version": "%s|"}}`, driverName, version.Driver)),
+		},
+		{
+			// An entry is emitted for every wrapping library even when it
+			// reports nothing, so the fields stay aligned by index.
+			name:                "outer library without a name or version",
+			outerLibraryName:    "",
+			outerLibraryVersion: "",
+			outerLibrarySet:     true,
+			want:                []byte(fmt.Sprintf(`{"driver":{"name": "%s|", "version": "%s|"}}`, driverName, version.Driver)),
+		},
+		{
+			name:                "multiple outer libraries with a gap in the middle",
+			outerLibraryName:    "F1|F2|F3",
+			outerLibraryVersion: "1.0||2.0",
+			outerLibrarySet:     true,
+			want:                []byte(fmt.Sprintf(`{"driver":{"name": "%s|F1|F2|F3", "version": "%s|1.0||2.0"}}`, driverName, version.Driver)),
 		},
 	}
 
@@ -139,7 +166,7 @@ func TestAppendClientDriver(t *testing.T) {
 
 			cb := func(_ int, dst []byte) ([]byte, error) {
 				var err error
-				dst, err = appendClientDriver(dst, test.outerLibraryName, test.outerLibraryVersion)
+				dst, err = appendClientDriver(dst, test.outerLibraryName, test.outerLibraryVersion, test.outerLibrarySet)
 
 				return dst, err
 			}
@@ -721,7 +748,7 @@ func FuzzEncodeClientMetadata(f *testing.F) {
 			t.Fatalf("error appending client app name: %v", err)
 		}
 
-		_, err = appendClientDriver(b, "", "")
+		_, err = appendClientDriver(b, "", "", false)
 		if err != nil {
 			t.Fatalf("error appending client driver: %v", err)
 		}

--- a/internal/integration/handshake_test.go
+++ b/internal/integration/handshake_test.go
@@ -8,6 +8,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -59,7 +60,7 @@ func TestHandshakeProse(t *testing.T) {
 		name string
 		env  map[string]string
 		opts *options.ClientOptions
-		want []byte
+		want string
 	}{
 		{
 			name: "1. valid AWS",
@@ -69,22 +70,11 @@ func TestHandshakeProse(t *testing.T) {
 				"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					bson.E{Key: "name", Value: "aws.lambda"},
-					bson.E{Key: "memory_mb", Value: 1024},
-					bson.E{Key: "region", Value: "us-east-2"},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "aws.lambda", "memory_mb": 1024, "region": "us-east-2"}`),
 		},
 		{
 			name: "2. valid Azure",
@@ -92,20 +82,11 @@ func TestHandshakeProse(t *testing.T) {
 				"FUNCTIONS_WORKER_RUNTIME": "node",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					bson.E{Key: "name", Value: "azure.func"},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "azure.func"}`),
 		},
 		{
 			name: "3. valid GCP",
@@ -116,23 +97,11 @@ func TestHandshakeProse(t *testing.T) {
 				"FUNCTION_REGION":      "us-central1",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					bson.E{Key: "name", Value: "gcp.func"},
-					bson.E{Key: "memory_mb", Value: 1024},
-					bson.E{Key: "region", Value: "us-central1"},
-					bson.E{Key: "timeout_sec", Value: int32(60)},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "gcp.func", "memory_mb": 1024, "region": "us-central1", "timeout_sec": 60}`),
 		},
 		{
 			name: "4. valid Vercel",
@@ -141,21 +110,11 @@ func TestHandshakeProse(t *testing.T) {
 				"VERCEL_REGION": "cdg1",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					bson.E{Key: "name", Value: "vercel"},
-					bson.E{Key: "region", Value: "cdg1"},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "vercel", "region": "cdg1"}`),
 		},
 		{
 			name: "5. invalid multiple providers",
@@ -164,17 +123,10 @@ func TestHandshakeProse(t *testing.T) {
 				"FUNCTIONS_WORKER_RUNTIME": "node",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version()),
 		},
 		{
 			name: "6. invalid long string",
@@ -189,20 +141,11 @@ func TestHandshakeProse(t *testing.T) {
 				}(),
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					{Key: "name", Value: "aws.lambda"},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "aws.lambda"}`),
 		},
 		{
 			name: "7. invalid wrong types",
@@ -211,20 +154,11 @@ func TestHandshakeProse(t *testing.T) {
 				"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "big",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-				{Key: "env", Value: bson.D{
-					{Key: "name", Value: "aws.lambda"},
-				}},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version(),
+				`{"name": "aws.lambda"}`),
 		},
 		{
 			name: "8. Invalid - AWS_EXECUTION_ENV does not start with \"AWS_Lambda_\"",
@@ -232,32 +166,18 @@ func TestHandshakeProse(t *testing.T) {
 				"AWS_EXECUTION_ENV": "EC2",
 			},
 			opts: nil,
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver",
+				version.Driver,
+				runtime.Version()),
 		},
 		{
 			name: "driver info included",
 			opts: options.Client().SetDriverInfo(driverInfo),
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|outer-library-name"},
-					{Key: "version", Value: version.Driver + "|outer-library-version"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|outer-library-platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|outer-library-name",
+				version.Driver+"|outer-library-version",
+				runtime.Version()+"|outer-library-platform"),
 		},
 	}
 
@@ -283,7 +203,7 @@ func TestHandshakeProse(t *testing.T) {
 			assert.True(mt, firstMessage.IsHandshake(), "expected first message to be a handshake")
 
 			clientMetadata := clientMetadataFromHandshake(mt, firstMessage.Sent.Command)
-			assertbson.EqualDocument(mt, tc.want, clientMetadata)
+			assertbson.EqualDocument(mt, extJSONToBSON(mt, tc.want), clientMetadata)
 		})
 	}
 }
@@ -353,7 +273,7 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 	testCases := []struct {
 		name       string
 		driverInfo options.DriverInfo
-		want       []byte
+		want       string
 
 		// append initialDriverInfo using client.AppendDriverInfo instead of as a
 		// client-level constructor.
@@ -366,17 +286,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: false,
 		},
 		{
@@ -386,17 +299,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform"),
 			append: false,
 		},
 		{
@@ -406,17 +312,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: false,
 		},
 		{
@@ -426,17 +325,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|",
+				runtime.Version()+"|Library Platform"),
 			append: false,
 		},
 		{
@@ -446,17 +338,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: true,
 		},
 		{
@@ -466,17 +351,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform"),
 			append: true,
 		},
 		{
@@ -486,17 +364,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: true,
 		},
 		{
@@ -506,17 +377,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|",
+				runtime.Version()+"|Library Platform"),
 			append: true,
 		},
 		{
@@ -526,17 +390,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "1.2",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library",
+				version.Driver+"|1.2",
+				runtime.Version()+"|Library Platform"),
 			append: true,
 		},
 		{
@@ -546,17 +403,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "1.2",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|1.2",
+				runtime.Version()+"|Library Platform|Library Platform"),
 			append: true,
 		},
 		{
@@ -566,17 +416,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|library",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform|Library Platform"),
 			append: true,
 		},
 		{
@@ -586,17 +429,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "1.2",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|library",
+				version.Driver+"|1.2|1.2",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: true,
 		},
 		{
@@ -606,17 +442,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform|Library Platform"),
 			append: true,
 		},
 		{
@@ -626,17 +455,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "1.2",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library|framework"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|framework",
+				version.Driver+"|1.2|1.2",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: true,
 		},
 		{
@@ -646,17 +468,10 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 				Version:  "2.0",
 				Platform: "Framework Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2|2.0"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library|library",
+				version.Driver+"|1.2|2.0",
+				runtime.Version()+"|Library Platform|Framework Platform"),
 			append: true,
 		},
 	}
@@ -712,7 +527,7 @@ func TestHandshakeProse_AppendMetadata_Test1_Test2_Test3(t *testing.T) {
 			assert.True(mt, gotMessage.IsHandshake(), "expected first message to be a handshake")
 
 			clientMetadata := clientMetadataFromHandshake(mt, gotMessage.Sent.Command)
-			assertbson.EqualDocument(mt, tc.want, clientMetadata)
+			assertbson.EqualDocument(mt, extJSONToBSON(mt, tc.want), clientMetadata)
 		})
 	}
 }
@@ -767,17 +582,10 @@ func TestHandshakeProse_AppendMetadata_MultipleUpdatesWithDuplicateFields(t *tes
 	// metadata value to make the tests more reliable and prevent
 	// false-positive assertion results. That deviates from the prose
 	// test.
-	want := mustMarshalBSON(bson.D{
-		{Key: "driver", Value: bson.D{
-			{Key: "name", Value: "mongo-go-driver|library|framework"},
-			{Key: "version", Value: version.Driver + "|1.2|2.0"},
-		}},
-		{Key: "os", Value: bson.D{
-			{Key: "type", Value: runtime.GOOS},
-			{Key: "architecture", Value: runtime.GOARCH},
-		}},
-		{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-	})
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library|framework",
+		version.Driver+"|1.2|2.0",
+		runtime.Version()+"|Library Platform|Framework Platform")
 
 	// 8. Wait 5ms for the connection to become idle.
 	time.Sleep(5 * time.Millisecond)
@@ -799,7 +607,7 @@ func TestHandshakeProse_AppendMetadata_MultipleUpdatesWithDuplicateFields(t *tes
 	assert.True(mt, updatedClientMetadata.IsHandshake(), "expected first message to be a handshake")
 
 	clientMetadata := clientMetadataFromHandshake(mt, updatedClientMetadata.Sent.Command)
-	assertbson.EqualDocument(mt, want, clientMetadata)
+	assertbson.EqualDocument(mt, extJSONToBSON(mt, want), clientMetadata)
 }
 
 // Test 5: Metadata is not appended if identical to initial metadata
@@ -834,17 +642,10 @@ func TestHandshakeProse_AppendMetadata_NotAppendedIfIdentical(t *testing.T) {
 	// metadata value to make the tests more reliable and prevent
 	// false-positive assertion results. That deviates from the prose
 	// test.
-	want := mustMarshalBSON(bson.D{
-		{Key: "driver", Value: bson.D{
-			{Key: "name", Value: "mongo-go-driver|library"},
-			{Key: "version", Value: version.Driver + "|1.2"},
-		}},
-		{Key: "os", Value: bson.D{
-			{Key: "type", Value: runtime.GOOS},
-			{Key: "architecture", Value: runtime.GOARCH},
-		}},
-		{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-	})
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library",
+		version.Driver+"|1.2",
+		runtime.Version()+"|Library Platform")
 
 	// 3. Wait 5ms for the connection to become idle.
 	time.Sleep(5 * time.Millisecond)
@@ -869,7 +670,7 @@ func TestHandshakeProse_AppendMetadata_NotAppendedIfIdentical(t *testing.T) {
 	assert.True(mt, updatedClientMetadata.IsHandshake(), "expected first message to be a handshake")
 
 	clientMetadata := clientMetadataFromHandshake(mt, updatedClientMetadata.Sent.Command)
-	assertbson.EqualDocument(mt, want, clientMetadata)
+	assertbson.EqualDocument(mt, extJSONToBSON(mt, want), clientMetadata)
 }
 
 // Test 6: Metadata is not appended if identical to initial metadata (separated
@@ -908,7 +709,7 @@ func TestHandshakeProse_AppendMetadata_NotAppendedIfIdentical_NonSequential(t *t
 	mt.Client.AppendDriverInfo(options.DriverInfo{
 		Name:     "framework",
 		Version:  "1.2",
-		Platform: "Framework Platform",
+		Platform: "Library Platform",
 	})
 
 	// Drain the proxy to ensure we only capture messages after appending.
@@ -924,17 +725,10 @@ func TestHandshakeProse_AppendMetadata_NotAppendedIfIdentical_NonSequential(t *t
 	// metadata value to make the tests more reliable and prevent
 	// false-positive assertion results. That deviates from the prose
 	// test.
-	want := mustMarshalBSON(bson.D{
-		{Key: "driver", Value: bson.D{
-			{Key: "name", Value: "mongo-go-driver|library|framework"},
-			{Key: "version", Value: version.Driver + "|1.2"},
-		}},
-		{Key: "os", Value: bson.D{
-			{Key: "type", Value: runtime.GOOS},
-			{Key: "architecture", Value: runtime.GOARCH},
-		}},
-		{Key: "platform", Value: runtime.Version() + "|Library Platform|Framework Platform"},
-	})
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library|framework",
+		version.Driver+"|1.2|1.2",
+		runtime.Version()+"|Library Platform|Library Platform")
 
 	// 7. Wait 5ms for the connection to become idle.
 	time.Sleep(5 * time.Millisecond)
@@ -960,7 +754,7 @@ func TestHandshakeProse_AppendMetadata_NotAppendedIfIdentical_NonSequential(t *t
 	assert.True(mt, updatedClientMetadata.IsHandshake(), "expected first message to be a handshake")
 
 	clientMetadata := clientMetadataFromHandshake(mt, updatedClientMetadata.Sent.Command)
-	assertbson.EqualDocument(mt, want, clientMetadata)
+	assertbson.EqualDocument(mt, extJSONToBSON(mt, want), clientMetadata)
 }
 
 // Test 7: Empty strings are considered unset when appending duplicate metadata.
@@ -971,7 +765,7 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings(t *testing.T) {
 		name               string
 		initialDriverInfo  options.DriverInfo
 		toAppendDriverInfo options.DriverInfo
-		want               []byte
+		want               string
 	}{
 		{
 			name: "name empty",
@@ -985,17 +779,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings(t *testing.T) {
 				Version:  "1.2",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|",
+				version.Driver+"|1.2",
+				runtime.Version()+"|Library Platform"),
 		},
 		{
 			name: "version empty",
@@ -1009,17 +796,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings(t *testing.T) {
 				Version:  "",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library",
+				version.Driver+"|",
+				runtime.Version()+"|Library Platform"),
 		},
 		{
 			name: "platform empty",
@@ -1033,17 +813,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings(t *testing.T) {
 				Version:  "1.2",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library",
+				version.Driver+"|1.2",
+				runtime.Version()),
 		},
 	}
 
@@ -1104,7 +877,7 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings(t *testing.T) {
 			assert.True(mt, updatedClientMetadata.IsHandshake(), "expected first message to be a handshake")
 
 			clientMetadata := clientMetadataFromHandshake(mt, updatedClientMetadata.Sent.Command)
-			assertbson.EqualDocument(mt, tc.want, clientMetadata)
+			assertbson.EqualDocument(mt, extJSONToBSON(mt, tc.want), clientMetadata)
 		})
 	}
 }
@@ -1118,7 +891,7 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 		name               string
 		initialDriverInfo  options.DriverInfo
 		toAppendDriverInfo options.DriverInfo
-		want               []byte
+		want               string
 	}{
 		{
 			name: "name empty",
@@ -1132,17 +905,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 				Version:  "1.2",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|",
+				version.Driver+"|1.2",
+				runtime.Version()+"|Library Platform"),
 		},
 		{
 			name: "version empty",
@@ -1156,17 +922,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 				Version:  "",
 				Platform: "Library Platform",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version() + "|Library Platform"},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library",
+				version.Driver+"|",
+				runtime.Version()+"|Library Platform"),
 		},
 		{
 			name: "platform empty",
@@ -1180,17 +939,10 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 				Version:  "1.2",
 				Platform: "",
 			},
-			want: mustMarshalBSON(bson.D{
-				{Key: "driver", Value: bson.D{
-					{Key: "name", Value: "mongo-go-driver|library"},
-					{Key: "version", Value: version.Driver + "|1.2"},
-				}},
-				{Key: "os", Value: bson.D{
-					{Key: "type", Value: runtime.GOOS},
-					{Key: "architecture", Value: runtime.GOARCH},
-				}},
-				{Key: "platform", Value: runtime.Version()},
-			}),
+			want: clientMetadataExtJSON(
+				"mongo-go-driver|library",
+				version.Driver+"|1.2",
+				runtime.Version()),
 		},
 	}
 
@@ -1247,7 +999,7 @@ func TestHandshakeProse_AppendMetadata_EmptyStrings_InitializedClient(t *testing
 
 			// 8. Assert that `initialClientMetadata` is identical to `updatedClientMetadata`.
 			clientMetadata := clientMetadataFromHandshake(mt, updatedClientMetadata.Sent.Command)
-			assertbson.EqualDocument(mt, tc.want, clientMetadata)
+			assertbson.EqualDocument(mt, extJSONToBSON(mt, tc.want), clientMetadata)
 		})
 	}
 }
@@ -1273,12 +1025,309 @@ func TestHandshakeProse_Handshake_Documents(t *testing.T) {
 	require.Equal(mt, "2", str, `expected backpressure field to be "2"`)
 }
 
+func TestHandshakeProse_Test10_Case1_GapInMiddleName(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: ""}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F2"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver||F2",
+		version.Driver+"||",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case2_GapInMiddleVersion(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F2", Version: "2.0"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1|F2",
+		version.Driver+"||2.0",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case3_TrailingDelimiterRetained(t *testing.T) {
+	mt := newHandshakeT(t)
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1",
+		version.Driver+"|",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case4_EqualVersionsDoNotCollapse(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: version.Driver}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1",
+		version.Driver+"|"+version.Driver,
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case5_EqualNamesDoNotCollapse(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "mongo-go-driver", Version: "1.0"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|mongo-go-driver",
+		version.Driver+"|1.0",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case6_DuplicatesStillDeduplicate(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1",
+		version.Driver+"|1.0",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case7_AllVersionsAbsent(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F2"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1|F2",
+		version.Driver+"||",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case8_AllNamesAbsent(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Version: "1.0"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Version: "2.0"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver||",
+		version.Driver+"|1.0|2.0",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case9_NonAdjacentDuplicate(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F2", Version: "2.0"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1|F2",
+		version.Driver+"|1.0|2.0",
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case10_PlatformOnlyDifferenceIsNotADuplicate(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0", Platform: "P1"}))
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{Name: "F1", Version: "1.0", Platform: "P2"}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|F1|F1",
+		version.Driver+"|1.0|1.0",
+		runtime.Version()+"|P1|P2")
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test10_Case11_WrapperMatchingDriverIdentity(t *testing.T) {
+	mt := newHandshakeT(t)
+
+	require.NoError(mt, mt.Client.AppendDriverInfoErr(options.DriverInfo{
+		Name:    "mongo-go-driver",
+		Version: version.Driver,
+	}))
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|mongo-go-driver",
+		version.Driver+"|"+version.Driver,
+		runtime.Version())
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test11_Case1_NameContainsDelimiter(t *testing.T) {
+	mt := newHandshakeTWithDriverInfo(t, &options.DriverInfo{
+		Name:     "library",
+		Version:  "1.2",
+		Platform: "Library Platform",
+	})
+
+	err := mt.Client.AppendDriverInfoErr(options.DriverInfo{
+		Name:     "frame|work",
+		Version:  "2.0",
+		Platform: "Framework Platform",
+	})
+	require.Error(mt, err)
+
+	// Wait 5ms for the connection to become idle so that the next
+	// operation establishes a new connection and handshakes again.
+	time.Sleep(5 * time.Millisecond)
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library",
+		version.Driver+"|1.2",
+		runtime.Version()+"|Library Platform")
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test11_Case2_VersionContainsDelimiter(t *testing.T) {
+	mt := newHandshakeTWithDriverInfo(t, &options.DriverInfo{
+		Name:     "library",
+		Version:  "1.2",
+		Platform: "Library Platform",
+	})
+
+	err := mt.Client.AppendDriverInfoErr(options.DriverInfo{
+		Name:     "framework",
+		Version:  "2|0",
+		Platform: "Framework Platform",
+	})
+	require.Error(mt, err)
+
+	// Wait 5ms for the connection to become idle so that the next
+	// operation establishes a new connection and handshakes again.
+	time.Sleep(5 * time.Millisecond)
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library",
+		version.Driver+"|1.2",
+		runtime.Version()+"|Library Platform")
+
+	requireHandshake(mt, want)
+}
+
+func TestHandshakeProse_Test11_Case3_PlatformContainsDelimiter(t *testing.T) {
+	mt := newHandshakeTWithDriverInfo(t, &options.DriverInfo{
+		Name:     "library",
+		Version:  "1.2",
+		Platform: "Library Platform",
+	})
+
+	err := mt.Client.AppendDriverInfoErr(options.DriverInfo{
+		Name:     "framework",
+		Version:  "2.0",
+		Platform: "Framework|Platform",
+	})
+	require.Error(mt, err)
+
+	// Wait 5ms for the connection to become idle so that the next
+	// operation establishes a new connection and handshakes again.
+	time.Sleep(5 * time.Millisecond)
+
+	mt.GetProxyCapture().Drain()
+
+	want := clientMetadataExtJSON(
+		"mongo-go-driver|library",
+		version.Driver+"|1.2",
+		runtime.Version()+"|Library Platform")
+
+	requireHandshake(mt, want)
+}
+
+// =============================================================================
+// Test Runner Helpers
+// =============================================================================
+
 // mustMarshalBSON marshals a value to BSON. It panics if any error occurs.
 func mustMarshalBSON(val interface{}) []byte {
 	bytes, err := bson.Marshal(val)
 	if err != nil {
 		panic(err)
 	}
+
+	return bytes
+}
+
+// clientMetadataExtJSON returns the expected client metadata document as
+// extended JSON. The name, version, and platform arguments are the full
+// delimited value for that field, including the driver's own leading entry. The
+// optional env argument is the extended JSON for the "env" subdocument, which
+// is omitted entirely when not supplied.
+func clientMetadataExtJSON(name, version, platform string, env ...string) string {
+	doc := fmt.Sprintf(`{
+	"driver": {"name": %q, "version": %q},
+	"os": {"type": %q, "architecture": %q},
+	"platform": %q`, name, version, runtime.GOOS, runtime.GOARCH, platform)
+
+	if len(env) > 0 {
+		doc += fmt.Sprintf(",\n\t\"env\": %s", env[0])
+	}
+
+	return doc + "\n}"
+}
+
+func extJSONToBSON(mt *mtest.T, extJSON string) []byte {
+	mt.Helper()
+
+	var doc bson.D
+	require.NoError(mt, bson.UnmarshalExtJSON(
+		[]byte(extJSON),
+		false,
+		&doc,
+	))
+
+	bytes, err := bson.Marshal(doc)
+	require.NoError(mt, err)
 
 	return bytes
 }
@@ -1295,4 +1344,51 @@ func clientMetadataFromHandshake(mt *mtest.T, cmd bsoncore.Document) []byte {
 	require.True(mt, ok, "the client field is not a BSON document")
 
 	return clientDoc
+}
+
+func requireHandshake(mt *mtest.T, wantStr string) {
+	// Send a ping command to the server and verify that the command succeeded.
+	err := mt.Client.Ping(context.Background(), nil)
+	require.NoError(mt, err, "Ping error: %v", err)
+
+	// Capture the first message sent after appending driver info.
+	gotMessage := mt.GetProxyCapture().TryNext()
+	require.NotNil(mt, gotMessage, "expected to capture a proxied message")
+	assert.True(mt, gotMessage.IsHandshake(), "expected first message to be a handshake")
+
+	got := clientMetadataFromHandshake(mt, gotMessage.Sent.Command)
+	want := extJSONToBSON(mt, wantStr)
+	assertbson.EqualDocument(mt, want, got)
+}
+
+func newHandshakeT(t *testing.T) *mtest.T {
+	t.Helper()
+
+	return newHandshakeTWithDriverInfo(t, nil)
+}
+
+func newHandshakeTWithDriverInfo(t *testing.T, driverInfo *options.DriverInfo) *mtest.T {
+	t.Helper()
+
+	clientOpts := options.Client().
+		// Set idle timeout to 1ms so that the operation after the appends
+		// establishes a new connection and handshakes again.
+		SetMaxConnIdleTime(1 * time.Millisecond)
+
+	if driverInfo != nil {
+		clientOpts = clientOpts.SetDriverInfo(driverInfo)
+	}
+
+	opts := mtest.NewOptions().ClientType(mtest.Proxy).ClientOptions(clientOpts)
+
+	mt := mtest.New(t, opts)
+	mt.Setup()
+
+	err := mt.Client.Ping(context.Background(), nil)
+	require.NoError(mt, err, "Ping error: %v", err)
+
+	// Wait 5ms for the connection to become idle.
+	time.Sleep(5 * time.Millisecond)
+
+	return mt
 }

--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -360,7 +360,9 @@ func executeAppendMetadata(ctx context.Context, op *operation) (*operationResult
 		}
 	}
 
-	client.AppendDriverInfo(driverInfo)
+	if err := client.AppendDriverInfoErr(driverInfo); err != nil {
+		return newErrorResult(err), nil
+	}
 
 	return newEmptyResult(), nil
 }

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -43,6 +45,10 @@ const (
 	defaultLocalThreshold       = 15 * time.Millisecond
 	defaultMaxPoolSize          = 100
 	defaultAdaptiveRetries uint = 2
+
+	// driverInfoDelimiter separates the entries contributed by each wrapping
+	// library within a client metadata field.
+	driverInfoDelimiter = "|"
 )
 
 var (
@@ -80,7 +86,12 @@ type Client struct {
 	httpClient                *http.Client
 	logger                    *logger.Logger
 	currentDriverInfo         *atomic.Pointer[options.DriverInfo]
-	seenDriverInfo            sync.Map
+
+	// driverInfoEntries holds one entry per wrapping library, in the order they
+	// were appended. Entries are joined positionally when building the
+	// handshake, so the list is kept rather than a running concatenation.
+	driverInfoMu      sync.Mutex
+	driverInfoEntries []options.DriverInfo
 
 	// in-use encryption fields
 	isAutoEncryptionSet bool
@@ -320,39 +331,101 @@ func (c *Client) connect() error {
 // (e.g. name, version, platform) that will be sent to the server in handshake
 // requests when establishing new connections.
 //
-// Repeated calls to AppendDriverInfo with equivalent DriverInfo is a no-op.
+// Entries in name and version correspond by index: a library that reports no
+// value contributes an empty entry, so a missing value never shifts the values
+// that follow it.
+//
+// Repeated calls to AppendDriverInfo with an equivalent DriverInfo are a no-op.
+// Equivalence is over the whole DriverInfo: two libraries that report the same
+// version are distinct entries and both are appended.
+//
+// No field may contain the "|" metadata delimiter. A DriverInfo that contains
+// one is ignored in its entirety, because appending it would corrupt the
+// index correspondence of every entry in the list. Use
+// [Client.AppendDriverInfoErr] to be told when that happens.
 //
 // Metadata is limited to 512 bytes; any excess will be truncated.
 func (c *Client) AppendDriverInfo(info options.DriverInfo) {
-	if _, loaded := c.seenDriverInfo.LoadOrStore(info, struct{}{}); loaded {
+	_ = c.AppendDriverInfoErr(info)
+}
+
+// AppendDriverInfoErr appends the provided [options.DriverInfo] to the client
+// metadata, reporting an error if the DriverInfo cannot be appended. It behaves
+// exactly like [Client.AppendDriverInfo] otherwise.
+//
+// An error is returned if any field contains the "|" metadata delimiter, in
+// which case no part of the DriverInfo is appended.
+func (c *Client) AppendDriverInfoErr(info options.DriverInfo) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"name", info.Name},
+		{"version", info.Version},
+		{"platform", info.Platform},
+	} {
+		if strings.Contains(field.value, driverInfoDelimiter) {
+			return fmt.Errorf("driver info %s %q must not contain %q",
+				field.name, field.value, driverInfoDelimiter)
+		}
+	}
+
+	c.appendDriverInfo(info)
+
+	return nil
+}
+
+// appendDriverInfo appends info to the accumulated client metadata. The caller
+// is responsible for validating info.
+func (c *Client) appendDriverInfo(info options.DriverInfo) {
+	c.driverInfoMu.Lock()
+	defer c.driverInfoMu.Unlock()
+
+	// Deduplicate on the whole DriverInfo. Comparing fields in isolation would
+	// collapse distinct libraries that happen to share a value, which breaks
+	// the index correspondence between the fields.
+	if slices.Contains(c.driverInfoEntries, info) {
 		return
 	}
 
+	c.driverInfoEntries = append(c.driverInfoEntries, info)
+
+	// Name and version are positional: every entry contributes a slot, so a
+	// library that reports no value contributes an empty one and the two fields
+	// stay aligned by index.
+	names := make([]string, 0, len(c.driverInfoEntries))
+	versions := make([]string, 0, len(c.driverInfoEntries))
+
+	for _, entry := range c.driverInfoEntries {
+		names = append(names, entry.Name)
+		versions = append(versions, entry.Version)
+	}
+
+	// DRIVERS-3251 requires positional alignment for driver.name and
+	// driver.version only, so platform keeps its existing behavior: a value is
+	// appended only when it is non-empty and differs from what has accumulated
+	// so far. It therefore does not correspond to name and version by index.
+	var platform string
 	if old := c.currentDriverInfo.Load(); old != nil {
-		if old.Name != "" && info.Name != "" && old.Name != info.Name {
-			info.Name = old.Name + "|" + info.Name
-		} else if old.Name != "" {
-			info.Name = old.Name
-		}
+		platform = old.Platform
+	}
 
-		if old.Version != "" && info.Version != "" && old.Version != info.Version {
-			info.Version = old.Version + "|" + info.Version
-		} else if old.Version != "" {
-			info.Version = old.Version
-		}
-
-		if old.Platform != "" && info.Platform != "" && old.Platform != info.Platform {
-			info.Platform = old.Platform + "|" + info.Platform
-		} else if old.Platform != "" {
-			info.Platform = old.Platform
-		}
+	switch {
+	case info.Platform == "":
+		// Platform is not positional, so a library that reports no platform
+		// contributes nothing rather than an empty entry.
+	case platform == "":
+		platform = info.Platform
+	default:
+		platform = platform + driverInfoDelimiter + info.Platform
 	}
 
 	// Copy-on-write so that the info stored in the client is immutable.
-	infoCopy := new(options.DriverInfo)
-	*infoCopy = info
-
-	c.currentDriverInfo.Store(infoCopy)
+	c.currentDriverInfo.Store(&options.DriverInfo{
+		Name:     strings.Join(names, driverInfoDelimiter),
+		Version:  strings.Join(versions, driverInfoDelimiter),
+		Platform: platform,
+	})
 }
 
 // Disconnect closes sockets to the topology referenced by this Client. It will

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -10,10 +10,14 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -596,4 +600,202 @@ func bootstrapNonTLSServer(t *testing.T) string {
 	}()
 
 	return l.Addr().String()
+}
+
+func TestClientAppendDriverInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		appended     []options.DriverInfo
+		wantName     string
+		wantVersion  string
+		wantPlatform string
+	}{
+		{
+			name:        "gap in the middle",
+			appended:    []options.DriverInfo{{Name: "F1", Version: "1.0"}, {Name: "F2"}, {Name: "F3", Version: "2.0"}},
+			wantName:    "F1|F2|F3",
+			wantVersion: "1.0||2.0",
+		},
+		{
+			name:        "leading gap",
+			appended:    []options.DriverInfo{{Name: "F1"}, {Name: "F2", Version: "2.0"}},
+			wantName:    "F1|F2",
+			wantVersion: "|2.0",
+		},
+		{
+			name:        "trailing delimiter retained",
+			appended:    []options.DriverInfo{{Name: "F1", Version: "1.0"}, {Name: "F2"}},
+			wantName:    "F1|F2",
+			wantVersion: "1.0|",
+		},
+		{
+			name:        "equal versions do not collapse",
+			appended:    []options.DriverInfo{{Name: "F1", Version: "1.0"}, {Name: "F2", Version: "1.0"}},
+			wantName:    "F1|F2",
+			wantVersion: "1.0|1.0",
+		},
+		{
+			name:        "equal names do not collapse",
+			appended:    []options.DriverInfo{{Name: "F1", Version: "1.0"}, {Name: "F1", Version: "2.0"}},
+			wantName:    "F1|F1",
+			wantVersion: "1.0|2.0",
+		},
+		{
+			name:        "duplicates still deduplicate",
+			appended:    []options.DriverInfo{{Name: "F1", Version: "1.0"}, {Name: "F1", Version: "1.0"}},
+			wantName:    "F1",
+			wantVersion: "1.0",
+		},
+		{
+			name:        "all versions absent",
+			appended:    []options.DriverInfo{{Name: "F1"}, {Name: "F2"}},
+			wantName:    "F1|F2",
+			wantVersion: "|",
+		},
+		{
+			name:        "all names absent",
+			appended:    []options.DriverInfo{{Version: "1.0"}, {Version: "2.0"}},
+			wantName:    "|",
+			wantVersion: "1.0|2.0",
+		},
+		{
+			name:         "platform does not deduplicate",
+			appended:     []options.DriverInfo{{Name: "F1", Platform: "p1"}, {Name: "F2", Platform: "p1"}},
+			wantName:     "F1|F2",
+			wantVersion:  "|",
+			wantPlatform: "p1|p1",
+		},
+		{
+			// Platform is not positional: only non-empty values contribute an
+			// entry, so an absent platform adds nothing.
+			name:         "platform skips absent values",
+			appended:     []options.DriverInfo{{Name: "F1", Platform: "p1"}, {Name: "F2"}},
+			wantName:     "F1|F2",
+			wantVersion:  "|",
+			wantPlatform: "p1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &Client{currentDriverInfo: &atomic.Pointer[options.DriverInfo]{}}
+			for _, info := range test.appended {
+				client.AppendDriverInfo(info)
+			}
+
+			got := client.currentDriverInfo.Load()
+			require.NotNil(t, got)
+			assert.Equal(t, test.wantName, got.Name, "name")
+			assert.Equal(t, test.wantVersion, got.Version, "version")
+			assert.Equal(t, test.wantPlatform, got.Platform, "platform")
+		})
+	}
+}
+
+// TestClientAppendDriverInfoConcurrent asserts that concurrent appends neither
+// race nor lose an entry. Comment out the driverInfoMu lock in
+// AppendDriverInfo and run with -race to see this fail.
+func TestClientAppendDriverInfoConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 8
+
+	client := &Client{currentDriverInfo: &atomic.Pointer[options.DriverInfo]{}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			client.AppendDriverInfo(options.DriverInfo{
+				Name:    fmt.Sprintf("F%d", i),
+				Version: fmt.Sprintf("%d.0", i),
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	got := client.currentDriverInfo.Load()
+	require.NotNil(t, got)
+
+	// Every append must be represented, so each field has one entry per
+	// goroutine. Order is not deterministic, but the count is.
+	assert.Len(t, strings.Split(got.Name, "|"), goroutines, "name entries")
+	assert.Len(t, strings.Split(got.Version, "|"), goroutines, "version entries")
+}
+
+func TestClientAppendDriverInfoErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		info    options.DriverInfo
+		wantErr bool
+	}{
+		{
+			name: "no delimiter",
+			info: options.DriverInfo{Name: "F1", Version: "1.0", Platform: "p1"},
+		},
+		{
+			name:    "delimiter in name",
+			info:    options.DriverInfo{Name: "F|1", Version: "1.0", Platform: "p1"},
+			wantErr: true,
+		},
+		{
+			name:    "delimiter in version",
+			info:    options.DriverInfo{Name: "F1", Version: "1|0", Platform: "p1"},
+			wantErr: true,
+		},
+		{
+			name:    "delimiter in platform",
+			info:    options.DriverInfo{Name: "F1", Version: "1.0", Platform: "p|1"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &Client{currentDriverInfo: &atomic.Pointer[options.DriverInfo]{}}
+
+			err := client.AppendDriverInfoErr(test.info)
+			if !test.wantErr {
+				require.NoError(t, err)
+				require.NotNil(t, client.currentDriverInfo.Load())
+
+				return
+			}
+
+			require.Error(t, err)
+
+			// Nothing is appended when the DriverInfo is rejected, so no
+			// partial entry can shift the index of a later one.
+			assert.Nil(t, client.currentDriverInfo.Load(), "expected no metadata to be stored")
+			assert.Empty(t, client.driverInfoEntries, "expected no entry to be recorded")
+		})
+	}
+}
+
+// TestClientAppendDriverInfoDropsInvalid asserts that the error-free variant
+// ignores a DriverInfo containing the delimiter rather than appending it.
+func TestClientAppendDriverInfoDropsInvalid(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{currentDriverInfo: &atomic.Pointer[options.DriverInfo]{}}
+
+	client.AppendDriverInfo(options.DriverInfo{Name: "F1", Version: "1.0"})
+	client.AppendDriverInfo(options.DriverInfo{Name: "F|2", Version: "2.0"})
+
+	got := client.currentDriverInfo.Load()
+	require.NotNil(t, got)
+	assert.Equal(t, "F1", got.Name, "name")
+	assert.Equal(t, "1.0", got.Version, "version")
 }

--- a/x/mongo/driver/auth/auth.go
+++ b/x/mongo/driver/auth/auth.go
@@ -72,10 +72,14 @@ type HandshakeOptions struct {
 	ServerAPI             *driver.ServerAPIOptions
 	LoadBalanced          bool
 
-	// Fields provided by a library that wraps the Go Driver.
+	// Fields provided by a library that wraps the Go Driver. Each is a
+	// delimited list with one entry per wrapping library. OuterLibrarySet
+	// reports whether any wrapping library is present, which cannot be inferred
+	// from the values because an empty entry is meaningful.
 	OuterLibraryName     string
 	OuterLibraryVersion  string
 	OuterLibraryPlatform string
+	OuterLibrarySet      bool
 }
 
 type authHandshaker struct {
@@ -108,7 +112,8 @@ func (ah *authHandshaker) GetHandshakeInformation(
 		LoadBalanced(ah.options.LoadBalanced).
 		OuterLibraryName(ah.options.OuterLibraryName).
 		OuterLibraryVersion(ah.options.OuterLibraryVersion).
-		OuterLibraryPlatform(ah.options.OuterLibraryPlatform)
+		OuterLibraryPlatform(ah.options.OuterLibraryPlatform).
+		OuterLibrarySet(ah.options.OuterLibrarySet)
 
 	if ah.options.Authenticator != nil {
 		if speculativeAuth, ok := ah.options.Authenticator.(SpeculativeAuthenticator); ok {

--- a/x/mongo/driver/topology/server.go
+++ b/x/mongo/driver/topology/server.go
@@ -818,7 +818,7 @@ func (s *Server) createConnection() *connection {
 				driverInfo := s.cfg.driverInfo.Load()
 				if driverInfo != nil {
 					handshaker = handshaker.OuterLibraryName(driverInfo.Name).OuterLibraryVersion(driverInfo.Version).
-						OuterLibraryPlatform(driverInfo.Platform)
+						OuterLibraryPlatform(driverInfo.Platform).OuterLibrarySet(true)
 				}
 			}
 

--- a/x/mongo/driver/topology/topology_options.go
+++ b/x/mongo/driver/topology/topology_options.go
@@ -323,6 +323,7 @@ func NewAuthenticatorConfig(authenticator driver.Authenticator, clientOpts ...Au
 					handshakeOpts.OuterLibraryName = di.Name
 					handshakeOpts.OuterLibraryVersion = di.Version
 					handshakeOpts.OuterLibraryPlatform = di.Platform
+					handshakeOpts.OuterLibrarySet = true
 				}
 			}
 
@@ -341,7 +342,8 @@ func NewAuthenticatorConfig(authenticator driver.Authenticator, clientOpts ...Au
 				if di := driverInfo.Load(); di != nil {
 					op = op.OuterLibraryName(di.Name).
 						OuterLibraryVersion(di.Version).
-						OuterLibraryPlatform(di.Platform)
+						OuterLibraryPlatform(di.Platform).
+						OuterLibrarySet(true)
 				}
 			}
 


### PR DESCRIPTION
GODRIVER-4097

## Summary

Update driver.name and driver.version to correspond 1-1 by index. Add Client.AppendDriverInfoErr, which reports a DriverInfo whose fields contain the | metadata delimiter.

Implements the spec change in mongodb/specifications#1975.

## Background & Motivation

ownstream analytics correlates driver.features to driver.name by index, so a shifted list silently misattributes features to the wrong library.
