### PR TITLE
bump github tools for release to 89904229

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash -eux {0}
@@ -33,11 +36,11 @@ jobs:
     outputs:
       prev_version: ${{ steps.pre-publish.outputs.prev_version }}
     steps:
-      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: mongodb-labs/drivers-github-tools/setup@v2
+      - uses: mongodb-labs/drivers-github-tools/setup@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -45,15 +48,17 @@ jobs:
           artifactory_username: ${{ vars.ARTIFACTORY_USERNAME }}
       - name: Pre Publish
         id: pre-publish
-        uses: mongodb-labs/drivers-github-tools/golang/pre-publish@v2
+        uses: mongodb-labs/drivers-github-tools/golang/pre-publish@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           version: ${{ inputs.version }}
           push_changes: ${{ inputs.push_changes }}
           ignored_branches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
+          dry_run: ${{ !inputs.push_changes }}
 
   static-scan:
     needs: [pre-publish]
     permissions:
+      contents: read
       security-events: write
     uses: ./.github/workflows/codeql.yml
     with:
@@ -68,18 +73,18 @@ jobs:
       contents: write
       security-events: read
     steps:
-      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: mongodb-labs/drivers-github-tools/setup@v2
+      - uses: mongodb-labs/drivers-github-tools/setup@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           artifactory_username: ${{ vars.ARTIFACTORY_USERNAME }}
       - name: Publish
-        uses: mongodb-labs/drivers-github-tools/golang/publish@v2
+        uses: mongodb-labs/drivers-github-tools/golang/publish@89904229eb55a063655af02f5838bd7fe76505e5 #v3
         with:
           version: ${{ inputs.version }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}


### PR DESCRIPTION
Bump mongodb-labs/drivers-github-tools to https://github.com/mongodb-labs/drivers-github-tools/commit/89904229eb55a063655af02f5838bd7fe76505e5 inlining with v2 of the go driver (v3 of tools)