### PR TITLE
GODRIVER-4135 Reject negative uncompressed size in DecompressPayload.

### DIFF
--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -155,6 +155,9 @@ var zstdReaderPool = sync.Pool{
 
 // DecompressPayload takes a byte slice that has been compressed and undoes it according to the options passed
 func DecompressPayload(in []byte, opts CompressionOpts) ([]byte, error) {
+	if opts.UncompressedSize < 0 {
+		return nil, fmt.Errorf("invalid uncompressed size: %d", opts.UncompressedSize)
+	}
 	switch opts.Compressor {
 	case wiremessage.CompressorNoOp:
 		return in, nil

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -102,6 +102,28 @@ func TestDecompressFailures(t *testing.T) {
 		_, err = DecompressPayload(compressedData, opts)
 		assert.Error(t, err)
 	})
+
+	t.Run("negative uncompressed size", func(t *testing.T) {
+		t.Parallel()
+
+		// A server-supplied uncompressedSize is an int32 read straight off the
+		// wire. A negative value reaches make() and panics with
+		// "makeslice: cap out of range" for the zlib and zstd branches.
+		for _, compressor := range []wiremessage.CompressorID{
+			wiremessage.CompressorSnappy,
+			wiremessage.CompressorZLib,
+			wiremessage.CompressorZstd,
+		} {
+			t.Run(compressor.String(), func(t *testing.T) {
+				opts := CompressionOpts{
+					Compressor:       compressor,
+					UncompressedSize: -1,
+				}
+				_, err := DecompressPayload([]byte{0x00, 0x01, 0x02, 0x03}, opts)
+				assert.Error(t, err)
+			})
+		}
+	})
 }
 
 var (


### PR DESCRIPTION
GODRIVER-4135

## Summary
This PR is based on #2569 with some updates. In particular, the test cases have been modified to directly test against a negative `CompressionOpts.UncompressedSize`, which the original PR intended to fix. 

## Background & Motivation
A server-supplied `uncompressedSize` is an int32 read straight off the wire. A negative value reaches make() and panics with "makeslice: cap out of range" for the zlib and zstd branches.