### PR TITLE
GODRIVER-4078 Document the aws-sdk-go-v2 minimum version requirement.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+    ignore:
+      # ext/awsauth declares the minimum aws-sdk-go-v2 version that is
+      # layout-compatible with its AWSCredentials type. See ext/awsauth/doc.go
+      # for more information.
+      - dependency-name: "github.com/aws/aws-sdk-go-v2"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:

--- a/etc/check_modules.sh
+++ b/etc/check_modules.sh
@@ -17,4 +17,23 @@ for mod in $mods; do
   echo "Checking $mod... done"
   popd > /dev/null
 done
+
+# ext/awsauth declares the minimum aws-sdk-go-v2 version that is layout-compatible with
+# its AWSCredentials type (see ext/awsauth/doc.go). That floor is easy to raise by
+# accident: "go work sync" rewrites each workspace member's go.mod with the
+# workspace-resolved maximum, and Dependabot's workspace update procedure runs it on
+# every gomod update. Assert the floor so an accidental bump fails loudly.
+awsauth_dep=github.com/aws/aws-sdk-go-v2
+awsauth_floor=v1.28.0
+echo "Checking ext/awsauth aws-sdk-go-v2 floor..."
+awsauth_got=$(cd ext/awsauth && GOWORK=off go list -m -f '{{.Version}}' "$awsauth_dep")
+if [ "$awsauth_got" != "$awsauth_floor" ]; then
+  echo "ext/awsauth requires $awsauth_dep $awsauth_got, want $awsauth_floor."
+  echo "If this was an unintended bump (e.g. from \"go work sync\"), restore the floor."
+  echo "If the floor is being raised on purpose, update ext/awsauth/doc.go and the"
+  echo "awsauth_floor value in this script."
+  exit_code=1
+fi
+echo "Checking ext/awsauth aws-sdk-go-v2 floor... done"
+
 exit $exit_code

--- a/ext/awsauth/doc.go
+++ b/ext/awsauth/doc.go
@@ -19,8 +19,8 @@
 // This module is a separate Go module that intentionally does not take a
 // dependency on the MongoDB Go Driver. Rather than importing the driver, it
 // adapts to the driver's options.AWSCredentialsProvider interface structurally:
-// the exported types in this package are defined to match that interface, so the
-// adapter satisfies it without an import.
+// the exported types in this package are defined to match that interface, so
+// the adapter satisfies it without an import.
 //
 // This decoupling exists for two reasons:
 //
@@ -28,6 +28,22 @@
 //     don't need AWS authentication never pull in the AWS SDK transitively.
 //   - It lets the two modules version independently and avoids a circular
 //     dependency between the driver and this adapter.
+//
+// # AWS SDK minimum version
+//
+// This module requires github.com/aws/aws-sdk-go-v2 v1.28.0. That is the
+// release in which aws.Credentials gained its AccountID field, making its
+// layout match this package's AWSCredentials type, which is what allows
+// Retrieve to convert between them with a plain type conversion instead of
+// copying field by field.
+//
+// The requirement is a minimum, not a pin. Go's Minimal Version Selection
+// (https://go.dev/ref/mod#minimal-version-selection) means an application
+// already depending on a newer aws-sdk-go-v2 keeps that newer version, while
+// one with no other constraint is not pulled above v1.28.0.
+//
+// If a future SDK release changes aws.Credentials' layout, the type conversion
+// stops compiling. internal/test/awsauth/compilecheck guards against that.
 //
 // NewCredentialsProvider() adapts an AWS CredentialsProvider to be used in:
 //

--- a/ext/awsauth/doc.go
+++ b/ext/awsauth/doc.go
@@ -45,6 +45,10 @@
 // If a future SDK release changes aws.Credentials' layout, the type conversion
 // stops compiling. internal/test/awsauth/compilecheck guards against that.
 //
+// "go work sync" rewrites each workspace member's go.mod with the
+// workspace-resolved maximum, which silently raises this floor.
+// etc/check_modules.sh asserts it so an accidental bump fails loudly.
+//
 // NewCredentialsProvider() adapts an AWS CredentialsProvider to be used in:
 //
 //	ClientOptions

--- a/ext/awsauth/go.mod
+++ b/ext/awsauth/go.mod
@@ -2,6 +2,11 @@ module go.mongodb.org/mongo-driver/ext/awsauth
 
 go 1.26
 
-require github.com/aws/aws-sdk-go-v2 v1.42.1
+// v1.28.0 is the earliest release whose aws.Credentials field layout matches
+// AWSCredentials, which is what lets Retrieve convert between them with a plain
+// type conversion. This is a minimum, not a pin: Minimal Version Selection
+// ensures users can build against any newer version they need. See doc.go for
+// more information.
+require github.com/aws/aws-sdk-go-v2 v1.28.0
 
 require github.com/aws/smithy-go v1.27.3 // indirect

--- a/ext/awsauth/go.sum
+++ b/ext/awsauth/go.sum
@@ -1,4 +1,4 @@
-github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
-github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
+github.com/aws/aws-sdk-go-v2 v1.28.0 h1:ne6ftNhY0lUvlazMUQF15FF6NH80wKmPRFG7g2q6TCw=
+github.com/aws/aws-sdk-go-v2 v1.28.0/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
 github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=


### PR DESCRIPTION
GODRIVER-4078

## Summary
The rationale of `awsauth` AWS SDK v2 minimum version was written down nowhere. As a result, "ext/awsauth/go.mod" had drifted up to requiring v1.42.1 via routine Dependabot bumps: https://github.com/mongodb/mongo-go-driver/pull/2560/changes#diff-a844bf3998a1c14547debbd4f085b0c3ac163ed7a4470cf32a157659b49b700e.

This PR records the rationale and stops the drift.
- Add the rationale to ext/awsauth/doc.go.
- Add a concise explanatory comment beside the dependency in ext/awsauth/go.mod.
- Add a Dependabot ignore on github.com/aws/aws-sdk-go-v2.
- ~~Update etc/check_modules.sh to assert the floor.~~
- Remove `./ext/awsauth` from go.work.
- Extend govulncheck to check github.com/aws/aws-sdk-go-v2 in ext/awsauth.

## Not a breaking change
Lowering the requirement cannot break a consumer: under MVS, anyone already on a newer SDK stays there. 