### PR TITLE
GODRIVER-4057 Pre-download PoC

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1317,6 +1317,18 @@ tasks:
         params:
           binary: bash
           args: [*task-runner, build-compile-check-all]
+  # TEMPORARY (profiling only, do not merge): same as go-build, but builds the
+  # image without the pre-downloaded Go toolchains so the two tasks form an A/B
+  # pair on the same variant.
+  - name: go-build-nowarm
+    tags: ["compile-check"]
+    commands:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          env:
+            COMPILECHECK_PREWARM: "0"
+          args: [*task-runner, build-compile-check-all]
   # Build with the same Go version that we're using for tests.
   - name: build
     tags: ["compile-check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # Install taskfile
 RUN go install github.com/go-task/task/v3/cmd/task@v3.39.2
 
+# Pre-download the Go toolchains used by internal/test/compilecheck so the test
+# doesn't fetch each one from the module proxy at run time. Keep in sync with
+# goVersions in internal/test/compilecheck/compile_check_test.go, which passes
+# this as a build arg.
+ARG COMPILECHECK_GO_VERSIONS="1.25.0 1.26.0"
+RUN for v in ${COMPILECHECK_GO_VERSIONS}; do GOTOOLCHAIN=go$v go version; done
+
 COPY etc/docker_entry.sh /root/docker_entry.sh
 COPY --from=libmongocrypt /root/install /root/install
 

--- a/internal/test/compilecheck/compile_check_test.go
+++ b/internal/test/compilecheck/compile_check_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -70,7 +71,9 @@ type goExecConfig struct {
 func execContainer(t *testing.T, c testcontainers.Container, cmd string) string {
 	t.Helper()
 
+	start := time.Now()
 	exit, out, err := c.Exec(context.Background(), []string{"bash", "-lc", cmd})
+	t.Logf("exec %v: %s", time.Since(start), cmd)
 	require.NoError(t, err)
 
 	b, err := io.ReadAll(out)
@@ -123,6 +126,13 @@ func TestCompileCheck(t *testing.T) {
 		toolchains = append(toolchains, ver+".0")
 	}
 	toolchainVersions := strings.Join(toolchains, " ")
+
+	// Profiling escape hatch: COMPILECHECK_PREWARM=0 builds the image without the
+	// pre-downloaded toolchains, so the A/B arms differ only in the build arg.
+	if os.Getenv("COMPILECHECK_PREWARM") == "0" {
+		toolchainVersions = ""
+	}
+	t.Logf("COMPILECHECK_GO_VERSIONS=%q", toolchainVersions)
 
 	// Build the image and start one container we can reuse for all subtests.
 	req := testcontainers.ContainerRequest{

--- a/internal/test/compilecheck/compile_check_test.go
+++ b/internal/test/compilecheck/compile_check_test.go
@@ -116,12 +116,23 @@ func TestCompileCheck(t *testing.T) {
 
 	rootDir := filepath.Dir(filepath.Dir(filepath.Dir(cwd)))
 
+	// Have the image pre-download exactly the toolchains this test pins with
+	// GOTOOLCHAIN, so goVersions stays the single source of truth.
+	toolchains := make([]string, 0, len(goVersions))
+	for _, ver := range goVersions {
+		toolchains = append(toolchains, ver+".0")
+	}
+	toolchainVersions := strings.Join(toolchains, " ")
+
 	// Build the image and start one container we can reuse for all subtests.
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context:       rootDir,
 			Dockerfile:    "Dockerfile",
 			PrintBuildLog: true,
+			BuildArgs: map[string]*string{
+				"COMPILECHECK_GO_VERSIONS": &toolchainVersions,
+			},
 		},
 		Files: []testcontainers.ContainerFile{
 			{


### PR DESCRIPTION
GODRIVER-4057

## Summary
Profile the pre-downloading.

Executions: https://spruce.corp.mongodb.com/version/6a99dbc666a16400071b0f4f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Background & Motivation
Evergreen ran a temporary go-build-nowarm task alongside go-build on the same variant, 2 executions each.
