### PR TITLE
GODRIVER-4108: Exclude remote TLS alerts from backpressure labels

### DIFF
--- a/internal/assert/assertions.go
+++ b/internal/assert/assertions.go
@@ -325,29 +325,30 @@ func validateEqualArgs(expected, actual interface{}) error {
 // representations appropriate to be presented to the user.
 //
 // If the values are not of like type, the returned strings will be prefixed
-// with the type name, and the value will be enclosed in parenthesis similar
+// with the type name, and the value will be enclosed in parentheses similar
 // to a type conversion in the Go grammar.
 func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
-		return fmt.Sprintf("%T(%s)", expected, truncatingFormat(expected)),
-			fmt.Sprintf("%T(%s)", actual, truncatingFormat(actual))
+		return fmt.Sprintf("%T(%s)", expected, truncatingFormat("%#v", expected)),
+			fmt.Sprintf("%T(%s)", actual, truncatingFormat("%#v", actual))
 	}
 	switch expected.(type) {
 	case time.Duration:
 		return fmt.Sprintf("%v", expected), fmt.Sprintf("%v", actual)
 	}
-	return truncatingFormat(expected), truncatingFormat(actual)
+	return truncatingFormat("%#v", expected), truncatingFormat("%#v", actual)
 }
 
 // truncatingFormat formats the data and truncates it if it's too long.
 //
 // This helps keep formatted error messages lines from exceeding the
 // bufio.MaxScanTokenSize max line length that the go testing framework imposes.
-func truncatingFormat(data interface{}) string {
-	value := fmt.Sprintf("%#v", data)
-	maxLen := bufio.MaxScanTokenSize - 100 // Give us some space the type info too if needed.
-	if len(value) > maxLen {
-		value = value[0:maxLen] + "<... truncated>"
+func truncatingFormat(format string, data interface{}) string {
+	value := fmt.Sprintf(format, data)
+	// Give us space for two truncated objects and the surrounding sentence.
+	maxMessageSize := bufio.MaxScanTokenSize/2 - 100
+	if len(value) > maxMessageSize {
+		value = value[0:maxMessageSize] + "<... truncated>"
 	}
 	return value
 }
@@ -905,7 +906,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 		expectedText = target.Error()
 	}
 
-	chain := buildErrorChainString(err)
+	chain := buildErrorChainString(err, false)
 
 	return Fail(t, fmt.Sprintf(
 		"Target error should be in err chain:\n"+
@@ -1089,16 +1090,38 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 	}
 }
 
-func buildErrorChainString(err error) string {
+func unwrapAll(err error) (errs []error) {
+	errs = append(errs, err)
+	switch x := err.(type) {
+	case interface{ Unwrap() error }:
+		err = x.Unwrap()
+		if err == nil {
+			return
+		}
+		errs = append(errs, unwrapAll(err)...)
+	case interface{ Unwrap() []error }:
+		for _, err := range x.Unwrap() {
+			errs = append(errs, unwrapAll(err)...)
+		}
+	}
+	return
+}
+
+func buildErrorChainString(err error, withType bool) string {
 	if err == nil {
 		return ""
 	}
 
-	e := errors.Unwrap(err)
-	chain := fmt.Sprintf("%q", err.Error())
-	for e != nil {
-		chain += fmt.Sprintf("\n\t%q", e.Error())
-		e = errors.Unwrap(e)
+	var chain string
+	errs := unwrapAll(err)
+	for i := range errs {
+		if i != 0 {
+			chain += "\n\t"
+		}
+		chain += fmt.Sprintf("%q", errs[i].Error())
+		if withType {
+			chain += fmt.Sprintf(" (%T)", errs[i])
+		}
 	}
 	return chain
 }
@@ -1143,4 +1166,46 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	return pass
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if errors.As(err, target) {
+		return true
+	}
+
+	expectedType := reflect.TypeOf(target).Elem().String()
+	if err == nil {
+		return Fail(t, fmt.Sprintf("An error is expected but got nil.\n"+
+			"expected: %s", expectedType), msgAndArgs...)
+	}
+
+	chain := buildErrorChainString(err, true)
+
+	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
+		"expected: %s\n"+
+		"in chain: %s", expectedType, truncatingFormat("%s", chain),
+	), msgAndArgs...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.As(err, target) {
+		return true
+	}
+
+	chain := buildErrorChainString(err, true)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %s\n"+
+		"in chain: %s", reflect.TypeOf(target).Elem().String(), truncatingFormat("%s", chain),
+	), msgAndArgs...)
 }

