### PR TITLE
GODRIVER-3967 Exclude ci/cd labels in release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - ignore-for-release
       - github_actions
       - submodules
+      - ci/cd
     authors:
       - mongodb-drivers-pr-bot
   categories:


### PR DESCRIPTION
CI/CD PRs and tickets don't need to be highlighted in release notes.