### PR TITLE
GODRIVER-4083 fix duplicate error logging for network error

### DIFF
--- a/x/mongo/driver/errors.go
+++ b/x/mongo/driver/errors.go
@@ -292,11 +292,14 @@ func (e Error) UnsupportedStorageEngine() bool {
 func (e Error) Error() string {
 	var msg string
 	if e.Name != "" {
-		msg = fmt.Sprintf("(%v)", e.Name)
+		msg = fmt.Sprintf("(%v) ", e.Name)
 	}
-	msg += " " + e.Message
-	if e.Wrapped != nil {
-		msg += ": " + e.Wrapped.Error()
+	msg += e.Message
+	if e.Wrapped != nil && e.Wrapped.Error() != e.Message {
+		if msg != "" {
+			msg += ": "
+		}
+		msg += e.Wrapped.Error()
 	}
 	return msg
 }

--- a/x/mongo/driver/operation_test.go
+++ b/x/mongo/driver/operation_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -861,6 +862,21 @@ func TestRetry(t *testing.T) {
 			time.Now().After(deadline),
 			"expected operation to complete only after the context deadline is exceeded")
 	})
+}
+
+func TestOperation_networkError(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("connection(host:27017[-1]) incomplete read of message header")
+
+	err := Operation{}.networkError(inner)
+	require.NotNil(t, err)
+
+	msg := err.Error()
+	require.Equal(t, 1, strings.Count(msg, inner.Error()),
+		"expected the wrapped error message to appear exactly once in %q", msg)
+	require.False(t, strings.HasPrefix(msg, " "),
+		"expected no leading space in %q", msg)
 }
 
 func TestDecodeOpReply(t *testing.T) {


### PR DESCRIPTION
(LOW PRIORITY) 
[GODRIVER-4083](https://jira.mongodb.org/browse/GODRIVER-4083)

## Summary

<!--- A summary of the changes proposed by this pull request. -->

Fixes the duplicate error message logging. 

## Background & Motivation

<!--- Rationale for the pull request. -->

before, network errors were being logged twice

## What I have done

added a check to see if error has already been logged.

## Test Plans

added a unit test to see if we still get duplicate error messages.