--- a/internal/assert/assertions_test.go
+++ b/internal/assert/assertions_test.go
@@ -1193,12 +1193,14 @@ func Test_validateEqualArgs(t *testing.T) {
 }
 
 func Test_truncatingFormat(t *testing.T) {
-	original := strings.Repeat("a", bufio.MaxScanTokenSize-102)
-	result := truncatingFormat(original)
+	// The limit leaves room for two formatted values plus the surrounding
+	// message, so a single value may occupy at most half of it.
+	original := strings.Repeat("a", bufio.MaxScanTokenSize/2-102)
+	result := truncatingFormat("%#v", original)
 	Equal(t, fmt.Sprintf("%#v", original), result, "string should not be truncated")
 
 	original = original + "x"
-	result = truncatingFormat(original)
+	result = truncatingFormat("%#v", original)
 	NotEqual(t, fmt.Sprintf("%#v", original), result, "string should have been truncated.")
 
 	if !strings.HasSuffix(result, "<... truncated>") {

--- a/internal/require/require.go
+++ b/internal/require/require.go
@@ -867,3 +867,27 @@ func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	}
 	t.FailNow()
 }
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -72,6 +72,15 @@ func wrapConnectionError(connErr ConnectionError) error {
 	if errors.As(connErr.Wrapped, &tlsRecordHeaderErr) {
 		return connErr
 	}
+	// An alert sent by the peer during the TLS handshake does not get a
+	// backpressure labels. Per the CMAP spec, drivers MUST NOT label non-I/O TLS
+	// errors as server overload conditions. A remote alert is non-I/O as the
+	// handshake was answered and refused by the peer, nothing failed to send or
+	// receive.
+	var opErr *net.OpError
+	if errors.As(connErr.Wrapped, &opErr) && opErr.Op == "remote error" {
+		return connErr
+	}
 	return driver.Error{
 		Labels:  []string{driver.ErrSystemOverloadedError, driver.ErrRetryableError, driver.NetworkError},
 		Wrapped: connErr,

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -14,6 +14,8 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1283,4 +1285,41 @@ func TestConnectionError(t *testing.T) {
 		_, err = conn.readWireMessage(ctx)
 		assert.ErrorContains(t, err, "client timed out waiting for server response")
 	})
+}
+
+func TestConnection_RemoteTLSAlert(t *testing.T) {
+	emtpyHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	srv := httptest.NewUnstartedServer(emtpyHandler)
+
+	// USE TLS 1.3 to ensure that the server sends a TLS alert when the client
+	// attempts to connect with TLS 1.2.
+	srv.TLS = &tls.Config{MinVersion: tls.VersionTLS13}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	addr := address.Address(srv.Listener.Addr().String())
+	connTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+	}
+
+	conn := newConnection(addr, WithTLSConfig(func(*tls.Config) *tls.Config {
+		return connTLSConfig
+	}))
+
+	err := conn.connect(context.Background())
+	require.Error(t, err)
+
+	// Confirm that the peer sent an alert rather than the handshake failing
+	// some other way.
+	var connErr ConnectionError
+	require.ErrorAs(t, err, &connErr)
+
+	var opErr *net.OpError
+	require.ErrorAs(t, connErr.Wrapped, &opErr)
+	require.Equal(t, "remote error", opErr.Op)
+
+	var de driver.Error
+	require.NotErrorAs(t, err, &de)
 }


### PR DESCRIPTION
GODRIVER-4108

## Summary

Unwrap net.OpError in [wrapConnectionError](https://github.com/mongodb/mongo-go-driver/blob/33c3f5e9e415b5e77b6908845156c6eac95b32f0/x/mongo/driver/topology/connection.go#L50) and return the connection error if the Op field is "remote error".

## Background & Motivation

A TLS peer can refuse a handshake with a reply, rather than dropping the connection. Right now the driver would label that error in a way that would back off and retry. But it's likely that the server would never accept the connection (e.g. a bad certificate).
