### PR TITLE
GODRIVER-4135 Reject negative uncompressed size in DecompressPayload

### DIFF
--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -155,6 +155,9 @@ var zstdReaderPool = sync.Pool{
 
 // DecompressPayload takes a byte slice that has been compressed and undoes it according to the options passed
 func DecompressPayload(in []byte, opts CompressionOpts) ([]byte, error) {
+	if opts.UncompressedSize < 0 {
+		return nil, fmt.Errorf("invalid uncompressed size: %d", opts.UncompressedSize)
+	}
 	switch opts.Compressor {
 	case wiremessage.CompressorNoOp:
 		return in, nil

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -102,6 +102,28 @@ func TestDecompressFailures(t *testing.T) {
 		_, err = DecompressPayload(compressedData, opts)
 		assert.Error(t, err)
 	})
+
+	t.Run("negative uncompressed size", func(t *testing.T) {
+		t.Parallel()
+
+		// A server-supplied uncompressedSize is an int32 read straight off the
+		// wire. A negative value reaches make() and panics with
+		// "makeslice: cap out of range" for the zlib and zstd branches.
+		for _, compressor := range []wiremessage.CompressorID{
+			wiremessage.CompressorSnappy,
+			wiremessage.CompressorZLib,
+			wiremessage.CompressorZstd,
+		} {
+			t.Run(compressor.String(), func(t *testing.T) {
+				opts := CompressionOpts{
+					Compressor:       compressor,
+					UncompressedSize: -1,
+				}
+				_, err := DecompressPayload([]byte{0x00, 0x01, 0x02, 0x03}, opts)
+				assert.Error(t, err)
+			})
+		}
+	})
 }
 
 var (


### PR DESCRIPTION
GODRIVER-4135

## Summary

`DecompressPayload` takes `CompressionOpts.UncompressedSize` straight from the OP_COMPRESSED frame and hands it to `make()` before any bytes are decompressed. The zlib and zstd branches size their output buffer directly from that value, so a negative size reaches `make([]byte, n)` / `make([]byte, 0, n)` and panics with `makeslice: cap out of range`, taking down the goroutine that read the reply. This puts a non-negative guard at the one point every caller funnels through.

## Background & Motivation

`uncompressedSize` is an `int32` read verbatim off the wire in `decompressWireMessage`, and unlike the compressed message length it never gets validated. `parseWmSizeBytes` already rejects a bad compressed length before allocating, but the parallel uncompressed size has no equivalent check, so a malformed or hostile OP_COMPRESSED response (a server, a proxy, or an unauthenticated MITM on the connection) can crash the read path. Keeping the check inside `DecompressPayload` sits it next to the allocation so every compressor branch is covered by one guard. Added a regression test that panics on the current tree and passes with the fix.