### PR TITLE
GODRIVER-4109: Exclude OCSP errors from backpressure label

### DIFF
--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -81,6 +81,16 @@ func wrapConnectionError(connErr ConnectionError) error {
 	if errors.As(connErr.Wrapped, &opErr) && opErr.Op == "remote error" {
 		return connErr
 	}
+	// An OCSP failure is a non-I/O TLS error per the CMAP spec: revocation
+	// checking is certificate validation, so a retry against the same server
+	// would fail the same way. ocsp.Verify soft-fails when no sreaponse can be
+	// obtained, an unreachable responder leaves the status unknown rather than
+	// erroring so every error that reaches here is a validation result, which
+	// cannot indicate server overload.
+	var ocspErr *ocsp.Error
+	if errors.As(connErr.Wrapped, &ocspErr) {
+		return connErr
+	}
 	return driver.Error{
 		Labels:  []string{driver.ErrSystemOverloadedError, driver.ErrRetryableError, driver.NetworkError},
 		Wrapped: connErr,

--- a/x/mongo/driver/topology/connection.go
+++ b/x/mongo/driver/topology/connection.go
@@ -83,7 +83,7 @@ func wrapConnectionError(connErr ConnectionError) error {
 	}
 	// An OCSP failure is a non-I/O TLS error per the CMAP spec: revocation
 	// checking is certificate validation, so a retry against the same server
-	// would fail the same way. ocsp.Verify soft-fails when no sreaponse can be
+	// would fail the same way. ocsp.Verify soft-fails when no response can be
 	// obtained, an unreachable responder leaves the status unknown rather than
 	// erroring so every error that reaches here is a validation result, which
 	// cannot indicate server overload.

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -1289,8 +1289,8 @@ func TestConnectionError(t *testing.T) {
 }
 
 func TestConnection_RemoteTLSAlert_NoBackpressure(t *testing.T) {
-	emtpyHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
-	srv := httptest.NewUnstartedServer(emtpyHandler)
+	emptyHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	srv := httptest.NewUnstartedServer(emptyHandler)
 
 	// USE TLS 1.3 to ensure that the server sends a TLS alert when the client
 	// attempts to connect with TLS 1.2.

--- a/x/mongo/driver/topology/connection_test.go
+++ b/x/mongo/driver/topology/connection_test.go
@@ -28,6 +28,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/mnet"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/ocsp"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/wiremessage"
 )
 
@@ -1287,7 +1288,7 @@ func TestConnectionError(t *testing.T) {
 	})
 }
 
-func TestConnection_RemoteTLSAlert(t *testing.T) {
+func TestConnection_RemoteTLSAlert_NoBackpressure(t *testing.T) {
 	emtpyHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 	srv := httptest.NewUnstartedServer(emtpyHandler)
 
@@ -1319,6 +1320,34 @@ func TestConnection_RemoteTLSAlert(t *testing.T) {
 	var opErr *net.OpError
 	require.ErrorAs(t, connErr.Wrapped, &opErr)
 	require.Equal(t, "remote error", opErr.Op)
+
+	var de driver.Error
+	require.NotErrorAs(t, err, &de)
+}
+
+func TestConnection_OCSPError_NoBackpressure(t *testing.T) {
+	emptyHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	srv := httptest.NewTLSServer(emptyHandler)
+	t.Cleanup(srv.Close)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+
+	addr := address.Address(srv.Listener.Addr().String())
+	connTLSConfig := &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	conn := newConnection(addr, WithTLSConfig(func(*tls.Config) *tls.Config {
+		return connTLSConfig
+	}))
+
+	err := conn.connect(context.Background())
+	require.Error(t, err)
+
+	var ocspErr *ocsp.Error
+	require.ErrorAs(t, err, &ocspErr)
 
 	var de driver.Error
 	require.NotErrorAs(t, err, &de)


### PR DESCRIPTION
GODRIVER-4109

## Summary

Add the following block to [wrapConnectionError](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/topology/connection.go#L50):

```go
var ocspErr *ocsp.Error
if errors.As(connErr.Wrapped, &ocspErr) {
    return connErr
}
```

## Background & Motivation

OCSP are non-I/O TLS errors since revocation checking is certificate validation and retrying the server would probably fail.
