### PR TITLE
GODRIVER-3956 Fix TLS record header error tests on Windows

### DIFF
--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -8,8 +8,11 @@ package mongo
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"io"
 	"math"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -514,4 +517,83 @@ func TestClient(t *testing.T) {
 		errmsg := `invalid value "-1s" for "Timeout": value must be positive`
 		assert.Equal(t, errmsg, err.Error(), "expected error %v, got %v", errmsg, err.Error())
 	})
+	t.Run("TLS handshake with a non-TLS server reports a TLS record header error", func(t *testing.T) {
+		t.Parallel()
+
+		// End-to-end check that a TLS-enabled Client pointed at a server that
+		// doesn't speak TLS reports the failure as a tls.RecordHeaderError
+		// rather than as a socket error.
+		addr := bootstrapNonTLSServer(t)
+
+		failures := make(chan error, 10)
+		client := setupClient(options.Client().
+			ApplyURI("mongodb://" + addr).
+			SetDirect(true).
+			SetTLSConfig(&tls.Config{InsecureSkipVerify: true}).
+			SetServerSelectionTimeout(3 * time.Second).
+			SetServerMonitor(&event.ServerMonitor{
+				ServerHeartbeatFailed: func(evt *event.ServerHeartbeatFailedEvent) {
+					select {
+					case failures <- evt.Failure:
+					default:
+					}
+				},
+			}))
+		defer func() { _ = client.Disconnect(bgCtx) }()
+
+		pingErr := client.Ping(bgCtx, nil)
+		require.Error(t, pingErr, "expected Ping to fail against a non-TLS server")
+
+		var recordHeaderErr tls.RecordHeaderError
+
+		select {
+		case failure := <-failures:
+			assert.True(t,
+				errors.As(failure, &recordHeaderErr),
+				"expected the heartbeat failure to be a tls.RecordHeaderError, but got %[1]T: %[1]v",
+				failure)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for a ServerHeartbeatFailedEvent")
+		}
+
+		var sse topology.ServerSelectionError
+		require.True(t,
+			errors.As(pingErr, &sse),
+			"expected a topology.ServerSelectionError, but got %[1]T: %[1]v",
+			pingErr)
+		require.Len(t, sse.Desc.Servers, 1, "expected exactly 1 server in the topology description")
+		assert.True(t,
+			errors.As(sse.Desc.Servers[0].LastError, &recordHeaderErr),
+			"expected the server's last error to be a tls.RecordHeaderError, but got %[1]T: %[1]v",
+			sse.Desc.Servers[0].LastError)
+	})
+}
+
+// bootstrapNonTLSServer starts a listener that responds to every connection with
+// bytes that aren't a valid TLS record, so a TLS client handshaking with it fails
+// with a tls.RecordHeaderError. It returns the listener's address.
+func bootstrapNonTLSServer(t *testing.T) string {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err, "could not set up a listener")
+	t.Cleanup(func() { _ = l.Close() })
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				if _, err := c.Write([]byte("not a TLS server")); err != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, c)
+			}()
+		}
+	}()
+
+	return l.Addr().String()
 }

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -68,9 +68,6 @@ func wrapConnectionError(connErr ConnectionError) error {
 	// tls.RecordHeaderError is a non-I/O TLS error per the CMAP spec: the peer
 	// sent bytes that don't form a valid TLS record. This cannot indicate
 	// server overload.
-	//
-	// TODO(GODRIVER-3956): Make the TLS record header error check and test work
-	// on Windows.
 	var tlsRecordHeaderErr tls.RecordHeaderError
 	if errors.As(connErr.Wrapped, &tlsRecordHeaderErr) {
 		return connErr

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -161,6 +161,42 @@ func TestConnection(t *testing.T) {
 					"expected a tls.RecordHeaderError wrapped by a ConnectionError, but got %[1]T: %[1]v",
 					connErr.Wrapped)
 			})
+			t.Run("connection reset during TLS handshake gets backpressure labels", func(t *testing.T) {
+				// Accept and immediately reset the connection. SetLinger(0)
+				// makes Close send a TCP RST instead of a FIN, so the TLS
+				// handshake fails with an I/O error, that is a network error
+				// rather than a non-I/O TLS error, so it must keep the
+				// backpressure labels.
+				addr := bootstrapConnections(t, 1, func(c net.Conn) {
+					if tcpConn, ok := c.(*net.TCPConn); ok {
+						_ = tcpConn.SetLinger(0)
+					}
+					_ = c.Close()
+				})
+
+				conn := newConnection(address.Address(addr.String()),
+					WithTLSConfig(func(*tls.Config) *tls.Config {
+						return &tls.Config{InsecureSkipVerify: true}
+					}),
+				)
+				err := conn.connect(context.Background())
+
+				var de driver.Error
+				require.True(t,
+					errors.As(err, &de),
+					"expected a driver.Error, but got %[1]T: %[1]v",
+					err)
+				require.True(t, de.HasErrorLabel(driver.ErrSystemOverloadedError),
+					"expected SystemOverloadedError label on a connection reset error, got: %v", err)
+				require.True(t, de.HasErrorLabel(driver.ErrRetryableError),
+					"expected RetryableError label on a connection reset error, got: %v", err)
+
+				var recordHeaderErr tls.RecordHeaderError
+				require.False(t,
+					errors.As(err, &recordHeaderErr),
+					"a connection reset must not be reported as a tls.RecordHeaderError, got: %v",
+					err)
+			})
 			t.Run("handshaker error", func(t *testing.T) {
 				err := errors.New("handshaker error")
 				var want error = ConnectionError{Wrapped: err, init: true}

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"sync"
@@ -129,7 +130,10 @@ func TestConnection(t *testing.T) {
 				// aren't a valid TLS record.
 				addr := bootstrapConnections(t, 1, func(c net.Conn) {
 					defer c.Close()
-					_, _ = c.Write([]byte("not a TLS server"))
+					if _, err := c.Write([]byte("not a TLS server")); err != nil {
+						return
+					}
+					_, _ = io.Copy(io.Discard, c)
 				})
 
 				conn := newConnection(address.Address(addr.String()),

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"math/rand"
 	"net"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -125,19 +124,6 @@ func TestConnection(t *testing.T) {
 					"expected x509.HostnameError, got %T: %v", connErr.Wrapped, connErr.Wrapped)
 			})
 			t.Run("TLS record header error does not get backpressure labels", func(t *testing.T) {
-				// Windows doesn't return a wrapped tls.RecordHeaderError, but
-				// returns
-				//
-				//   *net.OpError: read tcp 127.0.0.1:46242->127.0.0.1:46241: wsarecv: An established connection was aborted by the software in your host machine.
-				//
-				// Skip the test on Windows.
-				//
-				// TODO(GODRIVER-3956): Make the TLS record header error check
-				// and test work on Windows.
-				if runtime.GOOS == "windows" {
-					t.Skip("Skipping this test on Windows because tls.Conn.HandshakeContext doesn't return tls.RecordHeaderError on Windows")
-				}
-
 				// Create a conn that responds with non-TLS data. The TLS client
 				// will fail with tls.RecordHeaderError because the first bytes
 				// aren't a valid TLS record.


### PR DESCRIPTION
GODRIVER-3956

## Summary
Fix the TLS record header error tests on Windows.

## Background & Motivation
Previously, the test listener closed immediately without reading the client's ClientHello. Closing a socket with unread data queued is an abortive close (TCP RST), and Windows discards data already buffered on the receiving side when an RST arrives, so crypto/tls failed before it could parse the record header.
