### PR TITLE
GODRIVER-3967 exclude ci/cd from release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - ignore-for-release
       - github_actions
       - submodules
+      - ci/cd
     authors:
       - mongodb-drivers-pr-bot
   categories:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center"><img src="etc/assets/mongo-gopher.png" width="250"></p>
 <p align="center">
-  <a href="https://goreportcard.com/report/go.mongodb.org/mongo-driver/v2"><img src="https://goreportcard.com/badge/go.mongodb.org/mongo-driver/v2"></a>
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo"><img src="etc/assets/godev-mongo-blue.svg" alt="docs"></a>
   <a href="https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/bson"><img src="etc/assets/godev-bson-blue.svg" alt="docs"></a>
   <a href="https://www.mongodb.com/docs/drivers/go/current/"><img src="etc/assets/docs-mongodb-green.svg"></a>


### PR DESCRIPTION
GODRIVER-3967
## Summary

 CI/CD PRs and tickets don't need to be highlighted in release notes. 

