### PR TITLE
docs: fix required Go version in README to 1.25 (matches go.mod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The MongoDB Go Driver follows [semantic versioning](https://semver.org/) for its
 ## Requirements
 
 - Go 1.25 or higher. The Go Driver supports the last two Go minor versions.
-- Go 1.26 or higher is required to run the driver test suite.
+- Go 1.25 or higher is required to run the driver test suite.
 - MongoDB 4.4 and higher.
 
 ## Installation


### PR DESCRIPTION
## Summary
- `go.mod` requires `go 1.25.0`, but `README.md` stated **Go 1.26+** for the test suite.
- Updates README to require **Go 1.25+** for the test suite, matching the actual `go.mod` directive.

## Why
The README was more restrictive than the actual toolchain requirement. This aligns docs with `go.mod`.

Detected automatically with [driftcheck](https://github.com/yunaremaia/driftcheck).

## Test plan
- [x] `driftcheck` reports no remaining Go drift after the change
- [x] Diff is docs-only (single line in README.md)