### PR TITLE
GODRIVER-4136: reject BSON lengths below the 5-byte minimum before slicing

### DIFF
--- a/bson/copier.go
+++ b/bson/copier.go
@@ -89,6 +89,9 @@ func copyBytesToValueWriter(src []byte, wef writeElementFn) error {
 	if !ok {
 		return fmt.Errorf("couldn't read length from src, not enough bytes. length=%d", len(src))
 	}
+	if length < 5 {
+		return fmt.Errorf("invalid document length, must be at least 5 bytes. length=%d", length)
+	}
 	if len(src) < int(length) {
 		return fmt.Errorf("length read exceeds number of bytes available. length=%d bytes=%d", len(src), length)
 	}

--- a/bson/copier_test.go
+++ b/bson/copier_test.go
@@ -525,4 +525,15 @@ func TestCopier(t *testing.T) {
 			}
 		})
 	})
+	t.Run("copyBytesToValueWriter", func(t *testing.T) {
+		// A length below the 5 byte minimum must be rejected before it is used
+		// to reslice the remaining bytes.
+		for _, length := range []byte{0x00, 0x01, 0x02, 0x03, 0x04} {
+			src := []byte{length, 0x00, 0x00, 0x00, 0x00}
+			err := copyBytesToValueWriter(src, func(string) (ValueWriter, error) {
+				return nil, nil
+			})
+			assert.ErrorContains(t, err, "invalid document length")
+		}
+	})
 }

--- a/x/bsonx/bsoncore/array.go
+++ b/x/bsonx/bsoncore/array.go
@@ -173,6 +173,9 @@ func (a Array) Validate() error {
 	if int(length) > len(a) {
 		return NewArrayLengthError(int(length), len(a))
 	}
+	if length < 5 {
+		return ErrInvalidLength
+	}
 	if a[length-1] != 0x00 {
 		return ErrMissingNull
 	}

--- a/x/bsonx/bsoncore/array_test.go
+++ b/x/bsonx/bsoncore/array_test.go
@@ -36,6 +36,13 @@ func TestArray(t *testing.T) {
 				t.Errorf("Did not get expected error. got %v; want %v", got, want)
 			}
 		})
+		t.Run("ZeroLength", func(t *testing.T) {
+			want := ErrInvalidLength
+			got := Array{0x00, 0x00, 0x00, 0x00}.Validate()
+			if !compareErrors(got, want) {
+				t.Errorf("Did not get expected error. got %v; want %v", got, want)
+			}
+		})
 		t.Run("Invalid Element", func(t *testing.T) {
 			want := NewInsufficientBytesError(nil, nil)
 			r := make(Array, 7)
@@ -222,6 +229,12 @@ func TestArray(t *testing.T) {
 				bytes.NewBuffer([]byte{}),
 				nil,
 				io.EOF,
+			},
+			{
+				"length below minimum",
+				bytes.NewBuffer([]byte{4, 0, 0, 0, 0}),
+				nil,
+				ErrInvalidLength,
 			},
 			{
 				"empty Array",

--- a/x/bsonx/bsoncore/document.go
+++ b/x/bsonx/bsoncore/document.go
@@ -115,7 +115,7 @@ func newBufferFromReader(r io.Reader) ([]byte, error) {
 	}
 
 	length, _, _ := binaryutil.ReadI32(lengthBytes[:]) // ignore ok since we always have enough bytes to read a length
-	if length < 0 {
+	if length < 5 {
 		return nil, ErrInvalidLength
 	}
 	buffer := make([]byte, length)

--- a/x/bsonx/bsoncore/document_test.go
+++ b/x/bsonx/bsoncore/document_test.go
@@ -316,6 +316,12 @@ func TestDocument(t *testing.T) {
 				io.EOF,
 			},
 			{
+				"length below minimum",
+				bytes.NewBuffer([]byte{2, 0, 0, 0, 0}),
+				nil,
+				ErrInvalidLength,
+			},
+			{
 				"empty document",
 				bytes.NewBuffer([]byte{5, 0, 0, 0, 0}),
 				[]byte{5, 0, 0, 0, 0},


### PR DESCRIPTION
GODRIVER-4136

## Summary

`Array.Validate` reads the array length out of the input bytes and immediately indexes `a[length-1]`, but unlike its sibling `Document.Validate` it never enforces the 5-byte BSON minimum, so `bson.RawArray{0, 0, 0, 0}.Validate()` panics with `index out of range [-1]`. The same missing lower bound turns up at two more sites: `newBufferFromReader` rejects only negative lengths before it does `buffer[4:]`, so `bson.ReadDocument` and `bson.ReadArray` panic with `slice bounds out of range` on a stream whose header declares a length of 0 through 3, and `copyBytesToValueWriter` reslices with `rem[:length-4]`, so `bson.Marshal` panics on a struct field holding a short `bson.Raw` or `bsoncore.Document`. All three are entry points whose job is to vet bytes the caller does not trust.

Each site now rejects a length below the 5-byte minimum before it reaches the index, matching the `length < 5` guard that `Document.Validate` and both `StringN` methods already carry. Keeping the check next to the read means `Validate`, `ReadDocument`/`ReadArray` and `Marshal` all return an error rather than panicking, without callers having to pre-screen the bytes themselves.

## Background & Motivation

These are the documented ways to hand the driver BSON of unknown provenance: `Validate` exists precisely to be called on bytes you do not trust, `ReadDocument`/`ReadArray` read straight off an `io.Reader`, and re-marshaling a `bson.Raw` decoded from a server reply is routine. A 4-byte input is enough to take down the calling goroutine in each case.

Reproduced on `master` with a short table over the three paths, which panics seven times before the change and returns errors after it:

```go
bson.RawArray{0, 0, 0, 0}.Validate()                        // index out of range [-1]
bsoncore.Array{0, 0, 0, 0}.Validate()                       // index out of range [-1]
bson.ReadDocument(bytes.NewReader([]byte{2, 0, 0, 0, 0, 0}))  // slice bounds out of range [4:2]
bson.ReadArray(bytes.NewReader([]byte{0, 0, 0, 0, 0, 0}))     // slice bounds out of range [4:0]
bsoncore.NewDocumentFromReader(bytes.NewReader([]byte{3, 0, 0, 0, 0})) // slice bounds out of range [4:3]
bson.Marshal(bson.Raw{0, 0, 0, 0})                          // slice bounds out of range [:-4]
bson.Marshal(struct{ A bsoncore.Document }{bsoncore.Document{1, 0, 0, 0}}) // slice bounds out of range [:-3]
```

`Array.Validate` was the only one of the length-consuming methods in `bsoncore` missing the guard; `Document.Validate` has had it, and `wiremessage.ReadMsgSectionRawDocumentSequence` uses the same shape. Regression tests cover the `Validate` case, both `*FromReader` constructors and the copier. Verified with `go build ./...`, `golangci-lint` on `linux/amd64` and `linux/386`, and `go test -short -race ./...`.
